### PR TITLE
fix(init): apply nosuid/nodev/noexec per guest mount

### DIFF
--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -374,6 +374,10 @@ fn do_mount(
     flags: MountFlags,
     data: Option<&str>,
 ) -> Result<(), MountError> {
+    debug_assert!(
+        !flags.bind || !(flags.nosuid || flags.nodev || flags.noexec),
+        "a bind mount ignores nosuid/nodev/noexec in the initial mount() call; apply them with a separate MS_REMOUNT"
+    );
     let source_c = cstring(source, "source")?;
     let target_c = cstring(target, "target")?;
     let fstype_c = cstring(fstype, "fstype")?;
@@ -467,8 +471,6 @@ fn mount_volumes(
             seeded.push(&vol.dev);
         }
         do_mkdir_p(sys, &target, 0o755)?;
-        // Data volumes never need suid bits or device nodes; exec stays on so
-        // a user can run scripts they place on a volume.
         let flags = match vol.read_only {
             true => MountFlags::read_only().nosuid().nodev(),
             false => MountFlags::none().nosuid().nodev(),
@@ -682,9 +684,7 @@ fn mount_composefs_and_exec_broker_inner(
     do_mkdir(sys, &upper_work, 0o755)?;
 
     let opts = overlay_options();
-    // The workload rootfs stays permissive — images legitimately ship suid
-    // binaries and execute their own files; hardening lands on the infra,
-    // pseudo, and data mounts around it, not the rootfs itself.
+    // The workload rootfs stays permissive: images legitimately ship and exec their own suid binaries.
     do_mount(
         sys,
         "overlay",
@@ -1469,8 +1469,7 @@ mod tests {
         // /dev and /dev/pts keep device nodes (no nodev) but forbid suid + exec.
         assert_eq!(flags_for(DEV), MountFlags::none().nosuid().noexec());
         assert_eq!(flags_for(DEV_PTS), MountFlags::none().nosuid().noexec());
-        // The content store and overlay upper carry the workload's executables
-        // through the overlay, so exec stays on; neither needs suid or dev.
+        // Content store and overlay upper serve the workload's executables, so exec stays on.
         assert_eq!(flags_for(CONTENT), MountFlags::none().nosuid().nodev());
         assert_eq!(
             flags_for(UPPER_MOUNTPOINT),
@@ -1481,10 +1480,22 @@ mod tests {
             flags_for(COMPOSEFS_META),
             MountFlags::read_only().nosuid().nodev().noexec()
         );
-        // The workload rootfs stays permissive — images legitimately ship suid
-        // binaries and exec their own files. A regression that hardens it here
-        // would silently break those images, so pin it.
+        // Pin the permissive rootfs: a regression that hardens it would silently break suid-shipping images.
         assert_eq!(flags_for("/newroot"), MountFlags::none());
+    }
+
+    #[test]
+    #[should_panic(expected = "bind mount ignores")]
+    fn do_mount_rejects_security_flags_on_a_bind_mount() {
+        let sys = FakeSyscalls::new();
+        let _ = do_mount(
+            &sys,
+            "/src",
+            "/dst",
+            "none",
+            MountFlags::bind().nosuid(),
+            None,
+        );
     }
 
     #[test]

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -38,13 +38,43 @@ const RUN_TMPFS_OPTS: &str = "mode=0755,size=64m";
 const RUN_LOCK_TMPFS_OPTS: &str = "mode=1777,size=4m";
 const UNPRIV_PORT_START_SYSCTL: &str = "/proc/sys/net/ipv4/ip_unprivileged_port_start";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MountFlags {
-    None,
-    ReadOnly,
-    Bind,
-    Tmpfs,
-    TmpfsNoExec,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct MountFlags {
+    bind: bool,
+    read_only: bool,
+    nosuid: bool,
+    nodev: bool,
+    noexec: bool,
+}
+
+impl MountFlags {
+    fn none() -> Self {
+        Self::default()
+    }
+    fn bind() -> Self {
+        Self {
+            bind: true,
+            ..Self::default()
+        }
+    }
+    fn read_only() -> Self {
+        Self {
+            read_only: true,
+            ..Self::default()
+        }
+    }
+    fn nosuid(mut self) -> Self {
+        self.nosuid = true;
+        self
+    }
+    fn nodev(mut self) -> Self {
+        self.nodev = true;
+        self
+    }
+    fn noexec(mut self) -> Self {
+        self.noexec = true;
+        self
+    }
 }
 
 pub(crate) struct SandboxUser {
@@ -358,8 +388,13 @@ fn do_mount(
         })
 }
 
-fn do_mount_pseudo(sys: &dyn Syscalls, target: &str, fstype: &str) -> Result<(), MountError> {
-    do_mount(sys, "none", target, fstype, MountFlags::None, None)
+fn do_mount_pseudo(
+    sys: &dyn Syscalls,
+    target: &str,
+    fstype: &str,
+    flags: MountFlags,
+) -> Result<(), MountError> {
+    do_mount(sys, "none", target, fstype, flags, None)
 }
 
 fn do_move_mount(sys: &dyn Syscalls, from: &str, to: &str) -> Result<(), MountError> {
@@ -432,9 +467,11 @@ fn mount_volumes(
             seeded.push(&vol.dev);
         }
         do_mkdir_p(sys, &target, 0o755)?;
+        // Data volumes never need suid bits or device nodes; exec stays on so
+        // a user can run scripts they place on a volume.
         let flags = match vol.read_only {
-            true => MountFlags::ReadOnly,
-            false => MountFlags::None,
+            true => MountFlags::read_only().nosuid().nodev(),
+            false => MountFlags::none().nosuid().nodev(),
         };
         do_mount(sys, &vol.dev, &target, "ext4", flags, None)?;
     }
@@ -453,7 +490,7 @@ fn mount_run_tmpfs(
         "tmpfs",
         &run,
         "tmpfs",
-        MountFlags::Tmpfs,
+        MountFlags::none().nosuid().nodev(),
         Some(RUN_TMPFS_OPTS),
     )?;
     if let Some((uid, gid)) = run_ids {
@@ -466,7 +503,7 @@ fn mount_run_tmpfs(
         "tmpfs",
         &lock,
         "tmpfs",
-        MountFlags::TmpfsNoExec,
+        MountFlags::none().nosuid().nodev().noexec(),
         Some(RUN_LOCK_TMPFS_OPTS),
     )
 }
@@ -478,7 +515,14 @@ fn seed_volume_if_pristine(
     run_ids: Option<(u32, u32)>,
 ) -> Result<(), MountError> {
     do_mkdir(sys, VOLUME_SEED_MOUNT, 0o755).ok();
-    do_mount(sys, dev, VOLUME_SEED_MOUNT, "ext4", MountFlags::None, None)?;
+    do_mount(
+        sys,
+        dev,
+        VOLUME_SEED_MOUNT,
+        "ext4",
+        MountFlags::none().nosuid().nodev(),
+        None,
+    )?;
     let (uid, gid) = run_ids.unwrap_or((0, 0));
     let result = sys.seed_pristine_volume(VOLUME_SEED_MOUNT, image_target, uid, gid);
     do_umount(sys, VOLUME_SEED_MOUNT)?;
@@ -498,7 +542,7 @@ fn mask_proc_cmdline(
             err,
         })?;
     let target = format!("{newroot}{PROC_CMDLINE}");
-    do_mount(sys, &mask_file, &target, "none", MountFlags::Bind, None)
+    do_mount(sys, &mask_file, &target, "none", MountFlags::bind(), None)
 }
 
 fn ensure_dev_fd_links(sys: &dyn Syscalls) -> Result<(), MountError> {
@@ -576,8 +620,13 @@ fn mount_composefs_and_exec_broker_inner(
     raw_cmdline: &str,
     sys: &dyn Syscalls,
 ) -> Result<std::convert::Infallible, MountError> {
-    do_mount_pseudo(sys, SYS, "sysfs")?;
-    do_mount_pseudo(sys, DEV, "devtmpfs")?;
+    do_mount_pseudo(
+        sys,
+        SYS,
+        "sysfs",
+        MountFlags::none().nosuid().nodev().noexec(),
+    )?;
+    do_mount_pseudo(sys, DEV, "devtmpfs", MountFlags::none().nosuid().noexec())?;
 
     do_mkdir(sys, DEV_PTS, 0o755)?;
     do_mount(
@@ -585,7 +634,7 @@ fn mount_composefs_and_exec_broker_inner(
         "devpts",
         DEV_PTS,
         "devpts",
-        MountFlags::None,
+        MountFlags::none().nosuid().noexec(),
         Some("gid=5,mode=620,ptmxmode=666"),
     )?;
     let ptmx_c = cstring(DEV_PTMX, "ptmx-path")?;
@@ -600,7 +649,7 @@ fn mount_composefs_and_exec_broker_inner(
         content_tag,
         CONTENT,
         "virtiofs",
-        MountFlags::None,
+        MountFlags::none().nosuid().nodev(),
         None,
     )?;
 
@@ -613,7 +662,7 @@ fn mount_composefs_and_exec_broker_inner(
         descriptor_dev,
         COMPOSEFS_META,
         "erofs",
-        MountFlags::ReadOnly,
+        MountFlags::read_only().nosuid().nodev().noexec(),
         None,
     )?;
 
@@ -623,7 +672,7 @@ fn mount_composefs_and_exec_broker_inner(
         upper_dev,
         UPPER_MOUNTPOINT,
         "ext4",
-        MountFlags::None,
+        MountFlags::none().nosuid().nodev(),
         None,
     )?;
 
@@ -633,12 +682,15 @@ fn mount_composefs_and_exec_broker_inner(
     do_mkdir(sys, &upper_work, 0o755)?;
 
     let opts = overlay_options();
+    // The workload rootfs stays permissive — images legitimately ship suid
+    // binaries and execute their own files; hardening lands on the infra,
+    // pseudo, and data mounts around it, not the rootfs itself.
     do_mount(
         sys,
         "overlay",
         newroot,
         "overlay",
-        MountFlags::None,
+        MountFlags::none(),
         Some(&opts),
     )?;
 
@@ -1361,16 +1413,17 @@ mod tests {
                 source: "none".into(),
                 target: SYS.into(),
                 fstype: "sysfs".into(),
-                flags: MountFlags::None,
+                flags: MountFlags::none().nosuid().nodev().noexec(),
                 data: None,
             })
         );
-        // erofs descriptor is mounted read-only; upper as ext4 rw.
+        // erofs descriptor is mounted read-only and fully hardened (metadata
+        // only — never executed, no suid, no dev nodes).
         assert!(calls.contains(&Call::Mount {
             source: "/dev/vdb".into(),
             target: COMPOSEFS_META.into(),
             fstype: "erofs".into(),
-            flags: MountFlags::ReadOnly,
+            flags: MountFlags::read_only().nosuid().nodev().noexec(),
             data: None,
         }));
         // overlay is mounted onto the provided newroot with the data-only-lower opts.
@@ -1387,6 +1440,51 @@ mod tests {
             .unwrap();
         assert!(move_root < chroot, "move_mount(.,/) precedes chroot(.)");
         assert!(matches!(calls.last(), Some(Call::Fexecve(7))));
+    }
+
+    #[test]
+    fn boot_applies_per_mount_hardening_flags() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        let flags_for = |target: &str| -> MountFlags {
+            calls
+                .iter()
+                .find_map(|c| match c {
+                    Call::Mount {
+                        target: t, flags, ..
+                    } if t == target => Some(*flags),
+                    _ => None,
+                })
+                .expect("a mount was recorded for the target")
+        };
+        // Pseudo filesystems never hold suid bits, device nodes, or executables.
+        assert_eq!(flags_for(SYS), MountFlags::none().nosuid().nodev().noexec());
+        // /dev and /dev/pts keep device nodes (no nodev) but forbid suid + exec.
+        assert_eq!(flags_for(DEV), MountFlags::none().nosuid().noexec());
+        assert_eq!(flags_for(DEV_PTS), MountFlags::none().nosuid().noexec());
+        // The content store and overlay upper carry the workload's executables
+        // through the overlay, so exec stays on; neither needs suid or dev.
+        assert_eq!(flags_for(CONTENT), MountFlags::none().nosuid().nodev());
+        assert_eq!(
+            flags_for(UPPER_MOUNTPOINT),
+            MountFlags::none().nosuid().nodev()
+        );
+        // composefs metadata is read-only and fully hardened (never executed).
+        assert_eq!(
+            flags_for(COMPOSEFS_META),
+            MountFlags::read_only().nosuid().nodev().noexec()
+        );
+        // The workload rootfs stays permissive — images legitimately ship suid
+        // binaries and exec their own files. A regression that hardens it here
+        // would silently break those images, so pin it.
+        assert_eq!(flags_for("/newroot"), MountFlags::none());
     }
 
     #[test]
@@ -1852,18 +1950,19 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, Call::Umount(t) if t == VOLUME_SEED_MOUNT))
         );
-        // Both targets are mounted ext4 under newroot; the second is read-only.
+        // Both targets are mounted ext4 under newroot, nosuid+nodev; the
+        // second is also read-only.
         assert!(
             calls
                 .iter()
                 .any(|c| matches!(c, Call::Mount { target, fstype, flags, .. }
-            if target == "/newroot/data" && fstype == "ext4" && *flags == MountFlags::None))
+            if target == "/newroot/data" && fstype == "ext4" && *flags == MountFlags::none().nosuid().nodev()))
         );
         assert!(
             calls
                 .iter()
                 .any(|c| matches!(c, Call::Mount { target, flags, .. }
-            if target == "/newroot/cache" && *flags == MountFlags::ReadOnly))
+            if target == "/newroot/cache" && *flags == MountFlags::read_only().nosuid().nodev()))
         );
     }
 
