### PR TITLE
ci(static-nft): re-derive embedded nft from pinned source and diff committed blob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
               - 'scripts/static-nft.Dockerfile'
               - 'scripts/build-static-nft.sh'
               - 'scripts/verify-static-nft.sh'
-              - 'crates/lns-service/build.rs'
 
       # On a pure label add/remove the diff is unchanged, so the heavy jobs
       # have nothing new to prove — force their gates off and let only the
@@ -326,8 +325,9 @@ jobs:
 
   # Re-derive the embedded static nft from sha-pinned source and prove the
   # committed vendor/static-nft/ blob is byte-identical to a fresh build, so a
-  # blob+sha-pin swap can't pass review-blind. Gated to the rare PRs that touch
-  # the blob, its Dockerfile/build script, or build.rs's pin.
+  # blob swap can't pass review-blind. Gated to the rare PRs that touch the
+  # blob or its pinned source (Dockerfile / build script); build.rs's own sha
+  # pin is validated against the blob by check-release-build.
   verify-static-nft:
     needs: changes
     if: needs.changes.outputs['static-nft'] == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       code: ${{ steps.gate.outputs.code }}
       check-release-build: ${{ steps.gate.outputs['check-release-build'] }}
+      static-nft: ${{ steps.gate.outputs['static-nft'] }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -62,6 +63,12 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'scripts/lns-install/**'
               - 'scripts/lns-cli.sh'
+            static-nft:
+              - 'vendor/static-nft/**'
+              - 'scripts/static-nft.Dockerfile'
+              - 'scripts/build-static-nft.sh'
+              - 'scripts/verify-static-nft.sh'
+              - 'crates/lns-service/build.rs'
 
       # On a pure label add/remove the diff is unchanged, so the heavy jobs
       # have nothing new to prove — force their gates off and let only the
@@ -71,13 +78,16 @@ jobs:
           ACTION: ${{ github.event.action }}
           CODE: ${{ steps.filter.outputs.code }}
           CRB: ${{ steps.filter.outputs['check-release-build'] }}
+          SNFT: ${{ steps.filter.outputs['static-nft'] }}
         run: |
           if [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; then
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "check-release-build=false" >> "$GITHUB_OUTPUT"
+            echo "static-nft=false" >> "$GITHUB_OUTPUT"
           else
             echo "code=$CODE" >> "$GITHUB_OUTPUT"
             echo "check-release-build=$CRB" >> "$GITHUB_OUTPUT"
+            echo "static-nft=$SNFT" >> "$GITHUB_OUTPUT"
           fi
 
   # Enforce the PR label policy (exactly one type label, nothing outside the
@@ -314,6 +324,27 @@ jobs:
 
       - run: CARGO_LOCKED=--locked make build
 
+  # Re-derive the embedded static nft from sha-pinned source and prove the
+  # committed vendor/static-nft/ blob is byte-identical to a fresh build, so a
+  # blob+sha-pin swap can't pass review-blind. Gated to the rare PRs that touch
+  # the blob, its Dockerfile/build script, or build.rs's pin.
+  verify-static-nft:
+    needs: changes
+    if: needs.changes.outputs['static-nft'] == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/arm64, linux/amd64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - run: scripts/verify-static-nft.sh ${{ matrix.platform }}
+
   # Aggregate gate — single required status check on `main` branch
   # protection. Lets us split/rename the underlying jobs without
   # touching branch protection. Treats `skipped` as OK so docs-only PRs
@@ -322,7 +353,7 @@ jobs:
   # hard-fails so we don't accidentally green-light real code changes.
   check:
     runs-on: ubuntu-latest
-    needs: [changes, labels, lint, test, coverage, audit, check-release-build]
+    needs: [changes, labels, lint, test, coverage, audit, check-release-build, verify-static-nft]
     if: always()
     steps:
       - name: Verify all gates passed
@@ -337,8 +368,9 @@ jobs:
             || ! ok "${{ needs.test.result }}" \
             || ! ok "${{ needs.coverage.result }}" \
             || ! ok "${{ needs.audit.result }}" \
-            || ! ok "${{ needs.check-release-build.result }}"; then
-            echo "One or more gates failed: labels=${{ needs.labels.result }} lint=${{ needs.lint.result }} test=${{ needs.test.result }} coverage=${{ needs.coverage.result }} audit=${{ needs.audit.result }} check-release-build=${{ needs.check-release-build.result }}"
+            || ! ok "${{ needs.check-release-build.result }}" \
+            || ! ok "${{ needs.verify-static-nft.result }}"; then
+            echo "One or more gates failed: labels=${{ needs.labels.result }} lint=${{ needs.lint.result }} test=${{ needs.test.result }} coverage=${{ needs.coverage.result }} audit=${{ needs.audit.result }} check-release-build=${{ needs.check-release-build.result }} verify-static-nft=${{ needs.verify-static-nft.result }}"
             exit 1
           fi
           # Guard against the changes detector itself failing (e.g.

--- a/scripts/build-static-nft.sh
+++ b/scripts/build-static-nft.sh
@@ -20,7 +20,7 @@ case "$PLATFORM" in
 esac
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-OUT_DIR="$REPO_ROOT/vendor/static-nft"
+OUT_DIR="${LNS_STATIC_NFT_OUT_DIR:-$REPO_ROOT/vendor/static-nft}"
 STAGE_DIR="$(mktemp -d -t lns-static-nft.XXXXXX)"
 trap 'rm -rf "$STAGE_DIR"' EXIT
 

--- a/scripts/static-nft.Dockerfile
+++ b/scripts/static-nft.Dockerfile
@@ -9,7 +9,7 @@
 # Invoke via `scripts/build-static-nft.sh`. NFTABLES_VERSION + sha256 must
 # match the upstream Dockerfile pin — bumps go in lockstep with upstream.
 
-FROM alpine:3.23 AS build
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS build
 
 ARG NFTABLES_VERSION
 ARG NFTABLES_SHA256

--- a/scripts/verify-static-nft.sh
+++ b/scripts/verify-static-nft.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Re-derive the embedded static nft binary from sha-pinned source and prove the
+# committed vendor/static-nft/ blob is byte-identical to a fresh build.
+#
+# This is the independent re-derivation the size-floor + build.rs sha pin can't
+# give on their own: it stops a PR that swaps the vendored blob *and* the pinned
+# sha256 in build.rs from passing review-blind, because the rebuilt bytes come
+# from scripts/static-nft.Dockerfile (which pins NFTABLES_SHA256), not the PR.
+#
+# Usage:
+#   scripts/verify-static-nft.sh linux/arm64
+#   scripts/verify-static-nft.sh linux/amd64
+
+set -euo pipefail
+
+PLATFORM="${1:-linux/arm64}"
+case "$PLATFORM" in
+  linux/arm64) ARCH=arm64 ;;
+  linux/amd64) ARCH=amd64 ;;
+  *) echo "unsupported platform: $PLATFORM (want linux/arm64 or linux/amd64)" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ASSET=$(grep -oE 'NFTABLES_VERSION=[0-9.]+' "$REPO_ROOT/scripts/build-static-nft.sh" | head -1 | cut -d= -f2)
+ASSET="nft-${ASSET}-linux-${ARCH}-musl"
+COMMITTED="$REPO_ROOT/vendor/static-nft/$ASSET"
+
+if [ ! -f "$COMMITTED" ]; then
+  echo "::error::committed blob $COMMITTED is missing — nothing to verify against." >&2
+  exit 1
+fi
+
+REBUILD_DIR="$(mktemp -d -t lns-verify-nft.XXXXXX)"
+trap 'rm -rf "$REBUILD_DIR"' EXIT
+
+LNS_STATIC_NFT_OUT_DIR="$REBUILD_DIR" "$REPO_ROOT/scripts/build-static-nft.sh" "$PLATFORM"
+
+REBUILT="$REBUILD_DIR/$ASSET"
+if cmp -s "$REBUILT" "$COMMITTED"; then
+  echo "OK: $ASSET re-derived from pinned source is byte-identical to the committed blob."
+  shasum -a 256 "$COMMITTED"
+  exit 0
+fi
+
+echo "::error::$ASSET MISMATCH — the committed blob is NOT what scripts/static-nft.Dockerfile produces." >&2
+echo "::error::  rebuilt:   $(shasum -a 256 "$REBUILT"  | awk '{print $1}')" >&2
+echo "::error::  committed: $(shasum -a 256 "$COMMITTED" | awk '{print $1}')" >&2
+echo "::error::A blob swap requires the same change to land in scripts/static-nft.Dockerfile's pins, in the open." >&2
+exit 1


