### PR TITLE
fix(tray): stack concurrent notifications and show on active Space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "lns-session",
  "notify",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-virtualization",
  "oci-client",
@@ -3682,8 +3683,8 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -3695,10 +3696,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -3712,6 +3721,17 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3735,6 +3755,17 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3774,6 +3805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3824,31 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3909,9 +3975,9 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",

--- a/crates/lns-service/Cargo.toml
+++ b/crates/lns-service/Cargo.toml
@@ -80,6 +80,8 @@ notify          = "6"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2                 = "0.6"
 objc2-foundation      = { version = "0.3", features = ["NSError", "NSString", "NSURL", "NSFileHandle", "NSObject"] }
+# Tray window joins every macOS Space so a notification shows on the active desktop, not the one it was created on.
+objc2-app-kit         = { version = "0.3", features = ["NSApplication", "NSResponder", "NSWindow"] }
 objc2-virtualization  = { version = "0.3", features = [
     "VZVirtualMachine",
     "VZVirtualMachineConfiguration",

--- a/crates/lns-service/src/approval_flow/notification.rs
+++ b/crates/lns-service/src/approval_flow/notification.rs
@@ -62,6 +62,11 @@ impl Notifier for WindowNotifier {
         self.state.clear_informs();
         self.wake();
     }
+
+    fn connect_finished(&self, display_name: &str) {
+        self.state.clear_connecting(display_name);
+        self.wake();
+    }
 }
 
 #[cfg(test)]
@@ -169,11 +174,27 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn connect_finished_clears_the_connecting_placeholder() {
+        let (n, state, _rx) = fixture(false);
+        let mut offer = prompt("r1", "api.some-oauth.example");
+        offer.offer = Some("GitHub".into());
+        n.present(&offer);
+        state.connect_offer("r1");
+        assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
+        n.connect_finished("GitHub");
+        assert!(
+            state.snapshot().connecting.is_empty(),
+            "the resolved connect takes the placeholder down"
+        );
+    }
+
+    #[test]
     fn noop_notifier_methods_are_safe_to_call() {
         let n = NoopNotifier;
         n.present(&prompt("r1", "a.test"));
         n.dismiss("r1");
         n.inform("anything");
         n.clear_informs();
+        n.connect_finished("GitHub");
     }
 }

--- a/crates/lns-service/src/approval_flow/notification.rs
+++ b/crates/lns-service/src/approval_flow/notification.rs
@@ -67,6 +67,11 @@ impl Notifier for WindowNotifier {
         self.state.clear_connecting(display_name);
         self.wake();
     }