@@ -1933,7 +2032,11 @@ mod tests {
             })
             .expect("/run is mounted as tmpfs under newroot");
         let (flags, data) = run;
-        assert_eq!(flags, MountFlags::Tmpfs, "/run must be nosuid,nodev");
+        assert_eq!(
+            flags,
+            MountFlags::none().nosuid().nodev(),
+            "/run must be nosuid,nodev"
+        );
         let opts = data.expect("/run tmpfs carries options");
         assert!(opts.contains("mode=0755"), "/run must be 0755: {opts}");
         assert!(opts.contains("size="), "/run must be size-capped: {opts}");
@@ -1966,7 +2069,7 @@ mod tests {
         let (flags, data) = lock;
         assert_eq!(
             flags,
-            MountFlags::TmpfsNoExec,
+            MountFlags::none().nosuid().nodev().noexec(),
             "/run/lock must be nosuid,nodev,noexec"
         );
         assert!(
@@ -2336,7 +2439,7 @@ mod tests {
             .iter()
             .position(|c| {
                 matches!(c, Call::Mount { target, flags, .. }
-                if target == "/newroot/proc/cmdline" && *flags == MountFlags::Bind)
+                if target == "/newroot/proc/cmdline" && *flags == MountFlags::bind())
             })
             .expect("masked cmdline is bind-mounted over /newroot/proc/cmdline");
         let chroot = calls
@@ -2380,7 +2483,7 @@ mod tests {
     fn boot_aborts_when_the_cmdline_mask_cannot_be_bind_mounted() {
         let sys = FakeSyscalls::new().fail_when(|c| {
             matches!(c, Call::Mount { target, flags, .. }
-                if target == "/newroot/proc/cmdline" && *flags == MountFlags::Bind)
+                if target == "/newroot/proc/cmdline" && *flags == MountFlags::bind())
             .then_some(ErrorKind::PermissionDenied)
         });
         let err = mount_composefs_and_exec_broker_inner(

--- a/crates/lns-init/src/mount/real.rs
+++ b/crates/lns-init/src/mount/real.rs
@@ -26,13 +26,22 @@ impl Syscalls for RealSyscalls {
         flags: MountFlags,
         data: Option<&CStr>,
     ) -> io::Result<()> {
-        let f: libc::c_ulong = match flags {
-            MountFlags::None => 0,
-            MountFlags::ReadOnly => libc::MS_RDONLY,
-            MountFlags::Bind => libc::MS_BIND,
-            MountFlags::Tmpfs => libc::MS_NOSUID | libc::MS_NODEV,
-            MountFlags::TmpfsNoExec => libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
-        };
+        let mut f: libc::c_ulong = 0;
+        if flags.bind {
+            f |= libc::MS_BIND;
+        }
+        if flags.read_only {
+            f |= libc::MS_RDONLY;
+        }
+        if flags.nosuid {
+            f |= libc::MS_NOSUID;
+        }
+        if flags.nodev {
+            f |= libc::MS_NODEV;
+        }
+        if flags.noexec {
+            f |= libc::MS_NOEXEC;
+        }
         let data_ptr = data
             .map(|c| c.as_ptr() as *const libc::c_void)
             .unwrap_or(ptr::null());
@@ -193,7 +202,12 @@ impl Syscalls for RealSyscalls {
 
 pub fn mount_and_exec() -> Result<std::convert::Infallible, MountError> {
     let sys = RealSyscalls;
-    super::do_mount_pseudo(&sys, PROC, "proc")?;
+    super::do_mount_pseudo(
+        &sys,
+        PROC,
+        "proc",
+        super::MountFlags::none().nosuid().nodev().noexec(),
+    )?;
 
     let cmdline = std::fs::read_to_string("/proc/cmdline").map_err(MountError::DescriptorRead)?;
     let params = CmdlineParams::parse(&cmdline);


### PR DESCRIPTION
## What

`MountFlags` was a closed enum that conflated base behavior (`ReadOnly`/`Bind`) with the one hardened tmpfs case, so most guest mounts went up without `nosuid`/`nodev`/`noexec`. #9 hardened only the new `/run` + `/run/lock` tmpfs. This makes `MountFlags` a composable set (`bind` / `read_only` / `nosuid` / `nodev` / `noexec`) with builder methods and applies standard hardening per mount.

### Per-mount flags

| Mount | flags | rationale |
|-------|-------|-----------|
| `/proc`, `/sys` | nosuid,nodev,noexec | no executables, suid, or device nodes belong here |
| `/dev`, `/dev/pts` | nosuid,noexec | device nodes kept (no nodev); nothing exec/suid |
| `/content`, `/mnt/upper` | nosuid,nodev | exec kept — workload binaries are served through the overlay |
| `/composefs-meta` | read_only,nosuid,nodev,noexec | composefs manifest; metadata only, never executed |
| volumes | nosuid,nodev (+read_only when ro) | user data; never suid/dev; exec kept for user scripts |
| `/run`, `/run/lock` | nosuid,nodev (+noexec for lock) | unchanged from #9 |
| **overlay rootfs (`newroot`)** | **none (permissive)** | the workload's own fs — images legitimately ship suid binaries and exec their own files; hardening it would break them |

### Why this is safe

The workload accesses its filesystem through the permissive overlay (`newroot`); the hardened flags land on the infra / pseudo / data mounts around it, so no legitimate image breaks. It's defense-in-depth today (`no_new_privs` already blocks the suid path) and becomes load-bearing once a writable host-share (KVM/virtiofsd) runtime lands.

## Tests / verification

- New `boot_applies_per_mount_hardening_flags` pins the flags for every mount, **including that the rootfs stays permissive** (so a future regression that hardens it is caught). Existing flag assertions updated to the composable form.
- `mount.rs` stays at **100% line coverage**; `cargo test -p lns-init` green (71 mount tests).
- `/proc` hardening lives in `mount_and_exec` (`real.rs`); validated by `aarch64-unknown-linux-musl` cross-clippy since macOS `make lint` skips `#[cfg(target_os = "linux")]` code.