### PR TITLE
fix(relay): stamp host provenance on audit events and reject guest use of reserved event types

### DIFF
--- a/crates/lns-service/src/audit.rs
+++ b/crates/lns-service/src/audit.rs
@@ -196,6 +196,7 @@ fn volume_attached_obj(name: &str, target: &str) -> Map<String, Value> {
         "type".to_string(),
         Value::String("volume_attached".to_string()),
     );
+    obj.insert("origin".to_string(), Value::String("host".to_string()));
     obj.insert("name".to_string(), Value::String(name.to_string()));
     obj.insert("target".to_string(), Value::String(target.to_string()));
     obj
@@ -212,6 +213,16 @@ pub fn record_volume_attached(run_id: u32, name: &str, target: &str) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn volume_attached_obj_stamps_host_origin() {
+        let obj = volume_attached_obj("prism-data", "/data");
+        assert_eq!(
+            obj.get("origin").unwrap(),
+            "host",
+            "host-authored volume_attached events must be distinguishable from guest-proxied events"
+        );
+    }
 
     #[test]
     fn record_volume_attached_writes_name_and_target_as_genesis_line() {

--- a/crates/lns-service/src/relay/mod.rs
+++ b/crates/lns-service/src/relay/mod.rs
@@ -116,6 +116,30 @@ pub(super) async fn write_run_env_event<L: crate::audit::AuditLog, S: crate::aud
     write_chain_line(&bytes, chain, audit_file, anchor_sink).await
 }
 
