### PR TITLE
chore(supervisor): Bump lens-sandbox-core to 3adf8eb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=5d66e85d8a8e881c957fac3f29e657a4d088194a#5d66e85d8a8e881c957fac3f29e657a4d088194a"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=3adf8ebac0af817ce4ecf650d952b5983e9b53fa#3adf8ebac0af817ce4ecf650d952b5983e9b53fa"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -7022,7 +7022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "5d66e85d8a8e881c957fac3f29e657a4d088194a" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "3adf8ebac0af817ce4ecf650d952b5983e9b53fa" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

Bumps the pinned `lens-sandbox-core` git dependency in `lns-supervisor` from `5d66e85` to `3adf8eb`, picking up upstream changes to the shared sandbox core.

- `crates/lns-supervisor/Cargo.toml` and `Cargo.lock` updated in lockstep to the same rev.
- No source changes required — `cargo check -p lns-supervisor --target aarch64-unknown-linux-musl` passes against the new rev, so the upstream API is compatible.
- The incidental `windows-sys 0.61.2 → 0.48.0` line in `Cargo.lock` is `winapi-util`'s transitive, Windows-only dependency that never compiles on this project's macOS/Linux targets — lockfile re-resolution noise, not a behavior change.

## Test instructions

1. `cargo check -p lns-supervisor --target aarch64-unknown-linux-musl` — compiles clean against the new core rev.
2. Run the verification gate (`make lint && make complexity && make coverage`) — passes; no coverage impact since no source changed.