### PR TITLE
chore(skills): Add problem-first planning workflow skills

### DIFF
--- a/.claude/skills/problem-first-impl/SKILL.md
+++ b/.claude/skills/problem-first-impl/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: problem-first-impl
+description: >
+  Continuation of `/problem-first`. Confirms scope against product docs and
+  existing specs, writes the agreed Gherkin scenarios to a `.feature` file
+  in the target crate's test-layer directory, and enters technical planning
+  mode. Use when the user explicitly runs `/problem-first-impl`, or when
+  they ask to proceed to implementation after a `/problem-first` session.
+  Do NOT auto-invoke.
+---
+
+# Spec — Problem-First → Implementation
+
+Take the agreed problem + Gherkin scenarios from `/problem-first` and move to technical planning. This skill does two things: (1) a final scope confirmation against the product docs and existing specs, and (2) hand-off — writing the `.feature` file and entering plan mode.
+
+This skill is the "code path" continuation. If the goal is to file an issue for someone else to pick up, use `/problem-first-issue` instead.
+
+## Inputs
+
+You need the full output of a `/problem-first` session, or a GitHub issue carrying the same content:
+
+1. A **problem statement** (1-2 sentences).
+2. An agreed set of **Gherkin scenarios**.
+3. A **target crate** in this monorepo.
+4. An agreed **approach** — one-paragraph solution direction from `/problem-first` Phase 3.
+5. **Alternatives considered** and their rejection reasons (1-3).
+6. Optionally: **assumptions / constraints**, **non-goals**, **open questions**.
+
+### Invocation modes
+
+**Mode A — Continuation in the same session as `/problem-first`.**
+If `/problem-first` just ran in this conversation, read the full output (problem, scenarios, target crate, approach, alternatives, assumptions) directly from conversation context. Doc-level alignment was confirmed at intake — do not re-run that check. Briefly confirm: *"Using the problem, N scenarios, target crate `<crate>`, and chosen approach from the `/problem-first` session above (doc-alignment confirmed) — proceeding to code-level check."*
+
+**Mode B — Standalone (picking up a GitHub issue, or resuming cold).**
+If there is no prior `/problem-first` output in the session, the user is likely picking up work that was planned earlier. Either:
+
+- Ask for the source: *"Do you have a `/problem-first-issue` GitHub issue for this? Paste the number or URL and I'll read it (`gh issue view <n>`), or paste the problem + scenarios + approach directly."*
+- Or elicit all six input items above.
+
+In Mode B, product docs may have changed since the issue was filed. Re-run the doc-level alignment check from `/problem-first` Phase 4 before the code-level check — cheap insurance against silently implementing against stale direction.
+
+Do NOT fabricate content. If the approach is missing, do not proceed — send the user to `/problem-first` Phase 3 to decide direction before writing a `.feature` file. The approach is what makes the code-level check and the technical-planning phases meaningful; without it, this skill degrades into guessing.
+
+If the target crate is unclear, stop and determine it before continuing — the `.feature` file needs a home.
+
+## Process
+
+`/problem-first` covered Phases 1-4 (problem, behavior, direction, doc-level alignment). This skill continues from there with code-level checks and implementation.
+
+### Phase 4: Code-Level Check
+
+Doc-level alignment was confirmed at intake. This phase is the complementary check against the actual source tree — the things that can only be verified with the checkout in front of you.
+
+1. **Existing specs.** Read the target crate's feature files — `tests/behaviours/*.feature` (Layer 2) and, if relevant, `e2e/*.feature` (Layer 1). Do any overlap with the agreed scenarios? Overlapping scenarios must be reconciled (merge, rename, or replace), not silently duplicated.
+2. **Approach vs current source.** Open the crate. Does the agreed approach still fit the code as it exists today? Has the crate drifted since `/problem-first` ran? If it has, name the drift and decide: does the approach still hold, or do we go back?
+3. **Re-verify assumptions.** Walk through each load-bearing assumption from `/problem-first` Phase 3. Can you confirm it from the code? An assumption that looked safe at intake may be wrong in practice — if so, the approach may need revisiting. Send the user back to `/problem-first` rather than papering over it.
+
+**Re-check doc alignment only if needed.** In Mode A (same session as `/problem-first`), doc alignment was just confirmed — skip it. In Mode B (picking up a GitHub issue that was filed earlier), the product docs may have moved since the issue was filed. Re-run the doc-level check from `/problem-first` Phase 4 before proceeding.
+
+Then present a summary:
+
+- Problem statement (1-2 sentences)
+- Target crate(s)
+- Behavior scope (list the scenario titles, plus any reconciliation with existing specs)
+- Agreed approach (one paragraph)
+- Assumptions that still hold (and any that shifted, with what that means)
+- Explicit non-goals
+- Any new conflicts surfaced by looking at the code
+- Any docs that need updating if this work lands
+
+Ask: **"Are we aligned? Should I proceed to writing the `.feature` file and technical planning?"**
+
+Do not proceed without explicit confirmation.
+
+### Phase 5: Hand-off to Technical Planning
+
+Only after the user confirms alignment:
+
+1. Write the agreed Gherkin scenarios to the appropriate `.feature` file, following the repo's **Test layers** convention (see the repo-root `CLAUDE.md`). Default to **Layer 2** behavioural specs at `crates/<crate>/tests/behaviours/` — that's the primary coverage-bearing layer for user-visible behavior. Only put a scenario in **Layer 1** (`crates/<crate>/e2e/`) if it genuinely requires real binaries / a real microVM / real I/O. Match the file naming and style of existing `.feature` files in that directory; if a suitable existing file exists, append to it, otherwise create a new one (and add a step definition stub under `tests/behaviours/steps/` if the phrasing is new).
+2. Enter plan mode for technical implementation planning, starting from the agreed approach — not from a blank page. The plan refines the approach into concrete types, files, and steps. It should not reopen the "what direction" question; if it needs to, that's a scope drift and we go back to `/problem-first`.
+
+The Gherkin file is the contract. Implementation must satisfy it, nothing more, nothing less.
+
+If the change has non-obvious unit-test scope (e.g. internal helpers, error-mapping logic not visible at the Gherkin level — Layer 3 territory), note it in the plan — but Gherkin scenarios remain the acceptance bar. Each plan step should fold in its own failing-test-first work rather than deferring all tests to a tail-end step.
+
+## Rules
+
+- **Do not auto-invoke.** Only run when the user explicitly asks or uses `/problem-first-impl`.
+- **Do not re-run Phases 1-3.** That's `/problem-first`'s job. If inputs are missing, send the user back there.
+- **Do not re-run the doc-level alignment check in Mode A.** It just happened. Re-running it is wasted work and second-guesses the intake.
+- **Do re-run it in Mode B.** When picking up an issue filed earlier, docs may have drifted. A quick re-check is cheap insurance.
+- **Do not proceed without an agreed approach.** Scenarios alone aren't enough — without direction, Phase 4 has nothing to compare against and Phase 5 becomes a guessing game.
+- **Do not skip Phase 4.** The code-level check is the last chance to catch spec duplication, stale assumptions, or source drift before code starts.
+- **Do not write the `.feature` file before Phase 4 is explicitly confirmed.**
+- **Preserve the agreed Gherkin exactly.** Do not rephrase scenarios when writing the file.
+- **Use canonical terminology** from `docs/` and the Product Vision in the repo-root `CLAUDE.md`.
+- **Respect the test pyramid.** Behavioural specs land in Layer 2 (`tests/behaviours/`) unless they genuinely require real I/O (Layer 1, `e2e/`); they never spawn real subprocesses or hit the network at Layer 2.
+- **If scope or direction drifts during Phase 4 or Phase 5**, go back to `/problem-first` rather than papering over it here.

