### PR TITLE
fix(init): provide writable /run tmpfs; relocate guest tooling to /.lens

### DIFF
--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -322,6 +322,14 @@ fn do_mkdir_p(sys: &dyn Syscalls, path: &str, mode: u32) -> Result<(), MountErro
     Ok(())
 }
 
+fn do_lchown(sys: &dyn Syscalls, path: &str, uid: u32) -> Result<(), MountError> {
+    let c = cstring(path, "lchown-path")?;
+    sys.lchown(&c, uid, uid).map_err(|err| MountError::Syscall {
+        op: format!("lchown({path}, {uid})"),
+        err,
+    })
+}
+
 fn do_umount(sys: &dyn Syscalls, target: &str) -> Result<(), MountError> {
     let c = cstring(target, "umount-target")?;
     sys.umount(&c).map_err(|err| MountError::Syscall {
@@ -353,7 +361,11 @@ fn mount_volumes(
     Ok(())
 }
 
-fn mount_run_tmpfs(sys: &dyn Syscalls, newroot: &str) -> Result<(), MountError> {
+fn mount_run_tmpfs(
+    sys: &dyn Syscalls,
+    newroot: &str,
+    sandbox_user: Option<&SandboxUser>,
+) -> Result<(), MountError> {
     let run = format!("{newroot}{RUN}");
     do_mkdir(sys, &run, 0o755)?;
     do_mount(
@@ -364,6 +376,9 @@ fn mount_run_tmpfs(sys: &dyn Syscalls, newroot: &str) -> Result<(), MountError> 
         MountFlags::Tmpfs,
         Some(RUN_TMPFS_OPTS),
     )?;
+    if let Some(user) = sandbox_user {
+        do_lchown(sys, &run, user.uid)?;
+    }
     let lock = format!("{newroot}{RUN_LOCK}");
     do_mkdir(sys, &lock, 0o755)?;
     do_mount(
@@ -528,7 +543,7 @@ fn mount_composefs_and_exec_broker_inner(
 
     mount_volumes(sys, &params.volumes, newroot)?;
 
-    mount_run_tmpfs(sys, newroot)?;
+    mount_run_tmpfs(sys, newroot, sandbox_user)?;
 
     let broker_path_c = cstring(INIT_BROKER_PATH, "broker-path")?;
     let broker_fd = open_broker_fd(sys, &broker_path_c)?;
@@ -1590,6 +1605,75 @@ mod tests {
             lock < chroot,
             "the writable /run is in place before the pivot"
         );
+    }
+
+    #[test]
+    fn boot_chowns_run_to_the_sandbox_user_so_an_unprivileged_workload_can_write() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let user = SandboxUser {
+            name: "agent".into(),
+            uid: 4242,
+        };
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        let run_target = format!("{newroot}/run");
+        assert!(
+            sys.calls().iter().any(|c| matches!(
+                c,
+                Call::Lchown { path, uid: 4242, gid: 4242 } if path == &run_target
+            )),
+            "/run must be chowned to the sandbox user so it is actually writable"
+        );
+    }
+
+    #[test]
+    fn boot_leaves_run_root_owned_when_there_is_no_sandbox_user() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        assert!(
+            !sys.calls()
+                .iter()
+                .any(|c| matches!(c, Call::Lchown { path, .. } if path == "/newroot/run")),
+            "a rootful workload keeps the standard root-owned 0755 /run"
+        );
+    }
+
+    #[test]
+    fn boot_aborts_when_run_chown_fails_rather_than_run_with_an_unwritable_run() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap();
+        let run_target = format!("{newroot}/run");
+        let fail_on = run_target.clone();
+        let sys = FakeSyscalls::new().fail_when(move |c| {
+            matches!(c, Call::Lchown { path, .. } if path == &fail_on)
+                .then_some(std::io::ErrorKind::PermissionDenied)
+        });
+        let user = SandboxUser {
+            name: "agent".into(),
+            uid: 4242,
+        };
+        let err = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        )
+        .unwrap_err();
+        assert!(matches!(err, MountError::Syscall { op, .. } if op.contains("lchown")));
     }
 
     #[test]

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -24,13 +24,19 @@ const NEWROOT: &str = "/newroot";
 const INIT_BROKER_PATH: &str = "/init-broker";
 const VOLUME_SEED_MOUNT: &str = "/mnt/vol-seed";
 const PROC_CMDLINE: &str = "/proc/cmdline";
-const CMDLINE_MASK_FILE: &str = "/run/lns/.cmdline";
+const CMDLINE_MASK_FILE: &str = "/.lens/.cmdline";
+const RUN: &str = "/run";
+const RUN_LOCK: &str = "/run/lock";
+const RUN_TMPFS_OPTS: &str = "mode=0755,size=64m";
+const RUN_LOCK_TMPFS_OPTS: &str = "mode=1777,size=4m";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MountFlags {
     None,
     ReadOnly,
     Bind,
+    Tmpfs,
+    TmpfsNoExec,
 }
 
 pub(crate) struct SandboxUser {
@@ -347,6 +353,29 @@ fn mount_volumes(
     Ok(())
 }
 
+fn mount_run_tmpfs(sys: &dyn Syscalls, newroot: &str) -> Result<(), MountError> {
+    let run = format!("{newroot}{RUN}");
+    do_mkdir(sys, &run, 0o755)?;
+    do_mount(
+        sys,
+        "tmpfs",
+        &run,
+        "tmpfs",
+        MountFlags::Tmpfs,
+        Some(RUN_TMPFS_OPTS),
+    )?;
+    let lock = format!("{newroot}{RUN_LOCK}");
+    do_mkdir(sys, &lock, 0o755)?;
+    do_mount(
+        sys,
+        "tmpfs",
+        &lock,
+        "tmpfs",
+        MountFlags::TmpfsNoExec,
+        Some(RUN_LOCK_TMPFS_OPTS),
+    )
+}
+
 fn seed_volume_if_pristine(
     sys: &dyn Syscalls,
     dev: &str,
@@ -498,6 +527,8 @@ fn mount_composefs_and_exec_broker_inner(
     )?;
 
     mount_volumes(sys, &params.volumes, newroot)?;
+
+    mount_run_tmpfs(sys, newroot)?;
 
     let broker_path_c = cstring(INIT_BROKER_PATH, "broker-path")?;
     let broker_fd = open_broker_fd(sys, &broker_path_c)?;
@@ -1456,6 +1487,112 @@ mod tests {
     }
 
     #[test]
+    fn boot_mounts_run_as_a_hardened_writable_tmpfs() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let run = sys
+            .calls()
+            .into_iter()
+            .find_map(|c| match c {
+                Call::Mount {
+                    target,
+                    fstype,
+                    flags,
+                    data,
+                    ..
+                } if target == "/newroot/run" && fstype == "tmpfs" => Some((flags, data)),
+                _ => None,
+            })
+            .expect("/run is mounted as tmpfs under newroot");
+        let (flags, data) = run;
+        assert_eq!(flags, MountFlags::Tmpfs, "/run must be nosuid,nodev");
+        let opts = data.expect("/run tmpfs carries options");
+        assert!(opts.contains("mode=0755"), "/run must be 0755: {opts}");
+        assert!(opts.contains("size="), "/run must be size-capped: {opts}");
+    }
+
+    #[test]
+    fn boot_mounts_run_lock_as_a_sticky_noexec_tmpfs() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let lock = sys
+            .calls()
+            .into_iter()
+            .find_map(|c| match c {
+                Call::Mount {
+                    target,
+                    fstype,
+                    flags,
+                    data,
+                    ..
+                } if target == "/newroot/run/lock" && fstype == "tmpfs" => Some((flags, data)),
+                _ => None,
+            })
+            .expect("/run/lock is mounted as tmpfs under newroot");
+        let (flags, data) = lock;
+        assert_eq!(
+            flags,
+            MountFlags::TmpfsNoExec,
+            "/run/lock must be nosuid,nodev,noexec"
+        );
+        assert!(
+            data.expect("/run/lock tmpfs carries options")
+                .contains("mode=1777"),
+            "/run/lock must be world-writable sticky 1777"
+        );
+    }
+
+    #[test]
+    fn boot_mounts_run_after_overlay_and_before_pivot_with_lock_nested() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        let overlay = calls
+            .iter()
+            .position(|c| matches!(c, Call::Mount { fstype, .. } if fstype == "overlay"))
+            .unwrap();
+        let run = calls
+            .iter()
+            .position(|c| matches!(c, Call::Mount { target, fstype, .. } if target == "/newroot/run" && fstype == "tmpfs"))
+            .unwrap();
+        let lock = calls
+            .iter()
+            .position(|c| matches!(c, Call::Mount { target, .. } if target == "/newroot/run/lock"))
+            .unwrap();
+        let chroot = calls
+            .iter()
+            .position(|c| matches!(c, Call::Chroot(_)))
+            .unwrap();
+        assert!(
+            overlay < run,
+            "/run tmpfs mounts after the overlay root exists"
+        );
+        assert!(run < lock, "/run/lock mounts onto the fresh /run tmpfs");
+        assert!(
+            lock < chroot,
+            "the writable /run is in place before the pivot"
+        );
+    }
+
+    #[test]
     fn boot_writes_a_0600_cmdline_mask_with_the_relay_token_stripped() {
         let sys = FakeSyscalls::new();
         let _ = mount_composefs_and_exec_broker_inner(
@@ -1473,7 +1610,7 @@ mod tests {
                     path,
                     contents,
                     mode,
-                } if path == "/newroot/run/lns/.cmdline" => Some((contents, mode)),
+                } if path == "/newroot/.lens/.cmdline" => Some((contents, mode)),
                 _ => None,
             })
             .expect("masked cmdline file written under newroot");

