### PR TITLE
chore(ci): scope workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -31,8 +31,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 concurrency:
   # Serialise per kernels.toml change. Two operators opening bump
@@ -297,6 +296,8 @@ jobs:
     if: github.event_name == 'pull_request' && needs.detect-bump.outputs.is-bump == 'true'
     needs: [detect-bump, compute]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Tighten the `GITHUB_TOKEN` scope in the two release-automation workflows so each job gets only the permissions it actually uses.

### `publish-kernel.yml`
- Was `contents: write` at the **workflow** level, so `detect-bump`, `compute`, and `publish` all inherited write even though none of them push to the repo (they read, build, or talk to S3 with separate AWS credentials).
- Now defaults to `contents: read`; only the `back-fill` job — which `git push`es the back-filled `kernels.toml` to the PR branch — carries a job-level `contents: write`.
- Dropped the unused top-level `pull-requests: read`.

### `release-please.yml`
- Had **no** top-level `permissions:` block, so the two S3-only jobs (`deploy-lns-install`, `publish-lns-manifest`) ran with the repository's default token scope.
- Added a `contents: read` default. The two jobs that genuinely need write — `release-please` (opens release PRs / cuts releases) and `build-lns` (`gh release upload`) — keep their existing explicit job-level grants.

### `ci.yml`
- Already least-privilege (`contents/packages/pull-requests: read`, no job escalates). Unchanged.

## Why

Default-read with per-job escalation is the standard least-privilege posture for Actions workflows: a compromised dependency or action in a build/compute job can no longer use the ambient token to write to the repo.

## Notes
- No behavioural change — the jobs that push/release retain exactly the scope they had.
- `.github`-only change; coverage gate is a no-op for this diff.