### PR TITLE
fix(ci): make Kata bundle integrity check fail-closed + back-fill 3.30.0

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -197,12 +197,13 @@ jobs:
           URL="https://github.com/kata-containers/kata-containers/releases/download/${KATA}/kata-static-${KATA}-${KATA_ARCH}.tar.zst"
           echo "Fetching $URL (~670 MB)"
           curl -L --fail --output kata.tar.zst "$URL"
-          if [ -n "$BUNDLE_SHA" ]; then
-            echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
-            echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
-          else
-            echo "::warning::No kata_bundle_sha256 pinned for ${KATA_ARCH}; skipping bundle integrity check (kernel was pinned before bundle verification existed)."
+          if [ -z "$BUNDLE_SHA" ]; then
+            echo "::error::No kata_bundle_sha256 pinned for ${KATA_ARCH} in kernels.toml — refusing to process an unverified Kata bundle."
+            echo "::error::Re-run the bump via 'cargo run -p bump-kernel -- --kata-version <ver>' (it pins the bundle shas in-stream), or back-fill [current.kata_bundle_sha256] per runbooks/kernel-bump.md."
+            exit 1
           fi
+          echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
+          echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
           zstd -d kata.tar.zst -o kata.tar
 
       - name: Resolve kernel filename (auto-detect when pending)
@@ -441,12 +442,13 @@ jobs:
           set -euo pipefail
           URL="https://github.com/kata-containers/kata-containers/releases/download/${KATA}/kata-static-${KATA}-${KATA_ARCH}.tar.zst"
           curl -L --fail --output kata.tar.zst "$URL"
-          if [ -n "$BUNDLE_SHA" ]; then
-            echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
-            echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
-          else
-            echo "::warning::No kata_bundle_sha256 pinned for ${KATA_ARCH}; skipping bundle integrity check (kernel was pinned before bundle verification existed)."
+          if [ -z "$BUNDLE_SHA" ]; then
+            echo "::error::No kata_bundle_sha256 pinned for ${KATA_ARCH} in kernels.toml — refusing to publish an unverified Kata bundle."
+            echo "::error::Back-fill [current.kata_bundle_sha256] for this pin per runbooks/kernel-bump.md, or re-run the bump via bump-kernel (it pins the bundle shas in-stream)."
+            exit 1
           fi
+          echo "${BUNDLE_SHA}  kata.tar.zst" | sha256sum -c -
+          echo "Bundle verified against pinned kata_bundle_sha256 (${KATA_ARCH})."
           zstd -d kata.tar.zst -o kata.tar
           tar -xf kata.tar "./opt/kata/share/kata-containers/${FILENAME}"
           ARTIFACT="lns-kernel-${PV}-${{ matrix.arch }}"

--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -2,8 +2,8 @@ name: Publish lns guest kernel
 
 # Three-phase publish for crates/lns-service/kernels.toml.
 #
-#   detect-bump          gate: kernels.toml existed at base AND
-#                        changed AND exists at head
+#   detect-bump          gate: kernels.toml exists at base AND head
+#                        AND its published_version changed between them
 #   compute + back-fill  PR-time: per-arch sha + provenance back-fill
 #                        (no upload)
 #   publish              push to main (or workflow_dispatch) → CDN upload

--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -108,14 +108,23 @@ jobs:
             exit 0
           fi
 
-          if git diff --quiet "$BASE" -- crates/lns-service/kernels.toml; then
+          # A bump is a change to the *published artifact identity*, not any
+          # edit to the file. published_version names the artifact
+          # (lns-kernel-<published_version>-<arch>), so key on it: a comment
+          # tweak, or a back-fill of [current.kata_bundle_sha256] onto an
+          # already-published pin, must not trigger a re-publish of bytes
+          # that already exist (the overwrite guard would hard-fail).
+          pv() { sed -n 's/^[[:space:]]*published_version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' | head -1; }
+          HEAD_PV=$(pv < crates/lns-service/kernels.toml)
+          BASE_PV=$(git show "${BASE}:crates/lns-service/kernels.toml" | pv)
+          if [ "$HEAD_PV" = "$BASE_PV" ]; then
             echo "is-bump=false" >> "$GITHUB_OUTPUT"
-            echo "crates/lns-service/kernels.toml unchanged from base (workflow tweak only); nothing to publish."
+            echo "published_version unchanged (${HEAD_PV}) — comment/provenance/bundle-sha edit, not a new artifact; nothing to publish."
             exit 0
           fi
 
           echo "is-bump=true" >> "$GITHUB_OUTPUT"
-          echo "Detected kernel pin bump."
+          echo "Detected kernel pin bump: published_version ${BASE_PV} -> ${HEAD_PV}."
 
   # ────────────────────────────────────────────────────────────────
   # Phase 1: PR-time verify + compute (no upload).

--- a/crates/lns-service/kernels.toml
+++ b/crates/lns-service/kernels.toml
@@ -28,3 +28,11 @@ published_version = "6.18.15-192"
 [current.sha256]
 aarch64 = "c34f34b93598ddcd4235ae902f7a59bed95025340136dd84d8c0184b85414ba1"
 x86_64  = "2884cd8b108ba0910bb570cb2bb86698fd5fa9346951675ddb646f62a2e13486"