--- a/crates/lns-init/src/mount/real.rs
+++ b/crates/lns-init/src/mount/real.rs
@@ -30,6 +30,8 @@ impl Syscalls for RealSyscalls {
             MountFlags::None => 0,
             MountFlags::ReadOnly => libc::MS_RDONLY,
             MountFlags::Bind => libc::MS_BIND,
+            MountFlags::Tmpfs => libc::MS_NOSUID | libc::MS_NODEV,
+            MountFlags::TmpfsNoExec => libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
         };
         let data_ptr = data
             .map(|c| c.as_ptr() as *const libc::c_void)

--- a/crates/lns-service/src/composefs/descriptor.rs
+++ b/crates/lns-service/src/composefs/descriptor.rs
@@ -284,7 +284,7 @@ mod tests {
             .build(
                 &store,
                 &[RuntimeFileSpec {
-                    guest_path: "/run/lns/bin/super".into(),
+                    guest_path: "/.lens/bin/super".into(),
                     mode: 0o755,
                     source: RuntimeSource::Bytes(b"super-a".to_vec()),
                 }],
@@ -294,7 +294,7 @@ mod tests {
             .build(
                 &store,
                 &[RuntimeFileSpec {
-                    guest_path: "/run/lns/bin/super".into(),
+                    guest_path: "/.lens/bin/super".into(),
                     mode: 0o755,
                     source: RuntimeSource::Bytes(b"super-b".to_vec()),
                 }],

--- a/crates/lns-service/src/guest_tools/mod.rs
+++ b/crates/lns-service/src/guest_tools/mod.rs
@@ -163,7 +163,7 @@ fn extract_package(root: &Path, bytes: &[u8]) -> Result<()> {
 
 fn map_guest_tool_path(path: &Path) -> Option<PathBuf> {
     (path == Path::new("bin/busybox.static"))
-        .then(|| Path::new("run/lns/guest-tools/bin/busybox").to_path_buf())
+        .then(|| Path::new(".lens/guest-tools/bin/busybox").to_path_buf())
 }
 
 fn validate_archive_path(path: &Path) -> Result<()> {
@@ -227,10 +227,10 @@ mod tests {
     }
 
     #[test]
-    fn map_guest_tool_path_relocates_static_busybox_under_run_lns() {
+    fn map_guest_tool_path_relocates_static_busybox_under_dot_lens() {
         assert_eq!(
             map_guest_tool_path(Path::new("bin/busybox.static")).as_deref(),
-            Some(Path::new("run/lns/guest-tools/bin/busybox"))
+            Some(Path::new(".lens/guest-tools/bin/busybox"))
         );
         assert!(map_guest_tool_path(Path::new("bin/busybox")).is_none());
         assert!(map_guest_tool_path(Path::new("bin/sh")).is_none());
@@ -319,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_package_relocates_static_busybox_under_run_lns_guest_tools() {
+    fn extract_package_relocates_static_busybox_under_dot_lens_guest_tools() {
         let bytes = gzip_tar(|b| {
             write_tar_entry(b, "bin/busybox.static", b"busybox-bin");
             write_tar_entry(b, "bin/sh", b"unwanted");
@@ -327,8 +327,8 @@ mod tests {
         });
         let dir = tempfile::TempDir::new().unwrap();
         extract_package(dir.path(), &bytes).unwrap();
-        assert!(dir.path().join("run/lns/guest-tools/bin/busybox").is_file());
-        assert!(!dir.path().join("run/lns/guest-tools/bin/sh").exists());
+        assert!(dir.path().join(".lens/guest-tools/bin/busybox").is_file());
+        assert!(!dir.path().join(".lens/guest-tools/bin/sh").exists());
         assert!(
             !dir.path().join(".PKGINFO").exists(),
             "apk metadata skipped"
@@ -532,11 +532,8 @@ mod tests {
             ".ready marker must be written so the next call short-circuits"
         );
         assert!(
-            result
-                .root
-                .join("run/lns/guest-tools/bin/busybox")
-                .is_file(),
-            "busybox landed under run/lns/guest-tools"
+            result.root.join(".lens/guest-tools/bin/busybox").is_file(),
+            "busybox landed under .lens/guest-tools"
         );
         assert!(
             !result.root.join("lib").exists(),

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -33,7 +33,7 @@ pub(super) fn build_workload_argv(
     supervised: bool,
 ) -> Vec<String> {
     if supervised {
-        return vec!["/run/lns/bin/lns-supervisor".to_string()];
+        return vec!["/.lens/bin/lns-supervisor".to_string()];
     }
     let joined = match image_config {
         Some(cfg) => crate::workload_argv::from_image_config(cfg, override_cmd),
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn build_workload_argv_supervised_returns_supervisor_wrapper() {
         let argv = build_workload_argv(None, &["echo".into(), "hi".into()], true);
-        assert_eq!(argv, vec!["/run/lns/bin/lns-supervisor".to_string()]);
+        assert_eq!(argv, vec!["/.lens/bin/lns-supervisor".to_string()]);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/lns-service/src/runtime_layer/mod.rs
+++ b/crates/lns-service/src/runtime_layer/mod.rs
@@ -351,7 +351,7 @@ mod tests {
             .build(
                 &s,
                 &[RuntimeFileSpec {
-                    guest_path: "/run/lns/bin/lns-supervisor".into(),
+                    guest_path: "/.lens/bin/lns-supervisor".into(),
                     mode: 0o755,
                     source: RuntimeSource::Bytes(b"#!/bin/sh\necho fake supervisor".to_vec()),
                 }],
@@ -361,7 +361,7 @@ mod tests {
         assert_eq!(layer.manifest.label, "test-label");
         assert_eq!(layer.manifest.files.len(), 1);
         let e = &layer.manifest.files[0];
-        assert_eq!(e.path, "run/lns/bin/lns-supervisor");
+        assert_eq!(e.path, ".lens/bin/lns-supervisor");
         assert_eq!(e.mode, 0o755);
         assert!(matches!(e.kind, ManifestKind::Regular));
         assert!(e.digest.starts_with("sha256:"));
@@ -480,7 +480,7 @@ mod tests {
             .build(
                 &s,
                 &[RuntimeFileSpec {
-                    guest_path: "/run/lns/bin/super".into(),
+                    guest_path: "/.lens/bin/super".into(),
                     mode: 0o755,
                     source: RuntimeSource::HostFile(source),
                 }],
@@ -493,10 +493,7 @@ mod tests {
 
     #[test]
     fn normalize_guest_path_strips_leading_slash() {
-        assert_eq!(
-            normalize_guest_path("/run/lns/bin/x").unwrap(),
-            "run/lns/bin/x"
-        );
+        assert_eq!(normalize_guest_path("/.lens/bin/x").unwrap(), ".lens/bin/x");
     }
 
     #[test]
@@ -533,7 +530,7 @@ mod tests {
             .build(
                 &s,
                 &[RuntimeFileSpec {
-                    guest_path: "/run/lns/bin/foo".into(),
+                    guest_path: "/.lens/bin/foo".into(),
                     mode: 0o755,
                     source: RuntimeSource::Bytes(b"foo bytes".to_vec()),
                 }],
@@ -541,9 +538,8 @@ mod tests {
             .unwrap();
         layer.inject_into_filesystem(&mut fs).unwrap();
 
-        let run = fs.root.get_directory_mut(OsStr::new("run")).unwrap();
-        let lns = run.get_directory_mut(OsStr::new("lns")).unwrap();
-        let bin = lns.get_directory_mut(OsStr::new("bin")).unwrap();
+        let lens = fs.root.get_directory_mut(OsStr::new(".lens")).unwrap();
+        let bin = lens.get_directory_mut(OsStr::new("bin")).unwrap();
         let leaf_id = bin.leaf_id(OsStr::new("foo")).unwrap();
         assert!(matches!(
             &fs.leaves[leaf_id.0].content,
@@ -682,7 +678,7 @@ mod tests {
         assert!(matches!(
             &bin_sh.kind,
             ManifestKind::Symlink { target }
-                if target == "/run/lns/guest-tools/bin/busybox"
+                if target == "/.lens/guest-tools/bin/busybox"
         ));
     }
 
@@ -699,7 +695,7 @@ mod tests {
                 &[RuntimeFileSpec {
                     guest_path: "/bin/sh".into(),
                     mode: 0o777,
-                    source: RuntimeSource::Symlink("/run/lns/guest-tools/bin/busybox".into()),
+                    source: RuntimeSource::Symlink("/.lens/guest-tools/bin/busybox".into()),
                 }],
             )
             .unwrap();
@@ -711,7 +707,7 @@ mod tests {
         assert!(matches!(
             &leaf.content,
             LeafContent::Symlink(target)
-                if target.as_ref() == OsStr::new("/run/lns/guest-tools/bin/busybox")
+                if target.as_ref() == OsStr::new("/.lens/guest-tools/bin/busybox")
         ));
         assert_eq!(
             leaf.stat.st_mode & type_bits(libc::S_IFMT),
@@ -814,8 +810,8 @@ mod tests {
         let assets = fake_assets(&d);
         let layer = for_run(false, &s, &gt, Some(&assets)).unwrap().unwrap();
         let p = paths(&layer);
-        assert!(p.contains(&"run/lns/bin/lns-supervisor"));
-        assert!(!p.contains(&"run/lns/bin/supervisor.real"));
+        assert!(p.contains(&".lens/bin/lns-supervisor"));
+        assert!(!p.contains(&".lens/bin/supervisor.real"));
         assert!(p.contains(&".lens/nft"));
         assert!(!p.contains(&"bin/sh"));
         assert!(!layer.manifest.label.contains("imageless"));
@@ -831,7 +827,7 @@ mod tests {
         let assets = fake_assets(&d);
         let layer = for_run(true, &s, &gt, Some(&assets)).unwrap().unwrap();
         let p = paths(&layer);
-        assert!(p.contains(&"run/lns/bin/lns-supervisor"));
+        assert!(p.contains(&".lens/bin/lns-supervisor"));
         assert!(
             p.contains(&"bin/sh"),
             "imageless+supervised must carry /bin/sh"
@@ -849,7 +845,7 @@ mod tests {
         let p = paths(&layer);
         assert!(p.contains(&"marker"));
         assert!(!p.contains(&"bin/sh"));
-        assert!(!p.contains(&"run/lns/bin/supervisor.real"));
+        assert!(!p.contains(&".lens/bin/supervisor.real"));
         assert!(!layer.manifest.label.contains("imageless"));
     }
 
@@ -861,7 +857,7 @@ mod tests {
         let layer = for_run(true, &s, &gt, None).unwrap().unwrap();
         let p = paths(&layer);
         assert!(p.contains(&"bin/sh"));
-        assert!(!p.contains(&"run/lns/bin/supervisor.real"));
+        assert!(!p.contains(&".lens/bin/supervisor.real"));
         assert!(layer.manifest.label.ends_with("+imageless"));
     }
 }

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -94,11 +94,11 @@ echo "[wrap] init started, pid=$$, argv=$@"
 echo "[wrap] env (sorted):"
 env | sort | sed 's/^/[wrap]   /'
 echo "[wrap] /run tree:"
-ls -la /run /run/lns /run/lns/bin 2>&1 | sed 's/^/[wrap]   /'
+ls -la /run /run/lock 2>&1 | sed 's/^/[wrap]   /'
 echo "[wrap] /.lens tree:"
-ls -la /.lens 2>&1 | sed 's/^/[wrap]   /'
+ls -la /.lens /.lens/bin 2>&1 | sed 's/^/[wrap]   /'
 echo "[wrap] nft probe (supervisor checks /.lens/nft first, PATH second):"
-for p in /.lens/nft /run/lns/bin/nft /usr/sbin/nft; do
+for p in /.lens/nft /.lens/bin/nft /usr/sbin/nft; do
   if [ -e "$p" ]; then
     echo "[wrap]   ls $p -> $(ls -la "$p" 2>&1)"
   fi
@@ -107,7 +107,7 @@ done
 echo "[wrap]   exit=$?"
 
 echo "[wrap] launching supervisor.real (RUST_LOG=debug to force trace output through is_terminal silence)..."
-RUST_LOG=debug /run/lns/bin/supervisor.real "$@"
+RUST_LOG=debug /.lens/bin/supervisor.real "$@"
 RC=$?
 echo "[wrap] supervisor.real exited rc=$RC"
 echo "[wrap] sleeping 15s before init exits (so output flushes)"
@@ -125,18 +125,18 @@ pub fn runtime_specs(
 
     if std::env::var_os("LNS_DEBUG_WRAP").is_some() {
         specs.push(RuntimeFileSpec {
-            guest_path: "/run/lns/bin/supervisor.real".into(),
+            guest_path: "/.lens/bin/supervisor.real".into(),
             mode: 0o755,
             source: RuntimeSource::HostFile(assets.supervisor_bin.clone()),
         });
         specs.push(RuntimeFileSpec {
-            guest_path: "/run/lns/bin/lns-supervisor".into(),
+            guest_path: "/.lens/bin/lns-supervisor".into(),
             mode: 0o755,
             source: RuntimeSource::Bytes(DEBUG_WRAPPER.as_bytes().to_vec()),
         });
     } else {
         specs.push(RuntimeFileSpec {
-            guest_path: "/run/lns/bin/lns-supervisor".into(),
+            guest_path: "/.lens/bin/lns-supervisor".into(),
             mode: 0o755,
             source: RuntimeSource::HostFile(assets.supervisor_bin.clone()),
         });
@@ -175,7 +175,7 @@ pub fn imageless_runtime_extras() -> Vec<crate::runtime_layer::RuntimeFileSpec> 
     vec![RuntimeFileSpec {
         guest_path: "/bin/sh".into(),
         mode: 0o777,
-        source: RuntimeSource::Symlink("/run/lns/guest-tools/bin/busybox".into()),
+        source: RuntimeSource::Symlink("/.lens/guest-tools/bin/busybox".into()),
     }]
 }
 
@@ -262,7 +262,7 @@ mod tests {
             "/bin/sh source must be a symlink, got {content:?}"
         );
         if let RuntimeSource::Symlink(target) = content {
-            assert_eq!(target, "/run/lns/guest-tools/bin/busybox");
+            assert_eq!(target, "/.lens/guest-tools/bin/busybox");
         }
     }
 
@@ -373,7 +373,7 @@ mod tests {
         let specs = runtime_specs(&assets).expect("specs");
         let wrapper = specs
             .iter()
-            .find(|s| s.guest_path == "/run/lns/bin/lns-supervisor")
+            .find(|s| s.guest_path == "/.lens/bin/lns-supervisor")
             .expect("wrapper spec present");
         let source = &wrapper.source;
         assert!(
@@ -388,7 +388,7 @@ mod tests {
         assert!(
             specs
                 .iter()
-                .any(|s| s.guest_path == "/run/lns/bin/supervisor.real"),
+                .any(|s| s.guest_path == "/.lens/bin/supervisor.real"),
             "LNS_DEBUG_WRAP path must also ship the real supervisor at .real"
         );
     }
@@ -410,7 +410,7 @@ mod tests {
         let specs = runtime_specs(&assets).expect("specs");
         let canonical = specs
             .iter()
-            .find(|s| s.guest_path == "/run/lns/bin/lns-supervisor")
+            .find(|s| s.guest_path == "/.lens/bin/lns-supervisor")
             .expect("canonical spec present");
         let source = &canonical.source;
         assert!(
@@ -423,7 +423,7 @@ mod tests {
         assert!(
             !specs
                 .iter()
-                .any(|s| s.guest_path == "/run/lns/bin/supervisor.real"),
+                .any(|s| s.guest_path == "/.lens/bin/supervisor.real"),
             "default path must not ship `.real` indirection"
         );
     }

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -123,7 +123,7 @@ impl ExecSpec {
                 ),
                 (
                     "PATH".into(),
-                    "/run/lns/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                    "/.lens/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
                         .into(),
                 ),
             ],

--- a/crates/lns-session-broker/src/network.rs
+++ b/crates/lns-session-broker/src/network.rs
@@ -4,16 +4,16 @@ mod real;
 #[cfg(target_os = "linux")]
 pub use real::{bring_up_eth0, configure_dns};
 
-pub const BUSYBOX: &str = "/run/lns/guest-tools/bin/busybox";
+pub const BUSYBOX: &str = "/.lens/guest-tools/bin/busybox";
 pub const UDHCPC_SCRIPT_PATH: &str = "/tmp/lns-udhcpc.script";
 
-pub const DHCP_DNS_PATH: &str = "/run/lns/dhcp-dns";
+pub const DHCP_DNS_PATH: &str = "/.lens/dhcp-dns";
 pub const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 pub const FALLBACK_DNS: &[&str] = &["1.1.1.1", "8.8.8.8"];
 
-pub const UDHCPC_SCRIPT: &str = r#"#!/run/lns/guest-tools/bin/busybox sh
-BB=/run/lns/guest-tools/bin/busybox
+pub const UDHCPC_SCRIPT: &str = r#"#!/.lens/guest-tools/bin/busybox sh
+BB=/.lens/guest-tools/bin/busybox
 case "$1" in
 deconfig)
     "$BB" ip addr flush dev "$interface" 2>/dev/null
@@ -24,11 +24,11 @@ bound|renew)
     if [ -n "$router" ]; then
         "$BB" ip route add default via "$router" dev "$interface" 2>/dev/null || true
     fi
-    "$BB" mkdir -p /run/lns
-    : > /run/lns/dhcp-dns
+    "$BB" mkdir -p /.lens
+    : > /.lens/dhcp-dns
     if [ -n "$dns" ]; then
         for d in $dns; do
-            echo "$d" >> /run/lns/dhcp-dns
+            echo "$d" >> /.lens/dhcp-dns
         done
     fi
     ;;
@@ -151,7 +151,7 @@ mod tests {
             "$interface",
             "${ip}",
             "\"$BB\" ip route add default",
-            "/run/lns/dhcp-dns",
+            "/.lens/dhcp-dns",
             "echo \"$d\"",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

Make the guest's `/run` a proper writable tmpfs, and relocate lns guest tooling off `/run` so the two don't collide.

### 1. Writable `/run` tmpfs
`/run` is mounted as a hardened tmpfs (`nosuid,nodev`, mode 0755, size-capped) and `/run/lock` as a sticky `noexec` tmpfs (1777). Previously `/run` wasn't a real writable runtime dir, so standard images couldn't create runtime dirs (e.g. apache's `/var/run/apache2`).

### 2. Relocate guest tooling `/run/lns` → `/.lens`
Because `/run` is now a fresh tmpfs, anything lns places under `/run` would be shadowed. All lns-owned guest paths move to `/.lens` (supervisor, busybox/guest-tools, dhcp-dns, cmdline mask, PATH).

### 3. Chown `/run` to the sandbox user
The workload runs unprivileged, so the `/run` mountpoint is chowned to the run-as uid (mirroring the home-dir chown) so it's actually writable; `/run/lock` stays 1777, and a rootful workload keeps the standard root-owned `/run`.

Closes #2.

## Note
This relocation surfaced a separate guest-tools cache-invalidation gap (a stale cache serves busybox at the old `/run/lns` path) — tracked in #18 and fixed separately.

## Stacked follow-ups
- low-ports PR #19 (for #15) — based on this branch
- /dev/fd symlinks PR #20 (for #17) — based on the low-ports branch
