### PR TITLE
feat(integrations): add the integration catalog and connect flow

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -52,6 +52,83 @@ pub enum Command {
     Policy(PolicyArgs),
     #[command(about = "Manage credential providers and their per-machine value decisions.")]
     Credential(CredentialArgs),
+    #[command(about = "Manage the credential-integration catalog (connectable services).")]
+    Integration(IntegrationArgs),
+    #[command(about = "Connect an integration to this directory's policy.")]
+    Connect(ConnectArgs),
+    #[command(about = "Disconnect an integration from this directory's policy.")]
+    Disconnect(DisconnectArgs),
+}
+
+#[derive(clap::Args)]
+pub struct IntegrationArgs {
+    #[command(subcommand)]
+    pub command: IntegrationCommand,
+}
+
+#[derive(Subcommand)]
+pub enum IntegrationCommand {
+    #[command(about = "Declare a credential integration in your machine-global catalog.")]
+    Add(IntegrationAddArgs),
+    #[command(about = "List the bundled and user-declared integrations.")]
+    List,
+    #[command(about = "Remove a user-declared integration; bundled ones cannot be removed.")]
+    Remove(IntegrationRemoveArgs),
+}
+
+#[derive(clap::Args)]
+pub struct IntegrationAddArgs {
+    #[arg(
+        help = "New integration id; must not collide with a bundled or existing user integration."
+    )]
+    pub id: String,
+    #[arg(long, help = "Environment variable the placeholder is seeded into.")]
+    pub env_var: String,
+    #[arg(
+        long = "inject",
+        required = true,
+        value_parser = parse_injection,
+        help = "Per-domain injection as KIND:DOMAIN (api_key_header needs KIND:DOMAIN:HEADER). Repeatable."
+    )]
+    pub inject: Vec<lns_policy::providers::InjectionDef>,
+    #[arg(
+        long = "route",
+        help = "A host pattern the integration needs reachable. Repeatable."
+    )]
+    pub route: Vec<String>,
+    #[arg(
+        long,
+        help = "Placeholder value; auto-generated (self-identifying) when omitted."
+    )]
+    pub placeholder: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub struct IntegrationRemoveArgs {
+    #[arg(help = "User-declared integration id to remove.")]
+    pub id: String,
+}
+
+#[derive(clap::Args)]
+pub struct ConnectArgs {
+    #[arg(help = "Integration id to connect (from `lns integration list`).")]
+    pub id: String,
+    #[arg(
+        long,
+        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+    )]
+    pub policy: Option<PathBuf>,
+}
+
+#[derive(clap::Args)]
+pub struct DisconnectArgs {
+    #[arg(help = "Integration id to disconnect.")]
+    pub id: String,
+    #[arg(
+        long,
+        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+    )]
+    pub policy: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]

--- a/crates/lns-cli/src/credential/mod.rs
+++ b/crates/lns-cli/src/credential/mod.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use lns_policy::Policy;
 use lns_policy::credentials::{CredentialEntry, CredentialStore, JsonFileCredentialStore};