+
+    fn clear_all_connecting(&self) {
+        self.state.clear_all_connecting();
+        self.wake();
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +194,18 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn clear_all_connecting_drops_every_placeholder() {
+        let (n, state, _rx) = fixture(false);
+        let mut offer = prompt("r1", "api.some-oauth.example");
+        offer.offer = Some("GitHub".into());
+        n.present(&offer);
+        state.connect_offer("r1");
+        assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
+        n.clear_all_connecting();
+        assert!(state.snapshot().connecting.is_empty());
+    }
+
+    #[test]
     fn noop_notifier_methods_are_safe_to_call() {
         let n = NoopNotifier;
         n.present(&prompt("r1", "a.test"));
@@ -196,5 +213,6 @@ pub(crate) mod tests {
         n.inform("anything");
         n.clear_informs();
         n.connect_finished("GitHub");
+        n.clear_all_connecting();
     }
 }

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -42,6 +42,10 @@ pub trait Notifier: Send + Sync {
     fn dismiss(&self, id: &str);
     fn inform(&self, message: &str);
     fn clear_informs(&self);
+    /// Signals that an accepted offer's connect has resolved (either way), so any surface holding the card's slot can release it; default no-op for notifiers without one.
+    fn connect_finished(&self, display_name: &str) {
+        let _ = display_name;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,7 +63,13 @@ pub struct PendingPrompt {
 struct PendingEntry {
     host: String,
     deadline: Instant,
-    offer_integration_id: Option<String>,
+    offer: Option<OfferRef>,
+}
+
+#[derive(Debug, Clone)]
+struct OfferRef {
+    integration_id: String,
+    display_name: String,
 }
 
 pub struct ApprovalSession {
@@ -168,11 +178,14 @@ impl ApprovalSession {
 
     pub fn submit_pending(&self, req: RequestPending, now: Instant) {
         let matched = self.offer_id_and_name_for(&req.host);
-        let offer_integration_id = matched.as_ref().map(|(id, ..)| id.clone());
+        let offer_ref = matched.as_ref().map(|(id, name, _)| OfferRef {
+            integration_id: id.clone(),
+            display_name: name.clone(),
+        });
         // While a connect for this integration is in flight, hold the request silently and let that connect's batch release it — a fresh offer card would only cover the sign-in card.
-        let coalesced = offer_integration_id
-            .as_deref()
-            .is_some_and(|id| self.is_connecting(id));
+        let coalesced = offer_ref
+            .as_ref()
+            .is_some_and(|o| self.is_connecting(&o.integration_id));
         let mut pending = self.pending.lock().expect("pending mutex poisoned");
         if pending.contains_key(&req.id) {
             return;
@@ -182,7 +195,7 @@ impl ApprovalSession {
             PendingEntry {
                 host: req.host.clone(),
                 deadline: now + self.timeout,
-                offer_integration_id,
+                offer: offer_ref,
             },
         );
         drop(pending);
@@ -234,44 +247,49 @@ impl ApprovalSession {
 
     /// Drives one connect for the offered integration and releases **every** held request for it — allow-once on success, deny-once closed on failure or a missing connector. A second card for the same integration coalesces onto the in-flight connect instead of starting another. `token` selects the pasted-token connect over the interactive one.
     async fn connect_offer_with(&self, id: &str, token: Option<String>) -> DecisionOutcome {
-        let Some(integration_id) = self.offer_integration_of(id) else {
+        let Some(offer) = self.offer_of(id) else {
             return DecisionOutcome::UnknownId;
         };
-        if !self.begin_connecting(&integration_id) {
+        if !self.begin_connecting(&offer.integration_id) {
             // Another card already started this connect; its batch will release this request too.
             self.notifier.dismiss(id);
             return DecisionOutcome::Resolved;
         }
         // Hide every offer card for this integration so the sign-in card isn't covered; the requests stay held for the batch release.
-        for request_id in self.offer_request_ids(&integration_id) {
+        for request_id in self.offer_request_ids(&offer.integration_id) {
             self.notifier.dismiss(&request_id);
         }
         let connected = match self.connector.get() {
             Some(connector) => match token {
-                Some(value) => connector.connect_with_token(&integration_id, value).await,
-                None => connector.connect(&integration_id).await,
+                Some(value) => {
+                    connector
+                        .connect_with_token(&offer.integration_id, value)
+                        .await
+                }
+                None => connector.connect(&offer.integration_id).await,
             },
             None => false,
         };
-        self.finish_connecting(&integration_id);
+        self.finish_connecting(&offer.integration_id);
+        self.notifier.connect_finished(&offer.display_name);
         let decision = if connected {
             Decision::AllowOnce
         } else {
             Decision::DenyOnce
         };
-        for request_id in self.drain_offer_requests(&integration_id) {
+        for request_id in self.drain_offer_requests(&offer.integration_id) {
             self.send_decision_frame(&request_id, decision);
         }
         DecisionOutcome::Resolved
     }
 
-    /// The integration a held entry offers, if any; does not remove the entry.
-    fn offer_integration_of(&self, id: &str) -> Option<String> {
+    /// The offer a held entry carries, if any; does not remove the entry.
+    fn offer_of(&self, id: &str) -> Option<OfferRef> {
         self.pending
             .lock()
             .expect("pending mutex poisoned")
             .get(id)?
-            .offer_integration_id
+            .offer
             .clone()
     }
 
@@ -295,7 +313,7 @@ impl ApprovalSession {
             .lock()
             .expect("pending mutex poisoned")
             .iter()
-            .filter(|(_, e)| e.offer_integration_id.as_deref() == Some(integration_id))
+            .filter(|(_, e)| offers_integration(e, integration_id))
             .map(|(id, _)| id.clone())
             .collect()
     }
@@ -305,7 +323,7 @@ impl ApprovalSession {
         let mut pending = self.pending.lock().expect("pending mutex poisoned");
         let ids: Vec<String> = pending
             .iter()
-            .filter(|(_, e)| e.offer_integration_id.as_deref() == Some(integration_id))
+            .filter(|(_, e)| offers_integration(e, integration_id))
             .map(|(id, _)| id.clone())
             .collect();
         for id in &ids {
@@ -328,9 +346,9 @@ impl ApprovalSession {
                 // A request offering an integration that's mid sign-in must not be swept; its connect releases it.
                 .filter(|(_, entry)| {
                     entry
-                        .offer_integration_id
-                        .as_deref()
-                        .is_none_or(|id| !connecting.contains(id))
+                        .offer
+                        .as_ref()
+                        .is_none_or(|o| !connecting.contains(&o.integration_id))
                 })
                 .map(|(id, _)| id.clone())
                 .collect()
@@ -428,6 +446,13 @@ fn host_matches_pattern(pattern: &str, host: &str) -> bool {
     }
 }
 
+fn offers_integration(entry: &PendingEntry, integration_id: &str) -> bool {
+    entry
+        .offer
+        .as_ref()
+        .is_some_and(|o| o.integration_id == integration_id)
+}
+
 fn rule_for_always_decision(host: &str, decision: Decision) -> Option<RouteRule> {
     match decision {
         Decision::AllowAlways => Some(RouteRule::allow_host(host)),
@@ -449,6 +474,7 @@ pub(crate) mod tests {
         pub(crate) dismissed: StdMutex<Vec<String>>,
         pub(crate) informed: StdMutex<Vec<String>>,
         pub(crate) informs_cleared: StdMutex<usize>,
+        pub(crate) connects_finished: StdMutex<Vec<String>>,
     }
 
     impl Notifier for RecordingNotifier {
@@ -463,6 +489,12 @@ pub(crate) mod tests {
         }
         fn clear_informs(&self) {
             *self.informs_cleared.lock().unwrap() += 1;
+        }
+        fn connect_finished(&self, display_name: &str) {
+            self.connects_finished
+                .lock()
+                .unwrap()
+                .push(display_name.to_string());
         }
     }
 
@@ -1328,6 +1360,80 @@ pub(crate) mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn connect_offer_signals_connect_finished_with_the_offers_display_name() {
+        let connector = Arc::new(FakeConnector::new(true));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+
+        s.connect_offer("r1").await;
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "the resolved connect releases the slot its placeholder holds in the window"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_offer_failure_still_signals_connect_finished() {
+        let connector = Arc::new(FakeConnector::new(false));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+
+        s.connect_offer("r1").await;
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "a failed connect must not leave a connecting placeholder behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_offer_without_a_connector_signals_connect_finished() {
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            None,
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+
+        s.connect_offer("r1").await;
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_offer_with_token_signals_connect_finished() {
+        let connector = Arc::new(FakeConnector::new(true));
+        let (s, n, _rx) = offer_session(
+            vec![offerable_with_fallback(
+                "some-oauth",
+                "GitHub",
+                "api.some-oauth.example",
+            )],
+            Some(connector),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+
+        s.connect_offer_with_token("r1", "some-pasted-token".into())
+            .await;
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()]
+        );
+    }
+
     #[test]
     fn submit_pending_coalesces_a_request_while_its_integration_is_connecting() {
         let (s, n, _rx) = offer_session(
@@ -1350,7 +1456,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn connect_offer_for_a_sibling_while_connecting_does_not_start_a_second_connect() {
         let connector = Arc::new(FakeConnector::new(true));
-        let (s, _n, mut rx) = offer_session(
+        let (s, n, mut rx) = offer_session(
             vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
             Some(connector.clone()),
         );
@@ -1363,6 +1469,10 @@ pub(crate) mod tests {
         assert!(
             connector.connected.lock().unwrap().is_empty(),
             "a second sign-in must not run while one is in flight"
+        );
+        assert!(
+            n.connects_finished.lock().unwrap().is_empty(),
+            "the duplicate click must not release the in-flight connect's placeholder"
         );
         assert!(
             rx.try_recv().is_err(),

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -46,6 +46,8 @@ pub trait Notifier: Send + Sync {
     fn connect_finished(&self, display_name: &str) {
         let _ = display_name;
     }
+    /// Drops every in-flight connect placeholder on run teardown so a connect that never resolves can't keep the window pinned; default no-op.
+    fn clear_all_connecting(&self) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -216,23 +218,22 @@ impl ApprovalSession {
     }
 
     pub fn record_decision(&self, id: &str, decision: Decision) -> DecisionOutcome {
-        let Some(host) = self.remove_pending(id) else {
+        let Some(entry) = self.remove_pending(id) else {
             return DecisionOutcome::UnknownId;
         };
         self.notifier.dismiss(id);
         self.send_decision_frame(id, decision);
-        if let Some(rule) = rule_for_always_decision(&host, decision) {
+        if let Some(rule) = rule_for_always_decision(&entry.host, decision) {
             self.apply_persistent_rule(rule);
         }
         DecisionOutcome::Resolved
     }
 
-    fn remove_pending(&self, id: &str) -> Option<String> {
+    fn remove_pending(&self, id: &str) -> Option<PendingEntry> {
         self.pending
             .lock()
             .expect("pending mutex poisoned")
             .remove(id)
-            .map(|entry| entry.host)
     }
 
     /// Accepts a held request's integration offer via the interactive connect (oauth sign-in or a straight credential connect). See [`Self::connect_offer_with`].
@@ -357,10 +358,14 @@ impl ApprovalSession {
     }
 
     fn timeout_one(&self, id: &str) -> bool {
-        if self.remove_pending(id).is_none() {
+        let Some(entry) = self.remove_pending(id) else {
             return false;
-        }
+        };
         self.notifier.dismiss(id);
+        // A request clicked into a connect right as it expired leaves a placeholder no later connect will resolve; take it down with the request.
+        if let Some(offer) = &entry.offer {
+            self.notifier.connect_finished(&offer.display_name);
+        }
         self.send_decision_frame(id, Decision::Timeout);
         true
     }
@@ -389,6 +394,7 @@ impl ApprovalSession {
             self.notifier.dismiss(id);
         }
         self.notifier.clear_informs();
+        self.notifier.clear_all_connecting();
     }
 
     fn send_decision_frame(&self, id: &str, decision: Decision) {
@@ -475,6 +481,7 @@ pub(crate) mod tests {
         pub(crate) informed: StdMutex<Vec<String>>,
         pub(crate) informs_cleared: StdMutex<usize>,
         pub(crate) connects_finished: StdMutex<Vec<String>>,
+        pub(crate) all_connecting_cleared: StdMutex<usize>,
     }
 
     impl Notifier for RecordingNotifier {
@@ -495,6 +502,9 @@ pub(crate) mod tests {
                 .lock()
                 .unwrap()
                 .push(display_name.to_string());
+        }
+        fn clear_all_connecting(&self) {
+            *self.all_connecting_cleared.lock().unwrap() += 1;
         }
     }
 
@@ -887,6 +897,38 @@ pub(crate) mod tests {
             *n.informs_cleared.lock().unwrap(),
             1,
             "withdraw_run must call clear_informs exactly once"
+        );
+    }
+
+    #[test]
+    fn withdraw_run_clears_connecting_placeholders_so_window_does_not_stay_pinned() {
+        let (s, n, _store, _rx) = fixture();
+        s.submit_pending(pending("r1", "a"), Instant::now());
+
+        s.withdraw_run();
+
+        assert_eq!(
+            *n.all_connecting_cleared.lock().unwrap(),
+            1,
+            "an in-flight connect placeholder must not survive the run that started it"
+        );
+    }
+
+    #[test]
+    fn timeout_clears_a_connecting_placeholder_for_an_expired_offer() {
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            None,
+        );
+        let t0 = Instant::now();
+        s.submit_pending(pending("r1", "api.some-oauth.example"), t0);
+
+        s.tick_timeouts(t0 + TEST_TIMEOUT + Duration::from_secs(1));
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "timing out a clicked offer must release the placeholder no later connect will resolve"
         );
     }
 

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -398,6 +398,11 @@ impl WindowState {
             .retain(|e| e.display_name != display_name);
     }
 
+    /// Drops every connecting placeholder regardless of integration; used on run teardown so an in-flight connect can't keep the window pinned after the workload is gone.
+    pub fn clear_all_connecting(&self) {
+        self.lock().connecting.clear();
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, WindowInner> {
         self.inner.lock().expect("window state mutex poisoned")
     }
@@ -1165,6 +1170,27 @@ mod tests {
         s.connect_offer("r1");
         s.clear_connecting("Other Service");
         assert_eq!(s.snapshot().connecting, vec!["GitHub".to_string()]);
+    }
+
+    #[test]
+    fn clear_all_connecting_drops_every_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(
+            offer_prompt("r1", "api.some-oauth.example", "GitHub"),
+            tx.clone(),
+        );
+        s.insert_pending(
+            offer_prompt("r2", "api.other-oauth.example", "Other Service"),
+            tx,
+        );
+        s.connect_offer("r1");
+        s.connect_offer("r2");
+        s.clear_all_connecting();
+        assert!(
+            s.snapshot().connecting.is_empty(),
+            "run teardown takes down every in-flight placeholder so the window can close"
+        );
     }
 
     fn oauth_cred_prompt(id: &str, name: &str) -> CredentialPendingPrompt {

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -192,10 +192,10 @@ impl WindowState {
         self.lock().informs.clear();
     }
 
-    pub fn dismiss_first_inform(&self) {
+    pub fn dismiss_inform(&self, index: usize) {
         let mut g = self.lock();
-        if !g.informs.is_empty() {
-            g.informs.remove(0);
+        if index < g.informs.len() {
+            g.informs.remove(index);
         }
     }
 
@@ -213,7 +213,7 @@ impl WindowState {
         }
     }
 
-    /// Total pending across every flow; drives `tray::sync_viewport_visibility`.
+    /// Total pending across every flow.
     pub fn pending_count(&self) -> usize {
         let g = self.lock();
         g.pending.len() + g.pending_credentials.len() + g.pending_sign_ins.len()
@@ -459,18 +459,31 @@ mod tests {
     }
 
     #[test]
-    fn dismiss_first_inform_removes_oldest_and_preserves_rest() {
+    fn dismiss_inform_removes_the_indexed_entry_and_preserves_the_rest() {
         let s = WindowState::new();
         s.push_inform("first".into());
         s.push_inform("second".into());
-        s.dismiss_first_inform();
-        assert_eq!(s.snapshot().informs, vec!["second".to_string()]);
+        s.push_inform("third".into());
+        s.dismiss_inform(1);
+        assert_eq!(
+            s.snapshot().informs,
+            vec!["first".to_string(), "third".into()],
+            "dismissing a stacked banner drops that banner, not the oldest"
+        );
     }
 
     #[test]
-    fn dismiss_first_inform_when_empty_is_a_noop() {
+    fn dismiss_inform_out_of_bounds_is_a_noop() {
         let s = WindowState::new();
-        s.dismiss_first_inform();
+        s.push_inform("only".into());
+        s.dismiss_inform(5);
+        assert_eq!(s.snapshot().informs, vec!["only".to_string()]);
+    }
+
+    #[test]
+    fn dismiss_inform_when_empty_is_a_noop() {
+        let s = WindowState::new();
+        s.dismiss_inform(0);
         assert!(s.snapshot().informs.is_empty());
     }
 

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc;
 use crate::approval_flow::protocol::Decision;
 use crate::approval_flow::session::PendingPrompt;
 use crate::credential_flow::session::{CredentialDecisionRequest, CredentialPendingPrompt};
+use crate::credential_flow::store::CredentialEntry;
 use crate::oauth::SignInPivot;
 use lns_policy::integrations::TokenFallback;
 
@@ -60,22 +61,87 @@ struct WindowInner {
     pending: Vec<PendingEntry>,
     pending_credentials: Vec<CredentialPendingEntry>,
     pending_sign_ins: Vec<SignInEntry>,
-    informs: Vec<String>,
+    informs: Vec<InformEntry>,
+    connecting: Vec<ConnectingEntry>,
+    next_seq: u64,
+}
+
+impl WindowInner {
+    fn alloc_seq(&mut self) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+
+    fn take_connecting(&mut self, display_name: &str) -> Option<u64> {
+        let idx = self
+            .connecting
+            .iter()
+            .position(|e| e.display_name == display_name)?;
+        Some(self.connecting.remove(idx).seq)
+    }
+
+    fn order(&self) -> Vec<StackItem> {
+        let mut keyed: Vec<(u64, StackItem)> = Vec::new();
+        keyed.extend(seq_keyed(
+            self.informs.iter().map(|e| e.seq),
+            StackItem::Inform,
+        ));
+        keyed.extend(seq_keyed(
+            self.pending.iter().map(|e| e.seq),
+            StackItem::Network,
+        ));
+        keyed.extend(seq_keyed(
+            self.pending_sign_ins.iter().map(|e| e.seq),
+            StackItem::SignIn,
+        ));
+        keyed.extend(seq_keyed(
+            self.pending_credentials.iter().map(|e| e.seq),
+            StackItem::Credential,
+        ));
+        keyed.extend(seq_keyed(
+            self.connecting.iter().map(|e| e.seq),
+            StackItem::Connecting,
+        ));
+        keyed.sort_by_key(|(seq, _)| *seq);
+        keyed.into_iter().map(|(_, item)| item).collect()
+    }
+}
+
+fn seq_keyed(
+    seqs: impl Iterator<Item = u64>,
+    item: fn(usize) -> StackItem,
+) -> impl Iterator<Item = (u64, StackItem)> {
+    seqs.enumerate().map(move |(i, seq)| (seq, item(i)))
 }
 
 struct PendingEntry {
     prompt: PendingPrompt,
     decision_tx: mpsc::UnboundedSender<DecisionDelivery>,
+    seq: u64,
 }
 
 struct CredentialPendingEntry {
     prompt: CredentialCardPrompt,
     decision_tx: mpsc::UnboundedSender<CredentialDecisionDelivery>,
+    seq: u64,
 }
 
 struct SignInEntry {
     card: SignInCard,
     cancel: tokio::sync::oneshot::Sender<SignInPivot>,
+    seq: u64,
+}
+
+struct InformEntry {
+    msg: String,
+    seq: u64,
+}
+
+/// Holds an accepted offer's slot in the stack while its connect is in flight, so the card doesn't vanish and re-emerge somewhere else.
+struct ConnectingEntry {
+    display_name: String,
+    seq: u64,
 }
 
 impl WindowState {
@@ -94,9 +160,11 @@ impl WindowState {
         if g.pending.iter().any(|e| e.prompt.id == prompt.id) {
             return;
         }
+        let seq = g.alloc_seq();
         g.pending.push(PendingEntry {
             prompt,
             decision_tx,
+            seq,
         });
     }
 
@@ -118,6 +186,7 @@ impl WindowState {
         {
             return;
         }
+        let seq = g.alloc_seq();
         g.pending_credentials.push(CredentialPendingEntry {
             prompt: CredentialCardPrompt {
                 id: prompt.id,
@@ -128,6 +197,7 @@ impl WindowState {
                 token_fallback: prompt.token_fallback,
             },
             decision_tx,
+            seq,
         });
     }
 
@@ -137,7 +207,7 @@ impl WindowState {
             .retain(|e| e.prompt.id != id);
     }
 
-    /// Coalesces by `credential_id`; the `cancel` sender aborts the in-flight device-flow poll (or pivots it to a pasted token) when the card resolves.
+    /// Coalesces by `credential_id`; the `cancel` sender aborts the in-flight device-flow poll (or pivots it to a pasted token) when the card resolves. The card takes over a matching connecting placeholder's slot so it appears where the accepted card was.
     pub fn insert_sign_in(
         &self,
         card: SignInCard,
@@ -150,7 +220,10 @@ impl WindowState {
         {
             return;
         }
-        g.pending_sign_ins.push(SignInEntry { card, cancel });
+        let seq = g
+            .take_connecting(&card.display_name)
+            .unwrap_or_else(|| g.alloc_seq());
+        g.pending_sign_ins.push(SignInEntry { card, cancel, seq });
     }
 
     pub fn remove_sign_in(&self, credential_id: &str) {
@@ -185,7 +258,9 @@ impl WindowState {
     }
 
     pub fn push_inform(&self, msg: String) {
-        self.lock().informs.push(msg);
+        let mut g = self.lock();
+        let seq = g.alloc_seq();
+        g.informs.push(InformEntry { msg, seq });
     }
 
     pub fn clear_informs(&self) {
@@ -209,7 +284,13 @@ impl WindowState {
                 .map(|e| e.prompt.clone())
                 .collect(),
             sign_ins: g.pending_sign_ins.iter().map(|e| e.card.clone()).collect(),
-            informs: g.informs.clone(),
+            informs: g.informs.iter().map(|e| e.msg.clone()).collect(),
+            connecting: g
+                .connecting
+                .iter()
+                .map(|e| e.display_name.clone())
+                .collect(),
+            order: g.order(),
         }
     }
 
@@ -233,7 +314,7 @@ impl WindowState {
         self.route_offer(id, RequestAction::UseToken { value })
     }
 
-    /// Routes one connect action for the clicked request and immediately drops every other offer card for the same integration, so no sibling card flashes up before the in-flight connect releases them all.
+    /// Routes one connect action for the clicked request and immediately drops every other offer card for the same integration, so no sibling card flashes up before the in-flight connect releases them all. The clicked card's slot is kept by a connecting placeholder until the connect resolves.
     fn route_offer(&self, id: &str, action: RequestAction) -> bool {
         let mut g = self.lock();
         let Some(idx) = g.pending.iter().position(|e| e.prompt.id == id) else {
@@ -248,6 +329,10 @@ impl WindowState {
         if let Some(name) = offer {
             g.pending
                 .retain(|e| e.prompt.offer.as_deref() != Some(name.as_str()));
+            g.connecting.push(ConnectingEntry {
+                display_name: name,
+                seq: entry.seq,
+            });
         }
         true
     }
@@ -286,18 +371,31 @@ impl WindowState {
         true
     }
 
-    /// Mirror of [`Self::decide`] for the credential flow.
+    /// Mirror of [`Self::decide`] for the credential flow. A browser-consent accept on an oauth card keeps the card's slot via a connecting placeholder, because its device sign-in arrives asynchronously.
     pub fn decide_credential(&self, id: &str, request: CredentialDecisionRequest) -> bool {
         let mut g = self.lock();
         let Some(idx) = g.pending_credentials.iter().position(|e| e.prompt.id == id) else {
             return false;
         };
         let entry = g.pending_credentials.remove(idx);
+        if let Some(name) = consent_connect_name(&entry.prompt, &request) {
+            g.connecting.push(ConnectingEntry {
+                display_name: name,
+                seq: entry.seq,
+            });
+        }
         let _ = entry.decision_tx.send(CredentialDecisionDelivery {
             id: id.to_string(),
             request,
         });
         true
+    }
+
+    /// Drops every connecting placeholder for `display_name` once its connect has resolved.
+    pub fn clear_connecting(&self, display_name: &str) {
+        self.lock()
+            .connecting
+            .retain(|e| e.display_name != display_name);
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, WindowInner> {
@@ -311,6 +409,33 @@ pub struct Snapshot {
     pub pending_credentials: Vec<CredentialCardPrompt>,
     pub sign_ins: Vec<SignInCard>,
     pub informs: Vec<String>,
+    /// Display names of integrations whose accepted connect is still in flight, each holding its card's slot.
+    pub connecting: Vec<String>,
+    /// Every entry above in arrival order, so a card keeps its place in the stack as others come and go.
+    pub order: Vec<StackItem>,
+}
+
+/// One renderable entry of the approval window's stack, indexing into its [`Snapshot`] list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StackItem {
+    Inform(usize),
+    Network(usize),
+    SignIn(usize),
+    Credential(usize),
+    Connecting(usize),
+}
+
+/// The placeholder name for a consent-card decision that drives an asynchronous device sign-in — a browser-consent accept on an oauth card; a pasted token or a deny resolves synchronously and holds no slot.
+fn consent_connect_name(
+    prompt: &CredentialCardPrompt,
+    request: &CredentialDecisionRequest,
+) -> Option<String> {
+    let name = prompt.oauth_display_name.as_ref()?;
+    match request {
+        CredentialDecisionRequest::Allow(CredentialEntry::Stored { .. }) => None,
+        CredentialDecisionRequest::Allow(_) => Some(name.clone()),
+        _ => None,
+    }
 }
 
 static GLOBAL: OnceLock<Arc<WindowState>> = OnceLock::new();
@@ -917,6 +1042,195 @@ mod tests {
     fn pivot_sign_in_for_unknown_id_is_false() {
         let s = WindowState::new();
         assert!(!s.pivot_sign_in("nope", "some-x-token".into()));
+    }
+
+    #[test]
+    fn snapshot_order_interleaves_kinds_by_arrival() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        let (cred_tx, _crx) = unbounded_channel();
+        s.insert_pending(prompt("r1", "a.test"), tx.clone());
+        s.push_inform("warn".into());
+        s.insert_credential_pending(cred_prompt("c1", "some-provider"), false, cred_tx);
+        s.insert_pending(prompt("r2", "b.test"), tx);
+        assert_eq!(
+            s.snapshot().order,
+            vec![
+                StackItem::Network(0),
+                StackItem::Inform(0),
+                StackItem::Credential(0),
+                StackItem::Network(1),
+            ],
+            "the stack is ordered by arrival, not regrouped by kind, so cards never jump"
+        );
+    }
+
+    #[test]
+    fn connect_offer_keeps_the_clicked_cards_slot_with_a_connecting_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(
+            offer_prompt("r1", "api.some-oauth.example", "GitHub"),
+            tx.clone(),
+        );
+        s.insert_pending(prompt("r2", "example.com"), tx);
+        assert!(s.connect_offer("r1"));
+        let snap = s.snapshot();
+        assert_eq!(snap.connecting, vec!["GitHub".to_string()]);
+        assert_eq!(
+            snap.order,
+            vec![StackItem::Connecting(0), StackItem::Network(0)],
+            "accepting the offer leaves a placeholder in the card's slot instead of collapsing the stack"
+        );
+    }
+
+    #[test]
+    fn use_offer_token_keeps_the_clicked_cards_slot_with_a_connecting_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
+        assert!(s.use_offer_token("r1", "some-pasted-token".into()));
+        assert_eq!(s.snapshot().connecting, vec!["GitHub".to_string()]);
+    }
+
+    #[test]
+    fn decline_offer_leaves_no_connecting_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
+        assert!(s.decline_offer("r1"));
+        assert!(s.snapshot().connecting.is_empty());
+    }
+
+    #[test]
+    fn insert_sign_in_takes_over_a_matching_connecting_placeholders_slot() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(
+            offer_prompt("r1", "api.some-oauth.example", "GitHub"),
+            tx.clone(),
+        );
+        s.insert_pending(prompt("r2", "example.com"), tx);
+        s.connect_offer("r1");
+        let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
+        s.insert_sign_in(sign_in_card("some-oauth"), cancel_tx);
+        let snap = s.snapshot();
+        assert!(
+            snap.connecting.is_empty(),
+            "the sign-in card replaces the placeholder"
+        );
+        assert_eq!(
+            snap.order,
+            vec![StackItem::SignIn(0), StackItem::Network(0)],
+            "the sign-in card appears where the accepted card was, not underneath the other request"
+        );
+    }
+
+    #[test]
+    fn insert_sign_in_without_a_placeholder_appends_at_the_bottom() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(prompt("r1", "a.test"), tx);
+        let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
+        s.insert_sign_in(sign_in_card("some-oauth"), cancel_tx);
+        assert_eq!(
+            s.snapshot().order,
+            vec![StackItem::Network(0), StackItem::SignIn(0)]
+        );
+    }
+
+    #[test]
+    fn clear_connecting_drops_only_the_named_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(
+            offer_prompt("r1", "api.some-oauth.example", "GitHub"),
+            tx.clone(),
+        );
+        s.insert_pending(
+            offer_prompt("r2", "api.other-oauth.example", "Other Service"),
+            tx,
+        );
+        s.connect_offer("r1");
+        s.connect_offer("r2");
+        s.clear_connecting("GitHub");
+        assert_eq!(s.snapshot().connecting, vec!["Other Service".to_string()]);
+    }
+
+    #[test]
+    fn clear_connecting_for_an_unknown_name_is_a_noop() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
+        s.connect_offer("r1");
+        s.clear_connecting("Other Service");
+        assert_eq!(s.snapshot().connecting, vec!["GitHub".to_string()]);
+    }
+
+    fn oauth_cred_prompt(id: &str, name: &str) -> CredentialPendingPrompt {
+        CredentialPendingPrompt {
+            id: id.into(),
+            credential_id: "some-oauth".into(),
+            action: "use of some-oauth placeholder".into(),
+            oauth_display_name: Some(name.into()),
+            token_fallback: None,
+        }
+    }
+
+    #[test]
+    fn consent_accept_keeps_the_cards_slot_with_a_connecting_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_credential_pending(oauth_cred_prompt("c1", "GitHub"), false, tx);
+        assert!(s.decide_credential(
+            "c1",
+            CredentialDecisionRequest::Allow(CredentialEntry::HostDetect)
+        ));
+        let snap = s.snapshot();
+        assert_eq!(
+            snap.connecting,
+            vec!["GitHub".to_string()],
+            "the consent card's slot waits for the sign-in card its accept will produce"
+        );
+        assert_eq!(snap.order, vec![StackItem::Connecting(0)]);
+    }
+
+    #[test]
+    fn consent_accept_with_a_pasted_token_leaves_no_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_credential_pending(oauth_cred_prompt("c1", "GitHub"), false, tx);
+        assert!(s.decide_credential(
+            "c1",
+            CredentialDecisionRequest::Allow(CredentialEntry::Stored {
+                value: "some-pasted-token".into()
+            })
+        ));
+        assert!(
+            s.snapshot().connecting.is_empty(),
+            "a pasted token arms synchronously, so no slot needs holding"
+        );
+    }
+
+    #[test]
+    fn consent_deny_leaves_no_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_credential_pending(oauth_cred_prompt("c1", "GitHub"), false, tx);
+        assert!(s.decide_credential("c1", CredentialDecisionRequest::Deny));
+        assert!(s.snapshot().connecting.is_empty());
+    }
+
+    #[test]
+    fn plain_credential_accept_leaves_no_placeholder() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_credential_pending(cred_prompt("c1", "some-provider"), true, tx);
+        assert!(s.decide_credential(
+            "c1",
+            CredentialDecisionRequest::Allow(CredentialEntry::HostDetect)
+        ));
+        assert!(s.snapshot().connecting.is_empty());
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/notification.rs
+++ b/crates/lns-service/src/credential_flow/notification.rs
@@ -114,6 +114,11 @@ impl CredentialNotifier for WindowCredentialNotifier {
         self.state.clear_connecting(display_name);
         self.wake();
     }
+
+    fn clear_all_connecting(&self) {
+        self.state.clear_all_connecting();
+        self.wake();
+    }
 }
 
 #[cfg(test)]
@@ -295,6 +300,23 @@ mod tests {
     }
 
     #[test]
+    fn clear_all_connecting_drops_every_placeholder() {
+        let (n, state, _rx) = fixture(false, false);
+        let mut consent = prompt("c1", "some-oauth");
+        consent.oauth_display_name = Some("GitHub".into());
+        n.present(&consent);
+        state.decide_credential(
+            "c1",
+            crate::credential_flow::session::CredentialDecisionRequest::Allow(
+                crate::credential_flow::store::CredentialEntry::HostDetect,
+            ),
+        );
+        assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
+        n.clear_all_connecting();
+        assert!(state.snapshot().connecting.is_empty());
+    }
+
+    #[test]
     fn noop_notifier_methods_are_safe_to_call() {
         let n = NoopCredentialNotifier;
         n.present(&prompt("c1", "some-provider"));
@@ -302,6 +324,7 @@ mod tests {
         n.inform("anything");
         n.clear_informs();
         n.connect_finished("GitHub");
+        n.clear_all_connecting();
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/notification.rs
+++ b/crates/lns-service/src/credential_flow/notification.rs
@@ -109,6 +109,11 @@ impl CredentialNotifier for WindowCredentialNotifier {
         self.state.remove_sign_in(credential_id);
         self.wake();
     }
+
+    fn connect_finished(&self, display_name: &str) {
+        self.state.clear_connecting(display_name);
+        self.wake();
+    }
 }
 
 #[cfg(test)]
@@ -270,12 +275,33 @@ mod tests {
     }
 
     #[test]
+    fn connect_finished_clears_the_connecting_placeholder() {
+        let (n, state, _rx) = fixture(false, false);
+        let mut consent = prompt("c1", "some-oauth");
+        consent.oauth_display_name = Some("GitHub".into());
+        n.present(&consent);
+        state.decide_credential(
+            "c1",
+            crate::credential_flow::session::CredentialDecisionRequest::Allow(
+                crate::credential_flow::store::CredentialEntry::HostDetect,
+            ),
+        );
+        assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
+        n.connect_finished("GitHub");
+        assert!(
+            state.snapshot().connecting.is_empty(),
+            "the resolved connect takes the placeholder down"
+        );
+    }
+
+    #[test]
     fn noop_notifier_methods_are_safe_to_call() {
         let n = NoopCredentialNotifier;
         n.present(&prompt("c1", "some-provider"));
         n.dismiss("c1");
         n.inform("anything");
         n.clear_informs();
+        n.connect_finished("GitHub");
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -64,6 +64,10 @@ pub trait CredentialNotifier: Send + Sync {
     fn dismiss_sign_in(&self, credential_id: &str) {
         let _ = credential_id;
     }
+    /// Signals that an accepted consent's connect has resolved (either way), so any surface holding the card's slot can release it; default no-op.
+    fn connect_finished(&self, display_name: &str) {
+        let _ = display_name;
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -325,7 +329,10 @@ impl CredentialSession {
             return DecisionOutcome::UnknownId;
         };
         self.notifier.dismiss(prompt_id);
-        if self.run_oauth_connect(&credential_id).await {
+        let connected = self.run_oauth_connect(&credential_id).await;
+        self.notifier
+            .connect_finished(&self.display_name_for(&credential_id));
+        if connected {
             for request_id in &request_ids {
                 self.send_decision_frame(request_id, CredentialDecisionKind::Allow);
             }
@@ -574,6 +581,7 @@ mod tests {
         dismissed: StdMutex<Vec<String>>,
         informed: StdMutex<Vec<String>>,
         informs_cleared: StdMutex<usize>,
+        connects_finished: StdMutex<Vec<String>>,
     }
 
     impl RecordingNotifier {
@@ -615,6 +623,12 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(credential_id.to_string());
+        }
+        fn connect_finished(&self, display_name: &str) {
+            self.connects_finished
+                .lock()
+                .unwrap()
+                .push(display_name.to_string());
         }
     }
 
@@ -1761,9 +1775,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connect_oauth_signals_connect_finished_with_the_display_name() {
+        let (s, n, _store, _rx, _connected) =
+            oauth_fixture(FakeFlow::polling(vec![crate::oauth::PollOutcome::Token(
+                oauth_token(3600),
+            )]));
+        s.submit_pending(pending("c1", "some-oauth"), Instant::now());
+        s.connect_oauth("c1").await;
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "the resolved connect releases the slot the consent card's placeholder holds"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_oauth_failure_still_signals_connect_finished() {
+        let (s, n, _store, _rx, _connected) = oauth_fixture(FakeFlow::code_error());
+        s.submit_pending(pending("c1", "some-oauth"), Instant::now());
+        s.connect_oauth("c1").await;
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "a failed sign-in must not leave a connecting placeholder behind"
+        );
+    }
+
+    #[tokio::test]
     async fn connect_oauth_on_an_unknown_prompt_is_a_noop() {
-        let (s, _n, _store, _rx, _c) = oauth_fixture(FakeFlow::polling(vec![]));
+        let (s, n, _store, _rx, _c) = oauth_fixture(FakeFlow::polling(vec![]));
         assert_eq!(s.connect_oauth("nope").await, DecisionOutcome::UnknownId);
+        assert!(n.connects_finished.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -68,6 +68,8 @@ pub trait CredentialNotifier: Send + Sync {
     fn connect_finished(&self, display_name: &str) {
         let _ = display_name;
     }
+    /// Drops every in-flight connect placeholder on run teardown so a sign-in that never resolves can't keep the window pinned; default no-op.
+    fn clear_all_connecting(&self) {}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -506,10 +508,15 @@ impl CredentialSession {
     }
 
     fn timeout_one(&self, prompt_id: &str) -> bool {
-        let Some((_, request_ids)) = self.remove_pending(prompt_id) else {
+        let Some((credential_id, request_ids)) = self.remove_pending(prompt_id) else {
             return false;
         };
         self.notifier.dismiss(prompt_id);
+        // A consent clicked into a sign-in right as it expired leaves a placeholder no later sign-in will resolve; take it down with the prompt.
+        if self.oauth_configs.contains_key(&credential_id) {
+            self.notifier
+                .connect_finished(&self.display_name_for(&credential_id));
+        }
         for request_id in &request_ids {
             self.send_decision_frame(request_id, CredentialDecisionKind::Timeout);
         }
@@ -532,6 +539,7 @@ impl CredentialSession {
             self.notifier.dismiss(prompt_id);
         }
         self.notifier.clear_informs();
+        self.notifier.clear_all_connecting();
     }
 }
 
@@ -582,6 +590,7 @@ mod tests {
         informed: StdMutex<Vec<String>>,
         informs_cleared: StdMutex<usize>,
         connects_finished: StdMutex<Vec<String>>,
+        all_connecting_cleared: StdMutex<usize>,
     }
 
     impl RecordingNotifier {
@@ -629,6 +638,9 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(display_name.to_string());
+        }
+        fn clear_all_connecting(&self) {
+            *self.all_connecting_cleared.lock().unwrap() += 1;
         }
     }
 
@@ -1048,6 +1060,25 @@ mod tests {
             CredentialDecisionKind::Timeout
         );
         assert_eq!(n.dismissed.lock().unwrap().as_slice(), &["c1".to_string()]);
+        assert!(
+            n.connects_finished.lock().unwrap().is_empty(),
+            "a plain credential never holds a connect placeholder, so its timeout signals none"
+        );
+    }
+
+    #[test]
+    fn timeout_clears_a_connecting_placeholder_for_an_expired_oauth_consent() {
+        let (s, n, _store, _rx, _c) = oauth_fixture(FakeFlow::polling(vec![]));
+        let t0 = Instant::now();
+        s.submit_pending(pending("c1", "some-oauth"), t0);
+
+        s.tick_timeouts(t0 + TEST_TIMEOUT + Duration::from_secs(1));
+
+        assert_eq!(
+            n.connects_finished.lock().unwrap().as_slice(),
+            &["GitHub".to_string()],
+            "timing out a clicked consent must release the placeholder no later sign-in will resolve"
+        );
     }
 
     #[test]
@@ -1094,6 +1125,20 @@ mod tests {
             *n.informs_cleared.lock().unwrap(),
             1,
             "withdraw_run must call clear_informs exactly once"
+        );
+    }
+
+    #[test]
+    fn withdraw_run_clears_connecting_placeholders_so_window_does_not_stay_pinned() {
+        let (s, n, _store, _rx) = fixture();
+        s.submit_pending(pending("c1", "some-provider"), Instant::now());
+
+        s.withdraw_run();
+
+        assert_eq!(
+            *n.all_connecting_cleared.lock().unwrap(),
+            1,
+            "an in-flight sign-in placeholder must not survive the run that started it"
         );
     }
 

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -77,7 +77,6 @@ struct TrayApp {
     window_state: Arc<WindowState>,
     _tray: tray_icon::TrayIcon,
     last_visible: bool,
-    positioned: bool,
     /// Kept on `TrayApp` (not [`WindowState`]) so the snapshot passed to [`render_stack`] stays immutable.
     credential_inputs: HashMap<String, String>,
     /// Per-card progressive-disclosure state for the "use a token instead" fallback, keyed by the shown card's id.
@@ -139,7 +138,6 @@ impl TrayApp {
             window_state,
             _tray: tray,
             last_visible: false,
-            positioned: false,
             credential_inputs: HashMap::new(),
             token_drafts: HashMap::new(),
             current_height: WINDOW_HEIGHT,
@@ -147,22 +145,31 @@ impl TrayApp {
     }
 
     fn sync_viewport_visibility(&mut self, ctx: &egui::Context) {
-        if !self.positioned
-            && let Some(pos) = top_right_position(ctx)
-        {
-            ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(pos));
-            self.positioned = true;
-        }
-
         let items = stack_items(&self.window_state.snapshot());
         let should_show = !items.is_empty();
+        let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
+        let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
+        let target = target_height(&items, revealed, monitor_height);
+
         match visibility_transition(should_show, self.last_visible) {
             VisibilityTransition::Show => {
+                // Place and size the window before revealing it, or macOS flashes it un-positioned mid-screen for a frame.
+                let Some(pos) = top_right_position(ctx) else {
+                    ctx.request_repaint();
+                    return;
+                };
+                join_all_spaces();
+                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(pos));
+                ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
+                    WINDOW_WIDTH,
+                    target,
+                )));
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(false));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
                 // The frame that reveals the window saw is_visible=false, so eframe skipped ui(); kick a repaint so the now-visible window paints its cards.
                 ctx.request_repaint();
+                self.current_height = target;
                 self.last_visible = true;
             }
             VisibilityTransition::Hide => {
@@ -170,18 +177,15 @@ impl TrayApp {
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(true));
                 self.last_visible = false;
             }
-            VisibilityTransition::Unchanged => {}
-        }
-
-        let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
-        let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
-        let target = target_height(&items, revealed, monitor_height);
-        if (self.current_height - target).abs() > 0.5 {
-            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
-                WINDOW_WIDTH,
-                target,
-            )));
-            self.current_height = target;
+            VisibilityTransition::Unchanged => {
+                if self.last_visible && (self.current_height - target).abs() > 0.5 {
+                    ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
+                        WINDOW_WIDTH,
+                        target,
+                    )));
+                    self.current_height = target;
+                }
+            }
         }
     }
 }
@@ -938,6 +942,26 @@ fn install_activation_policy(opts: &mut eframe::NativeOptions) {
 
 #[cfg(not(target_os = "macos"))]
 fn install_activation_policy(_opts: &mut eframe::NativeOptions) {}
+
+/// Lets the always-on-top approval window appear on whichever macOS Space is active — including a full-screen app's Space — instead of staying pinned to the desktop it was created on.
+#[cfg(target_os = "macos")]
+fn join_all_spaces() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSWindowCollectionBehavior};
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        crate::log::warn!("skipped tray-window Space behavior: not on the main thread");
+        return;
+    };
+    let extra = NSWindowCollectionBehavior::CanJoinAllSpaces
+        | NSWindowCollectionBehavior::FullScreenAuxiliary;
+    for window in NSApplication::sharedApplication(mtm).windows().iter() {
+        window.setCollectionBehavior(window.collectionBehavior() | extra);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn join_all_spaces() {}
 
 fn load_icon() -> anyhow::Result<Icon> {
     const ICON_BYTES: &[u8] = include_bytes!("../assets/lensTemplate@2x.png");

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -18,9 +18,16 @@ use lns_policy::integrations::TokenFallback;
 
 const WINDOW_WIDTH: f32 = 460.0;
 const WINDOW_HEIGHT: f32 = 300.0;
-/// Used when a token-fallback field is revealed, which adds an input, a help link, and a Save button below the primary action — taller than the standard card.
-const WINDOW_HEIGHT_EXPANDED: f32 = 460.0;
 const SCREEN_EDGE_MARGIN: f32 = 20.0;
+
+const MIN_WINDOW_HEIGHT: f32 = 140.0;
+const FALLBACK_MAX_HEIGHT: f32 = 720.0;
+const INFORM_ITEM_HEIGHT: f32 = 56.0;
+const CARD_ITEM_HEIGHT: f32 = 250.0;
+/// Added per card whose token-fallback field is revealed: an input, a help link, and a Save button below the primary action.
+const TOKEN_REVEAL_EXTRA: f32 = 150.0;
+const STACK_ITEM_GAP: f32 = 14.0;
+const STACK_CHROME: f32 = 60.0;
 
 pub fn run_tray(
     shutdown: Arc<Shutdown>,
@@ -71,7 +78,7 @@ struct TrayApp {
     _tray: tray_icon::TrayIcon,
     last_visible: bool,
     positioned: bool,
-    /// Kept on `TrayApp` (not [`WindowState`]) so the snapshot passed to [`render_card`] stays immutable.
+    /// Kept on `TrayApp` (not [`WindowState`]) so the snapshot passed to [`render_stack`] stays immutable.
     credential_inputs: HashMap<String, String>,
     /// Per-card progressive-disclosure state for the "use a token instead" fallback, keyed by the shown card's id.
     token_drafts: HashMap<String, TokenDraft>,
@@ -147,14 +154,14 @@ impl TrayApp {
             self.positioned = true;
         }
 
-        let should_show = self.window_state.pending_count() > 0
-            || !self.window_state.snapshot().informs.is_empty();
+        let items = stack_items(&self.window_state.snapshot());
+        let should_show = !items.is_empty();
         match visibility_transition(should_show, self.last_visible) {
             VisibilityTransition::Show => {
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(false));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-                // The frame that reveals the window saw is_visible=false, so eframe skipped ui(); kick a repaint so the now-visible window paints its card.
+                // The frame that reveals the window saw is_visible=false, so eframe skipped ui(); kick a repaint so the now-visible window paints its cards.
                 ctx.request_repaint();
                 self.last_visible = true;
             }
@@ -166,12 +173,10 @@ impl TrayApp {
             VisibilityTransition::Unchanged => {}
         }
 
-        let target = if self.token_drafts.values().any(|d| d.revealed) {
-            WINDOW_HEIGHT_EXPANDED
-        } else {
-            WINDOW_HEIGHT
-        };
-        if self.current_height != target {
+        let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
+        let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
+        let target = target_height(&items, revealed, monitor_height);
+        if (self.current_height - target).abs() > 0.5 {
             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
                 WINDOW_WIDTH,
                 target,
@@ -199,7 +204,7 @@ impl eframe::App for TrayApp {
         prune_credential_inputs(&mut self.credential_inputs, &snapshot);
         prune_token_drafts(&mut self.token_drafts, &snapshot);
 
-        match render_card(
+        match render_stack(
             ui,
             &snapshot,
             &mut self.credential_inputs,
@@ -214,8 +219,8 @@ impl eframe::App for TrayApp {
                 self.window_state.decide_credential(&id, request);
                 ui.ctx().request_repaint();
             }
-            Some(CardAction::DismissInform) => {
-                self.window_state.dismiss_first_inform();
+            Some(CardAction::DismissInform { index }) => {
+                self.window_state.dismiss_inform(index);
                 ui.ctx().request_repaint();
             }
             Some(CardAction::OpenBrowser { url }) => {
@@ -264,7 +269,9 @@ enum CardAction {
         id: String,
         request: CredentialDecisionRequest,
     },
-    DismissInform,
+    DismissInform {
+        index: usize,
+    },
     OpenBrowser {
         url: String,
     },
@@ -293,7 +300,47 @@ enum TokenFallbackEvent {
     OpenHelp(String),
 }
 
-fn render_card(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StackItem {
+    Inform(usize),
+    Network(usize),
+    SignIn(usize),
+    Credential(usize),
+}
+
+/// Every pending entry, in the order it stacks down the window: passive informs on top, then network/connect cards, in-flight sign-ins, and credential prompts. Returning all of them — not just the first of each — is what keeps concurrent notifications from one service hiding another's.
+fn stack_items(snapshot: &Snapshot) -> Vec<StackItem> {
+    let mut items = Vec::new();
+    items.extend((0..snapshot.informs.len()).map(StackItem::Inform));
+    items.extend((0..snapshot.pending.len()).map(StackItem::Network));
+    items.extend((0..snapshot.sign_ins.len()).map(StackItem::SignIn));
+    items.extend((0..snapshot.pending_credentials.len()).map(StackItem::Credential));
+    items
+}
+
+fn item_height(item: &StackItem) -> f32 {
+    match item {
+        StackItem::Inform(_) => INFORM_ITEM_HEIGHT,
+        _ => CARD_ITEM_HEIGHT,
+    }
+}
+
+/// Window height that fits the whole stack, capped at the usable monitor height so a long stack scrolls inside the window rather than running off-screen.
+fn target_height(items: &[StackItem], revealed: usize, monitor_height: Option<f32>) -> f32 {
+    if items.is_empty() {
+        return MIN_WINDOW_HEIGHT;
+    }
+    let content = items.iter().map(item_height).sum::<f32>()
+        + STACK_ITEM_GAP * (items.len() - 1) as f32
+        + revealed as f32 * TOKEN_REVEAL_EXTRA
+        + STACK_CHROME;
+    let cap = monitor_height
+        .map(|h| (h - 2.0 * SCREEN_EDGE_MARGIN).max(MIN_WINDOW_HEIGHT))
+        .unwrap_or(FALLBACK_MAX_HEIGHT);
+    content.clamp(MIN_WINDOW_HEIGHT, cap)
+}
+
+fn render_stack(
     ui: &mut egui::Ui,
     snapshot: &Snapshot,
     credential_inputs: &mut HashMap<String, String>,
@@ -301,11 +348,8 @@ fn render_card(
 ) -> Option<CardAction> {
     use egui::{CornerRadius, Frame, Margin, Stroke};
 
-    if snapshot.pending.is_empty()
-        && snapshot.pending_credentials.is_empty()
-        && snapshot.sign_ins.is_empty()
-        && snapshot.informs.is_empty()
-    {
+    let items = stack_items(snapshot);
+    if items.is_empty() {
         return None;
     }
 
@@ -316,49 +360,62 @@ fn render_card(
         .inner_margin(Margin::same(22))
         .outer_margin(Margin::same(8))
         .show(ui, |ui| {
-            if let Some(action) = render_inform_banner(ui, snapshot) {
-                return Some(action);
-            }
-            // Network cards take precedence over credential cards when both are pending (S8).
-            if let Some(prompt) = snapshot.pending.first() {
-                // An integration domain offers a connect before the bare allow/deny; declining falls back to the network card.
-                if let Some(display_name) = &prompt.offer {
-                    let draft = token_drafts.entry(prompt.id.clone()).or_default();
-                    return render_offer_card(
-                        ui,
-                        prompt,
-                        display_name,
-                        draft,
-                        snapshot.pending.len(),
-                    );
-                }
-                return render_network_card(ui, prompt, snapshot.pending.len());
-            }
-            // An in-flight device sign-in is the live action the user must finish next.
-            if let Some(card) = snapshot.sign_ins.first() {
-                let draft = token_drafts.entry(card.credential_id.clone()).or_default();
-                return render_sign_in_card(ui, card, draft, snapshot.sign_ins.len());
-            }
-            if let Some(prompt) = snapshot.pending_credentials.first() {
-                let input = credential_inputs.entry(prompt.id.clone()).or_default();
-                let draft = token_drafts.entry(prompt.id.clone()).or_default();
-                return render_credential_card(
-                    ui,
-                    prompt,
-                    input,
-                    draft,
-                    snapshot.pending_credentials.len(),
-                );
-            }
-            None
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    let mut action = None;
+                    for (idx, item) in items.iter().enumerate() {
+                        if idx > 0 {
+                            ui.add_space(STACK_ITEM_GAP);
+                            ui.add(egui::Separator::default().spacing(0.0));
+                            ui.add_space(STACK_ITEM_GAP);
+                        }
+                        let fired =
+                            render_item(ui, item, snapshot, credential_inputs, token_drafts);
+                        action = action.or(fired);
+                    }
+                    action
+                })
+                .inner
         })
         .inner
 }
 
-fn render_inform_banner(ui: &mut egui::Ui, snapshot: &Snapshot) -> Option<CardAction> {
+fn render_item(
+    ui: &mut egui::Ui,
+    item: &StackItem,
+    snapshot: &Snapshot,
+    credential_inputs: &mut HashMap<String, String>,
+    token_drafts: &mut HashMap<String, TokenDraft>,
+) -> Option<CardAction> {
+    match *item {
+        StackItem::Inform(i) => render_inform_banner(ui, &snapshot.informs[i], i),
+        StackItem::Network(i) => {
+            let prompt = &snapshot.pending[i];
+            if let Some(display_name) = &prompt.offer {
+                let draft = token_drafts.entry(prompt.id.clone()).or_default();
+                render_offer_card(ui, prompt, display_name, draft)
+            } else {
+                render_network_card(ui, prompt)
+            }
+        }
+        StackItem::SignIn(i) => {
+            let card = &snapshot.sign_ins[i];
+            let draft = token_drafts.entry(card.credential_id.clone()).or_default();
+            render_sign_in_card(ui, card, draft)
+        }
+        StackItem::Credential(i) => {
+            let prompt = &snapshot.pending_credentials[i];
+            let input = credential_inputs.entry(prompt.id.clone()).or_default();
+            let draft = token_drafts.entry(prompt.id.clone()).or_default();
+            render_credential_card(ui, prompt, input, draft)
+        }
+    }
+}
+
+fn render_inform_banner(ui: &mut egui::Ui, msg: &str, index: usize) -> Option<CardAction> {
     use egui::{Align, CornerRadius, Frame, Layout, Margin, RichText, Sense, Stroke};
 
-    let msg = snapshot.informs.first()?;
     let banner = Frame::new()
         .fill(window::BG_TERTIARY)
         .stroke(Stroke::new(1.0, window::STATUS_WARNING))
@@ -373,24 +430,19 @@ fn render_inform_banner(ui: &mut egui::Ui, snapshot: &Snapshot) -> Option<CardAc
                 });
             });
         });
-    ui.add_space(14.0);
     if banner.response.interact(Sense::click()).clicked() {
-        Some(CardAction::DismissInform)
+        Some(CardAction::DismissInform { index })
     } else {
         None
     }
 }
 
-fn render_network_card(
-    ui: &mut egui::Ui,
-    prompt: &PendingPrompt,
-    pending_count: usize,
-) -> Option<CardAction> {
+fn render_network_card(ui: &mut egui::Ui, prompt: &PendingPrompt) -> Option<CardAction> {
     use egui::RichText;
 
     let id = prompt.id.clone();
 
-    render_card_header(ui, "APPROVAL NEEDED", pending_count);
+    render_card_header(ui, "APPROVAL NEEDED");
 
     ui.add_space(6.0);
     ui.label(
@@ -440,13 +492,12 @@ fn render_offer_card(
     prompt: &PendingPrompt,
     display_name: &str,
     draft: &mut TokenDraft,
-    pending_count: usize,
 ) -> Option<CardAction> {
     use egui::RichText;
 
     let id = prompt.id.clone();
 
-    render_card_header(ui, "CONNECT", pending_count);
+    render_card_header(ui, "CONNECT");
 
     ui.add_space(6.0);
     ui.label(
@@ -498,17 +549,16 @@ fn render_credential_card(
     prompt: &CredentialCardPrompt,
     input: &mut String,
     draft: &mut TokenDraft,
-    pending_count: usize,
 ) -> Option<CardAction> {
     use egui::RichText;
 
     let id = prompt.id.clone();
 
     if let Some(display_name) = &prompt.oauth_display_name {
-        return render_oauth_consent_card(ui, prompt, display_name, draft, pending_count);
+        return render_oauth_consent_card(ui, prompt, display_name, draft);
     }
 
-    render_card_header(ui, "CREDENTIAL NEEDED", pending_count);
+    render_card_header(ui, "CREDENTIAL NEEDED");
 
     ui.add_space(6.0);
     ui.label(
@@ -585,11 +635,10 @@ fn render_oauth_consent_card(
     prompt: &CredentialCardPrompt,
     display_name: &str,
     draft: &mut TokenDraft,
-    pending_count: usize,
 ) -> Option<CardAction> {
     use egui::RichText;
 
-    render_card_header(ui, "CONNECT", pending_count);
+    render_card_header(ui, "CONNECT");
 
     ui.add_space(6.0);
     ui.label(
@@ -650,11 +699,10 @@ fn render_sign_in_card(
     ui: &mut egui::Ui,
     card: &SignInCard,
     draft: &mut TokenDraft,
-    pending_count: usize,
 ) -> Option<CardAction> {
     use egui::RichText;
 
-    render_card_header(ui, "CONNECT", pending_count);
+    render_card_header(ui, "CONNECT");
 
     ui.add_space(6.0);
     ui.label(
@@ -766,26 +814,15 @@ fn render_token_fallback(
     event
 }
 
-fn render_card_header(ui: &mut egui::Ui, label: &str, pending_count: usize) {
-    use egui::{Align, Layout, RichText};
+fn render_card_header(ui: &mut egui::Ui, label: &str) {
+    use egui::RichText;
 
-    ui.horizontal(|ui| {
-        ui.label(
-            RichText::new(label)
-                .size(10.5)
-                .strong()
-                .color(window::ACCENT_GREEN),
-        );
-        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-            if pending_count > 1 {
-                ui.label(
-                    RichText::new(format!("1 of {pending_count}"))
-                        .size(10.5)
-                        .color(window::TEXT_MUTED),
-                );
-            }
-        });
-    });
+    ui.label(
+        RichText::new(label)
+            .size(10.5)
+            .strong()
+            .color(window::ACCENT_GREEN),
+    );
 }
 
 fn secret_input(ui: &mut egui::Ui, value: &mut String, hint: &str) -> egui::Response {
@@ -968,6 +1005,101 @@ mod tests {
             !inputs.contains_key("stale"),
             "stale buffer must be dropped"
         );
+    }
+
+    fn net_prompt(id: &str) -> PendingPrompt {
+        PendingPrompt {
+            id: id.to_string(),
+            host: "api.example.test".to_string(),
+            action: "CONNECT api.example.test:443".to_string(),
+            offer: None,
+            token_fallback: None,
+        }
+    }
+
+    fn sign_in(credential_id: &str) -> SignInCard {
+        SignInCard {
+            credential_id: credential_id.to_string(),
+            display_name: "Some Service".to_string(),
+            user_code: "WXYZ-1234".to_string(),
+            verification_uri: "https://some-oauth.example/device".to_string(),
+            token_fallback: None,
+        }
+    }
+
+    #[test]
+    fn stack_items_includes_every_pending_entry_so_none_is_hidden() {
+        let snapshot = Snapshot {
+            pending: vec![net_prompt("n1"), net_prompt("n2")],
+            pending_credentials: vec![credential_prompt("c1")],
+            sign_ins: vec![sign_in("s1")],
+            informs: vec!["one".into(), "two".into()],
+        };
+        assert_eq!(
+            stack_items(&snapshot),
+            vec![
+                StackItem::Inform(0),
+                StackItem::Inform(1),
+                StackItem::Network(0),
+                StackItem::Network(1),
+                StackItem::SignIn(0),
+                StackItem::Credential(0),
+            ],
+            "two concurrent services plus warnings all stack; nothing is dropped to a hidden queue"
+        );
+    }
+
+    #[test]
+    fn stack_items_is_empty_when_nothing_pends() {
+        let snapshot = Snapshot {
+            pending: Vec::new(),
+            pending_credentials: Vec::new(),
+            sign_ins: Vec::new(),
+            informs: Vec::new(),
+        };
+        assert!(stack_items(&snapshot).is_empty());
+    }
+
+    #[test]
+    fn target_height_is_the_floor_when_the_stack_is_empty() {
+        assert_eq!(target_height(&[], 0, Some(1080.0)), MIN_WINDOW_HEIGHT);
+    }
+
+    #[test]
+    fn target_height_grows_with_each_additional_card() {
+        let one = target_height(&[StackItem::Network(0)], 0, Some(2000.0));
+        let two = target_height(
+            &[StackItem::Network(0), StackItem::Credential(0)],
+            0,
+            Some(2000.0),
+        );
+        assert!(
+            two > one,
+            "a second concurrent card makes the window taller rather than hiding the first"
+        );
+    }
+
+    #[test]
+    fn target_height_adds_room_for_a_revealed_token_field() {
+        let collapsed = target_height(&[StackItem::Network(0)], 0, Some(2000.0));
+        let revealed = target_height(&[StackItem::Network(0)], 1, Some(2000.0));
+        assert!(revealed > collapsed);
+    }
+
+    #[test]
+    fn target_height_caps_a_long_stack_at_the_usable_monitor_height() {
+        let many: Vec<StackItem> = (0..40).map(StackItem::Network).collect();
+        assert_eq!(
+            target_height(&many, 0, Some(900.0)),
+            900.0 - 2.0 * SCREEN_EDGE_MARGIN,
+            "a long stack scrolls inside a screen-bounded window instead of running off-screen"
+        );
+    }
+
+    #[test]
+    fn target_height_falls_back_to_a_fixed_cap_without_a_known_monitor() {
+        let many: Vec<StackItem> = (0..40).map(StackItem::Network).collect();
+        assert_eq!(target_height(&many, 0, None), FALLBACK_MAX_HEIGHT);
     }
 
     #[test]

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -189,7 +189,7 @@ impl TrayApp {
         }
     }
 
-    /// Snaps the viewport to `target` — the scroll area's reported content height plus chrome, clamped to the screen. Driven by content size (not the window-bounded `min_rect`), so a card that grows taller than the current window still makes the window grow instead of clipping.
+    /// Snaps the viewport to `target` using measured content size, not the window-bounded `min_rect`, so a card taller than the current window grows it instead of being clipped.
     fn fit_height_to_content(&mut self, ctx: &egui::Context, target: f32) {
         if (self.current_height - target).abs() > 0.5 {
             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
@@ -330,14 +330,14 @@ fn item_height(item: &StackItem) -> f32 {
     }
 }
 
-/// The tallest the window may grow: the usable monitor height, or a fixed fallback when the monitor size isn't known yet. Beyond this the stack scrolls instead of running off-screen.
+/// The tallest the window may grow before the stack scrolls rather than running off-screen — the usable monitor height, or a fixed fallback when the monitor size isn't known yet.
 fn content_cap(monitor_height: Option<f32>) -> f32 {
     monitor_height
         .map(|h| (h - 2.0 * SCREEN_EDGE_MARGIN).max(MIN_WINDOW_HEIGHT))
         .unwrap_or(FALLBACK_MAX_HEIGHT)
 }
 
-/// A pre-measurement seed for the height: only the reveal frame (which skips ui()) uses it, after which ui() snaps the window to its measured content. Estimates per-item heights and clamps to [`content_cap`].
+/// A pre-measurement height seed for the reveal frame alone (which skips ui()), after which ui() snaps the window to its measured content.
 fn target_height(items: &[StackItem], revealed: usize, monitor_height: Option<f32>) -> f32 {
     if items.is_empty() {
         return MIN_WINDOW_HEIGHT;
@@ -349,7 +349,7 @@ fn target_height(items: &[StackItem], revealed: usize, monitor_height: Option<f3
     content.clamp(MIN_WINDOW_HEIGHT, content_cap(monitor_height))
 }
 
-/// Renders the stack and returns the fired action plus the content's natural height (the scroll area's `content_size`), which the caller adds chrome to and sizes the window from. Reporting content size — not the window-bounded laid-out size — is what lets the window grow to a card taller than itself instead of clipping it.
+/// Renders the stack and returns the fired action plus the content's natural height (the scroll area's `content_size`, not the window-bounded laid-out size), which the caller sizes the window from so a card taller than the window grows it instead of being clipped.
 fn render_stack(
     ui: &mut egui::Ui,
     snapshot: &Snapshot,

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -10,7 +10,9 @@ use tray_icon::{Icon, TrayIconBuilder};
 
 use crate::approval_flow::protocol::Decision;
 use crate::approval_flow::session::PendingPrompt;
-use crate::approval_flow::window::{self, CredentialCardPrompt, SignInCard, Snapshot, WindowState};
+use crate::approval_flow::window::{
+    self, CredentialCardPrompt, SignInCard, Snapshot, StackItem, WindowState,
+};
 use crate::credential_flow::session::CredentialDecisionRequest;
 use crate::credential_flow::store::CredentialEntry;
 use crate::shutdown::Shutdown;
@@ -23,11 +25,15 @@ const SCREEN_EDGE_MARGIN: f32 = 20.0;
 const MIN_WINDOW_HEIGHT: f32 = 140.0;
 const FALLBACK_MAX_HEIGHT: f32 = 720.0;
 const INFORM_ITEM_HEIGHT: f32 = 56.0;
+const CONNECTING_ITEM_HEIGHT: f32 = 80.0;
 const CARD_ITEM_HEIGHT: f32 = 250.0;
 /// Added per card whose token-fallback field is revealed: an input, a help link, and a Save button below the primary action.
 const TOKEN_REVEAL_EXTRA: f32 = 150.0;
 const STACK_ITEM_GAP: f32 = 14.0;
-const STACK_CHROME: f32 = 60.0;
+const FRAME_INNER_MARGIN: i8 = 22;
+const FRAME_OUTER_MARGIN: i8 = 8;
+/// The vertical space the frame's margins add around the scroll content; the window sizes to measured content + this chrome.
+const STACK_CHROME: f32 = 2.0 * (FRAME_INNER_MARGIN as f32 + FRAME_OUTER_MARGIN as f32);
 
 pub fn run_tray(
     shutdown: Arc<Shutdown>,
@@ -145,11 +151,8 @@ impl TrayApp {
     }
 
     fn sync_viewport_visibility(&mut self, ctx: &egui::Context) {
-        let items = stack_items(&self.window_state.snapshot());
-        let should_show = !items.is_empty();
-        let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
-        let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
-        let target = target_height(&items, revealed, monitor_height);
+        let order = self.window_state.snapshot().order;
+        let should_show = !order.is_empty();
 
         match visibility_transition(should_show, self.last_visible) {
             VisibilityTransition::Show => {
@@ -158,18 +161,22 @@ impl TrayApp {
                     ctx.request_repaint();
                     return;
                 };
+                // A seed height keeps the reveal frame (which skips ui()) close to size; ui() then snaps the window to its measured content so no estimate slop shows as bottom padding.
+                let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
+                let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
+                let seed = target_height(&order, revealed, monitor_height);
                 join_all_spaces();
                 ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(pos));
                 ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
                     WINDOW_WIDTH,
-                    target,
+                    seed,
                 )));
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(false));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                 ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-                // The frame that reveals the window saw is_visible=false, so eframe skipped ui(); kick a repaint so the now-visible window paints its cards.
+                // The frame that reveals the window saw is_visible=false, so eframe skipped ui(); kick a repaint so the now-visible window paints its cards and fits its height.
                 ctx.request_repaint();
-                self.current_height = target;
+                self.current_height = seed;
                 self.last_visible = true;
             }
             VisibilityTransition::Hide => {
@@ -177,15 +184,19 @@ impl TrayApp {
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(true));
                 self.last_visible = false;
             }
-            VisibilityTransition::Unchanged => {
-                if self.last_visible && (self.current_height - target).abs() > 0.5 {
-                    ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
-                        WINDOW_WIDTH,
-                        target,
-                    )));
-                    self.current_height = target;
-                }
-            }
+            // Resizing while visible is driven by ui()'s content measurement, not an estimate.
+            VisibilityTransition::Unchanged => {}
+        }
+    }
+
+    /// Snaps the viewport to `target` — the scroll area's reported content height plus chrome, clamped to the screen. Driven by content size (not the window-bounded `min_rect`), so a card that grows taller than the current window still makes the window grow instead of clipping.
+    fn fit_height_to_content(&mut self, ctx: &egui::Context, target: f32) {
+        if (self.current_height - target).abs() > 0.5 {
+            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
+                WINDOW_WIDTH,
+                target,
+            )));
+            self.current_height = target;
         }
     }
 }
@@ -208,12 +219,19 @@ impl eframe::App for TrayApp {
         prune_credential_inputs(&mut self.credential_inputs, &snapshot);
         prune_token_drafts(&mut self.token_drafts, &snapshot);
 
-        match render_stack(
+        let monitor_height = ui.ctx().input(|i| i.viewport().monitor_size).map(|m| m.y);
+        let cap = content_cap(monitor_height);
+        let (action, content_height) = render_stack(
             ui,
             &snapshot,
             &mut self.credential_inputs,
             &mut self.token_drafts,
-        ) {
+            cap - STACK_CHROME,
+        );
+        let target = (content_height + STACK_CHROME).clamp(MIN_WINDOW_HEIGHT, cap);
+        self.fit_height_to_content(ui.ctx(), target);
+
+        match action {
             Some(CardAction::Decide { id, decision }) => {
                 self.window_state.decide(&id, decision);
                 ui.ctx().request_repaint();
@@ -304,32 +322,22 @@ enum TokenFallbackEvent {
     OpenHelp(String),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StackItem {
-    Inform(usize),
-    Network(usize),
-    SignIn(usize),
-    Credential(usize),
-}
-
-/// Every pending entry, in the order it stacks down the window: passive informs on top, then network/connect cards, in-flight sign-ins, and credential prompts. Returning all of them — not just the first of each — is what keeps concurrent notifications from one service hiding another's.
-fn stack_items(snapshot: &Snapshot) -> Vec<StackItem> {
-    let mut items = Vec::new();
-    items.extend((0..snapshot.informs.len()).map(StackItem::Inform));
-    items.extend((0..snapshot.pending.len()).map(StackItem::Network));
-    items.extend((0..snapshot.sign_ins.len()).map(StackItem::SignIn));
-    items.extend((0..snapshot.pending_credentials.len()).map(StackItem::Credential));
-    items
-}
-
 fn item_height(item: &StackItem) -> f32 {
     match item {
         StackItem::Inform(_) => INFORM_ITEM_HEIGHT,
+        StackItem::Connecting(_) => CONNECTING_ITEM_HEIGHT,
         _ => CARD_ITEM_HEIGHT,
     }
 }
 
-/// Window height that fits the whole stack, capped at the usable monitor height so a long stack scrolls inside the window rather than running off-screen.
+/// The tallest the window may grow: the usable monitor height, or a fixed fallback when the monitor size isn't known yet. Beyond this the stack scrolls instead of running off-screen.
+fn content_cap(monitor_height: Option<f32>) -> f32 {
+    monitor_height
+        .map(|h| (h - 2.0 * SCREEN_EDGE_MARGIN).max(MIN_WINDOW_HEIGHT))
+        .unwrap_or(FALLBACK_MAX_HEIGHT)
+}
+
+/// A pre-measurement seed for the height: only the reveal frame (which skips ui()) uses it, after which ui() snaps the window to its measured content. Estimates per-item heights and clamps to [`content_cap`].
 fn target_height(items: &[StackItem], revealed: usize, monitor_height: Option<f32>) -> f32 {
     if items.is_empty() {
         return MIN_WINDOW_HEIGHT;
@@ -338,37 +346,36 @@ fn target_height(items: &[StackItem], revealed: usize, monitor_height: Option<f3
         + STACK_ITEM_GAP * (items.len() - 1) as f32
         + revealed as f32 * TOKEN_REVEAL_EXTRA
         + STACK_CHROME;
-    let cap = monitor_height
-        .map(|h| (h - 2.0 * SCREEN_EDGE_MARGIN).max(MIN_WINDOW_HEIGHT))
-        .unwrap_or(FALLBACK_MAX_HEIGHT);
-    content.clamp(MIN_WINDOW_HEIGHT, cap)
+    content.clamp(MIN_WINDOW_HEIGHT, content_cap(monitor_height))
 }
 
+/// Renders the stack and returns the fired action plus the content's natural height (the scroll area's `content_size`), which the caller adds chrome to and sizes the window from. Reporting content size — not the window-bounded laid-out size — is what lets the window grow to a card taller than itself instead of clipping it.
 fn render_stack(
     ui: &mut egui::Ui,
     snapshot: &Snapshot,
     credential_inputs: &mut HashMap<String, String>,
     token_drafts: &mut HashMap<String, TokenDraft>,
-) -> Option<CardAction> {
+    scroll_max: f32,
+) -> (Option<CardAction>, f32) {
     use egui::{CornerRadius, Frame, Margin, Stroke};
 
-    let items = stack_items(snapshot);
-    if items.is_empty() {
-        return None;
+    if snapshot.order.is_empty() {
+        return (None, 0.0);
     }
 
     Frame::new()
         .fill(window::BG_SECONDARY)
         .stroke(Stroke::new(1.0, window::BORDER))
         .corner_radius(CornerRadius::same(12))
-        .inner_margin(Margin::same(22))
-        .outer_margin(Margin::same(8))
+        .inner_margin(Margin::same(FRAME_INNER_MARGIN))
+        .outer_margin(Margin::same(FRAME_OUTER_MARGIN))
         .show(ui, |ui| {
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, false])
+            let out = egui::ScrollArea::vertical()
+                .max_height(scroll_max)
+                .auto_shrink([false, true])
                 .show(ui, |ui| {
                     let mut action = None;
-                    for (idx, item) in items.iter().enumerate() {
+                    for (idx, item) in snapshot.order.iter().enumerate() {
                         if idx > 0 {
                             ui.add_space(STACK_ITEM_GAP);
                             ui.add(egui::Separator::default().spacing(0.0));
@@ -379,8 +386,8 @@ fn render_stack(
                         action = action.or(fired);
                     }
                     action
-                })
-                .inner
+                });
+            (out.inner, out.content_size.y)
         })
         .inner
 }
@@ -414,7 +421,28 @@ fn render_item(
             let draft = token_drafts.entry(prompt.id.clone()).or_default();
             render_credential_card(ui, prompt, input, draft)
         }
+        StackItem::Connecting(i) => {
+            render_connecting_card(ui, &snapshot.connecting[i]);
+            None
+        }
     }
+}
+
+fn render_connecting_card(ui: &mut egui::Ui, display_name: &str) {
+    use egui::RichText;
+
+    render_card_header(ui, "CONNECT");
+
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        ui.add(egui::Spinner::new().size(18.0).color(window::ACCENT_GREEN));
+        ui.label(
+            RichText::new(format!("Connecting to {display_name}…"))
+                .size(16.0)
+                .strong()
+                .color(window::TEXT_ACCENT),
+        );
+    });
 }
 
 fn render_inform_banner(ui: &mut egui::Ui, msg: &str, index: usize) -> Option<CardAction> {
@@ -1017,6 +1045,8 @@ mod tests {
             pending_credentials: vec![credential_prompt("keep")],
             sign_ins: Vec::new(),
             informs: Vec::new(),
+            connecting: Vec::new(),
+            order: vec![StackItem::Credential(0)],
         };
         let mut inputs = HashMap::new();
         inputs.insert("keep".to_string(), "typed so far".to_string());
@@ -1031,62 +1061,20 @@ mod tests {
         );
     }
 
-    fn net_prompt(id: &str) -> PendingPrompt {
-        PendingPrompt {
-            id: id.to_string(),
-            host: "api.example.test".to_string(),
-            action: "CONNECT api.example.test:443".to_string(),
-            offer: None,
-            token_fallback: None,
-        }
-    }
-
-    fn sign_in(credential_id: &str) -> SignInCard {
-        SignInCard {
-            credential_id: credential_id.to_string(),
-            display_name: "Some Service".to_string(),
-            user_code: "WXYZ-1234".to_string(),
-            verification_uri: "https://some-oauth.example/device".to_string(),
-            token_fallback: None,
-        }
-    }
-
-    #[test]
-    fn stack_items_includes_every_pending_entry_so_none_is_hidden() {
-        let snapshot = Snapshot {
-            pending: vec![net_prompt("n1"), net_prompt("n2")],
-            pending_credentials: vec![credential_prompt("c1")],
-            sign_ins: vec![sign_in("s1")],
-            informs: vec!["one".into(), "two".into()],
-        };
-        assert_eq!(
-            stack_items(&snapshot),
-            vec![
-                StackItem::Inform(0),
-                StackItem::Inform(1),
-                StackItem::Network(0),
-                StackItem::Network(1),
-                StackItem::SignIn(0),
-                StackItem::Credential(0),
-            ],
-            "two concurrent services plus warnings all stack; nothing is dropped to a hidden queue"
-        );
-    }
-
-    #[test]
-    fn stack_items_is_empty_when_nothing_pends() {
-        let snapshot = Snapshot {
-            pending: Vec::new(),
-            pending_credentials: Vec::new(),
-            sign_ins: Vec::new(),
-            informs: Vec::new(),
-        };
-        assert!(stack_items(&snapshot).is_empty());
-    }
-
     #[test]
     fn target_height_is_the_floor_when_the_stack_is_empty() {
         assert_eq!(target_height(&[], 0, Some(1080.0)), MIN_WINDOW_HEIGHT);
+    }
+
+    #[test]
+    fn content_cap_insets_a_known_monitor_and_falls_back_without_one() {
+        assert_eq!(content_cap(Some(900.0)), 900.0 - 2.0 * SCREEN_EDGE_MARGIN);
+        assert_eq!(content_cap(None), FALLBACK_MAX_HEIGHT);
+        assert_eq!(
+            content_cap(Some(10.0)),
+            MIN_WINDOW_HEIGHT,
+            "a tiny monitor still leaves at least the floor so the scroll area never goes negative"
+        );
     }
 
     #[test]
@@ -1100,6 +1088,15 @@ mod tests {
         assert!(
             two > one,
             "a second concurrent card makes the window taller rather than hiding the first"
+        );
+    }
+
+    #[test]
+    fn a_connecting_placeholder_takes_less_room_than_a_full_card() {
+        assert!(item_height(&StackItem::Connecting(0)) < item_height(&StackItem::Network(0)));
+        assert_eq!(
+            item_height(&StackItem::Connecting(0)),
+            CONNECTING_ITEM_HEIGHT
         );
     }
 


### PR DESCRIPTION
## Summary

Two independent bugs made the tray approval window unreliable when more than one service was active at once, and on multi-Space macOS setups.

### 1. Concurrent notifications hid each other

The old renderer showed only the **first** pending entry of each kind (first network prompt, first credential prompt, first sign-in card). Every additional concurrent notification from a second service was silently queued behind it — invisible until the user acted on the first.

The renderer is replaced with a `stack_items`-driven scrollable list. Every pending entry across all four kinds (informs, network prompts, sign-ins, credential prompts) gets its own rendered card, stacked top-to-bottom in the window:

```
before: Network card for service A (service B hidden)
after:  Network card for service A
        ────────────────────────────
        Network card for service B
```

The window height is computed by `target_height` — sum of per-item heights plus chrome, clamped to the usable monitor height so a long stack scrolls inside the window rather than running off-screen.

### 2. Window stayed pinned to the Space it was created on

On macOS, an always-on-top window is by default bound to the Space (virtual desktop) where it first appeared. If the user switched to a full-screen app on another Space, the approval window was invisible even though a prompt was pending.

`join_all_spaces()` sets `NSWindowCollectionBehavior.CanJoinAllSpaces | .FullScreenAuxiliary` on the tray window at reveal time via `objc2-app-kit`. The window now follows the active Space, including full-screen app Spaces.

### 3. Positioning race on first reveal

The window position and size are now set **before** `Visible(true)`, eliminating a one-frame flash where the un-positioned window appeared mid-screen. If the monitor size isn't reported yet on the first frame, reveal is deferred by one repaint tick.

## Screenshots
### Before
<!-- Add screenshot or recording showing the old single-card behavior / wrong-Space behavior -->

### After
<!-- Add screenshot or recording showing the stacked cards and correct Space behavior -->

## Test instructions

1. Start two workloads in separate directories that each hit a distinct host. With both running, the tray window should show two stacked network cards simultaneously — neither hidden behind the other.
2. Switch to a full-screen app on a different macOS Space while a network prompt is pending. The approval window should appear on that Space, not remain invisible on the original desktop.
3. Dismiss one of two stacked inform banners. The clicked banner should disappear; the other should remain.
4. Reveal the "Use a token instead" fallback on one card in a multi-card stack. The window should grow to accommodate the token field without clipping the other cards.
5. With a tall enough stack that it exceeds the usable monitor height, scroll inside the window — all cards should be reachable without the window running off-screen.