### PR TITLE
fix(session-broker): keep the vsock syscall adapter host-compilable

### DIFF
--- a/crates/lns-session-broker/src/vsock/real.rs
+++ b/crates/lns-session-broker/src/vsock/real.rs
@@ -13,7 +13,11 @@ struct RealVsockSyscalls;
 impl VsockSyscalls for RealVsockSyscalls {
     fn socket(&self) -> io::Result<RawFd> {
         // SAFETY: socket(2) only reads its int args; SOCK_CLOEXEC keeps the listener out of the workload.
+        #[cfg(target_os = "linux")]
         let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
+        // SAFETY: socket(2) only reads its int args; this vsock path never runs on the host build.
+        #[cfg(not(target_os = "linux"))]
+        let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0) };
         if fd < 0 {
             Err(io::Error::last_os_error())
         } else {
@@ -49,6 +53,7 @@ impl VsockSyscalls for RealVsockSyscalls {
 
     fn accept_once(&self, listen_fd: RawFd) -> io::Result<RawFd> {
         // SAFETY: null addr/addrlen skips peer-address writeback; SOCK_CLOEXEC keeps the conn out of the workload.
+        #[cfg(target_os = "linux")]
         let fd = unsafe {
             libc::accept4(
                 listen_fd,
@@ -57,6 +62,9 @@ impl VsockSyscalls for RealVsockSyscalls {
                 libc::SOCK_CLOEXEC,
             )
         };
+        // SAFETY: null addr/addrlen skips peer-address writeback; this vsock path never runs on the host build.
+        #[cfg(not(target_os = "linux"))]
+        let fd = unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
         if fd < 0 {
             Err(io::Error::last_os_error())
         } else {


### PR DESCRIPTION
## Problem

`4dc2cf0` (CLOEXEC hardening) moved `RealVsockSyscalls` onto `libc::SOCK_CLOEXEC` and `libc::accept4` — both **Linux-only** — inside an `impl` that is **not** `#[cfg(target_os = "linux")]`-gated. That impl has to compile on the host, because `vsock::read_exact` is re-exported un-gated and is reached from host-compiled callers (`forward/real.rs`, `session.rs`).

The result: `cargo clippy --workspace --all-targets` (and therefore **`make lint`** and **`make coverage`**) no longer builds on macOS:

```
error[E0425]: cannot find value `SOCK_CLOEXEC` in crate `libc`
error[E0425]: cannot find function `accept4` in crate `libc`
  --> crates/lns-session-broker/src/vsock/real.rs
```

CI stayed green because it only cross-compiles the guest crate for `aarch64-unknown-linux-musl`, where the symbols exist. So the local pre-push gate is broken for anyone on macOS who rebases onto current `main`.

## Fix

Gate only the two offending syscall lines per target:

- **Linux** keeps the atomic `SOCK_CLOEXEC` / `accept4` hardening unchanged.
- **Host** falls back to plain `socket` / `accept`.

The host path is never executed — the broker only runs inside the Linux microVM — so this restores host compilation without weakening the in-guest CLOEXEC behaviour. `vsock/real.rs` remains a coverage-IGNORES leaf (host-tested via `FakeVsock` in `vsock.rs`).

## Verification

- `make lint` → exit 0 on macOS (was `Error 101`).
- Pre-push gate (`make lint && make complexity && make coverage-affected`) passes locally.
