### PR TITLE
ci: bump release-please-action to v5.0.0 (node24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,7 @@ jobs:
       lns-install-released: ${{ steps.release.outputs['scripts/lns-install--release_created'] }}
       lns-install-tag: ${{ steps.release.outputs['scripts/lns-install--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Bump `googleapis/release-please-action` from v4.4.1 → v5.0.0, pinned by commit SHA.

## Why

The v4.x action runs on Node 20. GitHub forces Node 20 actions off the runner default after **2026-06-16** and removes Node 20 entirely on **2026-09-16**, so the current pin would start emitting deprecation warnings and eventually break the Release workflow.

v5.0.0's [only breaking change](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0) is the node24 runtime upgrade — action inputs and behavior are unchanged, so this is a drop-in bump.

## Verification

Workflow-only change. The Release workflow runs on `push: main` and `workflow_dispatch`; the release-please step will exercise the new version on the next push to main after merge.