### PR TITLE
fix(service): re-derive integration routes when the policy file is reloaded

### DIFF
--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -16,6 +16,9 @@ pub type FrameSink = mpsc::UnboundedSender<HostFrame>;
 /// Supplies the registry credentials bundled into every emitted `Policy` frame so a network decision is never read upstream as "drop all credentials".
 pub type CredentialsProvider = Box<dyn Fn() -> Vec<Credential> + Send + Sync>;
 
+/// Maps a reloaded policy's `integrations:` ids to their catalog routes, so a load that records only the ids gets those routes back live — the boot path and the file watcher derive them the same way.
+pub type IntegrationRouteDeriver = Box<dyn Fn(&[String]) -> Vec<RouteRule> + Send + Sync>;
+
 /// A connectable integration whose routes aren't allowed yet, so a held request to one of its `patterns` offers to connect it before the plain allow/deny.
 pub struct OfferableIntegration {
     pub id: String,
@@ -67,6 +70,7 @@ pub struct ApprovalSession {
     sink: FrameSink,
     timeout: Duration,
     credentials_provider: OnceLock<CredentialsProvider>,
+    integration_routes: OnceLock<IntegrationRouteDeriver>,
     offerable: Vec<OfferableIntegration>,
     connector: OnceLock<Arc<dyn IntegrationConnector>>,
     connecting: Mutex<HashSet<String>>,
@@ -94,6 +98,7 @@ impl ApprovalSession {
             sink,
             timeout,
             credentials_provider: OnceLock::new(),
+            integration_routes: OnceLock::new(),
             offerable: Vec::new(),
             connector: OnceLock::new(),
             connecting: Mutex::new(HashSet::new()),
@@ -109,6 +114,11 @@ impl ApprovalSession {
     /// Installs the credentials closure once at boot; idempotent, the first provider wins.
     pub fn set_credentials_provider(&self, provider: CredentialsProvider) {
         let _ = self.credentials_provider.set(provider);
+    }
+
+    /// Installs the integration-route deriver once at boot so a watcher reload re-applies a connected integration's routes instead of dropping them; idempotent, the first wins.
+    pub fn set_integration_route_deriver(&self, deriver: IntegrationRouteDeriver) {
+        let _ = self.integration_routes.set(deriver);
     }
 
     /// Installs the integration connector once the credential subsystem exists; idempotent, the first wins.
@@ -337,7 +347,13 @@ impl ApprovalSession {
         true
     }
 
-    pub fn apply_external_policy(&self, new_policy: Policy) {
+    pub fn apply_external_policy(&self, mut new_policy: Policy) {
+        if let Some(derive) = self.integration_routes.get() {
+            new_policy
+                .network
+                .allowed_routes
+                .extend(derive(&new_policy.integrations));
+        }
         *self.policy.lock().expect("policy mutex poisoned") = new_policy.clone();
         let credentials = self.current_credentials();
         let _ = self.sink.send(HostFrame::Policy(PolicyMessage {
@@ -865,6 +881,34 @@ pub(crate) mod tests {
         let frame = rx.try_recv().expect("expected a policy frame");
         assert!(matches!(frame, HostFrame::Policy(_)));
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn apply_external_policy_re_derives_a_connected_integrations_routes() {
+        let (s, _n, _store, mut rx) = fixture();
+        s.set_integration_route_deriver(Box::new(|ids| {
+            ids.iter()
+                .filter(|id| id.as_str() == "some-oauth")
+                .map(|_| RouteRule::allow_host("api.some-oauth.example"))
+                .collect()
+        }));
+        let mut reloaded = Policy::default();
+        reloaded.connect("some-oauth");
+
+        s.apply_external_policy(reloaded);
+
+        let routes = s.current_policy().network.allowed_routes;
+        assert_eq!(
+            routes.len(),
+            1,
+            "a reloaded id-only policy gets its integration route back live, not dropped"
+        );
+        assert_eq!(routes[0].match_pattern, "api.some-oauth.example");
+        assert_eq!(
+            policy_frame(&mut rx).network.unwrap().allowed_routes[0].match_pattern,
+            "api.some-oauth.example",
+            "the hot-swap frame carries the re-derived route so the guest sees it"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/integrations.rs
+++ b/crates/lns-service/src/credential_flow/integrations.rs
@@ -47,6 +47,16 @@ fn signin_oauth(integ: &Integration) -> Option<&OauthAuth> {
     integ.oauth.as_ref().filter(|o| !o.client_id.is_empty())
 }
 
+/// The allow-routes a set of connected integration ids contributes, re-derived from the catalog so boot and a watcher reload reconstruct the same live routes from an id-only policy.
+pub fn applied_integration_routes(ids: &[String], catalog: &[Integration]) -> Vec<RouteRule> {
+    let applied: HashSet<&str> = ids.iter().map(String::as_str).collect();
+    catalog
+        .iter()
+        .filter(|integ| applied.contains(integ.id.as_str()))
+        .flat_map(|integ| integ.routes.iter().map(|r| r.to_route_rule()))
+        .collect()
+}
+
 /// Resolves the policy's applied integration ids against the effective catalog.
 pub fn resolve_applied_integrations(
     policy: &Policy,
@@ -54,14 +64,14 @@ pub fn resolve_applied_integrations(
 ) -> AppliedIntegrations {
     let applied: HashSet<&str> = policy.integrations.iter().map(String::as_str).collect();
 
-    let mut out = AppliedIntegrations::default();
+    let mut out = AppliedIntegrations {
+        routes: applied_integration_routes(&policy.integrations, catalog),
+        ..AppliedIntegrations::default()
+    };
     for integ in catalog {
-        let id = integ.id.as_str();
-        if !applied.contains(id) {
+        if !applied.contains(integ.id.as_str()) {
             continue;
         }
-        out.routes
-            .extend(integ.routes.iter().map(|r| r.to_route_rule()));
         if let Some(p) = wire_provider(integ) {
             out.providers.push(p);
         }
@@ -156,6 +166,21 @@ mod tests {
         let out = resolve_applied_integrations(&policy_applying(&[]), &catalog);
         assert!(out.providers.is_empty());
         assert!(out.routes.is_empty());
+    }
+
+    #[test]
+    fn applied_integration_routes_maps_connected_ids_to_their_catalog_routes() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        let routes = applied_integration_routes(&["gitlab".to_string()], &catalog);
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].match_pattern, "gitlab.com");
+        assert_eq!(routes[0].verdict, lns_policy::Verdict::Allow);
+    }
+
+    #[test]
+    fn applied_integration_routes_ignores_ids_absent_from_the_catalog() {
+        let catalog = vec![cred_integration("gitlab", "GITLAB_TOKEN", "gitlab.com")];
+        assert!(applied_integration_routes(&["nope".to_string()], &catalog).is_empty());
     }
 
     fn oauth_integration(id: &str, env_var: &str, domain: &str) -> Integration {

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -17,7 +17,7 @@ use crate::approval_flow::window::{
     self, CredentialDecisionDelivery, DecisionDelivery, RequestAction,
 };
 use crate::credential_flow::integrations::{
-    resolve_applied_integrations, resolve_connectable_integrations,
+    applied_integration_routes, resolve_applied_integrations, resolve_connectable_integrations,
 };
 use crate::credential_flow::notification::WindowCredentialNotifier;
 use crate::credential_flow::providers::{DefProvider, Provider};
@@ -285,6 +285,13 @@ fn make_policy_emitter(
     })
 }
 
+/// A watcher reload replaces the live policy from disk, where connected integrations are recorded id-only; this deriver re-applies their catalog routes so the reload doesn't drop them.
+fn make_integration_route_deriver(
+    catalog: Vec<lns_policy::integrations::Integration>,
+) -> crate::approval_flow::session::IntegrationRouteDeriver {
+    Box::new(move |ids| applied_integration_routes(ids, &catalog))
+}
+
 /// Connecting an un-connected catalog integration allows its routes on the approval session's live policy (and persists `integrations:`), so the held request proceeds without a relaunch.
 fn make_connect_emitter(
     session: Arc<ApprovalSession>,
@@ -487,6 +494,8 @@ pub(super) async fn start(
         ApprovalSession::new(policy, notifier, store, frame_tx, APPROVAL_TIMEOUT)
             .with_offers(offerable),
     );
+
+    session.set_integration_route_deriver(make_integration_route_deriver(catalog.clone()));
 
     tokio::spawn(decision_delivery_loop(
         Arc::downgrade(&session),
@@ -1057,6 +1066,34 @@ mod tests {
         let connect = make_connect_emitter(session.clone(), Arc::new(HashMap::new()));
         connect("gitlab");
         assert_eq!(session.current_policy().integrations, ["gitlab"]);
+    }
+
+    #[test]
+    fn make_integration_route_deriver_maps_connected_ids_to_catalog_routes() {
+        use lns_policy::integrations::{AuthKind, Integration, IntegrationRoute};
+        let catalog = vec![Integration {
+            id: "some-oauth".into(),
+            name: None,
+            auth_kind: AuthKind::Oauth,
+            routes: vec![IntegrationRoute {
+                match_pattern: "api.some-oauth.example".into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: None,
+            oauth: None,
+            token_fallback: None,
+        }];
+        let derive = make_integration_route_deriver(catalog);
+        let routes = derive(&["some-oauth".to_string()]);
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].match_pattern, "api.some-oauth.example");
+        assert!(
+            derive(&["nope".to_string()]).is_empty(),
+            "an id absent from the catalog contributes no route"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

After connecting an integration (e.g. via an OAuth offer), the connected integration's domain would fall back to an **ask** prompt on the next request, instead of staying allowed.

Root cause: there are two policy-load paths that disagree on how to handle `integrations:` → routes.

- **Boot** (`supervisor/adapter.rs`) re-derives the connected integrations' routes from the catalog and extends them into the live policy.
- The **policy-file watcher** (`approval_flow/watcher.rs` → `ApprovalSession::apply_external_policy`) reloads the file verbatim.

`connect_integration` persists only the integration id (routes are re-derived on load) and applies the routes to the live policy in-memory. But its own `store.save()` trips the watcher, which reloads the routeless file and **overwrites the live policy — dropping the just-applied routes — and pushes a routeless frame to the guest**. (Exposed by b66048f, which stopped persisting the routes into the file.)

## Fix

`apply_external_policy` now re-derives the connected integrations' routes from the boot catalog — the same derivation the boot path runs — so any reload (the watcher firing on a save, or a hand edit of `integrations:`) reconstructs the live routes instead of dropping them. The route deriver is injected at boot via `set_integration_route_deriver`, so the approval session maps ids→routes without owning the catalog.

This also fixes a latent bug: hand-editing `integrations:` in the policy file now brings the routes live without a relaunch.

## Tests

- `approval_flow/session.rs`: `apply_external_policy_re_derives_a_connected_integrations_routes` — a reloaded id-only policy gets its route back live and in the emitted frame.
- `credential_flow/integrations.rs`: unit tests for the new `applied_integration_routes` helper.
- `supervisor/adapter.rs`: `make_integration_route_deriver` builder test.
- Coverage gate green (lns-service: all files at 100%).