--- a/.claude/skills/problem-first-issue/SKILL.md
+++ b/.claude/skills/problem-first-issue/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: problem-first-issue
+description: >
+  Continuation of `/problem-first`. Creates a GitHub issue (open,
+  unassigned) capturing the agreed problem statement and Gherkin scenarios
+  as acceptance criteria. Use when the user explicitly runs
+  `/problem-first-issue`, or when they ask to file an issue for a problem
+  they've just worked through via `/problem-first`. Do NOT auto-invoke.
+model: sonnet
+---
+
+# Spec — Problem-First → GitHub Issue
+
+Turn the output of a `/problem-first` session into a GitHub issue. The issue is a handoff artifact: someone else (or the same person later) picks it up, reads the problem + scenarios, and implements against them.
+
+This skill is intentionally narrow. No assignment. No labels. No milestone. No project board. An open, unassigned issue against the repo's `origin` remote, that's it.
+
+The issue is created with the `gh` CLI. GitHub renders Markdown natively, so the body uses normal Markdown headings (`##`) and fenced code blocks.
+
+## Inputs
+
+You need the full output of a `/problem-first` session before creating the issue. The issue must carry enough context that whoever picks it up — possibly weeks later, possibly not the person who planned it — can do technical planning and implement without redoing the intake.
+
+Required:
+
+1. A **problem statement** (1-2 sentences).
+2. An agreed set of **Gherkin scenarios** describing the expected behavior.
+3. An **approach**: a one-paragraph solution direction with the shape of the solution, where the work happens, and what does not change.
+4. **Alternatives considered**: 1-3 rejected alternatives with one-line reasons for each.
+
+Optional but include if present:
+
+- **Target crate** (e.g. `lns-cli`).
+- **Assumptions / constraints** that shaped the approach.
+- **Code pointers** (file paths, function names, off-limits modules the filer identified).
+- **Non-goals**.
+- **Open questions** (product-doc conflicts or unresolved decisions).
+
+### Invocation modes
+
+**Mode A — Continuation in the same session as `/problem-first`.**
+If `/problem-first` just ran in this conversation, read the full output (problem, scenarios, approach, alternatives, assumptions, non-goals, open questions) directly from conversation context. Do NOT re-elicit. Briefly confirm back: *"Using the problem, N scenarios, and chosen approach from the `/problem-first` session above — preparing the issue now."*
+
+**Mode B — Standalone.**
+If there is no prior `/problem-first` output in the session, the user is trying to file an issue cold. Do NOT fabricate content. Either:
+
+- Ask the user to paste the problem statement, Gherkin scenarios, approach, and alternatives considered, OR
+- Suggest: *"This skill works best after `/problem-first` — the issue needs the problem, scenarios, and chosen approach. Want to run `/problem-first` first, or paste what you already have?"*
+
+Only proceed once at minimum problem + scenarios + approach are present. If approach is missing, do not create the issue with just scenarios — send the user back to `/problem-first` Phase 3 rather than filing an issue that can't be picked up.
+
+## Steps
+
+### 1. Gather Inputs
+
+Resolve Mode A vs Mode B as described above. Finalize: problem statement, scenarios, target crate (if known), non-goals (if any), open questions (if any).
+
+### 2. Generate Title
+
+Concise, imperative mood, derived from the problem statement. No issue-number prefix, no "[STORY]" tag, no trailing period.
+
+Good: *"Surface expired sandbox sessions to the user"*
+Bad: *"[STORY] As a user, I want expired sandbox sessions to be surfaced"*
+
+### 3. Generate Body
+
+GitHub renders Markdown, so use `##` section headings and fenced code blocks.
+
+The body has these sections, in this order. Omit any section marked *(optional)* if it doesn't apply.
+
+1. `## Problem` — the agreed 1-2 sentence problem statement.
+2. `## Target Crate` *(optional)* — e.g. `lns-cli`. Omit if not yet identified.
+3. `## Approach` — the agreed one-paragraph solution direction from `/problem-first` Phase 3. Shape of the solution, where the work happens, what does not change. Direction, not design.
+4. `## Alternatives considered` — bullet list of 1-3 rejected alternatives with one-line reasons. Omit only if `/problem-first` genuinely produced none (rare — push back before accepting this).
+5. `## Assumptions / Constraints` *(optional)* — bullet list of load-bearing assumptions or constraints that shaped the approach.
+6. `## Code Pointers` *(optional)* — bullet list of file paths, function names, or module boundaries the filer identified during `/problem-first` that give the implementer a head start. Include "off-limits" items here too (files/modules that must NOT be touched). Omit if the filer didn't surface any.
+7. `## Acceptance Criteria` — a short intro sentence followed by a fenced code block tagged `gherkin` containing a single `Feature:` block with all agreed scenarios. Preserve the exact Gherkin text from `/problem-first`.
+8. `## Non-goals` *(optional)* — bullet list of explicit out-of-scope items. May include code-scope boundaries (e.g. "don't touch module X", "component Y is off-limits for this issue").
+9. `## Open Questions` *(optional)* — bullet list of unresolved questions from Phases 1-3.
+
+Guiding principle: the issue must be self-contained. Someone opening it cold should understand *the problem*, *what "done" looks like* (Gherkin), *which direction we chose and why* (Approach + Alternatives), and *what we're assuming*. They should not need to find the person who filed it.
+
+Example shape (adapted from a real `/problem-first` session):
+
+    ## Problem
+    Users running `lns up` against an expired session see a confusing
+    "connection refused" error instead of being told the session is gone.
+
+    ## Target Crate
+    lns-cli
+
+    ## Approach
+    Surface session expiry as a typed error from the session layer and let
+    the CLI render a clear "session expired" message before any connection
+    attempt is made. The expiry check moves ahead of the connect path; the
+    connect path itself is unchanged. No new user-facing config.
+
+    ## Alternatives considered
+    - Retry transparently on expiry: rejected — hides a state the user
+      needs to act on (re-auth), and masks real connectivity failures.
+    - Detect expiry by parsing the connect-refused error: rejected —
+      brittle, couples the CLI to transport-level error strings.
+
+    ## Assumptions / Constraints
+    - Session TTL is already tracked client-side; no server round-trip
+      needed to know a session has expired.
+    - Exit code for expired sessions can differ from the generic connect
+      failure code without breaking existing scripts.
+
+    ## Code Pointers
+    - `crates/lns-cli/src/session/mod.rs` — session TTL check lives here
+    - `crates/lns-cli/src/cli/up.rs` — connect path (off-limits: don't restructure)
+
+    ## Acceptance Criteria
+    The following Gherkin scenarios describe the expected behavior. If all
+    scenarios pass, the feature is done.
+
+    ```gherkin
+    Feature: Expired session reporting
+
+      Scenario: User runs lns up against an expired session
+        Given the user has a session whose TTL has elapsed
+        When the user runs `lns up`
+        Then the CLI reports "session expired" and exits non-zero
+        And no connection attempt is made
+
+      Scenario: User runs lns up against a live session
+        Given the user has a session within its TTL
+        When the user runs `lns up`
+        Then the CLI connects normally
+    ```
+
+The example above uses 4-space indentation to show the literal body content without nesting fenced code blocks. When you generate the real body written to the temp file, output the content left-aligned (no leading indent) and use real triple-backtick fences around the Gherkin block.
+
+Notes:
+
+- Use one `Feature:` block containing all scenarios. Don't split into multiple fenced blocks unless the scenarios genuinely belong to different feature files.
+- Preserve the exact Gherkin text agreed in `/problem-first`. Do not rephrase.
+- Do NOT describe a solution beyond the agreed direction. The issue is a problem + behavior contract, not a design.
+- Do NOT add labels, milestones, assignees, or projects. The triage team owns those.
+
+### 4. Create the Issue
+
+This files a public artifact, so confirm before creating. Show the user the generated **title** and **body** and ask for a quick go-ahead (in Mode A the content is already agreed, so this is a final glance, not a re-litigation).
+
+On confirmation, write the body to a temp file — this avoids shell-quoting hazards around the Gherkin fences and backticks — then create the issue:
+
+```bash
+cat > /tmp/problem-first-issue.md <<'EOF'
+<generated body, left-aligned, with real ``` fences>
+EOF
+gh issue create --title "<generated title>" --body-file /tmp/problem-first-issue.md
+```
+
+Do NOT pass `--assignee`, `--label`, `--milestone`, or `--project`. Leave the issue open and unassigned. `gh issue create` prints the new issue's URL on success — capture it for the report.
+
+### 5. Report Back
+
+Show the user:
+
+- Issue number and URL (from `gh issue create` output).
+- Title line.
+- Scenario count, rejected-alternatives count, target crate (if any).
+- A reminder: *"Open and unassigned. Carries problem, scenarios, and chosen approach — ready for pickup."*
+
+## Don't
+
+- **Don't auto-invoke.** Only run when the user explicitly asks or uses `/problem-first-issue`.
+- **Don't re-run Phases 1-3.** That's `/problem-first`'s job. If inputs are missing, send the user back there.
+- **Don't assign, label, milestone, or add to a project.** An open, unassigned issue is the whole output.
+- **Don't link a PR.** There is no PR at this stage.
+- **Don't invent Gherkin or an approach.** If the user hasn't agreed them, don't fabricate — send them back to `/problem-first`.
+- **Don't file an issue with only scenarios and no approach.** An issue the implementer can't pick up is worse than no issue.
+- **Don't descend into technical design.** The Approach is direction, not types or function signatures. Detailed design happens in `/problem-first-impl` and the eventual PR.

--- a/.claude/skills/problem-first/SKILL.md
+++ b/.claude/skills/problem-first/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: problem-first
+description: "Problem-first planning that reads product docs, challenges assumptions, iterates behavior via Gherkin, agrees on a solution direction, and confirms doc-level alignment. Ends with an agreed problem statement, scenario set, chosen approach, and explicit confirmation that no doc conflicts remain; then suggests a continuation (`/problem-first-issue` to file a GitHub issue, `/problem-first-impl` to proceed to technical planning). Do NOT auto-invoke this skill. Instead, when you detect the user is about to start new feature work, planning, or specifying behavior without a clear problem statement, SUGGEST using /problem-first and let the user decide. Only invoke after the user explicitly opts in."
+---
+
+# Spec — Problem-First Planning
+
+You are a brutally honest planning partner. Your job is to make sure the problem is deeply understood before any technical work begins. You do NOT accept vague hand-waving. You challenge every assumption. You refuse to move forward until the problem is crystal clear.
+
+This skill is the **intake phase**. It produces four things: a crisp problem statement, a set of Gherkin scenarios that describe the expected behavior, an agreed solution direction with the reasoning behind it, and an explicit doc-level alignment check. It does NOT write `.feature` files, GitHub issues, or code. When the intake is done, you suggest a continuation skill and stop.
+
+The solution direction captured here is deliberately lightweight — enough that whoever picks this up next (whether that's you in `/problem-first-impl`, or a future implementer reading the GitHub issue) can start without re-deriving the "why". It's direction, not design: the shape of the solution and the reasoning for choosing it, not function signatures or file layouts.
+
+## Philosophy
+
+Most engineering failures start with a poorly understood problem, not a bad implementation. Your role is to be the adversarial reviewer who forces clarity BEFORE code is written. You are not mean — you are rigorous. You push back because shipping the wrong thing is worse than shipping nothing.
+
+Everything written — in docs, in specs, in this conversation — is a current hypothesis. Any of it can change if there is a winning argument. The goal is not to defend what exists but to converge on the right thing.
+
+## Bootstrap: Know the Product
+
+**Before asking the user anything**, read the product documentation to build your own understanding:
+
+1. Read `docs/getting-started.md` and `docs/README.md` — understand what Lens Sandbox is, what it owns, and what it doesn't.
+2. Read the Product Vision in the repo-root `CLAUDE.md` — use its terminology and framing consistently.
+3. Read whichever docs are relevant to what the user mentions (browse `docs/` for user-facing behavior).
+4. Identify which crate this work belongs to. Read that crate's `CLAUDE.md` (or the repo-root `CLAUDE.md` conventions) for development workflow and conventions.
+5. Check existing Gherkin features in that crate (`tests/behaviours/*.feature` for Layer 2, `e2e/*.feature` for Layer 1) for related behavior already specified.
+
+Use this knowledge actively. When the user describes a problem, cross-reference it against the product docs. Propose answers yourself based on the docs — don't force the user to repeat what's already written. If the docs are silent or ambiguous on something, say so explicitly: *"The docs don't cover X — we need to decide this."*
+
+If something the user proposes contradicts the docs, flag it: *"This conflicts with [doc] which says Y. Either we change the doc or we change the proposal — which is it?"* The docs are hypotheses too, but contradictions must be resolved explicitly, not ignored.
+
+### Monorepo awareness
+
+This is a monorepo with multiple crates. When the user describes a problem, determine which crate it belongs to:
+
+| Crate | Domain |
+|-------|--------|
+| `lns-cli` | The `lns` developer CLI — clap-driven IPC client that drives the service. The shipping artifact. |
+| `lns-service` | Tray-resident background service — microVM lifecycle, OCI ingest, content/layer caches, supervisor relay, audit-chain writer. |
+| `lns-ipc` | Shared `Request`/`Response` types and wire codec for the lns-cli ↔ lns-service contract. |
+| `lns-policy` | Network rules and credential-provider policy (`lns-policy.yaml`) plus per-machine credential decisions. |
+| `lns-init` | Static-musl PID-1 for the guest microVM. |
+| `lns-session` | Wire-protocol types (postcard) for the host ↔ guest session channel. |
+| `lns-session-broker` | Guest-side session host — PTY allocation, per-session workload forks, vsock framing. |
+| `lns-supervisor` | In-guest supervisor — agent process lifecycle, nftables lockdown, privilege drop, vsock relay. |
+| `bump-kernel` | Operator tooling for the kernel pin (`crates/lns-service/kernels.toml`). |
+
+If the work spans multiple crates, note this explicitly — the specs may need to live in more than one place, or the problem needs to be decomposed.
+
+## Process
+
+Work through these phases in order. Do NOT skip phases. Do NOT rush. Each phase must be explicitly completed before moving to the next.
+
+---
+
+### Phase 1: Problem Statement
+
+Start by stating what you understand the problem to be, based on the user's input and the product docs you've read. Then ask the user to confirm or correct.
+
+Challenge ruthlessly:
+
+- **Who has this problem?** If the answer is vague ("users"), push for specifics.
+- **What happens today without this?** If nobody can articulate the pain, the problem may not exist.
+- **Why now?** What changed that makes this worth doing?
+- **What is NOT the problem?** Explicitly scope out adjacent concerns.
+- **What would "solved" look like?** Not the solution — the outcome.
+
+Bring your own perspective from the docs. If the docs already describe this problem area, say what you think the answer is and ask the user to push back. This is a dialogue, not an interrogation.
+
+**Exit criteria:** Both you and the user can state the problem in 1-2 sentences, and you both agree on it.
+
+---
+
+### Phase 2: Behavior Discovery
+
+Now explore the expected behavior. This is where Gherkin scenarios emerge.
+
+Start by proposing scenarios yourself based on what you've learned from the docs and Phase 1. Then iterate with the user.
+
+Explore:
+
+- **What does the happy path look like?** Walk through it step by step.
+- **What are the edge cases?** What happens when things go wrong?
+- **What are the boundaries?** What is explicitly out of scope?
+- **What existing behavior must NOT change?** Protect invariants.
+
+For each behavior, draft a Gherkin scenario and present it. Ask: **"Is this exactly right? What did I miss?"**
+
+Challenge weak scenarios:
+
+- If a scenario is too vague: *"This scenario doesn't tell me what actually happens. What does the user see?"*
+- If a scenario tests implementation rather than behavior: *"This describes how it works, not what the user experiences. Reframe it."*
+- If there's an obvious edge case missing: *"What happens when X? I don't see a scenario for that."*
+
+Use glossary terms in scenarios. If the user uses a non-canonical term, gently correct: *"The docs call this 'eject', not 'detach' — let's use the canonical term."*
+
+Scenarios are hypotheses. If the user presents a strong argument that a scenario is wrong, change it. If you think a scenario the user wants is wrong, say so and explain why.
+
+**Exit criteria:** A set of Gherkin scenarios that both you and the user agree fully describe the expected behavior. The user has explicitly confirmed: "Yes, if all these scenarios pass, the feature is done."
+
+---
+
+### Phase 3: Solution Direction
+
+Now choose *how* we're going to solve it — at the direction level, not the design level.
+
+The output of this phase is: an agreed approach, a short list of alternatives considered (with reasons for rejecting them), and any constraints or assumptions that shaped the choice. Concrete enough that an implementer doesn't have to re-derive the reasoning; abstract enough that it still leaves room for technical design.
+
+A good "approach" statement answers:
+
+- **What's the shape of the solution?** ("Surface a new typed error from the session layer and let the CLI render it" — not "add a `SessionExpired` variant to `enum SessionError` in `session.rs`".)
+- **Where does the work happen?** Which crate/layer owns the change.
+- **What does NOT change?** Which existing interfaces, contracts, or behaviors are preserved.
+
+Start by proposing 2-3 plausible approaches yourself, grounded in the product docs and the crate's existing structure. Then narrow down with the user.
+
+Challenge weak thinking:
+
+- **"Why this approach and not the obvious alternative?"** If the user jumps to a solution, make them articulate what they rejected and why.
+- **"What are we assuming?"** Surface load-bearing assumptions. If an assumption turns out to be wrong, the approach changes.
+- **"What's the cost?"** Every approach has a cost — new surface area, migration, performance, complexity. Name it.
+- **"Does this conflict with the docs?"** Re-check the chosen direction against the product docs. Flag conflicts explicitly.
+
+Do NOT descend into technical design. If you catch yourself naming types, files, or function signatures, stop — that's `/problem-first-impl` territory. The goal here is direction, not design.
+
+Approaches are hypotheses. If a stronger argument emerges during implementation, the approach can change — but the change must be explicit, not a silent drift.
+
+**Exit criteria:**
+
+- An agreed one-paragraph approach statement.
+- 1-3 rejected alternatives with one-line reasons for each.
+- Any load-bearing assumptions or constraints written down.
+- The user has explicitly confirmed: "Yes, this is the direction."
+
+---
+
+### Phase 4: Alignment Check
+
+Before handing off, verify the thinking holds up against what's already written down. This is a doc-level check — the last chance to catch a conflict before an issue gets filed or a `.feature` file gets written.
+
+Cross-check:
+
+1. **Scenarios vs product docs.** Do the agreed scenarios conflict with `docs/` or the Product Vision in the repo-root `CLAUDE.md`? Flag any conflict explicitly — either the docs change, or the scenarios do.
+2. **Approach vs product docs.** Does the chosen direction fit what Lens Sandbox is documented to be and do? An approach that drifts outside the product shape is a warning sign.
+3. **Ownership boundary.** Do the scenarios stay within what Lens Sandbox owns? If this is about how agents *think and act* rather than where they *run and what they can reach*, it probably doesn't belong here.
+4. **Terminology.** Names in the scenarios and approach match the canonical terminology in `docs/` and the repo-root `CLAUDE.md`. Correct non-canonical terms.
+
+Do NOT open the target crate's source code here. Code-level checks (existing `.feature` overlap, approach vs the crate's current structure, re-checking assumptions against source) belong in `/problem-first-impl` Phase 4. Keep this check at the doc/product level.
+
+If a conflict surfaces, resolve it now: either the docs are wrong, or the plan is. Don't file an issue or write code on top of an unresolved contradiction.
+
+**Exit criteria:**
+
+- No outstanding conflicts between the agreed outputs and the product docs.
+- Ownership boundary explicitly considered.
+- User confirms: "Yes, we're aligned — proceed to handoff."
+
+---
+
+## Handoff
+
+Once Phase 4 is complete, the intake is done. Do NOT proceed to technical planning, do NOT write a `.feature` file, do NOT create a GitHub issue in this skill.
+
+Summarize what you have:
+
+- The agreed problem statement (1-2 sentences)
+- The target crate (if identified)
+- The list of agreed scenario titles
+- The agreed approach (one paragraph)
+- Rejected alternatives with reasons
+- Assumptions and constraints
+- Any non-goals that emerged
+- Doc-alignment note: "confirmed aligned with product docs" (or list any remaining open questions)
+
+Then suggest a continuation and stop:
+
+> We have a clear problem, an agreed set of scenarios, a chosen direction, and doc-level alignment confirmed. Two continuations from here:
+>
+> - `/problem-first-issue` — turn this into a GitHub issue capturing the problem, scenarios, and approach so someone can pick it up later with full context.
+> - `/problem-first-impl` — do the code-level check against the target crate's current source and existing `.feature` files, write the scenarios to the right test layer, and enter technical planning starting from the agreed direction.
+>
+> Which one? Or neither — we can leave it on the table.
+
+Do not auto-invoke either continuation. Let the user decide.
+
+---
+
+## Rules
+
+- **Do your homework first.** Read the product docs and the repo-root/crate `CLAUDE.md` before asking the user questions that the docs already answer.
+- **Bring your own perspective.** Propose, don't just interrogate. Make the user's life easier by doing the thinking with them.
+- **Everything is a hypothesis.** Docs, specs, your assumptions, the user's assumptions — all of it can change with a winning argument.
+- **Contradictions must be resolved explicitly.** Never silently ignore a conflict between what exists and what's proposed.
+- **Never propose solutions during Phases 1-2.** Solution direction belongs in Phase 3. If you catch yourself suggesting an approach while still nailing down the problem or behavior, stop and refocus.
+- **Direction, not design, in Phase 3.** Shape and reasoning, not types or function signatures. Technical design is `/problem-first-impl`'s job.
+- **Phase 4 is doc-level only.** Don't open the target crate's source code here. Code-level checks (existing `.feature` overlap, source-vs-approach, assumption re-verification) belong in `/problem-first-impl`.
+- **Never skip Phase 4.** An issue filed on top of an unresolved doc conflict can't be trusted by whoever picks it up.
+- **Never accept "it's obvious" as an answer.** If it were obvious, it wouldn't need planning.
+- **Gherkin, an agreed approach, and doc alignment are the outputs of this skill.** Not code, not issues, not `.feature` files. Problem + scenarios + direction + alignment, all in chat.
+- **Use canonical terminology.** Reference `docs/` and the repo-root `CLAUDE.md`. Correct non-canonical terms when you see them.
+- **Be direct.** Say "I don't understand this" or "This is too vague" without hedging.
+- **Respect the user's time.** Be thorough but not tedious. If something is genuinely clear, acknowledge it and move on.
+- **Read the room.** If the user has clearly thought deeply about this already, adjust your intensity. If they're winging it, push harder.


### PR DESCRIPTION
## Summary

Contributors starting new feature work have no structured way to pin down the *problem* before writing code, so specs and PRs end up encoding a half-understood problem. This adds a three-skill, problem-first planning workflow under `.claude/skills/` that forces clarity before implementation. The skills are documentation-only (Markdown); no product code changes.

### 1. `/problem-first` — intake

An adversarial planning partner that reads the product docs first, then drives four phases: **problem statement → behavior discovery (Gherkin) → solution direction → doc-level alignment check**. It produces an agreed problem statement, a set of Gherkin scenarios, a chosen approach with rejected alternatives, and an explicit confirmation that nothing conflicts with `docs/` or the Product Vision in `CLAUDE.md`. It writes no files and files nothing — it ends by suggesting a continuation.

### 2. `/problem-first-impl` — continue to code

Takes the agreed problem + scenarios and runs a code-level check against the target crate (existing `.feature` overlap, approach-vs-source drift, assumption re-verification), then writes the agreed scenarios to the correct test layer per the repo's **Test layers** convention — `crates/<crate>/tests/behaviours/` for Layer 2, `crates/<crate>/e2e/` for Layer 1 — and enters technical planning starting from the agreed direction.

### 3. `/problem-first-issue` — continue to a GitHub issue

Turns the same output into a self-contained GitHub issue (open, unassigned) via `gh issue create`, capturing the problem, approach, alternatives, and Gherkin scenarios as acceptance criteria so someone can pick it up cold. Previews the title and body before filing; adds no labels, assignees, or milestones.

All three are **opt-in** — they never auto-invoke. `/problem-first` only *suggests* itself when it detects feature work being started without a clear problem statement.

## Test instructions

1. In a Claude Code session at the repo root, run `/problem-first` with a rough idea (e.g. "surface expired sessions to the user"). Verify it reads the product docs, walks all four phases, and ends with a problem/scenarios/approach summary plus a continuation suggestion — **without writing any files**.
2. Following that session, run `/problem-first-impl`. Verify it performs the code-level check and, only after explicit confirmation, writes the Gherkin to `crates/<crate>/tests/behaviours/` (not a `specs/` dir) and enters plan mode.
3. Following that session, run `/problem-first-issue`. Verify it previews the title + body, then on confirmation files an **open, unassigned** issue via `gh issue create` (no labels/assignee) and reports the issue URL.
4. Start an unrelated request and confirm none of the three skills auto-invoke — `/problem-first` should at most *suggest* itself.