### PR TITLE
fix(ci): step-scope S3 credentials in publish-kernel so PR code cannot read them

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -40,12 +40,6 @@ concurrency:
   group: publish-kernel-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: false
 
-env:
-  AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-  S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
-  S3_BUCKET: ${{ secrets.S3_BUCKET }}
-
 jobs:
   # ────────────────────────────────────────────────────────────────
   # Phase 0: detect whether this is an actual kernel bump.
@@ -160,7 +154,11 @@ jobs:
 
       - name: Refuse to overwrite existing CDN artifact
         env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
           PV: ${{ steps.manifest.outputs.published_version }}
         run: |
           set -euo pipefail
@@ -372,7 +370,11 @@ jobs:
 
       - name: Refuse to overwrite existing CDN artifact (defence in depth)
         env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
           PV: ${{ steps.manifest.outputs.published_version }}
         run: |
           set -euo pipefail
@@ -436,7 +438,11 @@ jobs:
 
       - name: Upload to CDN origin
         env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
           PV: ${{ steps.manifest.outputs.published_version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

`publish-kernel.yml` set `AWS_ACCESS_KEY_ID` (= `secrets.S3_ACCESS_KEY_ID`), `S3_ENDPOINT_URL`, `S3_BUCKET`, and `AWS_DEFAULT_REGION` at **workflow level**, so they were present in every step of the `pull_request`-triggered compute job — including `cargo run -p bump-kernel` steps that compile and execute PR-author-controlled Rust and build scripts. A contributor with push access (or a compromised account) could exfiltrate the access-key id plus CDN bucket/endpoint there. (The write secret `AWS_SECRET_ACCESS_KEY` was already correctly step-scoped.)

## Fix

Removed the workflow-level `env:` block and step-scoped the full S3 coordinate set onto only the three steps that call `aws s3` — the two "refuse to overwrite" preflight checks and the "upload to CDN origin" step — alongside the secret key they already carried. The `cargo run -p bump-kernel` steps no longer inherit any S3/AWS credentials; `bump-kernel` reads none of them, so nothing breaks. The back-fill job calls no `aws s3` and is untouched.

## Verification

YAML parses; every `aws s3` step carries the complete S3 env set; no workflow-level S3 env remains; the PR-code steps no longer see the credentials. (`.github` workflows are not coverage-gated.)
