### PR TITLE
ci(release): scope release-please S3 jobs to the `release` environment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,16 @@
 name: Release
 
+# CDN-write S3 credentials live on the `release` GitHub environment
+# (Settings → Environments) rather than as repository secrets, so no
+# repo-wide CDN-write credential exists. deploy-lns-install, build-lns,
+# and publish-lns-manifest reference it and read S3_ACCESS_KEY_ID,
+# S3_SECRET_ACCESS_KEY, S3_ENDPOINT_URL, and S3_BUCKET from it; its
+# required reviewers hold each release run until a human approves the
+# CDN write. WARNING: unlike publish-kernel there is no base-ref
+# fail-safe here — these jobs READ the secrets, so the environment must
+# exist and be populated before this workflow runs on main, or the
+# secrets resolve empty and every upload breaks.
+
 on:
   push:
     branches: [main]
@@ -61,6 +72,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.lns-install-released == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_deploy_install)
     runs-on: ubuntu-latest
+    environment: release
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
@@ -127,6 +139,7 @@ jobs:
             runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
+    environment: release
     permissions:
       contents: write
     env:
@@ -272,6 +285,7 @@ jobs:
     # condition here documents intent and survives future refactors.
     if: needs.release-please.outputs.lns-released == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_build_lns)
     runs-on: ubuntu-latest
+    environment: release
     env:
       VERSION: ${{ needs.release-please.outputs.lns-version || inputs.lns_version }}
       TAG: ${{ needs.release-please.outputs.lns-tag || inputs.lns_tag }}


### PR DESCRIPTION
Migrates the three S3-touching jobs in `release-please.yml` — `deploy-lns-install`, `build-lns`, `publish-lns-manifest` — onto a `release` GitHub environment so the four `S3_*` CDN-write secrets can live as **environment** secrets instead of repository-wide ones. The `release-please` orchestration job is intentionally left without an `environment` key — it never touches S3.

Refs #40.

## What's in this PR (the code half)

- [x] `deploy-lns-install`, `build-lns`, `publish-lns-manifest` each reference `environment: release`.
- [x] Header note documenting the env requirement and the no-fail-safe footgun.

## What's still manual (the config half — owner: maintainer, in GitHub Settings)

- [ ] Create the `release` environment with the four `S3_*` secrets populated (same values as the current repo-level secrets). **Deployment branches and tags → Selected branches and tags → `main`.**
- [ ] **Delete** the four repository-level `S3_*` secrets.
- [ ] Confirm a release (or `workflow_dispatch` dry-run) still uploads the binaries + `lns-latest.json`.

## Sequencing — read before merging

1. **Land after #37 merges.** Until #37 is on `main`, publish-kernel's `compute` job still reads the repo-level `S3_*` secrets; deleting them earlier would strand it. (The *YAML* here is independent — only the **secret deletion** waits on #37.)
2. **Populate the `release` environment _before_ this merges.** Unlike publish-kernel (PR-time, with a base-ref build as fail-safe), these jobs **read** the secrets. If `release` is absent/empty when this hits `main`, GitHub auto-creates it empty, the `secrets.S3_*` refs resolve blank, and every upload breaks silently.

## Reviewer-gate note

`release-please.yml` runs on `push: main` / tags, so the required-reviewer gate is secret-scope hygiene / defense-in-depth, not a pwn-request fix. Consequence: every release now **pauses for manual approval** before any CDN write — a deliberate behavior change from today's fully-automatic releases.