+const HOST_RESERVED_EVENTS: &[&str] = &["run_env"];
+
+fn stamp_guest_audit_event(
+    mut obj: serde_json::Map<String, Value>,
+) -> Option<serde_json::Map<String, Value>> {
+    let event = obj.get("event").and_then(Value::as_str);
+    if let Some(event) = event
+        && HOST_RESERVED_EVENTS.contains(&event)
+    {
+        crate::log::warn!(
+            reserved_event = event,
+            "rejected guest audit_event with a host-reserved event value"
+        );
+        return None;
+    }
+    obj.remove("source");
+    obj.remove("origin");
+    obj.insert(
+        "origin".to_string(),
+        Value::String("guest-proxy".to_string()),
+    );
+    Some(obj)
+}
+
 pub(super) async fn handle_inbound<L: crate::audit::AuditLog, S: crate::audit::AnchorSink>(
     msg: Message,
     session: &Arc<ApprovalSession>,
@@ -136,7 +160,10 @@ pub(super) async fn handle_inbound<L: crate::audit::AuditLog, S: crate::audit::A
     let ty = obj.get("type").and_then(Value::as_str);
     match ty {
         Some("audit_event") => {
-            let bytes = chain.augment_obj(obj);
+            let Some(stamped) = stamp_guest_audit_event(obj) else {
+                return Ok(false);
+            };
+            let bytes = chain.augment_obj(stamped);
             write_chain_line(&bytes, chain, audit_file, anchor_sink).await?;
         }
         Some("request_pending") => {
@@ -564,6 +591,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_inbound_audit_event_stamps_guest_proxy_origin_and_strips_guest_provenance() {
+        let session = session_with_dummy_sink();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut log = MemLog::default();
+        let mut anchor = MemAnchor::default();
+        let stop = handle_inbound(
+            Message::Text(
+                r#"{"type":"audit_event","route":"deny","source":"host","origin":"host"}"#.into(),
+            ),
+            &session,
+            &credential_session_with_dummy_sink(),
+            &mut chain,
+            &mut log,
+            &mut anchor,
+        )
+        .await
+        .expect("handle_inbound");
+        assert!(!stop);
+        let written = String::from_utf8(log.bytes).unwrap();
+        let obj: Value = serde_json::from_str(written.trim_end()).unwrap();
+        assert_eq!(
+            obj.get("origin").and_then(Value::as_str),
+            Some("guest-proxy"),
+            "host must stamp every guest audit_event with the guest-proxy origin: {written}"
+        );
+        assert!(
+            obj.get("source").is_none(),
+            "guest-supplied `source` provenance must be stripped: {written}"
+        );
+        assert_eq!(
+            anchor.anchors.len(),
+            1,
+            "a stamped guest event is still written to the chain"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_audit_event_with_reserved_run_env_event_is_rejected_and_warns() {
+        let session = session_with_dummy_sink();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut log = MemLog::default();
+        let mut anchor = MemAnchor::default();
+        let stop = handle_inbound(
+            Message::Text(
+                r#"{"type":"audit_event","event":"run_env","env":{"GITHUB_TOKEN":"forged"}}"#
+                    .into(),
+            ),
+            &session,
+            &credential_session_with_dummy_sink(),
+            &mut chain,
+            &mut log,
+            &mut anchor,
+        )
+        .await
+        .expect("handle_inbound");
+        assert!(!stop, "a rejected forgery must not kill the relay");
+        assert!(
+            log.bytes.is_empty(),
+            "a guest event claiming the reserved `run_env` type must not reach the chain"
+        );
+        assert!(
+            anchor.anchors.is_empty(),
+            "a rejected forgery must not advance the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_audit_event_with_non_reserved_event_value_is_stamped_and_written() {
+        let session = session_with_dummy_sink();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut log = MemLog::default();
+        let mut anchor = MemAnchor::default();
+        handle_inbound(
+            Message::Text(r#"{"type":"audit_event","event":"net_connect","host":"x"}"#.into()),
+            &session,
+            &credential_session_with_dummy_sink(),
+            &mut chain,
+            &mut log,
+            &mut anchor,
+        )
+        .await
+        .expect("handle_inbound");
+        let written = String::from_utf8(log.bytes).unwrap();
+        let obj: Value = serde_json::from_str(written.trim_end()).unwrap();
+        assert_eq!(
+            obj.get("event").and_then(Value::as_str),
+            Some("net_connect")
+        );
+        assert_eq!(
+            obj.get("origin").and_then(Value::as_str),
+            Some("guest-proxy"),
+            "a guest event whose `event` value is not host-reserved is still stamped and written: {written}"
+        );
+        assert_eq!(anchor.anchors.len(), 1);
+    }
+
+    #[tokio::test]
     async fn write_run_env_event_records_injected_env_as_a_chain_entry() {
         let mut chain = lns_ipc::AuditChain::new();
         let mut log = MemLog::default();
@@ -581,6 +705,12 @@ mod tests {
         assert!(
             written.contains("CLAUDE_CODE_USE_BEDROCK"),
             "got: {written}"
+        );
+        let obj: Value = serde_json::from_str(written.trim_end()).unwrap();
+        assert_eq!(
+            obj.get("origin").and_then(Value::as_str),
+            Some("host"),
+            "the host-authored run_env event must carry the host origin: {written}"
         );
         assert!(written.contains("prev_hash"), "must chain: {written}");
         assert!(written.ends_with('\n'));

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -23,6 +23,7 @@ pub fn injected_env_audit(user_env: &[String]) -> Option<Map<String, Value>> {
     }
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("audit_event".to_string()));
+    obj.insert("origin".to_string(), Value::String("host".to_string()));
     obj.insert("event".to_string(), Value::String("run_env".to_string()));
     obj.insert("env".to_string(), Value::Object(env));
     Some(obj)
@@ -207,6 +208,16 @@ mod tests {
         assert_eq!(obj.get("event").unwrap(), "run_env");
         let env = obj.get("env").unwrap().as_object().unwrap();
         assert_eq!(env.get("CLAUDE_CODE_USE_BEDROCK").unwrap(), "1");
+    }
+
+    #[test]
+    fn injected_env_audit_stamps_host_origin() {
+        let obj = injected_env_audit(&["A=1".into()]).expect("event built");
+        assert_eq!(
+            obj.get("origin").unwrap(),
+            "host",
+            "the host-authored run_env event must be distinguishable from guest-proxied events"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`relay::handle_inbound` wrote any inbound frame with top-level `type:"audit_event"` verbatim into the host's hash chain and advanced the service-owned anchor — with no provenance marker and no field validation. A malicious workload could fabricate audit entries with arbitrary `source`/`result`, or impersonate the host-authored `run_env` event (which rides on the same `audit_event` type), and the CLI verifier — which only checks chain linkage — would report all of them as authentic.

(The `volume_attached` event type is not reachable via this path: `handle_inbound` dispatches on the top-level `type`, and `volume_attached` falls into the drop arm; only the `event:"run_env"` collision is reachable. The fix reserves on the `event` value accordingly.)

## Fix (additive, host-side write hardening)

- In the `audit_event` arm, before chaining: strip any guest-supplied `source`/`origin`, stamp host-applied `origin:"guest-proxy"`, and reject (drop + `log::warn!`, anchor **not** advanced) any guest event whose `event` value is host-reserved (`run_env`). The `lns-ipc` `augment_obj` API is unchanged.
- Stamp host-authored events with `origin:"host"`: the `run_env` builder (`workload_env::injected_env_audit`) and `audit::volume_attached_obj`.

No consumer change is required — the CLI verifier ignores these fields, so existing chains keep verifying and rejected forgeries simply never enter the chain.

## Verification

Four behavior-pinning tests (added before the implementation): origin stamping + `source` strip, reserved-event rejection without anchor advance, non-reserved passthrough, host-origin on `run_env`/`volume_attached`. `COVERAGE_CRATES=lns-service make coverage` → all touched files (`relay/mod.rs`, `workload_env.rs`, `audit.rs`) at 100%, 0 failures.
