### PR TITLE
chore(deps): bump lens-sandbox-core to the post-gate injection fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3040,7 +3040,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=3adf8ebac0af817ce4ecf650d952b5983e9b53fa#3adf8ebac0af817ce4ecf650d952b5983e9b53fa"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=c48ab6750021a650c446f400c732e4745ad569a2#c48ab6750021a650c446f400c732e4745ad569a2"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -4959,7 +4959,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5018,7 +5018,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5727,7 +5727,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7022,7 +7022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "3adf8ebac0af817ce4ecf650d952b5983e9b53fa" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "c48ab6750021a650c446f400c732e4745ad569a2" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
Pins `lens-sandbox-core` to [`c48ab67`](https://github.com/lensapp/lens-sandbox-core/commit/c48ab6750021a650c446f400c732e4745ad569a2) (lensapp/lens-sandbox-core#19), which collects credential injections **after** the connect gate resolves.

This completes the first-use OAuth fix. The in-guest proxy now MITMs a held connection whose credential is armed by accepting the integration offer mid-hold, instead of plain-relaying the credential placeholder upstream (which caused the first `gh auth status` after connecting to fail with 401). The host-side route re-derivation landed in #47.

Verified: `lns-supervisor` cross-builds cleanly against the new rev for `aarch64-unknown-linux-musl`, and the full pre-push gate (`make build`/`lint`/`test`/`complexity`) passed.