### PR TITLE
fix(build): verify embedded static-nft binary against a pinned sha256

### DIFF
--- a/crates/lns-service/Cargo.toml
+++ b/crates/lns-service/Cargo.toml
@@ -153,10 +153,12 @@ name    = "behaviours"
 harness = false
 
 # build.rs parses crates/lns-service/kernels.toml to derive
-# KERNEL_VERSION / KERNEL_SHA256 at compile time.
+# KERNEL_VERSION / KERNEL_SHA256 at compile time, and verifies the
+# embedded static-nft blob against a sha256 pinned in build.rs.
 [build-dependencies]
 serde      = { version = "1", features = ["derive"] }
 toml       = "0.8"
+sha2       = "0.10"
 
 [lints.clippy]
 cognitive_complexity = { level = "deny", priority = 1 }

--- a/crates/lns-service/build.rs
+++ b/crates/lns-service/build.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -7,6 +8,18 @@ const TARGET: &str = "aarch64-unknown-linux-musl";
 const PROFILE: &str = "release-init";
 
 const STATIC_NFT_VERSION: &str = "1.1.5";
+
+fn static_nft_sha256(arch: &str) -> &'static str {
+    match arch {
+        "amd64" => "975b614c82bd2042a6118a29275faa239ea02646cf45829f490f0e195156e3e9",
+        "arm64" => "1981fd2f1d1440c91672f94fbd9a47ac92a36fff9c16248a534210154c71540c",
+        other => panic!("static-nft embed: no pinned sha256 for arch=\"{other}\""),
+    }
+}
+
+fn hex_encode(bytes: impl AsRef<[u8]>) -> String {
+    bytes.as_ref().iter().map(|b| format!("{b:02x}")).collect()
+}
 
 #[derive(Deserialize)]
 struct KernelManifest {
@@ -139,6 +152,25 @@ fn stage_static_nft(workspace: &Path, out_dir: &Path) {
             dst.display(),
             dst_size,
             MIN_NFT_BYTES,
+        );
+    }
+
+    let bytes = std::fs::read(&dst).unwrap_or_else(|e| {
+        panic!(
+            "reading staged static-nft at {} for sha256: {e}",
+            dst.display()
+        )
+    });
+    let actual = hex_encode(Sha256::digest(&bytes));
+    let expected = static_nft_sha256(arch);
+    if actual != expected {
+        panic!(
+            "static-nft embed: {} sha256 mismatch.\n  expected (pinned in build.rs): {expected}\n  \
+             actual (staged blob):          {actual}\n\
+             The embedded nft binary programs the egress firewall; refusing to ship an \
+             unverified one. If you intentionally updated the binary, update the pinned \
+             sha256 in build.rs to match — do NOT copy it from the .sha256 companion file.",
+            dst.display(),
         );
     }
 


### PR DESCRIPTION
## Problem

`lns-service` embeds the statically-linked `nft` binary — the tool that programs the egress nftables ruleset, i.e. the network-egress enforcement boundary — via `include_bytes!`. The build-time staging in `build.rs::stage_static_nft` only checked the file exists and is > 500 KB. It never verified the bytes' sha256, and the committed `vendor/static-nft/*.sha256` companions are self-generated by `scripts/build-static-nft.sh`, so they're inert documentation rather than a trust anchor. A tampered `nft` (still > 500 KB, e.g. one that no-ops drop rules) would be embedded and shipped while passing CI and review.

## Fix

`stage_static_nft` now computes the sha256 of the staged per-arch blob and compares it to a constant pinned in reviewable Rust source (`build.rs`), panicking on mismatch — mirroring the existing `emit_kernel_pin` / `KERNEL_SHA256` pattern in the same file. The pin is deliberately **not** read from the `.sha256` companion files. `sha2` (already a runtime dep, already in `Cargo.lock`) is added under `[build-dependencies]`.

The pinned hashes are today's committed binaries, so this is a functional no-op right now — it just turns the trust anchor into reviewable source.

## Verification

`build.rs` is in the coverage-ignore list (host cross-build glue) → no unit-coverage burden. Confirmed `cargo build -p lns-service` runs the new sha gate without panic (hashes match), and a negative test (appending one byte to the arm64 blob — still > 500 KB, so it sails past the size floor) makes the build panic with `sha256 mismatch`, proving the sha check, not the size floor, is the authoritative gate.

Follow-up (not in this PR): a CI step that rebuilds `nft` from `scripts/static-nft.Dockerfile` (which already pins `NFTABLES_SHA256`) and byte-diffs the committed blob would add reproducible provenance on top of this integrity pin.
