### PR TITLE
fix(run): preserve image ownership when seeding a pristine volume

### DIFF
--- a/crates/lns-init/src/seed.rs
+++ b/crates/lns-init/src/seed.rs
@@ -23,8 +23,9 @@ pub fn prepare_pristine_volume(
     }
     if image_seed.is_dir() {
         copy_dir_recursive(image_seed, vol_root)?;
+    } else {
+        chown_recursive(vol_root, uid, gid)?;
     }
-    chown_recursive(vol_root, uid, gid)?;
     Ok(true)
 }
 
@@ -110,18 +111,24 @@ mod tests {
     }
 
     #[test]
-    fn prepare_pristine_volume_seeds_then_chowns_when_the_image_ships_the_target() {
+    fn prepare_pristine_volume_preserves_image_ownership_when_seeding() {
         let img = tempfile::tempdir().unwrap();
         std::fs::write(img.path().join("seed.txt"), b"x").unwrap();
         let vol = tempfile::tempdir().unwrap();
-        let (uid, gid) = current_ids(img.path());
+        let (image_uid, image_gid) = current_ids(img.path());
+        let run_as_uid = image_uid + 1;
 
-        let seeded = prepare_pristine_volume(vol.path(), img.path(), uid, gid).unwrap();
+        let seeded =
+            prepare_pristine_volume(vol.path(), img.path(), run_as_uid, image_gid).unwrap();
 
         assert!(seeded);
         assert_eq!(std::fs::read(vol.path().join("seed.txt")).unwrap(), b"x");
         let md = std::fs::metadata(vol.path().join("seed.txt")).unwrap();
-        assert_eq!((md.uid(), md.gid()), (uid, gid));
+        assert_eq!(
+            md.uid(),
+            image_uid,
+            "seeded content keeps the image's owner, not the run-as identity"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a named volume is first attached and the image ships a directory at the mount target, `lns-init` seeds the fresh ext4 volume by copying that directory (`copy_dir_recursive`, which mirrors uid/gid/mode from the image). Before this fix, the seeder then unconditionally called `chown_recursive` over the result, clobbering the mirrored ownership with the run-as identity.

### The failure mode

Images that use the **entrypoint-drop pattern** — no OCI `USER` directive, but a root entrypoint that calls gosu/su-exec/setuid before exec — are common (anything using a service account with a prelude). For these:

- `resolve_run_as` sees no `USER` directive → run-as identity = root (uid 0)
- `seed_volume_if_pristine` runs, seeds the volume from the image path, then calls `chown_recursive(vol_root, 0, 0)` — clobbering e.g. `drwx------ 10000:10000` to `drwx------ root:root`
- After the entrypoint drops to the service account (uid 10000), that process has no capabilities and cannot traverse its own data directory → `EACCES` on the first `stat` call

This reproduced on every run, including with a freshly discarded volume, because the seeder re-applied the clobber on each new pristine image.

### The fix

`prepare_pristine_volume` now chowns to the run-as identity **only when there is nothing to seed** (a genuinely empty volume, the writability-for-unprivileged-workload nicety). When seeding from the image, the ownership that `copy_dir_recursive` already mirrored is preserved — matching Docker's named-volume seeding semantics.

```rust
// Before
if image_seed.is_dir() {
    copy_dir_recursive(image_seed, vol_root)?;
}
chown_recursive(vol_root, uid, gid)?;   // clobbers image ownership

// After
if image_seed.is_dir() {
    copy_dir_recursive(image_seed, vol_root)?;   // preserve image owner/mode
} else {
    chown_recursive(vol_root, uid, gid)?;        // empty volume → make it writable by run-as
}
```

### Test

Replaced `prepare_pristine_volume_seeds_then_chowns_when_the_image_ships_the_target` (which pinned the buggy behavior and only passed because the run-as uid happened to match the image uid) with `prepare_pristine_volume_preserves_image_ownership_when_seeding`. The new test passes a run-as uid that differs from the image owner, so the old unconditional `chown_recursive` fails with `EPERM` on a non-root runner — making it deterministically RED before the fix, GREEN after. No root required.

## Screenshots
### Before
<!-- EACCES on stat('/opt/data/.env') from the hermes service account after entrypoint drop -->

### After
<!-- hermes starts cleanly, service account can traverse its seeded /opt/data -->

## Test instructions

1. **Reproducer (before the fix):** `lns run -v hermes:/opt/data -p 8642:8642 nousresearch/hermes-agent -- hermes` fails with `PermissionError: [Errno 13] Permission denied: '/opt/data/.env'`. After the fix, the same command runs successfully.

2. **Empty-volume writability still works:** `lns run -v scratch:/data some-image -- /bin/sh -c 'touch /data/hello && ls -la /data/hello'` — the new file is created without error (the chown-to-run-as path for the empty-volume case is exercised).

3. **Populated volume is left untouched:** run once to populate a volume, stop, run again — the volume is not re-seeded and content is intact.

4. **Unit gate:** `cargo test -p lns-init seed::` — all 15 tests pass, including the new `prepare_pristine_volume_preserves_image_ownership_when_seeding`.