### PR TITLE
fix(supervisor): redact secret-shaped env vars in LNS_DEBUG_WRAP dump

### DIFF
--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -92,7 +92,7 @@ exec >/dev/console 2>&1
 
 echo "[wrap] init started, pid=$$, argv=$@"
 echo "[wrap] env (sorted):"
-env | sort | sed 's/^/[wrap]   /'
+env | sort | sed -E 's/^([A-Z0-9_]*(TOKEN|SECRET|PASSWORD|KEY)[A-Z0-9_]*)=.*/\1=<redacted>/' | sed 's/^/[wrap]   /'
 echo "[wrap] /run tree:"
 ls -la /run /run/lock 2>&1 | sed 's/^/[wrap]   /'
 echo "[wrap] /.lens tree:"
@@ -384,6 +384,18 @@ mod tests {
             let body_str = std::str::from_utf8(body).expect("wrapper body utf-8");
             let msg = format!("wrapper missing [wrap]: {body_str}");
             assert!(body_str.contains("[wrap]"), "{msg}");
+            assert!(
+                body_str.contains("(TOKEN|SECRET|PASSWORD|KEY)"),
+                "env dump must redact secret-shaped names via a portable ERE: {body_str}"
+            );
+            assert!(
+                body_str.contains("=<redacted>"),
+                "env dump must mask secret-shaped values with <redacted>: {body_str}"
+            );
+            assert!(
+                !body_str.contains("env | sort | sed 's/^/[wrap]   /'"),
+                "env dump must not be a bare unredacted prefix dump: {body_str}"
+            );
         }
         assert!(
             specs


### PR DESCRIPTION
## Problem

The `LNS_DEBUG_WRAP` developer wrapper (`supervisor/mod.rs::DEBUG_WRAPPER`) dumped the full guest environment via `env | sort`, including `LENS_SANDBOX_TOKEN`, to a host-tee'd `console.log`.

## Fix

The env dump now pipes through a `sed` that masks the value of any variable whose name contains `TOKEN`, `SECRET`, `PASSWORD`, or `KEY` to `NAME=<redacted>` before the `[wrap]` prefix. The expression uses only busybox-`sed -E`-compatible features (bracket classes, grouped alternation, a `\1` backref) and no GNU-only case-insensitive flag, since the wrapper may run under busybox sed in the guest.

## Verification

Extended the existing serial test `runtime_specs_uses_debug_wrapper_when_env_set` (the new assertions were watched failing first) to assert the wrapper redacts secret-shaped names and no longer emits a bare unredacted dump. `cargo test -p lns-service` + `cargo clippy -p lns-service --all-targets -- -D warnings` clean. The change edits a string const + test only (no new executable lines), so the crate's 100% line-coverage floor is preserved.
