### PR TITLE
feat(kernel): verify upstream Kata bundle integrity before extraction

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -180,15 +180,22 @@ jobs:
       - name: Install zstd
         run: sudo apt-get update && sudo apt-get install -y zstd
 
-      - name: Fetch Kata static bundle
+      - name: Fetch + verify Kata static bundle
         env:
           KATA: ${{ steps.manifest.outputs.kata_version }}
           KATA_ARCH: ${{ matrix.kata_arch }}
+          BUNDLE_SHA: ${{ steps.manifest.outputs[format('kata_bundle_sha256_{0}', matrix.kata_arch)] }}
         run: |
           set -euo pipefail
           URL="https://github.com/kata-containers/kata-containers/releases/download/${KATA}/kata-static-${KATA}-${KATA_ARCH}.tar.zst"
           echo "Fetching $URL (~670 MB)"
           curl -L --fail --output kata.tar.zst "$URL"
+          if [ -n "$BUNDLE_SHA" ]; then
+            echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
+            echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
+          else
+            echo "::warning::No kata_bundle_sha256 pinned for ${KATA_ARCH}; skipping bundle integrity check (kernel was pinned before bundle verification existed)."
+          fi
           zstd -d kata.tar.zst -o kata.tar
 
       - name: Resolve kernel filename (auto-detect when pending)
@@ -382,16 +389,23 @@ jobs:
       - name: Install zstd
         run: sudo apt-get update && sudo apt-get install -y zstd
 
-      - name: Fetch + extract Kata kernel
+      - name: Fetch + verify + extract Kata kernel
         env:
           KATA: ${{ steps.manifest.outputs.kata_version }}
           KATA_ARCH: ${{ matrix.kata_arch }}
           FILENAME: ${{ steps.manifest.outputs.kernel_filename }}
           PV: ${{ steps.manifest.outputs.published_version }}
+          BUNDLE_SHA: ${{ steps.manifest.outputs[format('kata_bundle_sha256_{0}', matrix.kata_arch)] }}
         run: |
           set -euo pipefail
           URL="https://github.com/kata-containers/kata-containers/releases/download/${KATA}/kata-static-${KATA}-${KATA_ARCH}.tar.zst"
           curl -L --fail --output kata.tar.zst "$URL"
+          if [ -n "$BUNDLE_SHA" ]; then
+            echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
+            echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
+          else
+            echo "::warning::No kata_bundle_sha256 pinned for ${KATA_ARCH}; skipping bundle integrity check (kernel was pinned before bundle verification existed)."
+          fi
           zstd -d kata.tar.zst -o kata.tar
           tar -xf kata.tar "./opt/kata/share/kata-containers/${FILENAME}"
           ARTIFACT="lns-kernel-${PV}-${{ matrix.arch }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "toml",
  "toml_edit 0.22.27",

--- a/crates/bump-kernel/Cargo.toml
+++ b/crates/bump-kernel/Cargo.toml
@@ -20,6 +20,9 @@ serde_json = "1"
 # survive every round trip).
 toml       = "0.8"
 toml_edit  = "0.22"
+# Hashes the downloaded Kata bundles so `bump` can pin their sha256 in
+# kernels.toml; CI verifies the bundle against the pin before extraction.
+sha2       = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/bump-kernel/src/main.rs
+++ b/crates/bump-kernel/src/main.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result, bail, ensure};
 use clap::{Args, Parser, Subcommand};