+use lns_policy::integrations::{AuthKind, Catalog, Integration, effective_integrations};
 use lns_policy::providers::{ProviderDef, is_self_identifying};
 
 use crate::cli::{
@@ -16,13 +17,14 @@ pub fn run(
     cmd: &CredentialCommand,
     cwd: &Path,
     creds_path: &Path,
+    catalog_path: &Path,
     reader: &mut impl Read,
     writer: &mut impl Write,
 ) -> Result<i32> {
     match cmd {
         CredentialCommand::Add(args) => add(args, cwd, creds_path, reader, writer),
         CredentialCommand::AddInjection(args) => add_injection(args, cwd, writer),
-        CredentialCommand::Set(args) => set(args, cwd, creds_path, reader, writer),
+        CredentialCommand::Set(args) => set(args, cwd, creds_path, catalog_path, reader, writer),
         CredentialCommand::Clear(args) => clear(args, creds_path, writer),
         CredentialCommand::List(args) => list(args, cwd, creds_path, writer),
         CredentialCommand::Remove(args) => remove(args, cwd, creds_path, writer),
@@ -172,13 +174,16 @@ fn remove(
     Ok(0)
 }
 
-fn is_known(id: &str, policy: &Policy) -> bool {
+fn is_known(id: &str, policy: &Policy, catalog: &[Integration]) -> bool {
     lns_policy::providers::builtins().iter().any(|p| p.id == id)
         || policy
             .credentials
             .custom_providers
             .iter()
             .any(|p| p.id == id)
+        || catalog
+            .iter()
+            .any(|i| i.id == id && i.auth_kind == AuthKind::Credential)
 }
 
 fn load_creds(
@@ -198,14 +203,17 @@ fn set(
     args: &CredentialSetArgs,
     cwd: &Path,
     creds_path: &Path,
+    catalog_path: &Path,
     reader: &mut impl Read,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let policy = Policy::load_or_default(&policy_path(args.policy.as_deref(), cwd))
-        .context("loading policy")?;
-    if !is_known(&args.id, &policy) {
+    let path = policy_path(args.policy.as_deref(), cwd);
+    let policy = Policy::load_or_default(&path).context("loading policy")?;
+    let user_catalog = Catalog::load_or_default(catalog_path).context("loading integrations")?;
+    let catalog = effective_integrations(&user_catalog);
+    if !is_known(&args.id, &policy, &catalog) {
         bail!(
-            "unknown credential provider {:?}; declare it first with `lns credential add`",
+            "unknown credential provider {:?}; declare it with `lns credential add` or connect an integration",
             args.id
         );
     }
@@ -253,8 +261,8 @@ fn list(
     creds_path: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let policy = Policy::load_or_default(&policy_path(args.policy.as_deref(), cwd))
-        .context("loading policy")?;
+    let path = policy_path(args.policy.as_deref(), cwd);
+    let policy = Policy::load_or_default(&path).context("loading policy")?;
     let (_store, state) = load_creds(creds_path)?;
     for def in lns_policy::providers::builtins() {
         writeln!(
@@ -309,6 +317,10 @@ mod tests {
         std::io::empty()
     }
 
+    fn no_catalog() -> std::path::PathBuf {
+        std::path::PathBuf::from("/nonexistent-lns-test/.lns-integrations.yaml")
+    }
+
     fn acme_policy(dir: &Path) {
         let mut policy = Policy::default();
         policy.credentials.custom_providers.push(ProviderDef {
@@ -341,6 +353,7 @@ mod tests {
             &CredentialCommand::Set(args),
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut no_stdin(),
             &mut out,
         )
@@ -360,7 +373,15 @@ mod tests {
         let mut args = set_args("github");
         args.host = true;
         let mut out = Vec::new();
-        set(&args, dir.path(), &creds, &mut no_stdin(), &mut out).unwrap();
+        set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut no_stdin(),
+            &mut out,
+        )
+        .unwrap();
         assert_eq!(
             load_state(&creds).get("github"),
             Some(&CredentialEntry::HostDetect)
@@ -374,7 +395,15 @@ mod tests {
         let mut args = set_args("github");
         args.deny = true;
         let mut out = Vec::new();
-        set(&args, dir.path(), &creds, &mut no_stdin(), &mut out).unwrap();
+        set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut no_stdin(),
+            &mut out,
+        )
+        .unwrap();
         assert_eq!(
             load_state(&creds).get("github"),
             Some(&CredentialEntry::Deny)
@@ -389,7 +418,15 @@ mod tests {
         let mut args = set_args("acme");
         args.value = Some("acme_real".into());
         let mut out = Vec::new();
-        set(&args, dir.path(), &creds, &mut no_stdin(), &mut out).unwrap();
+        set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut no_stdin(),
+            &mut out,
+        )
+        .unwrap();
         assert!(load_state(&creds).contains_key("acme"));
     }
 
@@ -400,7 +437,15 @@ mod tests {
         let mut args = set_args("made-up");
         args.value = Some("x".into());
         let mut out = Vec::new();
-        let err = set(&args, dir.path(), &creds, &mut no_stdin(), &mut out).unwrap_err();
+        let err = set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut no_stdin(),
+            &mut out,
+        )
+        .unwrap_err();
         assert!(format!("{err:#}").contains("made-up"));
         assert!(
             !creds.exists(),
@@ -414,7 +459,15 @@ mod tests {
         let creds = dir.path().join("creds.json");
         let mut args = set_args("github");
         args.host = true;
-        set(&args, dir.path(), &creds, &mut no_stdin(), &mut Vec::new()).unwrap();
+        set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut no_stdin(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         let mut out = Vec::new();
         clear(
@@ -442,7 +495,15 @@ mod tests {
                 "openai" => a.value = Some("sk-real-token".into()),
                 _ => a.deny = true,
             }
-            set(&a, dir.path(), &creds, &mut no_stdin(), &mut Vec::new()).unwrap();
+            set(
+                &a,
+                dir.path(),
+                &creds,
+                &no_catalog(),
+                &mut no_stdin(),
+                &mut Vec::new(),
+            )
+            .unwrap();
         }
         let mut out = Vec::new();
         list(
@@ -538,6 +599,7 @@ mod tests {
             &set_value,
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut no_stdin(),
             &mut Vec::new(),
         )
@@ -631,6 +693,7 @@ mod tests {
             &args,
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut &b"ghp_real\n"[..],
             &mut Vec::new(),
         )
@@ -653,6 +716,7 @@ mod tests {
             &args,
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut &b"ghp_real\r\n"[..],
             &mut Vec::new(),
         )
@@ -675,6 +739,7 @@ mod tests {
             &args,
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut &b"ghp_real"[..],
             &mut Vec::new(),
         )
@@ -693,7 +758,15 @@ mod tests {
         let creds = dir.path().join("creds.json");
         let mut args = set_args("github");
         args.value_stdin = true;
-        let err = set(&args, dir.path(), &creds, &mut &b"\n"[..], &mut Vec::new()).unwrap_err();
+        let err = set(
+            &args,
+            dir.path(),
+            &creds,
+            &no_catalog(),
+            &mut &b"\n"[..],
+            &mut Vec::new(),
+        )
+        .unwrap_err();
         assert!(format!("{err:#}").contains("stdin"), "got: {err:#}");
         assert!(
             !creds.exists(),
@@ -711,6 +784,7 @@ mod tests {
             &args,
             dir.path(),
             &creds,
+            &no_catalog(),
             &mut &[0xff_u8, 0xfe][..],
             &mut Vec::new(),
         )

--- a/crates/lns-cli/src/integration/mod.rs
+++ b/crates/lns-cli/src/integration/mod.rs
@@ -1,0 +1,524 @@
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use lns_policy::Policy;
+use lns_policy::integrations::{
+    AuthKind, Catalog, CredentialAuth, Integration, IntegrationRoute, bundled_integrations,
+    effective_integrations,
+};
+use lns_policy::providers::is_self_identifying;
+
+use crate::cli::{
+    ConnectArgs, DisconnectArgs, IntegrationAddArgs, IntegrationCommand, IntegrationRemoveArgs,
+};
+use crate::run::summary::policy_path;
+
+pub fn run(cmd: &IntegrationCommand, catalog_path: &Path, writer: &mut impl Write) -> Result<i32> {
+    match cmd {
+        IntegrationCommand::Add(args) => add(args, catalog_path, writer),
+        IntegrationCommand::List => list(catalog_path, writer),
+        IntegrationCommand::Remove(args) => remove(args, catalog_path, writer),
+    }
+}
+
+/// Self-identifying so the MITM can detect it without false positives; explicit `--placeholder` is for shape-sensitive providers.
+fn generate_placeholder(id: &str) -> String {
+    format!("lns-placeholder-{id}-0000000000000000000000")
+}
+
+fn is_bundled(id: &str) -> bool {
+    bundled_integrations().iter().any(|i| i.id == id)
+}
+
+fn load_catalog(path: &Path) -> Result<Catalog> {
+    Catalog::load_or_default(path).with_context(|| format!("loading {}", path.display()))
+}
+
+fn kind_word(kind: AuthKind) -> &'static str {
+    match kind {
+        AuthKind::Credential => "credential",
+        AuthKind::Oauth => "oauth",
+    }
+}
+
+fn add(args: &IntegrationAddArgs, catalog_path: &Path, writer: &mut impl Write) -> Result<i32> {
+    if is_bundled(&args.id) {
+        bail!(
+            "{:?} is a bundled integration and cannot be redeclared",
+            args.id
+        );
+    }
+    let mut catalog = load_catalog(catalog_path)?;
+    if catalog.integrations.iter().any(|i| i.id == args.id) {
+        bail!("integration {:?} already exists in your catalog", args.id);
+    }
+    let placeholder = match &args.placeholder {
+        Some(p) if !is_self_identifying(p) => bail!(
+            "placeholder {p:?} must self-identify as fake (contain \"placeholder\" or \"lns\")"
+        ),
+        Some(p) => p.clone(),
+        None => generate_placeholder(&args.id),
+    };
+    let routes = args
+        .route
+        .iter()
+        .map(|host| IntegrationRoute {
+            match_pattern: host.clone(),
+            transport: None,
+            scheme: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+        })
+        .collect();
+    catalog.integrations.push(Integration {
+        id: args.id.clone(),
+        auth_kind: AuthKind::Credential,
+        routes,
+        credential: Some(CredentialAuth {
+            env_var: args.env_var.clone(),
+            placeholder,
+            injections: args.inject.clone(),
+        }),
+    });
+    catalog
+        .save_atomic(catalog_path)
+        .with_context(|| format!("writing {}", catalog_path.display()))?;
+    writeln!(writer, "Declared integration {:?} in your catalog", args.id)?;
+    writeln!(
+        writer,
+        "Connect it to a project with `lns connect {}`.",
+        args.id
+    )?;
+    Ok(0)
+}
+
+fn list(catalog_path: &Path, writer: &mut impl Write) -> Result<i32> {
+    let user = load_catalog(catalog_path)?;
+    for i in bundled_integrations() {
+        writeln!(writer, "{}  (bundled)  {}", i.id, kind_word(i.auth_kind))?;
+    }
+    for i in &user.integrations {
+        // A user id that shadows a bundled one is inert (bundled wins), so don't list it as live.
+        if is_bundled(&i.id) {
+            continue;
+        }
+        writeln!(writer, "{}  (user)  {}", i.id, kind_word(i.auth_kind))?;
+    }
+    Ok(0)
+}
+
+fn remove(
+    args: &IntegrationRemoveArgs,
+    catalog_path: &Path,
+    writer: &mut impl Write,
+) -> Result<i32> {
+    if is_bundled(&args.id) {
+        bail!(
+            "{:?} is a bundled integration and cannot be removed",
+            args.id
+        );
+    }
+    let mut catalog = load_catalog(catalog_path)?;
+    let before = catalog.integrations.len();
+    catalog.integrations.retain(|i| i.id != args.id);
+    if catalog.integrations.len() == before {
+        bail!("no integration {:?} in your catalog to remove", args.id);
+    }
+    catalog
+        .save_atomic(catalog_path)
+        .with_context(|| format!("writing {}", catalog_path.display()))?;
+    writeln!(writer, "Removed integration {:?}", args.id)?;
+    Ok(0)
+}
+
+pub fn connect(
+    args: &ConnectArgs,
+    cwd: &Path,
+    catalog_path: &Path,
+    writer: &mut impl Write,
+) -> Result<i32> {
+    let user = load_catalog(catalog_path)?;
+    let effective = effective_integrations(&user);
+    let Some(integ) = effective.iter().find(|i| i.id == args.id) else {
+        bail!(
+            "unknown integration {:?}; see `lns integration list`",
+            args.id
+        );
+    };
+    if integ.auth_kind == AuthKind::Oauth {
+        bail!(
+            "integration {:?} uses oauth, which isn't supported yet",
+            args.id
+        );
+    }
+    let path = policy_path(args.policy.as_deref(), cwd);
+    let mut policy = Policy::load_or_default(&path)
+        .with_context(|| format!("loading policy from {}", path.display()))?;
+    policy.connect(args.id.clone());
+    policy
+        .save_atomic(&path)
+        .with_context(|| format!("writing policy to {}", path.display()))?;
+    writeln!(
+        writer,
+        "Connected {:?}; relaunch any running sandbox to pick it up.",
+        args.id
+    )?;
+    Ok(0)
+}
+
+pub fn disconnect(args: &DisconnectArgs, cwd: &Path, writer: &mut impl Write) -> Result<i32> {
+    let path = policy_path(args.policy.as_deref(), cwd);
+    let mut policy = Policy::load_or_default(&path)
+        .with_context(|| format!("loading policy from {}", path.display()))?;
+    if !policy.disconnect(&args.id) {
+        bail!("{:?} is not connected in {}", args.id, path.display());
+    }
+    policy
+        .save_atomic(&path)
+        .with_context(|| format!("writing policy to {}", path.display()))?;
+    writeln!(writer, "Disconnected {:?}", args.id)?;
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lns_policy::providers::{InjectionDef, InjectionKind};
+    use tempfile::TempDir;
+
+    fn add_args(id: &str) -> IntegrationAddArgs {
+        IntegrationAddArgs {
+            id: id.into(),
+            env_var: "ACME_API_KEY".into(),
+            inject: vec![InjectionDef {
+                kind: InjectionKind::BearerHeader,
+                domain: "api.acme.corp".into(),
+                header: None,
+            }],
+            route: vec!["api.acme.corp".into()],
+            placeholder: None,
+        }
+    }
+
+    fn catalog_at(dir: &Path) -> std::path::PathBuf {
+        dir.join(".lns-integrations.yaml")
+    }
+
+    fn load(path: &Path) -> Catalog {
+        Catalog::load_or_default(path).unwrap()
+    }
+
+    fn write_user_catalog(path: &Path, integrations: Vec<Integration>) {
+        Catalog { integrations }.save_atomic(path).unwrap();
+    }
+
+    fn oauth_integration(id: &str) -> Integration {
+        Integration {
+            id: id.into(),
+            auth_kind: AuthKind::Oauth,
+            routes: vec![IntegrationRoute {
+                match_pattern: "api.somesaas.com".into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: None,
+        }
+    }
+
+    #[test]
+    fn add_declares_a_new_user_integration_with_routes_and_injection() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        let mut out = Vec::new();
+        add(&add_args("acme"), &path, &mut out).unwrap();
+        let catalog = load(&path);
+        assert_eq!(catalog.integrations.len(), 1);
+        let acme = &catalog.integrations[0];
+        assert_eq!(acme.id, "acme");
+        assert_eq!(acme.auth_kind, AuthKind::Credential);
+        assert_eq!(acme.routes[0].match_pattern, "api.acme.corp");
+        let cred = acme.credential.as_ref().unwrap();
+        assert_eq!(cred.env_var, "ACME_API_KEY");
+        assert!(is_self_identifying(&cred.placeholder));
+    }
+
+    #[test]
+    fn add_keeps_an_explicit_self_identifying_placeholder() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        let mut args = add_args("acme");
+        args.placeholder = Some("acme_LNSPLACEHOLDER".into());
+        add(&args, &path, &mut Vec::new()).unwrap();
+        assert_eq!(
+            load(&path).integrations[0]
+                .credential
+                .as_ref()
+                .unwrap()
+                .placeholder,
+            "acme_LNSPLACEHOLDER"
+        );
+    }
+
+    #[test]
+    fn add_rejects_a_placeholder_that_does_not_self_identify() {
+        let dir = TempDir::new().unwrap();
+        let mut args = add_args("acme");
+        args.placeholder = Some("real-looking-token".into());
+        let err = add(&args, &catalog_at(dir.path()), &mut Vec::new()).unwrap_err();
+        assert!(format!("{err:#}").contains("self-identify"));
+    }
+
+    #[test]
+    fn add_rejects_a_bundled_id() {
+        let dir = TempDir::new().unwrap();
+        let err = add(
+            &add_args("gitlab"),
+            &catalog_at(dir.path()),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("bundled"));
+    }
+
+    #[test]
+    fn add_rejects_a_duplicate_user_id() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        add(&add_args("acme"), &path, &mut Vec::new()).unwrap();
+        let err = add(&add_args("acme"), &path, &mut Vec::new()).unwrap_err();
+        assert!(format!("{err:#}").contains("already exists"));
+    }
+
+    #[test]
+    fn list_shows_bundled_and_user_integrations_labelled() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        add(&add_args("acme"), &path, &mut Vec::new()).unwrap();
+        let mut out = Vec::new();
+        list(&path, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("gitlab  (bundled)  credential"), "{text}");
+        assert!(text.contains("acme  (user)  credential"), "{text}");
+    }
+
+    #[test]
+    fn list_labels_an_oauth_user_integration() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        write_user_catalog(&path, vec![oauth_integration("somesaas")]);
+        let mut out = Vec::new();
+        list(&path, &mut out).unwrap();
+        assert!(
+            String::from_utf8(out)
+                .unwrap()
+                .contains("somesaas  (user)  oauth"),
+            "oauth kind must be labelled"
+        );
+    }
+
+    #[test]
+    fn list_skips_a_user_entry_that_shadows_a_bundled_id() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        write_user_catalog(
+            &path,
+            vec![Integration {
+                id: "gitlab".into(),
+                auth_kind: AuthKind::Credential,
+                routes: Vec::new(),
+                credential: Some(CredentialAuth {
+                    env_var: "EVIL".into(),
+                    placeholder: "lns-evil".into(),
+                    injections: Vec::new(),
+                }),
+            }],
+        );
+        let mut out = Vec::new();
+        list(&path, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("gitlab  (bundled)"), "{text}");
+        assert!(
+            !text.contains("gitlab  (user)"),
+            "a shadow must not be listed: {text}"
+        );
+    }
+
+    #[test]
+    fn list_surfaces_a_malformed_catalog_as_an_error() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        std::fs::write(&path, "integrations: not-a-list\n").unwrap();
+        let err = list(&path, &mut Vec::new()).unwrap_err();
+        assert!(format!("{err:#}").contains("loading"));
+    }
+
+    #[test]
+    fn remove_deletes_a_user_integration() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        add(&add_args("acme"), &path, &mut Vec::new()).unwrap();
+        remove(
+            &IntegrationRemoveArgs { id: "acme".into() },
+            &path,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert!(load(&path).integrations.is_empty());
+    }
+
+    #[test]
+    fn remove_rejects_a_bundled_id() {
+        let dir = TempDir::new().unwrap();
+        let err = remove(
+            &IntegrationRemoveArgs {
+                id: "gitlab".into(),
+            },
+            &catalog_at(dir.path()),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("bundled"));
+    }
+
+    #[test]
+    fn remove_errors_on_an_unknown_user_id() {
+        let dir = TempDir::new().unwrap();
+        let err = remove(
+            &IntegrationRemoveArgs { id: "ghost".into() },
+            &catalog_at(dir.path()),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("ghost"));
+    }
+
+    #[test]
+    fn connect_writes_a_bundled_integration_id_into_the_policy() {
+        let dir = TempDir::new().unwrap();
+        let catalog = catalog_at(dir.path());
+        let mut out = Vec::new();
+        connect(
+            &ConnectArgs {
+                id: "gitlab".into(),
+                policy: None,
+            },
+            dir.path(),
+            &catalog,
+            &mut out,
+        )
+        .unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        assert_eq!(policy.integrations, ["gitlab"]);
+    }
+
+    #[test]
+    fn connect_rejects_an_unknown_integration() {
+        let dir = TempDir::new().unwrap();
+        let err = connect(
+            &ConnectArgs {
+                id: "nope".into(),
+                policy: None,
+            },
+            dir.path(),
+            &catalog_at(dir.path()),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("unknown integration"));
+    }
+
+    #[test]
+    fn connect_rejects_an_oauth_integration_as_unsupported() {
+        let dir = TempDir::new().unwrap();
+        let catalog = catalog_at(dir.path());
+        write_user_catalog(&catalog, vec![oauth_integration("somesaas")]);
+        let err = connect(
+            &ConnectArgs {
+                id: "somesaas".into(),
+                policy: None,
+            },
+            dir.path(),
+            &catalog,
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("oauth"));
+    }
+
+    #[test]
+    fn disconnect_removes_a_connected_integration() {
+        let dir = TempDir::new().unwrap();
+        let catalog = catalog_at(dir.path());
+        connect(
+            &ConnectArgs {
+                id: "gitlab".into(),
+                policy: None,
+            },
+            dir.path(),
+            &catalog,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        disconnect(
+            &DisconnectArgs {
+                id: "gitlab".into(),
+                policy: None,
+            },
+            dir.path(),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        assert!(policy.integrations.is_empty());
+    }
+
+    #[test]
+    fn disconnect_errors_when_not_connected() {
+        let dir = TempDir::new().unwrap();
+        let err = disconnect(
+            &DisconnectArgs {
+                id: "gitlab".into(),
+                policy: None,
+            },
+            dir.path(),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("not connected"));
+    }
+
+    #[test]
+    fn run_dispatches_list() {
+        let dir = TempDir::new().unwrap();
+        let mut out = Vec::new();
+        run(&IntegrationCommand::List, &catalog_at(dir.path()), &mut out).unwrap();
+        assert!(
+            String::from_utf8(out)
+                .unwrap()
+                .contains("gitlab  (bundled)")
+        );
+    }
+
+    #[test]
+    fn run_dispatches_add_and_remove() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        run(
+            &IntegrationCommand::Add(add_args("acme")),
+            &path,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(load(&path).integrations.len(), 1);
+        run(
+            &IntegrationCommand::Remove(IntegrationRemoveArgs { id: "acme".into() }),
+            &path,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert!(load(&path).integrations.is_empty());
+    }
+}

--- a/crates/lns-cli/src/lib.rs
+++ b/crates/lns-cli/src/lib.rs
@@ -55,12 +55,14 @@ pub async fn run(cli: Cli) -> Result<i32> {
         Command::Credential(args) => {
             let cwd = std::env::current_dir()?;
             let creds_path = lns_policy::credentials::default_credentials_path();
+            let catalog_path = lns_policy::integrations::default_integrations_path();
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
             credential::run(
                 &args.command,
                 &cwd,
                 &creds_path,
+                &catalog_path,
                 &mut reader,
                 &mut std::io::stdout(),
             )?

--- a/crates/lns-cli/src/lib.rs
+++ b/crates/lns-cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod chord;
 pub mod cli;
 pub mod credential;
+pub mod integration;
 pub mod log;
 pub mod policy;
 pub mod raw_mode;
@@ -63,6 +64,19 @@ pub async fn run(cli: Cli) -> Result<i32> {
                 &mut reader,
                 &mut std::io::stdout(),
             )?
+        }
+        Command::Integration(args) => {
+            let catalog_path = lns_policy::integrations::default_integrations_path();
+            integration::run(&args.command, &catalog_path, &mut std::io::stdout())?
+        }
+        Command::Connect(args) => {
+            let cwd = std::env::current_dir()?;
+            let catalog_path = lns_policy::integrations::default_integrations_path();
+            integration::connect(&args, &cwd, &catalog_path, &mut std::io::stdout())?
+        }
+        Command::Disconnect(args) => {
+            let cwd = std::env::current_dir()?;
+            integration::disconnect(&args, &cwd, &mut std::io::stdout())?
         }
     };
     Ok(code)

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -29,7 +29,10 @@ fn add_rule(
         match_pattern: args.pattern.clone(),
         verdict,
         transport: transport_of(args.transport),
+        scheme: None,
         description: args.description.clone(),
+        tls_terminate: false,
+        rules: Vec::new(),
     });
     policy
         .save_atomic(&path)
@@ -172,7 +175,10 @@ mod tests {
             match_pattern: "ask.example".into(),
             verdict: Verdict::Ask,
             transport: Transport::Direct,
+            scheme: None,
             description: Some("undecided".into()),
+            tls_terminate: false,
+            rules: Vec::new(),
         });
         policy.save_atomic(&path).unwrap();
         let mut out = Vec::new();

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -262,7 +262,10 @@ mod tests {
             match_pattern: host.to_string(),
             verdict: Verdict::Allow,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         }
     }
 
@@ -271,7 +274,10 @@ mod tests {
             match_pattern: host.to_string(),
             verdict: Verdict::Deny,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         }
     }
 
@@ -411,7 +417,10 @@ mod tests {
             match_pattern: "ambiguous.example".to_string(),
             verdict: Verdict::Ask,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         });
         let s = format_summary(
             &run_args(Some("ubuntu")),

--- a/crates/lns-cli/tests/behaviours/credential_cli.feature
+++ b/crates/lns-cli/tests/behaviours/credential_cli.feature
@@ -22,6 +22,13 @@ Feature: shaping credential rules from the CLI
     When the developer sets the "github" credential to a stored value piped on stdin as "ghp_piped"
     Then "~/.lns-credentials.json" gains an entry for "github" with kind "stored" carrying "ghp_piped"
 
+  Scenario: Setting a credential for a catalog integration is accepted
+    A connected integration (e.g. the bundled "gitlab") is a known
+    credential provider too, so its value can be pre-set non-interactively
+    just like a built-in — the value arms its injection on next use.
+    When the developer sets the "gitlab" credential to a stored value "glpat-real"
+    Then "~/.lns-credentials.json" gains an entry for "gitlab" with kind "stored" carrying "glpat-real"
+
   Scenario: Setting a value from stdin with nothing piped fails clearly
     When the developer sets the "github" credential from empty stdin
     Then the command fails with a clear error mentioning stdin

--- a/crates/lns-cli/tests/behaviours/steps/credential_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/credential_cli.rs
@@ -25,10 +25,11 @@ fn creds_path(world: &mut BehaviourWorld) -> PathBuf {
 fn run_credential(world: &mut BehaviourWorld, cmd: CredentialCommand) {
     let dir = cwd(world);
     let creds = dir.join(".lns-credentials.json");
+    let catalog = dir.join(".lns-integrations.yaml");
     let stdin = world.stdin.clone().unwrap_or_default();
     let mut reader = stdin.as_bytes();
     let mut buf = Vec::<u8>::new();
-    let run = match credential::run(&cmd, &dir, &creds, &mut reader, &mut buf) {
+    let run = match credential::run(&cmd, &dir, &creds, &catalog, &mut reader, &mut buf) {
         Ok(exit_code) => CliRun {
             exit_code,
             output: String::from_utf8_lossy(&buf).into_owned(),
@@ -44,6 +45,7 @@ fn run_credential(world: &mut BehaviourWorld, cmd: CredentialCommand) {
 fn run_set_via_clap(world: &mut BehaviourWorld, tail: &[&str]) {
     let dir = cwd(world);
     let creds = dir.join(".lns-credentials.json");
+    let catalog = dir.join(".lns-integrations.yaml");
     let stdin = world.stdin.clone().unwrap_or_default();
     let mut reader = stdin.as_bytes();
     let mut full = vec![
@@ -58,7 +60,7 @@ fn run_set_via_clap(world: &mut BehaviourWorld, tail: &[&str]) {
                 panic!("expected a credential command");
             };
             let mut buf = Vec::<u8>::new();
-            match credential::run(&args.command, &dir, &creds, &mut reader, &mut buf) {
+            match credential::run(&args.command, &dir, &creds, &catalog, &mut reader, &mut buf) {
                 Ok(exit_code) => CliRun {
                     exit_code,
                     output: String::from_utf8_lossy(&buf).into_owned(),

--- a/crates/lns-cli/tests/behaviours/steps/custom_providers_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/custom_providers_cli.rs
@@ -25,10 +25,11 @@ fn creds_path(world: &mut BehaviourWorld) -> PathBuf {
 fn run_credential(world: &mut BehaviourWorld, cmd: CredentialCommand) {
     let dir = cwd(world);
     let creds = creds_path(world);
+    let catalog = dir.join(".lns-integrations.yaml");
     let stdin = world.stdin.clone().unwrap_or_default();
     let mut reader = stdin.as_bytes();
     let mut out = Vec::<u8>::new();
-    let run = match credential::run(&cmd, &dir, &creds, &mut reader, &mut out) {
+    let run = match credential::run(&cmd, &dir, &creds, &catalog, &mut reader, &mut out) {
         Ok(exit_code) => CliRun {
             exit_code,
             output: String::from_utf8_lossy(&out).into_owned(),
@@ -44,6 +45,7 @@ fn run_credential(world: &mut BehaviourWorld, cmd: CredentialCommand) {
 fn run_add_via_clap(world: &mut BehaviourWorld, tail: &[&str]) {
     let dir = cwd(world);
     let creds = creds_path(world);
+    let catalog = dir.join(".lns-integrations.yaml");
     let mut full = vec![
         "lns".to_string(),
         "credential".to_string(),
@@ -57,16 +59,18 @@ fn run_add_via_clap(world: &mut BehaviourWorld, tail: &[&str]) {
             };
             let mut reader = std::io::empty();
             let mut out = Vec::<u8>::new();
-            let run = match credential::run(&args.command, &dir, &creds, &mut reader, &mut out) {
-                Ok(exit_code) => CliRun {
-                    exit_code,
-                    output: String::from_utf8_lossy(&out).into_owned(),
-                },
-                Err(e) => CliRun {
-                    exit_code: 1,
-                    output: format!("{e:#}"),
-                },
-            };
+            let run =
+                match credential::run(&args.command, &dir, &creds, &catalog, &mut reader, &mut out)
+                {
+                    Ok(exit_code) => CliRun {
+                        exit_code,
+                        output: String::from_utf8_lossy(&out).into_owned(),
+                    },
+                    Err(e) => CliRun {
+                        exit_code: 1,
+                        output: format!("{e:#}"),
+                    },
+                };
             world.result = Some(run);
         }
         Err(e) => {

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -95,7 +95,10 @@ fn that_policy_has(world: &mut BehaviourWorld, verdict: String, allows: usize, d
             match_pattern: format!("allow-{i}.example"),
             verdict: Verdict::Allow,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         });
     }
     for i in 0..denies {
@@ -103,7 +106,10 @@ fn that_policy_has(world: &mut BehaviourWorld, verdict: String, allows: usize, d
             match_pattern: format!("deny-{i}.example"),
             verdict: Verdict::Deny,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         });
     }
     policy

--- a/crates/lns-policy/src/integrations.rs
+++ b/crates/lns-policy/src/integrations.rs
@@ -1,0 +1,618 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::providers::InjectionDef;
+use crate::{HttpRule, RouteRule, Scheme, Transport, Verdict, is_false};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthKind {
+    Credential,
+    Oauth,
+}
+
+/// A route an integration needs reachable. Verdict is implicitly `allow`; `transport` defaults to direct. Materializes into a full [`RouteRule`] at run time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntegrationRoute {
+    #[serde(rename = "match")]
+    pub match_pattern: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<Transport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<Scheme>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub tls_terminate: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<HttpRule>,
+}
+
+impl IntegrationRoute {
+    /// HTTP-level `rules` can only be enforced when the proxy terminates TLS, so declaring them implies termination.
+    pub fn to_route_rule(&self) -> RouteRule {
+        RouteRule {
+            match_pattern: self.match_pattern.clone(),
+            verdict: Verdict::Allow,
+            transport: self.transport.unwrap_or(Transport::Direct),
+            scheme: self.scheme,
+            description: None,
+            tls_terminate: self.tls_terminate || !self.rules.is_empty(),
+            rules: self.rules.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialAuth {
+    pub env_var: String,
+    pub placeholder: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub injections: Vec<InjectionDef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Integration {
+    pub id: String,
+    pub auth_kind: AuthKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<IntegrationRoute>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential: Option<CredentialAuth>,
+}
+
+impl Integration {
+    /// A `credential` integration must carry its `credential:` block; `oauth` is recognized but inert until that work lands.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.auth_kind {
+            AuthKind::Credential if self.credential.is_none() => Err(format!(
+                "integration {:?} declares authKind credential but has no `credential:` block",
+                self.id
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Catalog {
+    #[serde(default)]
+    pub integrations: Vec<Integration>,
+}
+
+impl Catalog {
+    fn validate(&self) -> Result<(), String> {
+        for i in &self.integrations {
+            i.validate()?;
+        }
+        Ok(())
+    }
+
+    pub fn load_or_default(path: &Path) -> io::Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(text) => {
+                let catalog: Catalog = serde_yaml::from_str(&text)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                catalog
+                    .validate()
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Ok(catalog)
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn save_atomic(&self, path: &Path) -> io::Result<()> {
+        let yaml = serde_yaml::to_string(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("yaml.tmp");
+        fs::write(&tmp, yaml)?;
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+const BUNDLED_YAML: &str = include_str!("integrations.yaml");
+
+static BUNDLED: LazyLock<Vec<Integration>> =
+    LazyLock::new(|| parse_catalog(BUNDLED_YAML).integrations);
+
+/// Panics on a malformed or inconsistent manifest; the shipped catalog is test-proven well-formed, so the production caller never hits those arms.
+fn parse_catalog(yaml_src: &str) -> Catalog {
+    let catalog: Catalog =
+        serde_yaml::from_str(yaml_src).expect("bundled integration catalog must be valid YAML");
+    catalog
+        .validate()
+        .expect("bundled integration catalog must be internally consistent");
+    catalog
+}
+
+pub fn bundled_integrations() -> &'static [Integration] {
+    BUNDLED.as_slice()
+}
+
+/// Falls back to `./.lns-integrations.yaml` when `HOME` is unset rather than panicking.
+pub fn default_integrations_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("LNS_INTEGRATIONS_PATH") {
+        return PathBuf::from(p);
+    }
+    std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".lns-integrations.yaml"))
+        .unwrap_or_else(|| PathBuf::from(".lns-integrations.yaml"))
+}
+
+/// The effective catalog is the bundled set extended with user entries whose id isn't already shipped — a bundled id can never be shadowed.
+pub fn effective_integrations(user: &Catalog) -> Vec<Integration> {
+    let mut out: Vec<Integration> = bundled_integrations().to_vec();
+    let bundled_ids: HashSet<&str> = out.iter().map(|i| i.id.as_str()).collect();
+    let extra: Vec<Integration> = user
+        .integrations
+        .iter()
+        .filter(|i| !bundled_ids.contains(i.id.as_str()))
+        .cloned()
+        .collect();
+    out.extend(extra);
+    out
+}
+
+pub trait CatalogStore: Send + Sync {
+    fn save(&self, catalog: &Catalog) -> io::Result<()>;
+}
+
+pub struct FileCatalogStore {
+    pub path: PathBuf,
+}
+
+impl FileCatalogStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl CatalogStore for FileCatalogStore {
+    fn save(&self, catalog: &Catalog) -> io::Result<()> {
+        catalog.save_atomic(&self.path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::InjectionKind;
+
+    fn credential(env_var: &str, placeholder: &str, domain: &str) -> CredentialAuth {
+        CredentialAuth {
+            env_var: env_var.into(),
+            placeholder: placeholder.into(),
+            injections: vec![InjectionDef {
+                kind: InjectionKind::BearerHeader,
+                domain: domain.into(),
+                header: None,
+            }],
+        }
+    }
+
+    fn route(host: &str) -> IntegrationRoute {
+        IntegrationRoute {
+            match_pattern: host.into(),
+            transport: None,
+            scheme: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+        }
+    }
+
+    fn sample_integration() -> Integration {
+        Integration {
+            id: "acme".into(),
+            auth_kind: AuthKind::Credential,
+            routes: vec![route("api.acme.corp")],
+            credential: Some(credential(
+                "ACME_API_KEY",
+                "acme_LNSPLACEHOLDER0000",
+                "api.acme.corp",
+            )),
+        }
+    }
+
+    fn oauth_integration() -> Integration {
+        Integration {
+            id: "examplehub".into(),
+            auth_kind: AuthKind::Oauth,
+            routes: vec![route("api.examplehub.com")],
+            credential: None,
+        }
+    }
+
+    #[test]
+    fn a_simple_integration_route_round_trips_as_just_a_match() {
+        let r = route("gitlab.com");
+        let yaml = serde_yaml::to_string(&r).unwrap();
+        assert!(yaml.contains("match: gitlab.com"), "got: {yaml}");
+        assert!(
+            !yaml.contains("verdict")
+                && !yaml.contains("transport")
+                && !yaml.contains("tlsTerminate"),
+            "a bare route must stay minimal: {yaml}"
+        );
+        let parsed: IntegrationRoute = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn a_least_privilege_integration_route_round_trips_with_scheme_and_http_rules() {
+        let r = IntegrationRoute {
+            match_pattern: "gitlab.com".into(),
+            transport: None,
+            scheme: Some(Scheme::Https),
+            tls_terminate: false,
+            rules: vec![HttpRule {
+                method: Some("GET".into()),
+                path: Some("/api/v4/**".into()),
+            }],
+        };
+        let yaml = serde_yaml::to_string(&r).unwrap();
+        assert!(yaml.contains("scheme: https"), "got: {yaml}");
+        assert!(yaml.contains("path: /api/v4/**"), "got: {yaml}");
+        let parsed: IntegrationRoute = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn to_route_rule_grants_allow_and_defaults_transport_to_direct() {
+        let rr = route("gitlab.com").to_route_rule();
+        assert_eq!(rr.match_pattern, "gitlab.com");
+        assert_eq!(rr.verdict, Verdict::Allow);
+        assert_eq!(rr.transport, Transport::Direct);
+        assert!(!rr.tls_terminate);
+        assert!(rr.rules.is_empty());
+    }
+
+    #[test]
+    fn to_route_rule_honours_an_explicit_transport() {
+        let mut r = route("gitlab.com");
+        r.transport = Some(Transport::Upstream);
+        assert_eq!(r.to_route_rule().transport, Transport::Upstream);
+    }
+
+    #[test]
+    fn to_route_rule_implies_tls_termination_when_http_rules_are_present() {
+        let r = IntegrationRoute {
+            match_pattern: "gitlab.com".into(),
+            transport: None,
+            scheme: Some(Scheme::Https),
+            tls_terminate: false,
+            rules: vec![HttpRule {
+                method: Some("GET".into()),
+                path: None,
+            }],
+        };
+        let rr = r.to_route_rule();
+        assert!(
+            rr.tls_terminate,
+            "HTTP-level rules can't be enforced without terminating TLS"
+        );
+        assert_eq!(rr.scheme, Some(Scheme::Https));
+        assert_eq!(rr.rules.len(), 1);
+    }
+
+    #[test]
+    fn auth_kind_serializes_in_snake_case() {
+        assert_eq!(
+            serde_yaml::to_string(&AuthKind::Credential).unwrap().trim(),
+            "credential"
+        );
+        assert_eq!(
+            serde_yaml::to_string(&AuthKind::Oauth).unwrap().trim(),
+            "oauth"
+        );
+    }
+
+    #[test]
+    fn credential_integration_round_trips_with_a_named_credential_block() {
+        let i = sample_integration();
+        let yaml = serde_yaml::to_string(&i).unwrap();
+        assert!(yaml.contains("authKind: credential"), "got: {yaml}");
+        assert!(yaml.contains("credential:"), "got: {yaml}");
+        assert!(yaml.contains("envVar: ACME_API_KEY"), "got: {yaml}");
+        let parsed: Integration = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, i);
+    }
+
+    #[test]
+    fn an_oauth_integration_round_trips_without_a_credential_block() {
+        let i = oauth_integration();
+        let yaml = serde_yaml::to_string(&i).unwrap();
+        assert!(yaml.contains("authKind: oauth"), "got: {yaml}");
+        assert!(
+            !yaml.contains("credential"),
+            "an oauth entry must not carry credential fields: {yaml}"
+        );
+        let parsed: Integration = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, i);
+    }
+
+    #[test]
+    fn validate_rejects_a_credential_integration_missing_its_block() {
+        let bad = Integration {
+            id: "x".into(),
+            auth_kind: AuthKind::Credential,
+            routes: Vec::new(),
+            credential: None,
+        };
+        let err = bad.validate().unwrap_err();
+        assert!(err.contains("credential"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_credential_integration() {
+        assert!(sample_integration().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_an_oauth_integration_with_no_block() {
+        assert!(oauth_integration().validate().is_ok());
+    }
+
+    #[test]
+    fn catalog_round_trips_and_empty_integrations_is_the_default() {
+        let empty: Catalog = serde_yaml::from_str("{}").unwrap();
+        assert!(empty.integrations.is_empty());
+        let c = Catalog {
+            integrations: vec![sample_integration()],
+        };
+        let parsed: Catalog = serde_yaml::from_str(&serde_yaml::to_string(&c).unwrap()).unwrap();
+        assert_eq!(parsed, c);
+    }
+
+    #[test]
+    fn bundled_catalog_parses_and_carries_no_builtin_id() {
+        let ids: HashSet<&str> = bundled_integrations()
+            .iter()
+            .map(|i| i.id.as_str())
+            .collect();
+        assert!(
+            !ids.is_empty(),
+            "the bundled catalog should ship at least one service"
+        );
+        for builtin in ["github", "openai", "anthropic", "linear", "telegram"] {
+            assert!(
+                !ids.contains(builtin),
+                "bundled catalog must not shadow the compiled-in built-in {builtin}"
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_catalog_ships_gitlab_and_huggingface() {
+        let ids: HashSet<&str> = bundled_integrations()
+            .iter()
+            .map(|i| i.id.as_str())
+            .collect();
+        assert!(ids.contains("gitlab"), "got: {ids:?}");
+        assert!(ids.contains("huggingface"), "got: {ids:?}");
+    }
+
+    #[test]
+    fn every_bundled_integration_is_a_valid_credential_with_self_identifying_placeholder_and_routes()
+     {
+        for i in bundled_integrations() {
+            assert!(i.validate().is_ok(), "{} is inconsistent", i.id);
+            assert_eq!(
+                i.auth_kind,
+                AuthKind::Credential,
+                "{} ships as credential kind until oauth lands",
+                i.id
+            );
+            let cred = i.credential.as_ref().expect("credential block present");
+            assert!(
+                crate::providers::is_self_identifying(&cred.placeholder),
+                "{} placeholder must self-identify: {}",
+                i.id,
+                cred.placeholder
+            );
+            assert!(
+                !i.routes.is_empty(),
+                "{} must declare the routes it needs",
+                i.id
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "bundled integration catalog must be valid YAML")]
+    fn parse_catalog_panics_on_malformed_yaml() {
+        parse_catalog("integrations: [ this is : not valid");
+    }
+
+    #[test]
+    #[should_panic(expected = "bundled integration catalog must be internally consistent")]
+    fn parse_catalog_panics_on_a_credential_entry_missing_its_block() {
+        parse_catalog("integrations:\n  - id: x\n    authKind: credential\n");
+    }
+
+    #[test]
+    fn a_bundled_entry_pasted_into_a_user_file_deserializes_identically() {
+        let entry = bundled_integrations()[0].clone();
+        let as_user_catalog = Catalog {
+            integrations: vec![entry.clone()],
+        };
+        let yaml = serde_yaml::to_string(&as_user_catalog).unwrap();
+        let parsed: Catalog = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.integrations, vec![entry]);
+    }
+
+    #[test]
+    fn load_or_default_returns_empty_when_file_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let c = Catalog::load_or_default(&dir.path().join("nope.yaml")).unwrap();
+        assert_eq!(c, Catalog::default());
+    }
+
+    #[test]
+    fn load_or_default_reads_an_existing_user_catalog() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(".lns-integrations.yaml");
+        Catalog {
+            integrations: vec![sample_integration()],
+        }
+        .save_atomic(&path)
+        .unwrap();
+        let c = Catalog::load_or_default(&path).unwrap();
+        assert_eq!(c.integrations.len(), 1);
+        assert_eq!(c.integrations[0].id, "acme");
+    }
+
+    #[test]
+    fn load_or_default_surfaces_non_not_found_io_errors() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("is-a-dir");
+        fs::create_dir(&path).unwrap();
+        let err = Catalog::load_or_default(&path).unwrap_err();
+        assert_ne!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn load_or_default_surfaces_invalid_yaml_as_io_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("broken.yaml");
+        fs::write(&path, "integrations: not-a-list\n").unwrap();
+        let err = Catalog::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn load_or_default_rejects_an_inconsistent_credential_entry_as_invalid_data() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("inconsistent.yaml");
+        fs::write(
+            &path,
+            "integrations:\n  - id: x\n    authKind: credential\n",
+        )
+        .unwrap();
+        let err = Catalog::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn save_atomic_round_trips_creates_parent_and_leaves_no_tmp() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nested/dir/.lns-integrations.yaml");
+        let c = Catalog {
+            integrations: vec![sample_integration()],
+        };
+        c.save_atomic(&path).unwrap();
+        assert!(path.exists());
+        assert!(!path.with_extension("yaml.tmp").exists());
+        assert_eq!(Catalog::load_or_default(&path).unwrap(), c);
+    }
+
+    #[test]
+    fn file_catalog_store_save_writes_yaml_readable_by_load_or_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(".lns-integrations.yaml");
+        let store = FileCatalogStore::new(path.clone());
+        let c = Catalog {
+            integrations: vec![sample_integration()],
+        };
+        store.save(&c).unwrap();
+        assert_eq!(Catalog::load_or_default(&path).unwrap(), c);
+    }
+
+    #[test]
+    fn file_catalog_store_save_to_unwritable_parent_surfaces_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let not_a_dir = dir.path().join("file");
+        fs::write(&not_a_dir, b"").unwrap();
+        let store = FileCatalogStore::new(not_a_dir.join("nested/.lns-integrations.yaml"));
+        let err = store.save(&Catalog::default()).unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn effective_integrations_is_bundled_only_for_an_empty_user_catalog() {
+        let eff = effective_integrations(&Catalog::default());
+        assert_eq!(eff.len(), bundled_integrations().len());
+    }
+
+    #[test]
+    fn effective_integrations_appends_a_user_only_integration() {
+        let user = Catalog {
+            integrations: vec![sample_integration()],
+        };
+        let eff = effective_integrations(&user);
+        assert_eq!(eff.len(), bundled_integrations().len() + 1);
+        assert!(eff.iter().any(|i| i.id == "acme"));
+    }
+
+    #[test]
+    fn effective_integrations_drops_a_user_entry_that_shadows_a_bundled_id() {
+        let mut shadow = sample_integration();
+        shadow.id = "gitlab".into();
+        shadow.credential = Some(credential("EVIL", "lns-evil", "gitlab.com"));
+        let user = Catalog {
+            integrations: vec![shadow],
+        };
+        let eff = effective_integrations(&user);
+        assert_eq!(
+            eff.len(),
+            bundled_integrations().len(),
+            "a user shadow must not add a second gitlab"
+        );
+        let gitlab = eff.iter().find(|i| i.id == "gitlab").unwrap();
+        assert_ne!(
+            gitlab.credential.as_ref().unwrap().env_var,
+            "EVIL",
+            "the bundled gitlab definition must win over a user shadow"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_integrations_path_uses_override_when_set() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::set("LNS_INTEGRATIONS_PATH", "/tmp/custom-integrations.yaml");
+        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
+        assert_eq!(
+            default_integrations_path(),
+            PathBuf::from("/tmp/custom-integrations.yaml")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_integrations_path_falls_back_to_home_dotfile() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::unset("LNS_INTEGRATIONS_PATH");
+        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
+        assert_eq!(
+            default_integrations_path(),
+            PathBuf::from("/home/dev/.lns-integrations.yaml")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_integrations_path_falls_back_to_cwd_when_home_unset() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::unset("LNS_INTEGRATIONS_PATH");
+        let _g2 = EnvVarGuard::unset("HOME");
+        assert_eq!(
+            default_integrations_path(),
+            PathBuf::from(".lns-integrations.yaml")
+        );
+    }
+}

--- a/crates/lns-policy/src/integrations.rs
+++ b/crates/lns-policy/src/integrations.rs
@@ -407,6 +407,29 @@ mod tests {
     }
 
     #[test]
+    fn bundled_gitlab_injects_both_private_token_for_glab_and_bearer_for_oauth_clients() {
+        let gitlab = bundled_integrations()
+            .iter()
+            .find(|i| i.id == "gitlab")
+            .expect("gitlab is bundled");
+        let injections = &gitlab.credential.as_ref().unwrap().injections;
+        assert!(
+            injections
+                .iter()
+                .any(|inj| inj.kind == InjectionKind::ApiKeyHeader
+                    && inj.domain == "gitlab.com"
+                    && inj.header.as_deref() == Some("PRIVATE-TOKEN")),
+            "glab sends its PAT in PRIVATE-TOKEN; expected an api_key_header injection for it, got: {injections:?}"
+        );
+        assert!(
+            injections
+                .iter()
+                .any(|inj| inj.kind == InjectionKind::BearerHeader && inj.domain == "gitlab.com"),
+            "Authorization: Bearer clients still need covering, got: {injections:?}"
+        );
+    }
+
+    #[test]
     fn every_bundled_integration_is_a_valid_credential_with_self_identifying_placeholder_and_routes()
      {
         for i in bundled_integrations() {

--- a/crates/lns-policy/src/integrations.yaml
+++ b/crates/lns-policy/src/integrations.yaml
@@ -7,6 +7,9 @@ integrations:
       envVar: GITLAB_TOKEN
       placeholder: glpat-LNSPLACEHOLDER0000000000000000
       injections:
+        - kind: api_key_header
+          domain: gitlab.com
+          header: PRIVATE-TOKEN
         - kind: bearer_header
           domain: gitlab.com
   - id: huggingface

--- a/crates/lns-policy/src/integrations.yaml
+++ b/crates/lns-policy/src/integrations.yaml
@@ -1,0 +1,22 @@
+integrations:
+  - id: gitlab
+    authKind: credential
+    routes:
+      - match: gitlab.com
+    credential:
+      envVar: GITLAB_TOKEN
+      placeholder: glpat-LNSPLACEHOLDER0000000000000000
+      injections:
+        - kind: bearer_header
+          domain: gitlab.com
+  - id: huggingface
+    authKind: credential
+    routes:
+      - match: huggingface.co
+      - match: "*.huggingface.co"
+    credential:
+      envVar: HF_TOKEN
+      placeholder: hf_LNSPLACEHOLDER0000000000000000000
+      injections:
+        - kind: bearer_header
+          domain: huggingface.co

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 pub mod credentials;
+pub mod integrations;
 pub mod providers;
 #[cfg(test)]
 mod test_env;
@@ -14,6 +15,8 @@ mod test_env;
 pub struct Policy {
     #[serde(default)]
     pub network: NetworkPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub integrations: Vec<String>,
     #[serde(default, skip_serializing_if = "CredentialsSection::is_empty")]
     pub credentials: CredentialsSection,
 }
@@ -50,6 +53,10 @@ impl Default for NetworkPolicy {
     }
 }
 
+pub(crate) fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RouteRule {
@@ -59,7 +66,22 @@ pub struct RouteRule {
     pub verdict: Verdict,
     pub transport: Transport,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<Scheme>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub tls_terminate: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<HttpRule>,
+}
+
+/// HTTP method/path restriction within a route rule; wire-compatible with lens-sandbox-core's `HttpRule`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HttpRule {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,6 +97,13 @@ pub enum Verdict {
 pub enum Transport {
     Upstream,
     Direct,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Scheme {
+    Http,
+    Https,
 }
 
 impl Policy {
@@ -104,6 +133,19 @@ impl Policy {
     pub fn add_rule(&mut self, rule: RouteRule) {
         self.network.allowed_routes.push(rule);
     }
+
+    pub fn connect(&mut self, id: impl Into<String>) {
+        let id = id.into();
+        if !self.integrations.contains(&id) {
+            self.integrations.push(id);
+        }
+    }
+
+    pub fn disconnect(&mut self, id: &str) -> bool {
+        let before = self.integrations.len();
+        self.integrations.retain(|i| i != id);
+        self.integrations.len() != before
+    }
 }
 
 pub trait PolicyStore: Send + Sync {
@@ -132,7 +174,10 @@ impl RouteRule {
             match_pattern: host.into(),
             verdict: Verdict::Allow,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         }
     }
 
@@ -141,7 +186,10 @@ impl RouteRule {
             match_pattern: host.into(),
             verdict: Verdict::Deny,
             transport: Transport::Direct,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         }
     }
 }
@@ -190,6 +238,59 @@ mod tests {
             !yaml.contains("matchPattern"),
             "rust field name leaked into wire format:\n{yaml}"
         );
+    }
+
+    #[test]
+    fn schemes_serialize_in_lowercase() {
+        assert_eq!(serde_yaml::to_string(&Scheme::Http).unwrap().trim(), "http");
+        assert_eq!(
+            serde_yaml::to_string(&Scheme::Https).unwrap().trim(),
+            "https"
+        );
+    }
+
+    #[test]
+    fn a_plain_route_omits_the_richness_keys() {
+        let yaml = serde_yaml::to_string(&RouteRule::allow_host("api.github.com")).unwrap();
+        assert!(
+            !yaml.contains("scheme") && !yaml.contains("tlsTerminate") && !yaml.contains("rules"),
+            "a plain allow rule must stay minimal:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn a_rich_route_rule_round_trips_with_sandbox_core_wire_names() {
+        let rule = RouteRule {
+            match_pattern: "gitlab.com".into(),
+            verdict: Verdict::Allow,
+            transport: Transport::Direct,
+            scheme: Some(Scheme::Https),
+            description: None,
+            tls_terminate: true,
+            rules: vec![HttpRule {
+                method: Some("GET".into()),
+                path: Some("/api/v4/**".into()),
+            }],
+        };
+        let yaml = serde_yaml::to_string(&rule).unwrap();
+        assert!(yaml.contains("scheme: https"), "got:\n{yaml}");
+        assert!(yaml.contains("tlsTerminate: true"), "got:\n{yaml}");
+        assert!(yaml.contains("path: /api/v4/**"), "got:\n{yaml}");
+        let parsed: RouteRule = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, rule);
+    }
+
+    #[test]
+    fn an_http_rule_omits_absent_method_and_path() {
+        let any = HttpRule {
+            method: None,
+            path: None,
+        };
+        let yaml = serde_yaml::to_string(&any).unwrap();
+        assert!(!yaml.contains("method"), "got:\n{yaml}");
+        assert!(!yaml.contains("path"), "got:\n{yaml}");
+        let parsed: HttpRule = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, any);
     }
 
     #[test]
@@ -364,7 +465,7 @@ network:
     }
 
     #[test]
-    fn legacy_network_only_yaml_parses_with_empty_custom_providers() {
+    fn legacy_network_only_yaml_parses_with_empty_custom_providers_and_integrations() {
         let yaml = "\
 network:
   allowedRoutes: []
@@ -373,5 +474,79 @@ network:
 ";
         let p: Policy = serde_yaml::from_str(yaml).unwrap();
         assert!(p.credentials.custom_providers.is_empty());
+        assert!(p.integrations.is_empty());
+    }
+
+    #[test]
+    fn default_policy_omits_the_integrations_key() {
+        let yaml = serde_yaml::to_string(&Policy::default()).unwrap();
+        assert!(
+            !yaml.contains("integrations"),
+            "an empty integrations list must not clutter the shareable file:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn policy_with_integrations_yaml_roundtrip_is_lossless() {
+        let mut p = Policy::default();
+        p.connect("gitlab");
+        p.connect("acme");
+        let yaml = serde_yaml::to_string(&p).unwrap();
+        assert!(yaml.contains("integrations"), "got:\n{yaml}");
+        let parsed: Policy = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn existing_custom_providers_yaml_still_parses_with_empty_integrations() {
+        let yaml = "\
+network:
+  allowedRoutes: []
+  defaultVerdict: ask
+  defaultTransport: direct
+credentials:
+  customProviders:
+    - id: acme
+      envVar: ACME_API_KEY
+      placeholder: acme_LNSPLACEHOLDER0000000000000000000000
+      injections:
+        - kind: bearer_header
+          domain: api.acme.corp
+";
+        let p: Policy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(p.credentials.custom_providers.len(), 1);
+        assert!(p.integrations.is_empty());
+    }
+
+    #[test]
+    fn connect_adds_an_integration_id() {
+        let mut p = Policy::default();
+        p.connect("github");
+        assert_eq!(p.integrations, ["github"]);
+    }
+
+    #[test]
+    fn connect_is_idempotent_and_does_not_duplicate() {
+        let mut p = Policy::default();
+        p.connect("github");
+        p.connect("github");
+        assert_eq!(p.integrations, ["github"]);
+    }
+
+    #[test]
+    fn disconnect_removes_an_applied_integration_and_reports_true() {
+        let mut p = Policy::default();
+        p.connect("github");
+        p.connect("gitlab");
+        assert!(p.disconnect("github"));
+        assert_eq!(p.integrations, ["gitlab"]);
+    }
+
+    #[test]
+    fn disconnect_reports_false_when_the_id_is_not_applied() {
+        let mut p = Policy::default();
+        p.connect("gitlab");
+        assert!(!p.disconnect("github"));
+        assert_eq!(p.integrations, ["gitlab"]);
     }
 }

--- a/crates/lns-service/src/approval_flow/protocol.rs
+++ b/crates/lns-service/src/approval_flow/protocol.rs
@@ -222,7 +222,10 @@ mod tests {
             match_pattern: "api.linear.app".into(),
             verdict: Verdict::Allow,
             transport: Transport::Upstream,
+            scheme: None,
             description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
         });
         let frame = HostFrame::Policy(PolicyMessage {
             network: Some(net),

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -188,6 +188,26 @@ impl ApprovalSession {
             ));
         }
     }
+
+    /// Connects an integration live: records it under `integrations:`, allows its routes, persists, and emits so a held request sees the routes (and, once the credential is valued, the injection) without a relaunch.
+    pub fn connect_integration(&self, id: &str, routes: Vec<RouteRule>) {
+        let snapshot = {
+            let mut policy = self.policy.lock().expect("policy mutex poisoned");
+            policy.connect(id);
+            policy.network.allowed_routes.extend(routes);
+            policy.clone()
+        };
+        let credentials = self.current_credentials();
+        let _ = self.sink.send(HostFrame::Policy(PolicyMessage {
+            network: Some(snapshot.network.clone()),
+            credentials,
+        }));
+        if let Err(e) = self.store.save(&snapshot) {
+            self.notifier.inform(&format!(
+                "integration connected in-memory but not persisted: {e}"
+            ));
+        }
+    }
 }
 
 fn rule_for_always_decision(host: &str, decision: Decision) -> Option<RouteRule> {
@@ -739,5 +759,39 @@ pub(crate) mod tests {
 
         let deny = rule_for_always_decision("h", Decision::DenyAlways).unwrap();
         assert_eq!(deny.verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn connect_integration_records_the_id_allows_routes_emits_and_persists() {
+        let (s, _n, store, mut rx) = fixture();
+        s.connect_integration("gitlab", vec![RouteRule::allow_host("gitlab.com")]);
+        let saves = store.saves.lock().unwrap();
+        assert_eq!(saves.len(), 1, "the connection is persisted once");
+        assert_eq!(saves[0].integrations, ["gitlab"]);
+        assert!(
+            saves[0]
+                .network
+                .allowed_routes
+                .iter()
+                .any(|r| r.match_pattern == "gitlab.com"),
+            "the integration's route is allowed"
+        );
+        drop(saves);
+        let v = serde_json::to_value(rx.try_recv().expect("policy frame")).unwrap();
+        assert_eq!(v["type"], "policy");
+        assert_eq!(
+            v["network"]["allowedRoutes"][0]["match"], "gitlab.com",
+            "the live frame carries the route so a held request can proceed"
+        );
+    }
+
+    #[test]
+    fn connect_integration_informs_when_persist_fails() {
+        let (s, n, store, _rx) = fixture();
+        store.fail_next(io::ErrorKind::PermissionDenied, "disk full");
+        s.connect_integration("gitlab", vec![RouteRule::allow_host("gitlab.com")]);
+        let informed = n.informed.lock().unwrap();
+        assert_eq!(informed.len(), 1);
+        assert!(informed[0].contains("not persisted"), "got: {:?}", informed);
     }
 }

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -189,20 +189,21 @@ impl ApprovalSession {
         }
     }
 
-    /// Connects an integration live: records it under `integrations:`, allows its routes, persists, and emits so a held request sees the routes (and, once the credential is valued, the injection) without a relaunch.
+    /// Connects an integration live: records the id under `integrations:` and persists only that, while the routes are applied to the in-memory policy and emitted so a held request sees them — boot re-derives the routes from the catalog, so persisting them would leave a residual allow that `disconnect` can't revoke.
     pub fn connect_integration(&self, id: &str, routes: Vec<RouteRule>) {
-        let snapshot = {
+        let (to_persist, live_network) = {
             let mut policy = self.policy.lock().expect("policy mutex poisoned");
             policy.connect(id);
+            let to_persist = policy.clone();
             policy.network.allowed_routes.extend(routes);
-            policy.clone()
+            (to_persist, policy.network.clone())
         };
         let credentials = self.current_credentials();
         let _ = self.sink.send(HostFrame::Policy(PolicyMessage {
-            network: Some(snapshot.network.clone()),
+            network: Some(live_network),
             credentials,
         }));
-        if let Err(e) = self.store.save(&snapshot) {
+        if let Err(e) = self.store.save(&to_persist) {
             self.notifier.inform(&format!(
                 "integration connected in-memory but not persisted: {e}"
             ));
@@ -762,26 +763,26 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn connect_integration_records_the_id_allows_routes_emits_and_persists() {
+    fn connect_integration_persists_only_the_id_but_emits_the_route_live() {
         let (s, _n, store, mut rx) = fixture();
         s.connect_integration("gitlab", vec![RouteRule::allow_host("gitlab.com")]);
         let saves = store.saves.lock().unwrap();
         assert_eq!(saves.len(), 1, "the connection is persisted once");
         assert_eq!(saves[0].integrations, ["gitlab"]);
         assert!(
-            saves[0]
+            !saves[0]
                 .network
                 .allowed_routes
                 .iter()
                 .any(|r| r.match_pattern == "gitlab.com"),
-            "the integration's route is allowed"
+            "the route must not be baked into the file — boot re-derives it from the catalog, so persisting it would survive `disconnect`"
         );
         drop(saves);
         let v = serde_json::to_value(rx.try_recv().expect("policy frame")).unwrap();
         assert_eq!(v["type"], "policy");
         assert_eq!(
             v["network"]["allowedRoutes"][0]["match"], "gitlab.com",
-            "the live frame carries the route so a held request can proceed"
+            "the live frame still carries the route so a held request can proceed"
         );
     }
 

--- a/crates/lns-service/src/credential_flow/integrations.rs
+++ b/crates/lns-service/src/credential_flow/integrations.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use lns_policy::integrations::{AuthKind, Integration};
 use lns_policy::providers::ProviderDef;
@@ -11,6 +11,25 @@ use crate::credential_flow::providers::DefProvider;
 pub struct AppliedIntegrations {
     pub providers: Vec<DefProvider>,
     pub routes: Vec<RouteRule>,
+}
+
+/// Catalog credential-integrations that aren't yet connected: seeded unarmed for detection, with their routes held ready to allow live on connect.
+#[derive(Default)]
+pub struct ConnectableIntegrations {
+    pub providers: Vec<DefProvider>,
+    pub routes: HashMap<String, Vec<RouteRule>>,
+}
+
+fn def_provider_from(
+    integ: &Integration,
+    cred: &lns_policy::integrations::CredentialAuth,
+) -> DefProvider {
+    DefProvider::new(ProviderDef {
+        id: integ.id.clone(),
+        env_var: cred.env_var.clone(),
+        placeholder: cred.placeholder.clone(),
+        injections: cred.injections.clone(),
+    })
 }
 
 /// Resolves the policy's applied integration ids against the effective catalog, skipping any id already owned by a built-in or a declared custom provider so the greenfield path never double-handles a service.
@@ -42,12 +61,41 @@ pub fn resolve_applied_integrations(
         if integ.auth_kind == AuthKind::Credential
             && let Some(cred) = &integ.credential
         {
-            out.providers.push(DefProvider::new(ProviderDef {
-                id: integ.id.clone(),
-                env_var: cred.env_var.clone(),
-                placeholder: cred.placeholder.clone(),
-                injections: cred.injections.clone(),
-            }));
+            out.providers.push(def_provider_from(integ, cred));
+        }
+    }
+    out
+}
+
+/// The catalog credential-integrations a run can offer to connect: every credential-kind entry not already owned by a built-in, a custom provider, or an applied integration.
+pub fn resolve_connectable_integrations(
+    policy: &Policy,
+    catalog: &[Integration],
+) -> ConnectableIntegrations {
+    let owned: HashSet<&str> = lns_policy::providers::builtins()
+        .iter()
+        .map(|p| p.id.as_str())
+        .chain(
+            policy
+                .credentials
+                .custom_providers
+                .iter()
+                .map(|p| p.id.as_str()),
+        )
+        .chain(policy.integrations.iter().map(String::as_str))
+        .collect();
+
+    let mut out = ConnectableIntegrations::default();
+    for integ in catalog {
+        if owned.contains(integ.id.as_str()) || integ.auth_kind != AuthKind::Credential {
+            continue;
+        }
+        if let Some(cred) = &integ.credential {
+            out.providers.push(def_provider_from(integ, cred));
+            out.routes.insert(
+                integ.id.clone(),
+                integ.routes.iter().map(|r| r.to_route_rule()).collect(),
+            );
         }
     }
     out
@@ -171,5 +219,66 @@ mod tests {
         let out = resolve_applied_integrations(&policy_applying(&["huggingface"]), &catalog);
         let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         assert_eq!(ids, ["huggingface"]);
+    }
+
+    #[test]
+    fn connectable_includes_an_unconnected_catalog_credential_integration() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        let c = resolve_connectable_integrations(&policy_applying(&[]), &catalog);
+        assert_eq!(c.providers.len(), 1);
+        assert_eq!(c.providers[0].id(), "gitlab");
+        assert_eq!(c.routes.get("gitlab").map(|r| r.len()), Some(1));
+    }
+
+    #[test]
+    fn connectable_excludes_an_already_applied_integration() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        let c = resolve_connectable_integrations(&policy_applying(&["gitlab"]), &catalog);
+        assert!(
+            c.providers.is_empty(),
+            "an applied integration is not connectable"
+        );
+        assert!(c.routes.is_empty());
+    }
+
+    #[test]
+    fn connectable_excludes_builtin_and_custom_provider_ids() {
+        let catalog = vec![
+            cred_integration("github", "GITHUB_TOKEN", "api.github.com"),
+            cred_integration("acme", "ACME_API_KEY", "api.acme.corp"),
+        ];
+        let mut policy = policy_applying(&[]);
+        policy.credentials.custom_providers.push(ProviderDef {
+            id: "acme".into(),
+            env_var: "ACME_API_KEY".into(),
+            placeholder: "acme_LNSPLACEHOLDER".into(),
+            injections: Vec::new(),
+        });
+        let c = resolve_connectable_integrations(&policy, &catalog);
+        assert!(
+            c.providers.is_empty(),
+            "built-in and custom-provider ids are already owned"
+        );
+    }
+
+    #[test]
+    fn connectable_excludes_an_oauth_integration() {
+        let catalog = vec![Integration {
+            id: "somesaas".into(),
+            auth_kind: AuthKind::Oauth,
+            routes: vec![IntegrationRoute {
+                match_pattern: "api.somesaas.com".into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: None,
+        }];
+        let c = resolve_connectable_integrations(&policy_applying(&[]), &catalog);
+        assert!(
+            c.providers.is_empty(),
+            "oauth can't be connected via the credential flow yet"
+        );
     }
 }

--- a/crates/lns-service/src/credential_flow/integrations.rs
+++ b/crates/lns-service/src/credential_flow/integrations.rs
@@ -1,0 +1,175 @@
+use std::collections::HashSet;
+
+use lns_policy::integrations::{AuthKind, Integration};
+use lns_policy::providers::ProviderDef;
+use lns_policy::{Policy, RouteRule};
+
+use crate::credential_flow::providers::DefProvider;
+
+/// The wire providers and routes a run's applied integrations contribute.
+#[derive(Default)]
+pub struct AppliedIntegrations {
+    pub providers: Vec<DefProvider>,
+    pub routes: Vec<RouteRule>,
+}
+
+/// Resolves the policy's applied integration ids against the effective catalog, skipping any id already owned by a built-in or a declared custom provider so the greenfield path never double-handles a service.
+pub fn resolve_applied_integrations(
+    policy: &Policy,
+    catalog: &[Integration],
+) -> AppliedIntegrations {
+    let already_owned: HashSet<&str> = lns_policy::providers::builtins()
+        .iter()
+        .map(|p| p.id.as_str())
+        .chain(
+            policy
+                .credentials
+                .custom_providers
+                .iter()
+                .map(|p| p.id.as_str()),
+        )
+        .collect();
+    let applied: HashSet<&str> = policy.integrations.iter().map(String::as_str).collect();
+
+    let mut out = AppliedIntegrations::default();
+    for integ in catalog {
+        let id = integ.id.as_str();
+        if !applied.contains(id) || already_owned.contains(id) {
+            continue;
+        }
+        out.routes
+            .extend(integ.routes.iter().map(|r| r.to_route_rule()));
+        if integ.auth_kind == AuthKind::Credential
+            && let Some(cred) = &integ.credential
+        {
+            out.providers.push(DefProvider::new(ProviderDef {
+                id: integ.id.clone(),
+                env_var: cred.env_var.clone(),
+                placeholder: cred.placeholder.clone(),
+                injections: cred.injections.clone(),
+            }));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential_flow::providers::Provider;
+    use lns_policy::integrations::{CredentialAuth, IntegrationRoute};
+    use lns_policy::providers::{InjectionDef, InjectionKind};
+
+    fn cred_integration(id: &str, env_var: &str, domain: &str) -> Integration {
+        Integration {
+            id: id.into(),
+            auth_kind: AuthKind::Credential,
+            routes: vec![IntegrationRoute {
+                match_pattern: domain.into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: Some(CredentialAuth {
+                env_var: env_var.into(),
+                placeholder: format!("lns-{id}-placeholder"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: domain.into(),
+                    header: None,
+                }],
+            }),
+        }
+    }
+
+    fn policy_applying(ids: &[&str]) -> Policy {
+        Policy {
+            integrations: ids.iter().map(|s| s.to_string()).collect(),
+            ..Policy::default()
+        }
+    }
+
+    #[test]
+    fn resolves_an_applied_credential_integration_into_a_provider_and_its_routes() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        let out = resolve_applied_integrations(&policy_applying(&["gitlab"]), &catalog);
+        assert_eq!(out.providers.len(), 1);
+        assert_eq!(out.providers[0].id(), "gitlab");
+        assert_eq!(out.providers[0].env_var(), "GITLAB_TOKEN");
+        assert_eq!(out.routes.len(), 1);
+        assert_eq!(out.routes[0].match_pattern, "gitlab.com");
+        assert_eq!(out.routes[0].verdict, lns_policy::Verdict::Allow);
+    }
+
+    #[test]
+    fn skips_a_catalog_integration_that_is_not_applied() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        let out = resolve_applied_integrations(&policy_applying(&[]), &catalog);
+        assert!(out.providers.is_empty());
+        assert!(out.routes.is_empty());
+    }
+
+    #[test]
+    fn skips_an_applied_id_that_collides_with_a_builtin() {
+        // A catalog entry mis-id'd as a built-in must never be resolved — the built-in owns it.
+        let catalog = vec![cred_integration("github", "GITHUB_TOKEN", "api.github.com")];
+        let out = resolve_applied_integrations(&policy_applying(&["github"]), &catalog);
+        assert!(out.providers.is_empty(), "built-in id must be skipped");
+        assert!(out.routes.is_empty());
+    }
+
+    #[test]
+    fn skips_an_applied_id_that_collides_with_a_declared_custom_provider() {
+        let catalog = vec![cred_integration("acme", "ACME_API_KEY", "api.acme.corp")];
+        let mut policy = policy_applying(&["acme"]);
+        policy.credentials.custom_providers.push(ProviderDef {
+            id: "acme".into(),
+            env_var: "ACME_API_KEY".into(),
+            placeholder: "acme_LNSPLACEHOLDER".into(),
+            injections: Vec::new(),
+        });
+        let out = resolve_applied_integrations(&policy, &catalog);
+        assert!(
+            out.providers.is_empty(),
+            "a declared custom provider owns the id; the integration path must defer"
+        );
+    }
+
+    #[test]
+    fn an_applied_oauth_integration_contributes_routes_but_no_provider() {
+        let catalog = vec![Integration {
+            id: "somesaas".into(),
+            auth_kind: AuthKind::Oauth,
+            routes: vec![IntegrationRoute {
+                match_pattern: "api.somesaas.com".into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: None,
+        }];
+        let out = resolve_applied_integrations(&policy_applying(&["somesaas"]), &catalog);
+        assert!(
+            out.providers.is_empty(),
+            "oauth has no static credential to inject yet"
+        );
+        assert_eq!(
+            out.routes.len(),
+            1,
+            "an integration's routes apply regardless of auth kind"
+        );
+    }
+
+    #[test]
+    fn resolves_only_the_applied_subset_of_a_multi_entry_catalog() {
+        let catalog = vec![
+            cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com"),
+            cred_integration("huggingface", "HF_TOKEN", "huggingface.co"),
+        ];
+        let out = resolve_applied_integrations(&policy_applying(&["huggingface"]), &catalog);
+        let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
+        assert_eq!(ids, ["huggingface"]);
+    }
+}

--- a/crates/lns-service/src/credential_flow/mod.rs
+++ b/crates/lns-service/src/credential_flow/mod.rs
@@ -1,6 +1,7 @@
 //! Wire frames live in [`crate::approval_flow::protocol`] so a single `HostFrame` / `GuestFrame` carries both the network and credential flows.
 
 pub mod detection;
+pub mod integrations;
 pub mod notification;
 pub mod providers;
 pub mod registry;

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -1,6 +1,6 @@
 //! The credential-rule source of truth lives in `~/.lns-credentials.json`, not `lns-policy.yaml`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -16,6 +16,9 @@ pub type FrameSink = mpsc::UnboundedSender<HostFrame>;
 
 /// Invoked after a state-changing decision so a follow-up `Policy` frame arms the matching injection.
 pub type PolicyEmitter = Box<dyn Fn(&CredentialStateFile) + Send + Sync>;
+
+/// Invoked when an un-connected catalog integration is accepted, to connect it live (allow its routes + persist `integrations:`).
+pub type ConnectEmitter = Box<dyn Fn(&str) + Send + Sync>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialPendingPrompt {
@@ -61,6 +64,8 @@ pub struct CredentialSession {
     policy_emitter: PolicyEmitter,
     timeout: Duration,
     custom_providers: Arc<Vec<DefProvider>>,
+    connectable: HashSet<String>,
+    connect: ConnectEmitter,
 }
 
 impl CredentialSession {
@@ -91,12 +96,25 @@ impl CredentialSession {
             policy_emitter,
             timeout,
             custom_providers: Arc::new(Vec::new()),
+            connectable: HashSet::new(),
+            connect: Box::new(|_| {}),
         }
     }
 
     /// Captures the run's custom providers once at construction so a mid-run policy edit can't retroactively change a running workload's placeholder set.
     pub fn with_custom_providers(mut self, custom_providers: Arc<Vec<DefProvider>>) -> Self {
         self.custom_providers = custom_providers;
+        self
+    }
+
+    /// Marks the catalog integrations that aren't connected yet: detecting one offers to connect, and accepting runs `connect` to allow its routes live.
+    pub fn with_connect_emitter(
+        mut self,
+        connectable: HashSet<String>,
+        connect: ConnectEmitter,
+    ) -> Self {
+        self.connectable = connectable;
+        self.connect = connect;
         self
     }
 
@@ -131,10 +149,15 @@ impl CredentialSession {
             },
         );
         drop(pending);
+        let action = if self.connectable.contains(&req.credential_id) {
+            format!("connect to {}", req.credential_id)
+        } else {
+            req.action
+        };
         self.notifier.present(&CredentialPendingPrompt {
             id: req.id,
             credential_id: req.credential_id,
-            action: req.action,
+            action,
         });
     }
 
@@ -155,7 +178,13 @@ impl CredentialSession {
         };
         self.notifier.dismiss(id);
         let kind = decision_kind_of(&request);
+        // Accepting an un-connected catalog integration connects it live (routes) before the value is armed, so the held request sees both.
+        let connect_now = matches!(request, CredentialDecisionRequest::Allow(_))
+            && self.connectable.contains(&credential_id);
         if let Some(entry) = persistent_entry(request) {
+            if connect_now {
+                (self.connect)(&credential_id);
+            }
             self.apply_persistent_entry(credential_id, entry);
         }
         for request_id in &request_ids {
@@ -937,5 +966,91 @@ mod tests {
             Some(CredentialEntry::Deny)
         );
         assert_eq!(persistent_entry(CredentialDecisionRequest::Timeout), None);
+    }
+
+    type ConnectableFixture = (
+        CredentialSession,
+        Arc<RecordingNotifier>,
+        Arc<CapturingStore>,
+        mpsc::UnboundedReceiver<HostFrame>,
+        Arc<StdMutex<Vec<String>>>,
+    );
+
+    fn fixture_connectable(connectable: &[&str]) -> ConnectableFixture {
+        let notifier = Arc::new(RecordingNotifier::default());
+        let store = Arc::new(CapturingStore::default());
+        let (tx, rx) = mpsc::unbounded_channel();
+        let connected = Arc::new(StdMutex::new(Vec::new()));
+        let connected_cb = connected.clone();
+        let set: HashSet<String> = connectable.iter().map(|s| s.to_string()).collect();
+        let session = CredentialSession::new(
+            CredentialStateFile::new(),
+            notifier.clone(),
+            store.clone(),
+            tx,
+            TEST_TIMEOUT,
+        )
+        .with_connect_emitter(
+            set,
+            Box::new(move |id| connected_cb.lock().unwrap().push(id.to_string())),
+        );
+        (session, notifier, store, rx, connected)
+    }
+
+    #[test]
+    fn submit_pending_flavors_the_action_as_connect_for_a_connectable_id() {
+        let (s, n, _store, _rx, _connected) = fixture_connectable(&["gitlab"]);
+        s.submit_pending(pending("c1", "gitlab"), Instant::now());
+        let p = n.presented.lock().unwrap();
+        assert_eq!(p[0].action, "connect to gitlab");
+    }
+
+    #[test]
+    fn allow_for_a_connectable_id_connects_live_and_records_the_value() {
+        let (s, _n, store, _rx, connected) = fixture_connectable(&["gitlab"]);
+        s.submit_pending(pending("c1", "gitlab"), Instant::now());
+        s.record_decision(
+            "c1",
+            CredentialDecisionRequest::Allow(CredentialEntry::HostDetect),
+        );
+        assert_eq!(
+            connected.lock().unwrap().as_slice(),
+            &["gitlab".to_string()],
+            "accepting a connectable id connects it"
+        );
+        assert_eq!(
+            store.saves.lock().unwrap()[0].get("gitlab"),
+            Some(&CredentialEntry::HostDetect),
+            "the value decision is still recorded"
+        );
+    }
+
+    #[test]
+    fn deny_for_a_connectable_id_does_not_connect() {
+        let (s, _n, store, _rx, connected) = fixture_connectable(&["gitlab"]);
+        s.submit_pending(pending("c1", "gitlab"), Instant::now());
+        s.record_decision("c1", CredentialDecisionRequest::Deny);
+        assert!(
+            connected.lock().unwrap().is_empty(),
+            "denying must not connect the integration"
+        );
+        assert_eq!(
+            store.saves.lock().unwrap()[0].get("gitlab"),
+            Some(&CredentialEntry::Deny)
+        );
+    }
+
+    #[test]
+    fn allow_for_a_non_connectable_id_does_not_connect() {
+        let (s, _n, _store, _rx, connected) = fixture_connectable(&[]);
+        s.submit_pending(pending("c1", "github"), Instant::now());
+        s.record_decision(
+            "c1",
+            CredentialDecisionRequest::Allow(CredentialEntry::HostDetect),
+        );
+        assert!(
+            connected.lock().unwrap().is_empty(),
+            "a built-in/connected id must not trigger a connect"
+        );
     }
 }

--- a/crates/lns-service/src/relay/adapter.rs
+++ b/crates/lns-service/src/relay/adapter.rs
@@ -152,7 +152,22 @@ async fn handle_connection(
     let resume_anchor = crate::audit::read_anchor_async(&anchor_path).await;
     let mut chain = lns_ipc::AuditChain::resuming_from_anchor(resume_anchor.as_ref());
     let mut anchor_sink = crate::audit::FileAnchorSink::new(anchor_path);
-    super::write_run_env_event(&user_env, &mut chain, &mut audit_file, &mut anchor_sink).await?;
+    let extra_managed: Vec<String> = {
+        use crate::credential_flow::providers::Provider;
+        credential_session
+            .custom_providers()
+            .iter()
+            .map(|p| p.env_var().to_string())
+            .collect()
+    };
+    super::write_run_env_event(
+        &user_env,
+        &extra_managed,
+        &mut chain,
+        &mut audit_file,
+        &mut anchor_sink,
+    )
+    .await?;
 
     let result = serve(
         &mut write,

--- a/crates/lns-service/src/relay/mod.rs
+++ b/crates/lns-service/src/relay/mod.rs
@@ -105,11 +105,12 @@ async fn write_chain_line<L: crate::audit::AuditLog, S: crate::audit::AnchorSink
 
 pub(super) async fn write_run_env_event<L: crate::audit::AuditLog, S: crate::audit::AnchorSink>(
     user_env: &[String],
+    extra_managed: &[String],
     chain: &mut lns_ipc::AuditChain,
     audit_file: &mut L,
     anchor_sink: &mut S,
 ) -> Result<()> {
-    let Some(obj) = crate::workload_env::injected_env_audit(user_env) else {
+    let Some(obj) = crate::workload_env::injected_env_audit(user_env, extra_managed) else {
         return Ok(());
     };
     let bytes = chain.augment_obj(obj);
@@ -694,6 +695,7 @@ mod tests {
         let mut anchor = MemAnchor::default();
         write_run_env_event(
             &["CLAUDE_CODE_USE_BEDROCK=1".into()],
+            &[],
             &mut chain,
             &mut log,
             &mut anchor,
@@ -722,7 +724,7 @@ mod tests {
         let mut chain = lns_ipc::AuditChain::new();
         let mut log = MemLog::default();
         let mut anchor = MemAnchor::default();
-        write_run_env_event(&[], &mut chain, &mut log, &mut anchor)
+        write_run_env_event(&[], &[], &mut chain, &mut log, &mut anchor)
             .await
             .expect("write_run_env_event");
         assert!(log.bytes.is_empty(), "no injected env → no audit line");

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -48,6 +48,7 @@ pub(super) fn exec_env_strings(
     override_cmd: &[String],
     user_env: &[String],
     supervised: bool,
+    extra_managed: &[String],
 ) -> crate::workload_env::WorkloadEnv {
     let agent_command = supervised.then(|| match image_config {
         Some(cfg) => crate::workload_argv::from_image_config(cfg, override_cmd),
@@ -56,7 +57,12 @@ pub(super) fn exec_env_strings(
     let image_env = image_config
         .and_then(|c| c.config.as_ref())
         .and_then(|c| c.env.as_deref());
-    crate::workload_env::run_workload_env(image_env, user_env, agent_command.as_deref())
+    crate::workload_env::run_workload_env(
+        image_env,
+        user_env,
+        agent_command.as_deref(),
+        extra_managed,
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -155,7 +161,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn exec_env_strings_supervised_derives_agent_command_from_the_override_cmd() {
-        let env = exec_env_strings(None, &["echo".into(), "hi".into()], &[], true);
+        let env = exec_env_strings(None, &["echo".into(), "hi".into()], &[], true, &[]);
         assert!(
             env.env.contains(&"AGENT_COMMAND=echo hi".to_string()),
             "expected AGENT_COMMAND in supervised env, got: {env:?}"
@@ -174,6 +180,7 @@ mod tests {
             ],
             &[],
             true,
+            &[],
         );
         let agent = env
             .env
@@ -194,6 +201,7 @@ mod tests {
             &["echo".into(), "hi".into()],
             &["FOO=bar".into()],
             false,
+            &[],
         );
         assert_eq!(
             env.env,
@@ -234,7 +242,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let env = exec_env_strings(Some(&cfg), &[], &[], true);
+        let env = exec_env_strings(Some(&cfg), &[], &[], true, &[]);
         assert!(env.env.contains(&"AGENT_COMMAND=/srv arg".to_string()));
     }
 
@@ -250,7 +258,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let env = exec_env_strings(Some(&cfg), &[], &["PORT=4000".into()], true);
+        let env = exec_env_strings(Some(&cfg), &[], &["PORT=4000".into()], true, &[]);
         assert!(
             env.env.contains(&"PORT=4000".to_string()),
             "user overrides image: {env:?}"

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -210,6 +210,10 @@ async fn orchestrate(
             &args.cmd,
             &args.env,
             session.is_some(),
+            session
+                .as_ref()
+                .map(|s| s.managed_env_vars.as_slice())
+                .unwrap_or(&[]),
         );
         for refused in &composed.refused {
             let _ = frame_tx

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -13,7 +14,9 @@ use crate::approval_flow::protocol::PolicyMessage;
 use crate::approval_flow::session::ApprovalSession;
 use crate::approval_flow::watcher::PolicyWatcher;
 use crate::approval_flow::window::{self, CredentialDecisionDelivery, DecisionDelivery};
-use crate::credential_flow::integrations::resolve_applied_integrations;
+use crate::credential_flow::integrations::{
+    resolve_applied_integrations, resolve_connectable_integrations,
+};
 use crate::credential_flow::notification::WindowCredentialNotifier;
 use crate::credential_flow::providers::{self, DefProvider, Provider};
 use crate::credential_flow::registry::expand_credentials_for_wire_with_custom;
@@ -24,7 +27,7 @@ use crate::credential_flow::store::{
 use crate::credential_flow::watcher::CredentialWatcher;
 use crate::log;
 use crate::relay;
-use lns_policy::{FilePolicyStore, Policy};
+use lns_policy::{FilePolicyStore, Policy, RouteRule};
 
 use super::real::RealFs;
 use super::traits::{Fs, WritableFile};
@@ -250,6 +253,17 @@ fn make_policy_emitter(
     })
 }
 
+/// Connecting an un-connected catalog integration allows its routes on the approval session's live policy (and persists `integrations:`), so the held request proceeds without a relaunch.
+fn make_connect_emitter(
+    session: Arc<ApprovalSession>,
+    routes: Arc<HashMap<String, Vec<RouteRule>>>,
+) -> crate::credential_flow::session::ConnectEmitter {
+    Box::new(move |id| {
+        let rules = routes.get(id).cloned().unwrap_or_default();
+        session.connect_integration(id, rules);
+    })
+}
+
 type CredentialSubsystem = (
     Arc<CredentialSession>,
     crate::credential_flow::watcher::CredentialWatcher,
@@ -259,6 +273,8 @@ fn start_credential_subsystem(
     session: Arc<ApprovalSession>,
     credential_frame_tx: tokio::sync::mpsc::UnboundedSender<HostFrame>,
     custom_providers: Arc<Vec<DefProvider>>,
+    connectable_ids: HashSet<String>,
+    connectable_routes: Arc<HashMap<String, Vec<RouteRule>>>,
 ) -> Result<CredentialSubsystem> {
     // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
     let credentials_path = default_credentials_path();
@@ -278,6 +294,7 @@ fn start_credential_subsystem(
         credential_frame_tx.clone(),
         custom_providers.clone(),
     );
+    let connect_emitter = make_connect_emitter(session.clone(), connectable_routes);
     let credential_session = Arc::new(
         CredentialSession::with_policy_emitter(
             initial_credential_state,
@@ -287,7 +304,8 @@ fn start_credential_subsystem(
             APPROVAL_TIMEOUT,
             policy_emitter,
         )
-        .with_custom_providers(custom_providers),
+        .with_custom_providers(custom_providers)
+        .with_connect_emitter(connectable_ids, connect_emitter),
     );
 
     tokio::spawn(credential_delivery_loop(
@@ -320,9 +338,18 @@ pub(super) async fn start(
         load_user_catalog_or_warn(&lns_policy::integrations::default_integrations_path());
     let catalog = lns_policy::integrations::effective_integrations(&user_catalog);
     let applied = resolve_applied_integrations(&policy, &catalog);
+    // Un-connected catalog integrations are seeded unarmed so their use offers a live connect.
+    let connectable = resolve_connectable_integrations(&policy, &catalog);
     policy.network.allowed_routes.extend(applied.routes);
+    let connectable_ids: HashSet<String> = connectable
+        .providers
+        .iter()
+        .map(|p| p.id().to_string())
+        .collect();
+    let connectable_routes = Arc::new(connectable.routes);
     let mut custom = providers::build_policy_providers(&policy);
     custom.extend(applied.providers);
+    custom.extend(connectable.providers);
     let custom_providers = Arc::new(custom);
     let managed_env_vars = collect_managed_env_vars(&custom_providers);
 
@@ -358,8 +385,13 @@ pub(super) async fn start(
     let watcher = PolicyWatcher::spawn(policy_path.to_path_buf(), session.clone())
         .with_context(|| format!("watching policy {}", policy_path.display()))?;
 
-    let (credential_session, credential_watcher) =
-        start_credential_subsystem(session.clone(), credential_frame_tx, custom_providers)?;
+    let (credential_session, credential_watcher) = start_credential_subsystem(
+        session.clone(),
+        credential_frame_tx,
+        custom_providers,
+        connectable_ids,
+        connectable_routes,
+    )?;
 
     let supervisor_bin = ensure().await?;
     let relay = relay::spawn(run_id, session, credential_session, frame_rx, user_env)?;
@@ -694,6 +726,38 @@ mod tests {
     #[test]
     fn collect_managed_env_vars_lists_each_run_providers_env_var() {
         assert_eq!(collect_managed_env_vars(&acme_custom()), ["ACME_API_KEY"]);
+    }
+
+    #[test]
+    fn make_connect_emitter_connects_the_integration_on_the_approval_session() {
+        let (session, mut rx) = fixture_session();
+        while rx.try_recv().is_ok() {}
+        let mut routes = HashMap::new();
+        routes.insert(
+            "gitlab".to_string(),
+            vec![lns_policy::RouteRule::allow_host("gitlab.com")],
+        );
+        let connect = make_connect_emitter(session.clone(), Arc::new(routes));
+        connect("gitlab");
+        assert_eq!(session.current_policy().integrations, ["gitlab"]);
+        assert!(
+            session
+                .current_policy()
+                .network
+                .allowed_routes
+                .iter()
+                .any(|r| r.match_pattern == "gitlab.com"),
+            "the integration's route is allowed live"
+        );
+        assert!(rx.try_recv().is_ok(), "a Policy frame is emitted");
+    }
+
+    #[test]
+    fn make_connect_emitter_with_no_routes_for_an_id_still_connects_it() {
+        let (session, _rx) = fixture_session();
+        let connect = make_connect_emitter(session.clone(), Arc::new(HashMap::new()));
+        connect("gitlab");
+        assert_eq!(session.current_policy().integrations, ["gitlab"]);
     }
 
     #[test]

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -13,6 +13,7 @@ use crate::approval_flow::protocol::PolicyMessage;
 use crate::approval_flow::session::ApprovalSession;
 use crate::approval_flow::watcher::PolicyWatcher;
 use crate::approval_flow::window::{self, CredentialDecisionDelivery, DecisionDelivery};
+use crate::credential_flow::integrations::resolve_applied_integrations;
 use crate::credential_flow::notification::WindowCredentialNotifier;
 use crate::credential_flow::providers::{self, DefProvider};
 use crate::credential_flow::registry::expand_credentials_for_wire_with_custom;
@@ -187,6 +188,20 @@ fn load_credentials_or_warn(store: &dyn CredentialStore, path: &Path) -> Credent
     }
 }
 
+/// Defaults to an empty user catalog and warns on load error, so a malformed `~/.lns-integrations.yaml` doesn't break a run — the bundled catalog still applies.
+fn load_user_catalog_or_warn(path: &Path) -> lns_policy::integrations::Catalog {
+    match lns_policy::integrations::Catalog::load_or_default(path) {
+        Ok(catalog) => catalog,
+        Err(e) => {
+            let path_str = path.display();
+            log::warn!(
+                "could not load {path_str} ({e}); using the bundled integration catalog only"
+            );
+            lns_policy::integrations::Catalog::default()
+        }
+    }
+}
+
 /// `Weak` so the closure doesn't keep the credential session alive past the run; a dropped session yields an empty list.
 fn make_credentials_provider(
     credential_session: &Arc<CredentialSession>,
@@ -293,10 +308,17 @@ pub(super) async fn start(
     guest_tools_root: PathBuf,
     user_env: Vec<String>,
 ) -> Result<SupervisorSession> {
-    let policy = Policy::load_or_default(policy_path)
+    let mut policy = Policy::load_or_default(policy_path)
         .with_context(|| format!("loading policy {}", policy_path.display()))?;
-    // Captured once here so the run's placeholder set is fixed at boot; a later policy edit can't reach an already-forked workload.
-    let custom_providers = Arc::new(providers::build_policy_providers(&policy));
+    // Applied integrations resolve against the effective catalog (bundled ∪ user) into both wire credentials and allow-routes, captured once at boot so a later edit can't reach an already-forked workload.
+    let user_catalog =
+        load_user_catalog_or_warn(&lns_policy::integrations::default_integrations_path());
+    let catalog = lns_policy::integrations::effective_integrations(&user_catalog);
+    let applied = resolve_applied_integrations(&policy, &catalog);
+    policy.network.allowed_routes.extend(applied.routes);
+    let mut custom = providers::build_policy_providers(&policy);
+    custom.extend(applied.providers);
+    let custom_providers = Arc::new(custom);
 
     let window_state = window::get().context(
         "approval window state was not installed at boot; \
@@ -542,6 +564,43 @@ mod tests {
         assert!(
             state.is_empty(),
             "malformed credentials file must surface as empty in-memory state, got {state:?}"
+        );
+    }
+
+    #[test]
+    fn load_user_catalog_or_warn_reads_an_existing_user_catalog() {
+        use lns_policy::integrations::{AuthKind, Catalog, CredentialAuth, Integration};
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join(".lns-integrations.yaml");
+        Catalog {
+            integrations: vec![Integration {
+                id: "acme".into(),
+                auth_kind: AuthKind::Credential,
+                routes: Vec::new(),
+                credential: Some(CredentialAuth {
+                    env_var: "ACME_API_KEY".into(),
+                    placeholder: "acme_LNSPLACEHOLDER".into(),
+                    injections: Vec::new(),
+                }),
+            }],
+        }
+        .save_atomic(&path)
+        .unwrap();
+        let catalog = load_user_catalog_or_warn(&path);
+        assert_eq!(catalog.integrations.len(), 1);
+        assert_eq!(catalog.integrations[0].id, "acme");
+    }
+
+    #[test]
+    fn load_user_catalog_or_warn_defaults_to_empty_and_warns_on_load_error() {
+        init_tracing_capture();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join(".lns-integrations.yaml");
+        std::fs::write(&path, "integrations: not-a-list\n").unwrap();
+        let catalog = load_user_catalog_or_warn(&path);
+        assert!(
+            catalog.integrations.is_empty(),
+            "a malformed user catalog must surface as empty so the run still gets the bundled set"
         );
     }
 

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -15,7 +15,7 @@ use crate::approval_flow::watcher::PolicyWatcher;
 use crate::approval_flow::window::{self, CredentialDecisionDelivery, DecisionDelivery};
 use crate::credential_flow::integrations::resolve_applied_integrations;
 use crate::credential_flow::notification::WindowCredentialNotifier;
-use crate::credential_flow::providers::{self, DefProvider};
+use crate::credential_flow::providers::{self, DefProvider, Provider};
 use crate::credential_flow::registry::expand_credentials_for_wire_with_custom;
 use crate::credential_flow::session::CredentialSession;
 use crate::credential_flow::store::{
@@ -202,6 +202,11 @@ fn load_user_catalog_or_warn(path: &Path) -> lns_policy::integrations::Catalog {
     }
 }
 
+/// The env vars seeded as placeholders for this run's custom providers + connected integrations; stripped from `-e` so a real secret can't bypass the placeholder. Built-ins are handled globally by `is_managed_env`.
+fn collect_managed_env_vars(providers: &[DefProvider]) -> Vec<String> {
+    providers.iter().map(|p| p.env_var().to_string()).collect()
+}
+
 /// `Weak` so the closure doesn't keep the credential session alive past the run; a dropped session yields an empty list.
 fn make_credentials_provider(
     credential_session: &Arc<CredentialSession>,
@@ -319,6 +324,7 @@ pub(super) async fn start(
     let mut custom = providers::build_policy_providers(&policy);
     custom.extend(applied.providers);
     let custom_providers = Arc::new(custom);
+    let managed_env_vars = collect_managed_env_vars(&custom_providers);
 
     let window_state = window::get().context(
         "approval window state was not installed at boot; \
@@ -367,6 +373,7 @@ pub(super) async fn start(
         relay,
         watcher: Some(watcher),
         credential_watcher: Some(credential_watcher),
+        managed_env_vars,
     })
 }
 
@@ -682,6 +689,11 @@ mod tests {
                 header: None,
             }],
         })])
+    }
+
+    #[test]
+    fn collect_managed_env_vars_lists_each_run_providers_env_var() {
+        assert_eq!(collect_managed_env_vars(&acme_custom()), ["ACME_API_KEY"]);
     }
 
     #[test]

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -65,6 +65,8 @@ pub struct SupervisorSession {
     pub watcher: Option<crate::approval_flow::watcher::PolicyWatcher>,
     // Mirror of `watcher` for the credential state file.
     pub credential_watcher: Option<crate::credential_flow::watcher::CredentialWatcher>,
+    // Env vars of the run's custom providers + connected integrations, stripped from `-e` so a real secret can't bypass the placeholder.
+    pub managed_env_vars: Vec<String>,
 }
 
 impl SupervisorSession {

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -624,6 +624,7 @@ mod tests {
             },
             watcher: None,
             credential_watcher: None,
+            managed_env_vars: Vec::new(),
         }
     }
 

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -7,13 +7,21 @@ pub struct WorkloadEnv {
     pub refused: Vec<String>,
 }
 
-pub fn injected_env_audit(user_env: &[String]) -> Option<Map<String, Value>> {
+/// A var is managed if a built-in claims it or the run's custom providers / connected integrations declare it; managed vars are seeded as placeholders, never carried from `-e`.
+fn is_run_managed(env_var: &str, extra_managed: &[String]) -> bool {
+    providers::is_managed_env(env_var) || extra_managed.iter().any(|m| m == env_var)
+}
+
+pub fn injected_env_audit(
+    user_env: &[String],
+    extra_managed: &[String],
+) -> Option<Map<String, Value>> {
     let mut env = Map::new();
     for kv in user_env {
         let Some((k, v)) = kv.split_once('=') else {
             continue;
         };
-        if providers::is_managed_env(k) {
+        if is_run_managed(k, extra_managed) {
             continue;
         }
         env.insert(k.to_string(), Value::String(v.to_string()));
@@ -29,7 +37,11 @@ pub fn injected_env_audit(user_env: &[String]) -> Option<Map<String, Value>> {
     Some(obj)
 }
 
-pub fn compose_workload_env(image_env: Option<&[String]>, user_env: &[String]) -> WorkloadEnv {
+pub fn compose_workload_env(
+    image_env: Option<&[String]>,
+    user_env: &[String],
+    extra_managed: &[String],
+) -> WorkloadEnv {
     let mut entries: Vec<(String, String)> = Vec::new();
     if let Some(image) = image_env {
         for kv in image {
@@ -43,7 +55,7 @@ pub fn compose_workload_env(image_env: Option<&[String]>, user_env: &[String]) -
         let Some((k, v)) = kv.split_once('=') else {
             continue;
         };
-        if providers::is_managed_env(k) {
+        if is_run_managed(k, extra_managed) {
             refused.push(k.to_string());
             continue;
         }
@@ -62,9 +74,10 @@ pub fn run_workload_env(
     image_env: Option<&[String]>,
     user_env: &[String],
     agent_command: Option<&str>,
+    extra_managed: &[String],
 ) -> WorkloadEnv {
     const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
-    let mut composed = compose_workload_env(image_env, user_env);
+    let mut composed = compose_workload_env(image_env, user_env, extra_managed);
     if let Some(agent_command) = agent_command {
         // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the supervisor PTY opt-in or the command.
         composed.env.push(format!("AGENT_COMMAND={agent_command}"));
@@ -97,72 +110,87 @@ mod tests {
 
     #[test]
     fn a_single_user_var_is_carried() {
-        let c = compose_workload_env(None, &["CLAUDE_CODE_USE_BEDROCK=1".into()]);
+        let c = compose_workload_env(None, &["CLAUDE_CODE_USE_BEDROCK=1".into()], &[]);
         assert_eq!(env(&c), ["CLAUDE_CODE_USE_BEDROCK=1"]);
         assert!(c.refused.is_empty());
     }
 
     #[test]
     fn multiple_user_vars_are_all_carried() {
-        let c = compose_workload_env(None, &["A=1".into(), "B=2".into()]);
+        let c = compose_workload_env(None, &["A=1".into(), "B=2".into()], &[]);
         assert!(c.env.contains(&"A=1".to_string()));
         assert!(c.env.contains(&"B=2".to_string()));
     }
 
     #[test]
     fn value_is_split_on_the_first_equals_only() {
-        let c = compose_workload_env(None, &["DSN=user=admin;pw=x".into()]);
+        let c = compose_workload_env(None, &["DSN=user=admin;pw=x".into()], &[]);
         assert_eq!(env(&c), ["DSN=user=admin;pw=x"]);
     }
 
     #[test]
     fn an_empty_value_is_preserved() {
-        let c = compose_workload_env(None, &["FEATURE_X=".into()]);
+        let c = compose_workload_env(None, &["FEATURE_X=".into()], &[]);
         assert_eq!(env(&c), ["FEATURE_X="]);
     }
 
     #[test]
     fn user_value_overrides_the_image_env() {
-        let c = compose_workload_env(Some(&["PORT=3003".into()]), &["PORT=4000".into()]);
+        let c = compose_workload_env(Some(&["PORT=3003".into()]), &["PORT=4000".into()], &[]);
         assert_eq!(env(&c), ["PORT=4000"]);
     }
 
     #[test]
     fn image_vars_not_overridden_are_kept() {
-        let c = compose_workload_env(Some(&["FOO=bar".into()]), &["BAZ=1".into()]);
+        let c = compose_workload_env(Some(&["FOO=bar".into()]), &["BAZ=1".into()], &[]);
         assert!(c.env.contains(&"FOO=bar".to_string()));
         assert!(c.env.contains(&"BAZ=1".to_string()));
     }
 
     #[test]
     fn a_user_override_of_a_managed_credential_is_refused_and_dropped() {
-        let c = compose_workload_env(None, &["GITHUB_TOKEN=ghp_real".into()]);
+        let c = compose_workload_env(None, &["GITHUB_TOKEN=ghp_real".into()], &[]);
         assert!(c.env.is_empty(), "credential var must not reach workload");
         assert_eq!(c.refused, ["GITHUB_TOKEN"]);
     }
 
     #[test]
+    fn a_connected_integrations_env_var_is_refused_and_dropped() {
+        let c = compose_workload_env(
+            None,
+            &["GITLAB_TOKEN=glpat_real".into(), "SAFE=1".into()],
+            &["GITLAB_TOKEN".to_string()],
+        );
+        assert_eq!(
+            c.env,
+            ["SAFE=1"],
+            "the integration token must not reach the workload"
+        );
+        assert_eq!(c.refused, ["GITLAB_TOKEN"]);
+    }
+
+    #[test]
     fn a_malformed_user_entry_without_equals_is_ignored() {
-        let c = compose_workload_env(None, &["NOTANASSIGNMENT".into()]);
+        let c = compose_workload_env(None, &["NOTANASSIGNMENT".into()], &[]);
         assert!(c.env.is_empty());
         assert!(c.refused.is_empty());
     }
 
     #[test]
     fn a_malformed_image_entry_without_equals_is_ignored() {
-        let c = compose_workload_env(Some(&["JUSTAKEY".into()]), &[]);
+        let c = compose_workload_env(Some(&["JUSTAKEY".into()]), &[], &[]);
         assert!(c.env.is_empty());
     }
 
     #[test]
     fn run_workload_env_carries_user_env_for_an_unsupervised_run() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None);
+        let c = run_workload_env(None, &["FOO=bar".into()], None, &[]);
         assert_eq!(c.env, ["FOO=bar"], "user -e must reach a policy-less run");
     }
 
     #[test]
     fn run_workload_env_adds_no_supervisor_vars_when_unsupervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None);
+        let c = run_workload_env(None, &["FOO=bar".into()], None, &[]);
         assert!(
             !c.env
                 .iter()
@@ -174,7 +202,7 @@ mod tests {
 
     #[test]
     fn run_workload_env_appends_agent_command_and_term_when_supervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], Some("echo hi"));
+        let c = run_workload_env(None, &["FOO=bar".into()], Some("echo hi"), &[]);
         assert!(c.env.contains(&"FOO=bar".to_string()), "got: {:?}", c.env);
         assert!(c.env.contains(&"AGENT_COMMAND=echo hi".to_string()));
         assert!(c.env.contains(&"TERM=xterm-256color".to_string()));
@@ -182,15 +210,27 @@ mod tests {
 
     #[test]
     fn run_workload_env_keeps_supervisor_term_after_a_user_term_so_it_cannot_be_clobbered() {
-        let c = run_workload_env(None, &["TERM=dumb".into()], Some("sh"));
+        let c = run_workload_env(None, &["TERM=dumb".into()], Some("sh"), &[]);
         let last_term = c.env.iter().rposition(|e| e.starts_with("TERM=")).unwrap();
         assert_eq!(c.env[last_term], "TERM=xterm-256color");
     }
 
     #[test]
     fn run_workload_env_surfaces_refused_credentials() {
-        let c = run_workload_env(None, &["GITHUB_TOKEN=x".into()], None);
+        let c = run_workload_env(None, &["GITHUB_TOKEN=x".into()], None, &[]);
         assert_eq!(c.refused, ["GITHUB_TOKEN"]);
+        assert!(c.env.is_empty());
+    }
+
+    #[test]
+    fn run_workload_env_refuses_a_connected_integration_var_via_extra_managed() {
+        let c = run_workload_env(
+            None,
+            &["GITLAB_TOKEN=real".into()],
+            None,
+            &["GITLAB_TOKEN".to_string()],
+        );
+        assert_eq!(c.refused, ["GITLAB_TOKEN"]);
         assert!(c.env.is_empty());
     }
 
@@ -203,7 +243,8 @@ mod tests {
 
     #[test]
     fn injected_env_audit_records_non_credential_vars() {
-        let obj = injected_env_audit(&["CLAUDE_CODE_USE_BEDROCK=1".into()]).expect("event built");
+        let obj =
+            injected_env_audit(&["CLAUDE_CODE_USE_BEDROCK=1".into()], &[]).expect("event built");
         assert_eq!(obj.get("type").unwrap(), "audit_event");
         assert_eq!(obj.get("event").unwrap(), "run_env");
         let env = obj.get("env").unwrap().as_object().unwrap();
@@ -223,21 +264,36 @@ mod tests {
     #[test]
     fn injected_env_audit_omits_managed_credentials() {
         let obj =
-            injected_env_audit(&["A=1".into(), "GITHUB_TOKEN=x".into()]).expect("event built");
+            injected_env_audit(&["A=1".into(), "GITHUB_TOKEN=x".into()], &[]).expect("event built");
         let env = obj.get("env").unwrap().as_object().unwrap();
         assert!(env.contains_key("A"));
         assert!(!env.contains_key("GITHUB_TOKEN"));
     }
 
     #[test]
+    fn injected_env_audit_omits_a_connected_integrations_value_from_the_log() {
+        let obj = injected_env_audit(
+            &["A=1".into(), "GITLAB_TOKEN=glpat_real".into()],
+            &["GITLAB_TOKEN".to_string()],
+        )
+        .expect("event built");
+        let env = obj.get("env").unwrap().as_object().unwrap();
+        assert!(env.contains_key("A"));
+        assert!(
+            !env.contains_key("GITLAB_TOKEN"),
+            "a connected integration's real token must never land in the audit log"
+        );
+    }
+
+    #[test]
     fn injected_env_audit_is_none_when_nothing_is_injected() {
-        assert!(injected_env_audit(&[]).is_none());
-        assert!(injected_env_audit(&["GITHUB_TOKEN=x".into()]).is_none());
+        assert!(injected_env_audit(&[], &[]).is_none());
+        assert!(injected_env_audit(&["GITHUB_TOKEN=x".into()], &[]).is_none());
     }
 
     #[test]
     fn injected_env_audit_skips_malformed_entries() {
-        let obj = injected_env_audit(&["NOEQUALS".into(), "A=1".into()]).expect("event built");
+        let obj = injected_env_audit(&["NOEQUALS".into(), "A=1".into()], &[]).expect("event built");
         let env = obj.get("env").unwrap().as_object().unwrap();
         assert!(!env.contains_key("NOEQUALS"));
         assert!(env.contains_key("A"));

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn injected_env_audit_stamps_host_origin() {
-        let obj = injected_env_audit(&["A=1".into()]).expect("event built");
+        let obj = injected_env_audit(&["A=1".into()], &[]).expect("event built");
         assert_eq!(
             obj.get("origin").unwrap(),
             "host",

--- a/crates/lns-service/tests/behaviours/steps/env_injection.rs
+++ b/crates/lns-service/tests/behaviours/steps/env_injection.rs
@@ -38,7 +38,7 @@ fn given_registry_seeds(_world: &mut BehaviourWorld) {
 fn when_user_runs(world: &mut BehaviourWorld, cmd: String) {
     let user_env = user_env_from(&cmd);
     let image_env = world.image_env.clone();
-    world.composed_env = Some(run_workload_env(image_env.as_deref(), &user_env, None));
+    world.composed_env = Some(run_workload_env(image_env.as_deref(), &user_env, None, &[]));
     world.user_env = user_env;
 }
 
@@ -112,7 +112,7 @@ fn then_audit_records(
     key: String,
     value: String,
 ) -> Result<(), String> {
-    let obj = lns_service::workload_env::injected_env_audit(&world.user_env)
+    let obj = lns_service::workload_env::injected_env_audit(&world.user_env, &[])
         .ok_or("no run_env audit event was built")?;
     let env = obj
         .get("env")

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ You drive everything through one binary: the `lns` CLI.
   `ask` verdict, the approval window, and editing rules with `lns policy`.
 - **[Credentials](credentials.md)** — how placeholders keep real secrets out of
   the workload, the built-in providers, and managing them with `lns credential`.
+- **[Integrations](integrations.md)** — connect workloads to external services
+  (credential injection + the routes they need) with `lns integration` and
+  `lns connect`.
 - **[Audit](audit.md)** — the per-run audit chain and verifying it with
   `lns audit`.
 - **[The background service](service.md)** — what `lns-service` does and managing

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -145,4 +145,6 @@ static placeholder — it carries real STS material.
 
 - [Policy and approvals](policy.md) — credential decisions follow the same
   allow / deny / ask model as network rules.
+- [Integrations](integrations.md) — bundle a provider's injection with the routes
+  it needs into a connectable service.
 - [CLI reference](cli-reference.md) — the full `lns credential` flag list.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -91,9 +91,16 @@ integrations:
       envVar: GITLAB_TOKEN
       placeholder: glpat-LNSPLACEHOLDER0000000000000000
       injections:
+        - kind: api_key_header
+          domain: gitlab.com
+          header: PRIVATE-TOKEN
         - kind: bearer_header
           domain: gitlab.com
 ```
+
+An entry may list several injections so one credential reaches a service however its
+clients send it — here both the `PRIVATE-TOKEN` header `glab` uses and the
+`Authorization: Bearer` form OAuth-style clients send.
 
 A route may carry the same detail a [policy rule](policy.md#rules) can — a `scheme`
 and HTTP method/path `rules` for least-privilege access — beyond the bare `match`.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,110 @@
+# Integrations
+
+An **integration** teaches Lens Sandbox how to connect a workload to an external
+service — bundling the service's credential injection *and* the network routes it
+needs into one named, reusable unit. Connecting GitLab to a project, for example,
+both allows `gitlab.com` and arranges for a `GITLAB_TOKEN` placeholder to be swapped
+for your real token at the boundary (see [Credentials](credentials.md) for how
+placeholders work).
+
+## The catalog
+
+The set of integrations Lens Sandbox knows about is a **catalog** with two layers:
+
+- **Bundled** — ships inside `lns` and grows with each release, so common services
+  work without any setup on your part.
+- **User** — your own additions in `~/.lns-integrations.yaml`
+  (override the path with `LNS_INTEGRATIONS_PATH`).
+
+The effective catalog is the union of the two; a user entry can't shadow a bundled
+id. List everything Lens Sandbox can connect:
+
+```bash
+lns integration list
+```
+
+### Declaring your own
+
+For an internal service, declare an integration in your user catalog:
+
+```bash
+lns integration add acme \
+  --env-var ACME_API_TOKEN \
+  --inject bearer_header:api.acme.internal \
+  --route api.acme.internal
+```
+
+- `id` — the integration id; must not collide with a bundled or existing user id.
+- `--env-var` — the environment variable the placeholder is seeded into.
+- `--inject KIND:DOMAIN` — how and where the real value is injected (repeatable); the
+  same kinds as [custom credential providers](credentials.md#injection-kinds).
+- `--route HOST` — a host pattern the integration needs reachable (repeatable).
+- `--placeholder` — a specific placeholder; auto-generated (self-identifying) when
+  omitted.
+
+Remove a user integration (bundled ones can't be removed):
+
+```bash
+lns integration remove acme
+```
+
+## Connecting
+
+An integration only affects a project once you **connect** it, which records it in
+that directory's [`lns-policy.yaml`](policy.md):
+
+```bash
+lns connect gitlab
+lns disconnect gitlab
+```
+
+The policy stores the integration by id under `integrations:`, so the definition
+resolves from the catalog at run time and the shareable policy stays small:
+
+```yaml
+network:
+  allowedRoutes: []
+  defaultVerdict: ask
+  defaultTransport: direct
+integrations:
+  - gitlab
+```
+
+When a connected integration's run starts, its declared routes are allowed and its
+placeholder is seeded. The first request carrying that placeholder follows the
+ordinary credential [value decision](credentials.md#value-decisions) — it pauses for
+approval if you haven't bound a value yet, exactly like a built-in provider. Set one
+ahead of time with `lns credential set <id>`. A new integration reaches a workload
+only at launch, so relaunch a running sandbox to pick it up.
+
+## The catalog file
+
+The bundled and user catalogs share one schema, so an entry is portable between them:
+
+```yaml
+integrations:
+  - id: gitlab
+    authKind: credential
+    routes:
+      - match: gitlab.com
+    credential:
+      envVar: GITLAB_TOKEN
+      placeholder: glpat-LNSPLACEHOLDER0000000000000000
+      injections:
+        - kind: bearer_header
+          domain: gitlab.com
+```
+
+A route may carry the same detail a [policy rule](policy.md#rules) can — a `scheme`
+and HTTP method/path `rules` for least-privilege access — beyond the bare `match`.
+
+`authKind` is `credential` today. `oauth` (an interactive sign-in that obtains the
+token for you, rather than you supplying it) is reserved for a future release;
+connecting an `oauth` integration isn't supported yet.
+
+## See also
+
+- [Credentials](credentials.md) — how placeholders keep real secrets out of the
+  workload, and the per-machine value decisions integrations reuse.
+- [Policy and approvals](policy.md) — the `lns-policy.yaml` file that records which
+  integrations a project has connected.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -135,5 +135,7 @@ re-approve them.
 
 - [Credentials](credentials.md) — credential decisions live alongside network
   policy and follow the same allow / deny / ask model.
+- [Integrations](integrations.md) — connecting an integration records it under
+  `integrations:` and allows the routes it declares.
 - [Running workloads](running-workloads.md) — `--policy` and the run summary.
 - [CLI reference](cli-reference.md) — the full `lns policy` flag list.


### PR DESCRIPTION
## Stack — 1 of 3

> Part of the credentials → integrations rework, split into a reviewable stack.
> Merge bottom-up.
>
> 1. **➡️ #42 — `integrations-catalog` → `main` (this PR)**
> 2. #43 — `oauth-device-flow` → `integrations-catalog`
> 3. #44 — `credential-cutover` → `oauth-device-flow`

## What this lands

The data-driven **integration catalog** foundation. Purely additive — nothing is removed from the existing credential mechanism yet (that's PR #3).

- `lns-policy`: integration catalog model + richer route rules; bundled `integrations.yaml`.
- `lns-service`: resolves applied integrations into wire credentials and routes; strips connected integrations' env vars from `-e` and the audit; auto-detects and connects un-connected integrations live.
- `lns-cli`: `lns integration` catalog management (connect/disconnect); accepts connected integration ids in `lns credential set`.
- GitLab tokens injected via `PRIVATE-TOKEN` as well as bearer.
- Docs: integration catalog + connect flow.

## Commits (8)

```
feat(policy):   add integration catalog and richer route rules
feat(service):  resolve applied integrations into wire credentials and routes
feat(cli):      add integration catalog management and connect/disconnect
docs:           document the integration catalog and connect flow
fix(service):   strip connected integrations' env vars from -e and the audit
feat(service):  auto-detect un-connected integrations and connect them live
fix(policy):    inject GitLab tokens via PRIVATE-TOKEN as well as bearer
fix(cli):       accept connected integration ids in `lns credential set`
```

## Notes

- Draft: per-boundary gate (`make lint && make complexity && make coverage`) not yet run on this exact tip — CI will verify.
- Heads-up unrelated to this stack: `crates/lns-session-broker/src/vsock/real.rs` (from main's CLOEXEC fix) fails macOS-host `make lint` because the `RealVsockSyscalls` impl isn't `#[cfg(target_os = "linux")]`-gated; CI lints it cross-compiled so it's green there.
