### PR TITLE
fix(session-broker): set CLOEXEC on broker fds and close them before workload exec

### DIFF
--- a/crates/lns-session-broker/src/pty/real.rs
+++ b/crates/lns-session-broker/src/pty/real.rs
@@ -20,10 +20,15 @@ impl PtySyscalls for RealPtySyscalls {
         // SAFETY: posix_openpt allocates a new master fd.
         let fd = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY) };
         if fd < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(fd)
+            return Err(io::Error::last_os_error());
         }
+        // SAFETY: fd is the freshly-allocated master; FD_CLOEXEC keeps it out of the workload exec.
+        if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
+            let err = io::Error::last_os_error();
+            close(fd);
+            return Err(err);
+        }
+        Ok(fd)
     }
 
     fn grantpt(&self, master: RawFd) -> io::Result<()> {

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 use std::io;
 use std::os::fd::RawFd;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_long, c_uint};
 use std::ptr;
 use std::sync::mpsc::SyncSender;
 
@@ -362,14 +362,23 @@ fn send_exit(conn: &SharedFd, code: i32) {
 
 fn make_pipe() -> Result<(RawFd, RawFd), SessionError> {
     let mut fds = [0i32; 2];
-    // SAFETY: pipe(2) writes a pair of fds into the 2-element array.
-    if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
+    // SAFETY: pipe2 writes a pair of fds into the 2-element array; O_CLOEXEC keeps them out of the workload exec.
+    if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
         return Err(SessionError::Io(io::Error::last_os_error()));
     }
     Ok((fds[0], fds[1]))
 }
 
 fn exec_child(argv: &[String], env: &[String]) -> ! {
+    // SAFETY: post-dup2 child; raw close_range (no musl binding) drops every fd>=3 so conn/pty.master/listeners never survive execvp.
+    unsafe {
+        libc::syscall(
+            libc::SYS_close_range,
+            3 as c_long,
+            c_uint::MAX as c_long,
+            0 as c_long,
+        )
+    };
     for kv in env {
         if let Ok(c) = CString::new(kv.as_str()) {
             let raw = c.into_raw();

--- a/crates/lns-session-broker/src/vsock/real.rs
+++ b/crates/lns-session-broker/src/vsock/real.rs
@@ -12,8 +12,8 @@ struct RealVsockSyscalls;
 
 impl VsockSyscalls for RealVsockSyscalls {
     fn socket(&self) -> io::Result<RawFd> {
-        // SAFETY: socket(2) only reads its int args.
-        let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0) };
+        // SAFETY: socket(2) only reads its int args; SOCK_CLOEXEC keeps the listener out of the workload.
+        let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
         if fd < 0 {
             Err(io::Error::last_os_error())
         } else {
@@ -48,8 +48,15 @@ impl VsockSyscalls for RealVsockSyscalls {
     }
 
     fn accept_once(&self, listen_fd: RawFd) -> io::Result<RawFd> {
-        // SAFETY: null addr/addrlen tells accept(2) to skip peer-address writeback.
-        let fd = unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
+        // SAFETY: null addr/addrlen skips peer-address writeback; SOCK_CLOEXEC keeps the conn out of the workload.
+        let fd = unsafe {
+            libc::accept4(
+                listen_fd,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                libc::SOCK_CLOEXEC,
+            )
+        };
         if fd < 0 {
             Err(io::Error::last_os_error())
         } else {


### PR DESCRIPTION
## Problem

The guest-PID-1 session broker forks+execs the untrusted workload but never set close-on-exec on its fds and never closed internal fds before exec. The workload therefore inherited:

- the `BROKER_PORT` / `FORWARD_PORT` listening vsock sockets,
- its own live host↔guest connection fd,
- the PTY master,
- and (with concurrent exec sessions) other sessions' connection fds.

A malicious workload could enumerate `/proc/self/fd` and forge `ServerFrame`s, hijack future host-initiated `lns exec` / port-forward connections, and read other sessions' stdin.

## Fix

- `vsock/real.rs` — create vsock sockets with `SOCK_CLOEXEC`; accept with `accept4(.., SOCK_CLOEXEC)`.
- `pty/real.rs` — set `FD_CLOEXEC` on the PTY master after `posix_openpt` (and close it on the `fcntl` error path).
- `session/real.rs` — create session pipes with `pipe2(O_CLOEXEC)`; in `exec_child` (the single post-`dup2` chokepoint for both the TTY and pipe child arms) call `close_range(3, ~0, 0)` so no broker fd above stdio survives `execvp`. This also closes the PTY master the TTY arm never closed, and avoids threading the listener fds down into the child.

`close_range` has no `libc` binding on `*-musl`, so it goes through the raw `SYS_close_range` syscall (Linux ≥ 5.9; the pinned guest kernel is well past that). No `log::` call is added in the post-fork child — that path must stay async-signal-safe.

## Verification

These files are `#[cfg(target_os="linux")]` guest static-musl code, in the coverage-ignore list (no unit-coverage burden); host `cargo test` and macOS `make lint` don't see them. Verified with cross-clippy:

```
cargo clippy -p lns-session-broker --target aarch64-unknown-linux-musl --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks
```
→ clean.

⚠️ Runtime behavior can't be exercised by host CI; confirm with the live-microVM smoke test (`crates/lns-cli/tests/smoke/interactive-shell.exp`) before merge. The change is pure CLOEXEC/`close_range` hardening with no happy-path behavioral change — fds 0/1/2 are wired by `dup2` before `close_range`, which only drops fds ≥ 3.
