### PR TITLE
ci: enforce PR label policy and standardize create-pr labeling

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -94,6 +94,26 @@ Rules:
 - If multiple commits with mixed types, use the most significant prefix
 - If a single commit, reuse its message as the PR title
 
+### 3b. Determine Label
+
+Every PR gets exactly one type label, derived directly from the title prefix chosen above. The mapping:
+
+| Title prefix | Label |
+|--------------|-------|
+| `feat` | `enhancement` |
+| `fix` | `bug` |
+| `docs` | `documentation` |
+| `chore` | `chore` |
+| `refactor` | `refactor` |
+| `test` | `test` |
+| `ci` | `ci` |
+
+Rules:
+- The label always matches the title prefix — pick the prefix first, the label follows.
+- For mixed-type PRs, the label tracks the same "most significant prefix" used for the title, so title and label never disagree.
+- `chore(deps):` dependency bumps stay `chore` — the `dependencies` label exists but is applied only when the user explicitly asks.
+- These labels are expected to already exist in the repo. If `gh pr create` rejects a missing label, create it with `gh label create "<name>"` and retry.
+
 ### 4. Write PR Body
 
 Scale the description to match the complexity of the changes. A one-commit typo fix needs one sentence. A multi-commit feature needs a thorough write-up.
@@ -169,7 +189,7 @@ Example:
 ### 5. Create PR
 
 ```bash
-gh pr create --title "feat(scope): Title here" --body "$(cat <<'EOF'
+gh pr create --title "feat(scope): Title here" --label "enhancement" --body "$(cat <<'EOF'
 ## Summary
 
 <narrative or bullet points — scale to complexity>
@@ -208,7 +228,7 @@ Show the user the PR URL returned by `gh pr create`.
 
 - **Don't create PR if on main** - ask user to create a branch first
 - **Don't force push** - just regular push
-- **Don't add labels** unless the user explicitly asks
+- **Don't add more than one type label** - exactly one, derived from the title prefix (see step 3b). Add extra labels (e.g. `dependencies`) only when the user explicitly asks.
 - **Don't auto-merge** - just create the PR
 - **Don't add "Generated with Claude Code"** or any AI attribution to the PR body
 - **Don't add Co-Authored-By trailers** to commits or PR body

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -113,6 +113,7 @@ Rules:
 - For mixed-type PRs, the label tracks the same "most significant prefix" used for the title, so title and label never disagree.
 - `chore(deps):` dependency bumps stay `chore` — the `dependencies` label exists but is applied only when the user explicitly asks.
 - These labels are expected to already exist in the repo. If `gh pr create` rejects a missing label, create it with `gh label create "<name>"` and retry.
+- CI enforces this: the `labels` job in `.github/workflows/ci.yml` (via `scripts/check-pr-labels.sh`) fails the PR unless it carries exactly one type label and no labels outside the sanctioned set. A PR with zero or two type labels is blocked.
 
 ### 4. Write PR Body
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    # labeled/unlabeled added so the label-policy gate re-runs when a label is
+    # fixed; the changes job short-circuits the heavy jobs on those events.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
   push:
     branches: [main]
@@ -25,8 +28,8 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      check-release-build: ${{ steps.filter.outputs['check-release-build'] }}
+      code: ${{ steps.gate.outputs.code }}
+      check-release-build: ${{ steps.gate.outputs['check-release-build'] }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -59,6 +62,36 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'scripts/lns-install/**'
               - 'scripts/lns-cli.sh'
+
+      # On a pure label add/remove the diff is unchanged, so the heavy jobs
+      # have nothing new to prove — force their gates off and let only the
+      # `labels` policy check run. Other events pass the filter outputs through.
+      - id: gate
+        env:
+          ACTION: ${{ github.event.action }}
+          CODE: ${{ steps.filter.outputs.code }}
+          CRB: ${{ steps.filter.outputs['check-release-build'] }}
+        run: |
+          if [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "check-release-build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=$CODE" >> "$GITHUB_OUTPUT"
+            echo "check-release-build=$CRB" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Enforce the PR label policy (exactly one type label, nothing outside the
+  # sanctioned set). Always runs on PRs — independent of the code path filter —
+  # so unlabeled/mislabeled PRs are blocked even when only docs changed.
+  labels:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Enforce PR label policy
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: echo "$PR_LABELS" | scripts/check-pr-labels.sh
 
   lint:
     runs-on: ubuntu-latest
@@ -289,22 +322,23 @@ jobs:
   # hard-fails so we don't accidentally green-light real code changes.
   check:
     runs-on: ubuntu-latest
-    needs: [changes, lint, test, coverage, audit, check-release-build]
+    needs: [changes, labels, lint, test, coverage, audit, check-release-build]
     if: always()
     steps:
       - name: Verify all gates passed
         run: |
           ok() {
             # Pass if success, or skipped (path-filtered jobs skip on
-            # docs-only / release-irrelevant PRs).
+            # docs-only / release-irrelevant PRs; labels skips on push: main).
             [ "$1" = "success" ] || [ "$1" = "skipped" ]
           }
-          if ! ok "${{ needs.lint.result }}" \
+          if ! ok "${{ needs.labels.result }}" \
+            || ! ok "${{ needs.lint.result }}" \
             || ! ok "${{ needs.test.result }}" \
             || ! ok "${{ needs.coverage.result }}" \
             || ! ok "${{ needs.audit.result }}" \
             || ! ok "${{ needs.check-release-build.result }}"; then
-            echo "One or more gates failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} coverage=${{ needs.coverage.result }} audit=${{ needs.audit.result }} check-release-build=${{ needs.check-release-build.result }}"
+            echo "One or more gates failed: labels=${{ needs.labels.result }} lint=${{ needs.lint.result }} test=${{ needs.test.result }} coverage=${{ needs.coverage.result }} audit=${{ needs.audit.result }} check-release-build=${{ needs.check-release-build.result }}"
             exit 1
           fi
           # Guard against the changes detector itself failing (e.g.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "label": "autorelease: pending,release",
+  "release-label": "autorelease: tagged,release",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
   "plugins": ["cargo-workspace"],

--- a/scripts/check-pr-labels.sh
+++ b/scripts/check-pr-labels.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Enforce the PR label policy: exactly one type label, and no labels outside the
+# sanctioned vocabulary. Reads the PR's label names as a JSON array on stdin.
+#
+# Usage: echo '["bug","dependencies"]' | scripts/check-pr-labels.sh
+#
+# Type labels (exactly one required): enhancement bug documentation chore
+#   refactor test ci release.
+# Auxiliary labels (tolerated as extras): dependencies, autorelease: pending,
+#   autorelease: tagged.
+# Any label outside those two sets fails the check.
+
+set -euo pipefail
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+fi
+
+type_labels=(enhancement bug documentation chore refactor test ci release)
+aux_labels=(dependencies "autorelease: pending" "autorelease: tagged")
+
+contains() {
+  local needle="$1"; shift
+  local item
+  for item in "$@"; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+type_count=0
+unknown=()
+while IFS= read -r label; do
+  [ -z "$label" ] && continue
+  if contains "$label" "${type_labels[@]}"; then
+    type_count=$((type_count + 1))
+  elif ! contains "$label" "${aux_labels[@]}"; then
+    unknown+=("$label")
+  fi
+done < <(jq -r '.[]')
+
+status=0
+if [ "$type_count" -ne 1 ]; then
+  echo "::error::PR must carry exactly one type label (one of: ${type_labels[*]}); found ${type_count}."
+  status=1
+fi
+if [ "${#unknown[@]}" -gt 0 ]; then
+  echo "::error::PR carries label(s) outside the allowed set: ${unknown[*]}"
+  status=1
+fi
+if [ "$status" -eq 0 ]; then
+  echo "PR label policy satisfied: exactly one type label, no stray labels."
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

PRs in this repo were effectively unlabeled. The label set was just the GitHub defaults (none designed for this project), the `create-pr` skill explicitly avoided labeling, and nothing kept labels consistent — so filtering and triage had nothing to go on.

This PR establishes a single PR-type taxonomy, teaches the skill to apply it, and enforces it in CI so the convention can't silently rot.

### 1. Label taxonomy (hybrid)

Each PR carries exactly **one type label**, derived directly from its conventional-commit title prefix. We reuse the three default labels that fit and add the rest:

| Title prefix | Label | Status |
|---|---|---|
| `feat` | `enhancement` | reused |
| `fix` | `bug` | reused |
| `docs` | `documentation` | reused |
| `chore` | `chore` | new |
| `refactor` | `refactor` | new |
| `test` | `test` | new |
| `ci` | `ci` | new |
| — | `dependencies` | new (manual-only) |
| `chore(main): release …` | `release` | new (release-please) |

`dependencies` exists for manual use but is never auto-applied (`chore(deps):` bumps stay `chore`). The labels themselves were created in the repo out-of-band, and all existing open and closed PRs were backfilled from their titles.

### 2. `create-pr` skill applies the label

New step 3b maps the title prefix to the label and wires `--label` into `gh pr create`. Because the label is derived from the same prefix as the title, the two can never disagree. The old *\"don't add labels\"* rule is reversed to *\"exactly one type label.\"*

### 3. CI enforcement folded into the existing `check` gate

A new lightweight `labels` job runs `scripts/check-pr-labels.sh` against the PR's labels:

- **exactly one** type label from `{enhancement, bug, documentation, chore, refactor, test, ci, release}`
- `dependencies` and `autorelease: *` tolerated as extras
- **any** other label fails the check

It's wired into the `check` aggregate — already the single required status check on `main` — so no branch-protection change is needed. The check is presence-only (it does not cross-check the label against the title).

To make label fixes responsive without re-running the heavy suite, the workflow now also triggers on `labeled`/`unlabeled`, and the `changes` job short-circuits `code`/`check-release-build` to `false` on those events — so a label toggle re-runs only the `labels` policy check while lint/test/coverage/build skip (and the aggregate treats skipped as OK).

### 4. release-please PRs get `release`

`release-please-config.json` now sets `label: \"autorelease: pending,release\"` and `release-label: \"autorelease: tagged,release\"`, so release PRs satisfy the policy (`release` is their one type label; `autorelease:*` are tolerated extras) in both pending and tagged states.