### PR DESCRIPTION
## What

The embedded static `nft` binary (`vendor/static-nft/`) is the egress-firewall enforcer baked into the guest. #30 made its trust anchor reviewable — `build.rs` pins a per-arch sha256 and panics on mismatch against the staged blob — but nothing **independently re-derives** those bytes, so a PR that swaps the vendored blob *and* the pinned constant together passes review-blind.

This PR closes that gap:

- **`scripts/verify-static-nft.sh`** rebuilds `nft` from the sha-pinned `scripts/static-nft.Dockerfile` (which pins `NFTABLES_SHA256` and digest-pins the `alpine:3.23` base) into a temp dir and asserts the committed `vendor/static-nft/<asset>` is **byte-identical** (`cmp`). Reuses `build-static-nft.sh` via a new `LNS_STATIC_NFT_OUT_DIR` override, so the pinned `NFTABLES_VERSION`/`SHA256` live in one place.
- **`ci.yml`** gains a path-gated `verify-static-nft` matrix job (linux/arm64 + linux/amd64, QEMU + buildx) wired into the aggregate `check` gate. It fires when `vendor/static-nft/**`, the Dockerfile, or the build/verify scripts change.

The chain is closed: rebuilt-from-pinned-source ≡ committed blob (this job) ≡ `build.rs` pin (existing compile-time check in `check-release-build`). A blob swap trips this job's `cmp`; a `build.rs`-pin change trips `check-release-build`'s compile-time panic. `build.rs` is deliberately **not** in this job's trigger — it produces neither the committed blob nor the rebuild, so it can't change the `cmp` verdict, and including it would drag unrelated `build.rs` edits (e.g. kernel-pin changes) through a slow QEMU rebuild for nothing.

## This PR's own CI is the proof

This PR touches `build-static-nft.sh`, the Dockerfile, and the verify script, so the new job runs here against both arches — a green run *is* the reproducibility confirmation.

## Assumption / fallback

The check asserts the stripped static Alpine `nft` build is byte-reproducible from pinned source. The `alpine:3.23` base is now digest-pinned, but `apk add` still resolves package versions from the live 3.23 index, so a future toolchain / static-lib bump can still make the rebuild diverge. If that happens the job fails loudly and isolates the cause; the fix is to rebuild the committed blob from the new base and commit both together (or, if it ever becomes chronically non-reproducible, compare against a pinned sha of the rebuilt artifact rather than `cmp` the blob). No reason to expect that today (no embedded timestamps post-`strip`; build-id is content-derived).
