### PR TITLE
fix(guest-tools): key the tooling cache on the producing binary

### DIFF
--- a/crates/lns-service/src/guest_tools/mod.rs
+++ b/crates/lns-service/src/guest_tools/mod.rs
@@ -53,11 +53,14 @@ pub struct GuestTools {
 pub(crate) async fn ensure_with<F: Fetcher>(
     fetcher: &F,
     cache_root: PathBuf,
+    build_id: &str,
     packages: &[PackageSpec],
 ) -> Result<GuestTools> {
     let apks_dir = cache_root.join("apks");
-    let extracted = cache_root.join("extracted");
+    let extracted_root = cache_root.join("extracted");
+    let extracted = extracted_root.join(build_id);
     tokio::fs::create_dir_all(&apks_dir).await?;
+    prune_stale_extracts(&extracted_root, build_id).await;
 
     if extracted.join(".ready").exists() {
         return Ok(GuestTools { root: extracted });
@@ -79,6 +82,17 @@ pub(crate) async fn ensure_with<F: Fetcher>(
 
     tokio::fs::write(extracted.join(".ready"), b"").await?;
     Ok(GuestTools { root: extracted })
+}
+
+async fn prune_stale_extracts(extracted_root: &Path, keep: &str) {
+    let Ok(mut entries) = tokio::fs::read_dir(extracted_root).await else {
+        return;
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if entry.file_name().to_str() != Some(keep) {
+            tokio::fs::remove_dir_all(entry.path()).await.ok();
+        }
+    }
 }
 
 async fn ensure_apk_with<F: Fetcher>(
@@ -478,14 +492,14 @@ mod tests {
     #[tokio::test]
     async fn ensure_with_short_circuits_when_ready_marker_present() {
         let dir = tempfile::TempDir::new().unwrap();
-        let extracted = dir.path().join("extracted");
+        let extracted = dir.path().join("extracted").join("test-build");
         tokio::fs::create_dir_all(&extracted).await.unwrap();
         tokio::fs::write(extracted.join(".ready"), b"")
             .await
             .unwrap();
 
         let fetcher = FakeFetcher::new();
-        let result = ensure_with(&fetcher, dir.path().to_path_buf(), PACKAGES)
+        let result = ensure_with(&fetcher, dir.path().to_path_buf(), "test-build", PACKAGES)
             .await
             .unwrap();
         assert_eq!(result.root, extracted);
@@ -498,7 +512,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_with_clears_partial_extract_before_redoing_work() {
         let dir = tempfile::TempDir::new().unwrap();
-        let extracted = dir.path().join("extracted");
+        let extracted = dir.path().join("extracted").join("test-build");
         tokio::fs::create_dir_all(&extracted).await.unwrap();
         tokio::fs::write(extracted.join("stale.txt"), b"old")
             .await
@@ -510,7 +524,7 @@ mod tests {
             spec.name, spec.version
         );
         let fetcher = FakeFetcher::new().err(url, "boom");
-        let _err = ensure_with(&fetcher, dir.path().to_path_buf(), PACKAGES)
+        let _err = ensure_with(&fetcher, dir.path().to_path_buf(), "test-build", PACKAGES)
             .await
             .unwrap_err();
         assert!(
@@ -523,10 +537,10 @@ mod tests {
     async fn ensure_with_completes_end_to_end_writing_ready_marker_after_full_extract() {
         let (packages, fetcher) = matched_test_pin();
         let dir = tempfile::TempDir::new().unwrap();
-        let result = ensure_with(&fetcher, dir.path().to_path_buf(), &packages)
+        let result = ensure_with(&fetcher, dir.path().to_path_buf(), "test-build", &packages)
             .await
             .expect("ensure_with happy path");
-        assert_eq!(result.root, dir.path().join("extracted"));
+        assert_eq!(result.root, dir.path().join("extracted").join("test-build"));
         assert!(
             result.root.join(".ready").exists(),
             ".ready marker must be written so the next call short-circuits"
@@ -553,5 +567,53 @@ mod tests {
         let base = Path::new("/cache");
         let p = cache_subpath(base);
         assert_eq!(p, base.join("guest-tools").join(ALPINE_VERSION).join(ARCH));
+    }
+
+    #[tokio::test]
+    async fn ensure_with_buckets_extracted_per_build_id_but_shares_apks() {
+        let (packages, fetcher) = matched_test_pin();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let a = ensure_with(&fetcher, dir.path().to_path_buf(), "build-a", &packages)
+            .await
+            .unwrap();
+        let b = ensure_with(&fetcher, dir.path().to_path_buf(), "build-b", &packages)
+            .await
+            .unwrap();
+
+        assert_ne!(
+            a.root, b.root,
+            "a binary with a different layout must not reuse another's extracted tree"
+        );
+        assert!(a.root.ends_with("extracted/build-a"));
+        assert!(b.root.ends_with("extracted/build-b"));
+        assert_eq!(
+            fetcher.calls.lock().unwrap().len(),
+            1,
+            "the sha-pinned apk cache is shared across build ids — the second build must not refetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_with_reclaims_a_previous_build_ids_extracted_tree() {
+        let (packages, fetcher) = matched_test_pin();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let stale = dir.path().join("extracted").join("old-build");
+        tokio::fs::create_dir_all(&stale).await.unwrap();
+        tokio::fs::write(stale.join(".ready"), b"").await.unwrap();
+
+        let fresh = ensure_with(&fetcher, dir.path().to_path_buf(), "new-build", &packages)
+            .await
+            .unwrap();
+
+        assert!(
+            !stale.exists(),
+            "a binary no longer running must not leave its extracted tree behind"
+        );
+        assert!(
+            fresh.root.join(".ready").exists(),
+            "the current build's extracted tree is the one that survives"
+        );
     }
 }

--- a/crates/lns-service/src/guest_tools/real.rs
+++ b/crates/lns-service/src/guest_tools/real.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
+use tokio::sync::OnceCell;
 
-use super::{Fetcher, GuestTools, PACKAGES, cache_subpath, ensure_with};
+use super::{Fetcher, GuestTools, PACKAGES, cache_subpath, ensure_with, sha256_hex};
+
+static BUILD_ID: OnceCell<String> = OnceCell::const_new();
 
 pub(super) struct RealFetcher;
 
@@ -21,5 +24,17 @@ impl Fetcher for RealFetcher {
 
 pub async fn ensure() -> Result<GuestTools> {
     let cache = cache_subpath(&crate::cache::root()?);
-    ensure_with(&RealFetcher, cache, PACKAGES).await
+    let build_id = BUILD_ID.get_or_try_init(compute_build_id).await?;
+    ensure_with(&RealFetcher, cache, build_id, PACKAGES).await
+}
+
+async fn compute_build_id() -> Result<String> {
+    let exe = std::env::current_exe()
+        .context("resolving current executable to key the guest-tools cache")?;
+    tokio::task::spawn_blocking(move || {
+        let bytes = std::fs::read(&exe)
+            .with_context(|| format!("reading {} to key the guest-tools cache", exe.display()))?;
+        anyhow::Ok(sha256_hex(&bytes))
+    })
+    .await?
 }

--- a/scripts/coverage-floor.sh
+++ b/scripts/coverage-floor.sh
@@ -50,7 +50,7 @@ crates/lns-service/build.rs                              host cross-build glue (
 crates/lns-service/src/kernel/real.rs                    production wiring over reqwest + tokio::fs; pinned by wiremock tests in kernel.rs
 crates/lns-service/src/kernel/traits.rs                  trait/type-level declarations; LLVM phantom DA on trait headers
 crates/lns-service/src/image/real.rs                     production wiring over oci_client::Client + linux/host-arch resolver; pinned by fake-Registry tests in image/mod.rs
-crates/lns-service/src/guest_tools/real.rs               production wiring over reqwest::get for dl-cdn.alpinelinux.org + cache::root(); pinned by fake-Fetcher tests in guest_tools/mod.rs
+crates/lns-service/src/guest_tools/real.rs               production wiring over reqwest::get for dl-cdn.alpinelinux.org + cache::root() + current_exe() self-hash build id; pinned by fake-Fetcher tests in guest_tools/mod.rs
 crates/lns-service/src/supervisor/traits.rs              trait/type-level declarations; LLVM phantom DA on trait headers
 crates/lns-service/src/forward/real.rs                   macOS Vz vsock connector + tokio TCP listener/splice syscall leaf; PortForwarder lifecycle + accept-error classification pinned by fake-forwarder and classify_accept_error tests in forward/mod.rs
 crates/lns-cli/src/service/real.rs                       leaf adapters (RealPinger, RealChildProbe, send_request, send_cancel_impl, spawn_service_impl) over tokio UnixStream + std::process; loop logic tested via _with + FakePinger/FakeChild


### PR DESCRIPTION
## Problem

The guest-tools cache key (`cache_subpath`) was only `<ALPINE_VERSION>/<ARCH>`, and extraction is gated by a build-agnostic `.ready` sentinel. So **any two builds share one extracted tree** — including a local `cargo build --release` and the installed release — and whichever populates it first wins.

When a build whose in-guest tooling layout differs from another (e.g. a branch that relocated guest tooling) populates the cache, the next build sees `.ready`, **skips re-extraction, and ships that foreign layout verbatim** (`walk_guest_tools` emits each file at its path relative to the cached tree). The result observed in practice: the session-broker couldn't find busybox at the path it expected, so `bring_up_eth0` failed, loopback never came up, the in-guest proxy on `127.0.0.1:3128` was unreachable, and **network policy enforcement was silently disabled** — no approval prompts, all outbound connections refused.

A `dev`/`release` channel split (an earlier iteration of this PR) only separates by profile. It misses the case that actually bites a developer: a locally-built `--release` is a dev artifact, yet shares the `release` bucket with the installed release and poisons it.

## Fix

Key the **extracted** tree on the identity of the binary that produced it — a sha256 of the running `lns-service` executable:

```
~/Library/Caches/lns/guest-tools/<ALPINE_VERSION>/<ARCH>/
  apks/                 <- shared across builds (already sha-pinned, content-addressed)
  extracted/<build-id>/ <- one tree per producing binary
```

A tree is reused **iff** it was produced by a byte-identical binary, which by construction agrees on the layout the broker expects. Debug, release, locally-built `--release`, and a future release each get their own bucket; the profile-based channel is subsumed (debug and release binaries differ in bytes anyway) and removed. The sha-pinned apk download stays at the shared per-arch root, so builds reuse it instead of refetching.

The build id is hashed **once per process**: `lns-service` is a long-lived service, so it hashes its own executable behind a `OnceCell` at first use rather than re-reading tens of MB on every `lns run`. Reading once at first use also captures the *running* code's identity — not whatever bytes happen to be on disk after an in-place upgrade.

Each `ensure()` also **prunes sibling buckets**, keeping only the live binary's extracted tree, so per-build bucketing doesn't leak disk across rebuilds and upgrades. Pruning is best-effort (matching the file's existing `.ok()` cache-cleanup idiom) — a stray un-removable entry reclaims nothing but never blocks the run.

`build_id` is computed in the production adapter (`guest_tools/real.rs`, which is coverage-exempt wiring); `ensure_with` takes it as an injected `&str` so the pure core stays host-tested.

## Testing

- `ensure_with_buckets_extracted_per_build_id_but_shares_apks` pins both halves: two build ids yield distinct extracted trees, and the apk is fetched exactly once.
- `ensure_with_reclaims_a_previous_build_ids_extracted_tree` pins that a prior build's extracted tree is removed when a new build runs.
- `cache_subpath` test reverted to the per-arch layout; the `build_channel` helper and its test removed.
- `make lint`, `make complexity`, and the `lns-service` coverage gate all clean — `guest_tools/mod.rs` at 100%.

## Trade-off

A developer iterating re-extracts busybox per rebuild (local, sub-second; the apk download is *not* repeated). Acceptable — it's dwarfed by microVM boot, and it's the cost of never silently running with networking unenforced. Disk stays bounded: each `ensure()` reclaims prior buckets.

## Not in this PR

The `.ready` sentinel still trusts that a matching-`build-id` tree is intact. Binary identity makes a *wrong-layout* reuse impossible, but a half-extracted tree from a crashed run under the same build id would still be trusted. Stamping `.ready` with a completion/content check is a separate hardening.