## Test instructions

1. **Policy script — pass cases:** each prints `PR label policy satisfied` and exits 0:
   - `echo '[\"bug\"]' | scripts/check-pr-labels.sh`
   - `echo '[\"enhancement\",\"dependencies\"]' | scripts/check-pr-labels.sh`
   - `echo '[\"release\",\"autorelease: pending\"]' | scripts/check-pr-labels.sh`
2. **Policy script — fail cases:** each prints a `::error::` line and exits 1:
   - `echo '[]' | scripts/check-pr-labels.sh` → \"found 0\"
   - `echo '[\"bug\",\"enhancement\"]' | scripts/check-pr-labels.sh` → \"found 2\"
   - `echo '[\"bug\",\"help wanted\"]' | scripts/check-pr-labels.sh` → \"outside the allowed set: help wanted\"
3. **This PR itself:** confirm the `labels` job passes (it carries exactly `ci`), and that the heavy jobs ran normally (this was an `opened`/`synchronize` event, not a label toggle).
4. **Label-toggle short-circuit:** remove and re-add a label on this PR; confirm a new CI run fires in which `lint`/`test`/`coverage`/`check-release-build` are **skipped** and only `labels` (+ `changes`) run, and `check` still reports green.
5. **release-please:** on the next release PR, confirm it carries both `autorelease: pending` and `release`, and that `check` passes.