+
+# sha256 of each upstream `kata-static-<kata_version>-<arch>.tar.zst`.
+# Kata publishes no checksum of its own; the publish-kernel workflow now
+# hard-fails without these, so this pre-existing pin is back-filled from
+# the upstream bytes. New bumps pin them in-stream via bump-kernel.
+[current.kata_bundle_sha256]
+arm64 = "3f9df0cc898716caa3dd29315d1d5a1e9a6ad2b355ed6a4698eca81a8fbcdc41"
+amd64 = "e65aa5e5bd9f4d59bcd12a8c44a00966406e7329511dd3f756026b6eedc8ad26"

--- a/runbooks/kernel-bump.md
+++ b/runbooks/kernel-bump.md
@@ -92,8 +92,10 @@ overwrite-refusal guard). Then the `compute` job runs per-arch:
    contract).
 3. Downloads Kata's `kata-static-<tag>-<arch>.tar.zst` and verifies it
    against the `kata_bundle_sha256` you pinned in Step 1 before
-   extracting (a bundle pinned before this check existed is skipped
-   with a warning).
+   extracting. A missing pin is a hard failure (both compute and
+   publish): back-fill `[current.kata_bundle_sha256]` for the pin per
+   [Back-filling a legacy pin](#back-filling-a-legacy-kata_bundle_sha256)
+   before publishing.
 4. Resolves the kernel filename for the requested variant.
 5. Extracts, conditionally gunzips (aarch64 only), computes sha256.
 
@@ -318,6 +320,36 @@ manifest says. Possible causes:
 
 Investigate via `git log -p crates/lns-service/kernels.toml` and run
 `bump-kernel` again to reset.
+
+### CI: `No kata_bundle_sha256 pinned for <arch> in kernels.toml`
+
+The bundle-integrity check is mandatory on both the compute and
+publish jobs — a missing `[current.kata_bundle_sha256]` entry is a
+hard failure, not a skipped warning. A `bump-kernel`-driven bump
+always pins these, so this only fires for a legacy pin made before
+the check existed (or a hand-edited manifest). Back-fill it per the
+section below, then re-run.
+
+## Back-filling a legacy kata_bundle_sha256
+
+Pins made before bundle verification existed have no
+`[current.kata_bundle_sha256]` table and will now hard-fail any
+re-publish. To back-fill one in place without otherwise re-bumping:
+
+```sh
+KATA=$(cargo run -q -p bump-kernel -- show | sed -n 's/^kata_version=//p')
+for arch in arm64 amd64; do
+  url="https://github.com/kata-containers/kata-containers/releases/download/${KATA}/kata-static-${KATA}-${arch}.tar.zst"
+  printf '%s = "%s"\n' "$arch" \
+    "$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)"
+done
+```
+
+Add the two printed lines under a `[current.kata_bundle_sha256]` table
+in `crates/lns-service/kernels.toml` (same arch keys `arm64` / `amd64`
+the `bump` subcommand writes), open a PR, and let CI verify. Kata
+publishes no checksum of its own, so these are operator-computed from
+the upstream bytes — exactly what a real bump does in-stream.
 
 ## References
 


### PR DESCRIPTION
## What

Makes the Kata kernel-bundle integrity check fail-closed. #27 added the `kata_bundle_sha256` pin + verification, but the check **warned-and-skipped** when the pin was absent, and the current 3.30.0 pin (made before the check existed) had no shas — so the publish path could upload an *unverified* Kata bundle. This closes both halves:

### 1. Fail-closed (mandatory)
A missing `kata_bundle_sha256` is now a **hard failure** on both the `compute` and `publish` jobs, not a skipped warning.

### 2. Back-fill 3.30.0
`[current.kata_bundle_sha256]` is filled with both arch shas, **computed from the upstream `kata-static-3.30.0-<arch>.tar.zst` bytes** (Kata publishes no checksum of its own):

| arch | sha256 |
|------|--------|
| arm64 | `3f9df0cc898716caa3dd29315d1d5a1e9a6ad2b355ed6a4698eca81a8fbcdc41` |
| amd64 | `e65aa5e5bd9f4d59bcd12a8c44a00966406e7329511dd3f756026b6eedc8ad26` |

### 3. detect-bump keys on `published_version`
`detect-bump` treated *any* `kernels.toml` edit as a bump, so back-filling shas onto an already-published pin would have triggered `compute` and hard-failed its overwrite guard (6.18.15-192 already exists). It now keys on `published_version` — the token that names the published artifact — so comment/provenance/bundle-sha edits don't spuriously re-publish.

## Verification

- This PR's own `publish-kernel` run is the proof: `published_version` is unchanged (6.18.15-192 → 6.18.15-192), so `detect-bump` reports `is-bump=false` and `compute`/`publish` skip — no spurious overwrite failure.
- `bump-kernel show` on the updated manifest emits both `kata_bundle_sha256_{arm64,amd64}`.
- Runbook updated: the hard-fail behavior + a "Back-filling a legacy `kata_bundle_sha256`" procedure.

Note: #37 also touches `publish-kernel.yml` but edits disjoint regions, so they merge independently.