-use std::io::{self, BufRead, Write};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::io::{self, BufRead, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 mod operations;
 
@@ -137,7 +139,6 @@ fn cmd_bump(cli: BumpArgs) -> Result<()> {
     let manifest_path = workspace.join(KERNELS_TOML);
     let original = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
-    let updated = bump_manifest(&original, &cli.kata_version, cli.variant.as_str())?;
 
     let subject = format!(
         "{}(lns): bump guest kernel to Kata {}",
@@ -154,6 +155,9 @@ fn cmd_bump(cli: BumpArgs) -> Result<()> {
     println!("       kernel_filename    ...      -> \"pending\"  (CI back-fills)");
     println!("       published_version  ...      -> \"pending\"  (CI back-fills)");
     println!("       [current.sha256].* cleared  -> \"\"         (CI back-fills)");
+    println!(
+        "       [current.kata_bundle_sha256] -> sha256 of each upstream bundle (computed now)"
+    );
     println!();
     println!("==> Commit subject: {subject}");
     println!(
@@ -169,6 +173,14 @@ fn cmd_bump(cli: BumpArgs) -> Result<()> {
         println!("Aborted.");
         return Ok(());
     }
+
+    let bundle_shas = resolve_bundle_shas(&cli.kata_version, cli.dry_run)?;
+    let updated = bump_manifest(
+        &original,
+        &cli.kata_version,
+        cli.variant.as_str(),
+        &bundle_shas,
+    )?;
 
     std::fs::write(&manifest_path, &updated)
         .with_context(|| format!("writing {}", manifest_path.display()))?;
@@ -202,7 +214,8 @@ fn cmd_bump(cli: BumpArgs) -> Result<()> {
     println!();
     println!("==> PR opened: {pr_url}");
     println!("==> What happens next:");
-    println!("     1. CI's `publish-kernel` workflow downloads Kata, resolves the variant,");
+    println!("     1. CI's `publish-kernel` workflow downloads Kata, verifies each bundle");
+    println!("        against the kata_bundle_sha256 just pinned, resolves the variant,");
     println!("        computes per-arch sha256s, and commits the values back to your PR");
     println!("        as `chore(kernel): fill provenance and shas for ...`.");
     println!("     2. After the bot commit appears, click \"Re-run all jobs\" in the PR's");
@@ -239,6 +252,69 @@ fn cmd_back_fill(args: BackFillArgs) -> Result<()> {
         archs,
     );
     Ok(())
+}
+
+const KATA_BUNDLE_ARCHES: [&str; 2] = ["arm64", "amd64"];
+
+fn resolve_bundle_shas(kata_version: &str, dry_run: bool) -> Result<BTreeMap<String, String>> {
+    if dry_run {
+        println!();
+        println!(
+            "==> --dry-run: skipping the ~1.3 GB bundle download; kata_bundle_sha256 shown as a placeholder."
+        );
+        return Ok(KATA_BUNDLE_ARCHES
+            .iter()
+            .map(|a| {
+                (
+                    a.to_string(),
+                    "<computed-from-bundle-download-on-a-real-bump>".to_string(),
+                )
+            })
+            .collect());
+    }
+    let mut shas = BTreeMap::new();
+    for kata_arch in KATA_BUNDLE_ARCHES {
+        let url = kata_bundle_url(kata_version, kata_arch);
+        println!("==> Downloading {url}");
+        println!("       (~670 MB; hashing in-stream to pin kata_bundle_sha256.{kata_arch})");
+        let sha = curl_sha256(&url)?;
+        println!("       {kata_arch} sha256 = {sha}");
+        shas.insert(kata_arch.to_string(), sha);
+    }
+    Ok(shas)
+}
+
+fn kata_bundle_url(kata_version: &str, kata_arch: &str) -> String {
+    format!(
+        "https://github.com/kata-containers/kata-containers/releases/download/\
+         {kata_version}/kata-static-{kata_version}-{kata_arch}.tar.zst"
+    )
+}
+
+fn curl_sha256(url: &str) -> Result<String> {
+    let mut child = Command::new("curl")
+        .args(["-L", "--fail", "--silent", "--show-error", url])
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("invoking curl to download the Kata bundle (is curl on PATH?)")?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .context("capturing curl stdout for hashing")?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 1 << 16];
+    loop {
+        let n = stdout
+            .read(&mut buf)
+            .context("reading Kata bundle bytes from curl")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let status = child.wait().context("waiting on curl")?;
+    ensure!(status.success(), "curl failed downloading {url} ({status})");
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn validate_kata_release_exists(version: &str) -> Result<()> {
@@ -379,8 +455,9 @@ fn gh_pr_create(dir: &Path, subject: &str, cli: &BumpArgs, base: &str) -> Result
          \n\
          1. Validates the Kata release tarball exists upstream.\n\
          2. Refuses if the CDN origin already has an artifact at the destination URL.\n\
-         3. Downloads Kata's static bundle, resolves the `vmlinuz-*` matching the \
-            `{variant}` variant, conditionally gunzips (aarch64 only), and computes \
+         3. Downloads Kata's static bundle, verifies it against the \
+            `kata_bundle_sha256` pinned in this PR, resolves the `vmlinuz-*` matching \
+            the `{variant}` variant, conditionally gunzips (aarch64 only), and computes \
             sha256 for each arch.\n\
          4. Commits provenance + per-arch SHAs back to this PR branch as \
             `chore(kernel): fill provenance and shas for ...`.\n\

--- a/crates/bump-kernel/src/operations.rs
+++ b/crates/bump-kernel/src/operations.rs
@@ -3,7 +3,7 @@ use clap::ValueEnum;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use toml_edit::{DocumentMut, value};
+use toml_edit::{DocumentMut, Item, Table, value};
 
 pub(crate) const KERNELS_TOML: &str = "crates/lns-service/kernels.toml";
 
@@ -75,6 +75,8 @@ struct ShowCurrent {
     kernel_variant: Option<String>,
     published_version: Option<String>,
     sha256: BTreeMap<String, String>,
+    #[serde(default)]
+    kata_bundle_sha256: BTreeMap<String, String>,
 }
 
 pub(crate) fn render_show(raw: &str, arch: Option<&str>) -> Result<String> {
@@ -98,6 +100,9 @@ pub(crate) fn render_show(raw: &str, arch: Option<&str>) -> Result<String> {
         "published_version={}\n",
         m.current.published_version.unwrap_or_default()
     ));
+    for (kata_arch, sha) in &m.current.kata_bundle_sha256 {
+        out.push_str(&format!("kata_bundle_sha256_{kata_arch}={sha}\n"));
+    }
     if let Some(a) = arch {
         let sha = m.current.sha256.get(a).cloned().unwrap_or_default();
         if sha.is_empty() {
@@ -176,7 +181,17 @@ pub(crate) fn back_fill_manifest(current: &str, results: &[ComputeResult]) -> Re
     Ok(doc.to_string())
 }
 
-pub(crate) fn bump_manifest(current: &str, kata_version: &str, variant: &str) -> Result<String> {
+pub(crate) fn bump_manifest(
+    current: &str,
+    kata_version: &str,
+    variant: &str,
+    bundle_shas: &BTreeMap<String, String>,
+) -> Result<String> {
+    ensure!(
+        !bundle_shas.is_empty(),
+        "no kata_bundle_sha256 values to pin — bump-kernel computes these from the downloaded Kata bundles"
+    );
+
     let mut doc: DocumentMut = current
         .parse()
         .context("parsing kernels.toml as a toml_edit document")?;
@@ -203,6 +218,13 @@ pub(crate) fn bump_manifest(current: &str, kata_version: &str, variant: &str) ->
     for arch in arches {
         shas[&arch] = value("");
     }
+
+    let mut bundle_tbl = Table::new();
+    bundle_tbl.set_implicit(false);
+    for (kata_arch, sha) in bundle_shas {
+        bundle_tbl[kata_arch] = value(sha.as_str());
+    }
+    current_tbl["kata_bundle_sha256"] = Item::Table(bundle_tbl);
 
     Ok(doc.to_string())
 }
@@ -280,9 +302,17 @@ x86_64  = \"bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222\"
         toml::from_str(manifest).unwrap()
     }
 
+    fn sample_bundle_shas() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("arm64".to_string(), "c".repeat(64)),
+            ("amd64".to_string(), "d".repeat(64)),
+        ])
+    }
+
     #[test]
     fn bump_clears_pending_fields_and_shas() {
-        let out = bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline").unwrap();
+        let out =
+            bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline", &sample_bundle_shas()).unwrap();
         let v = parsed(&out);
         let current = &v["current"];
         assert_eq!(current["kata_version"].as_str(), Some("3.31.0"));
@@ -295,21 +325,51 @@ x86_64  = \"bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222\"
     }
 
     #[test]
+    fn bump_pins_kata_bundle_shas_creating_the_table_when_absent() {
+        let out =
+            bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline", &sample_bundle_shas()).unwrap();
+        let v = parsed(&out);
+        let bundle = v["current"]["kata_bundle_sha256"].as_table().unwrap();
+        assert_eq!(bundle["arm64"].as_str(), Some("c".repeat(64).as_str()));
+        assert_eq!(bundle["amd64"].as_str(), Some("d".repeat(64).as_str()));
+    }
+
+    #[test]
+    fn bump_overwrites_a_preexisting_bundle_sha_table() {
+        let with_stale = format!(
+            "{SAMPLE_MANIFEST}\n[current.kata_bundle_sha256]\narm64 = \"{stale}\"\namd64 = \"{stale}\"\n",
+            stale = "0".repeat(64),
+        );
+        let out = bump_manifest(&with_stale, "3.31.0", "mainline", &sample_bundle_shas()).unwrap();
+        let v = parsed(&out);
+        let bundle = v["current"]["kata_bundle_sha256"].as_table().unwrap();
+        assert_eq!(bundle["arm64"].as_str(), Some("c".repeat(64).as_str()));
+        assert_eq!(bundle["amd64"].as_str(), Some("d".repeat(64).as_str()));
+    }
+
+    #[test]
     fn bump_preserves_comments() {
-        let out = bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline").unwrap();
+        let out =
+            bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline", &sample_bundle_shas()).unwrap();
         assert!(out.starts_with("# Top comment that should survive editing."));
     }
 
     #[test]
     fn bump_can_switch_variant() {
-        let out = bump_manifest(SAMPLE_MANIFEST, "3.31.0", "tdx").unwrap();
+        let out = bump_manifest(SAMPLE_MANIFEST, "3.31.0", "tdx", &sample_bundle_shas()).unwrap();
         let v = parsed(&out);
         assert_eq!(v["current"]["kernel_variant"].as_str(), Some("tdx"));
     }
 
     #[test]
     fn bump_fails_on_missing_current_table() {
-        let err = bump_manifest("[other]\nfoo=1\n", "3.31.0", "mainline").unwrap_err();
+        let err = bump_manifest(
+            "[other]\nfoo=1\n",
+            "3.31.0",
+            "mainline",
+            &sample_bundle_shas(),
+        )
+        .unwrap_err();
         assert!(format!("{err:#}").contains("[current]"));
     }
 
@@ -319,6 +379,7 @@ x86_64  = \"bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222\"
             "[current]\nkata_version=\"3.30.0\"\nkernel_filename=\"x\"\npublished_version=\"y\"\n",
             "3.31.0",
             "mainline",
+            &sample_bundle_shas(),
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("[current.sha256]"));
@@ -335,8 +396,15 @@ published_version=\"v\"
 
 [current.sha256]
 ";
-        let err = bump_manifest(manifest, "3.31.0", "mainline").unwrap_err();
+        let err = bump_manifest(manifest, "3.31.0", "mainline", &sample_bundle_shas()).unwrap_err();
         assert!(format!("{err:#}").contains("empty"));
+    }
+
+    #[test]
+    fn bump_fails_when_no_bundle_shas_provided() {
+        let err =
+            bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline", &BTreeMap::new()).unwrap_err();
+        assert!(format!("{err:#}").contains("kata_bundle_sha256"));
     }
 
     #[test]
@@ -384,6 +452,21 @@ aarch64=\"a\"
     fn show_rejects_unparseable_toml() {
         let err = render_show("this is not toml at all {{{", None).unwrap_err();
         assert!(format!("{err:#}").contains("parsing kernels.toml"));
+    }
+
+    #[test]
+    fn show_emits_kata_bundle_shas_keyed_by_kata_arch_when_present() {
+        let bumped =
+            bump_manifest(SAMPLE_MANIFEST, "3.31.0", "mainline", &sample_bundle_shas()).unwrap();
+        let out = render_show(&bumped, None).unwrap();
+        assert!(out.contains(&format!("kata_bundle_sha256_arm64={}", "c".repeat(64))));
+        assert!(out.contains(&format!("kata_bundle_sha256_amd64={}", "d".repeat(64))));
+    }
+
+    #[test]
+    fn show_omits_kata_bundle_shas_when_the_table_is_absent() {
+        let out = render_show(SAMPLE_MANIFEST, None).unwrap();
+        assert!(!out.contains("kata_bundle_sha256_"));
     }
 
     fn r(arch: &str, sha: &str) -> ComputeResult {

--- a/runbooks/kernel-bump.md
+++ b/runbooks/kernel-bump.md
@@ -58,14 +58,25 @@ The CLI does this for you:
 3. Requires a clean git tree (commit or stash any local edits first).
 4. Refuses if the target branch `chore/bump-kernel-<tag>` already
    exists locally or on origin.
-5. Edits `crates/lns-service/kernels.toml`:
+5. Downloads each upstream `kata-static-<tag>-<arch>.tar.zst` (~670 MB
+   per arch; arm64 + amd64) and hashes it in-stream to pin its sha256.
+   Kata publishes no checksum of its own, so this local download is the
+   integrity anchor: the value lands in the PR for review and CI then
+   verifies the bundle against it before extraction.
+6. Edits `crates/lns-service/kernels.toml`:
    - `kata_version` → your input
    - `kernel_variant` → your variant
    - `kernel_filename`, `published_version` → `"pending"`
    - all `[current.sha256]` values → `""`
-6. Creates branch `chore/bump-kernel-<tag>`, commits with subject
+   - `[current.kata_bundle_sha256]` `arm64` / `amd64` → the sha256 of
+     each bundle you just downloaded
+7. Creates branch `chore/bump-kernel-<tag>`, commits with subject
    `<type>(lns): bump guest kernel to Kata <tag>`, pushes, opens a PR
    via `gh`.
+
+> `--dry-run` skips the ~1.3 GB download and shows
+> `kata_bundle_sha256` as a placeholder, so you can preview the branch
+> / commit / PR plan cheaply; a real bump performs the download.
 
 ### Step 2 — Wait for the bot back-fill (~3–5 min)
 
@@ -79,7 +90,10 @@ overwrite-refusal guard). Then the `compute` job runs per-arch:
 2. Refuses if the CDN origin already has an artifact at the destination URL
    (the [overwrite refusal](#emergency-overwriting-an-already-published-artifact)
    contract).
-3. Downloads Kata's `kata-static-<tag>-<arch>.tar.zst`.
+3. Downloads Kata's `kata-static-<tag>-<arch>.tar.zst` and verifies it
+   against the `kata_bundle_sha256` you pinned in Step 1 before
+   extracting (a bundle pinned before this check existed is skipped
+   with a warning).
 4. Resolves the kernel filename for the requested variant.
 5. Extracts, conditionally gunzips (aarch64 only), computes sha256.
 
@@ -118,6 +132,7 @@ What to look for:
 | `kernel_filename` | The bot wrote `vmlinuz-<x.y.z-build>`. Cross-check against the workflow run's job summary. |
 | `published_version` | Equals `kernel_filename` minus the `vmlinuz-` prefix. |
 | `[current.sha256]` | Two values, both 64 hex chars. Cross-check against the workflow run's matrix outputs. |
+| `[current.kata_bundle_sha256]` | `arm64` + `amd64`, both 64 hex chars, written by your `bump-kernel` run. CI verified the downloaded bundle against these. |
 | Bot commit author | `github-actions[bot]` (the GITHUB_TOKEN-authored back-fill). |
 | Commit subject | Your original `<type>(lns): bump guest kernel to Kata <tag>`. |
 


### PR DESCRIPTION
## What

The `publish-kernel` pipeline fetched Kata's ~670 MB static bundle (`kata-static-<tag>-<arch>.tar.zst`) with `curl` and extracted it with **no integrity check**. The published kernel image *is* sha-verified before the CDN upload, but that sha is itself derived from the first unverified download — trust-on-first-download, with no committed anchor for the bundle bytes the kernel is carved out of.

This pins and verifies the bundle:

- **`bump-kernel bump`** now downloads each upstream bundle (arm64 + amd64) and hashes it in-stream, writing the per-arch sha256 into a new `[current.kata_bundle_sha256]` table in `kernels.toml`. Kata publishes no checksum of its own, so this local download is the integrity anchor — the value lands in the PR diff for human review.
- **`publish-kernel.yml`** verifies the downloaded `.tar.zst` against that pin with `sha256sum -c` **before** `zstd`/extraction, in *both* the compute and publish phases.
- **`bump-kernel show`** emits `kata_bundle_sha256_<arch>` for the workflow to consume.

## Conditional by design

The check is conditional: a kernel pinned **before** this field existed (the current `3.30.0` entry) emits a warning and proceeds. So:
- This PR leaves `kernels.toml` untouched — the current already-published kernel is unaffected, and this PR's own `publish-kernel` run is a no-op (`detect-bump` sees no `kernels.toml` change).
- The guard engages automatically on the **next** kernel bump, which now ships with a `kata_bundle_sha256` pin.

## Tradeoff

`bump` gains a ~1.3 GB download (both bundles) on each — infrequent — kernel bump, in exchange for an integrity anchor that originates from the operator's own download rather than CI's. `--dry-run` skips the download and shows a placeholder.

## Tests / coverage

- `operations.rs` stays at **100%** — new tests pin: bundle-sha table creation, overwrite of a stale table, the empty-shas guard, and `show` emitting/omitting the pin.
- The download/hash I/O lives in `main.rs`, the already-coverage-exempt CLI adapter.
- Runbook (`runbooks/kernel-bump.md`) updated for the new bump step and review checklist.