### PR TITLE
feat: lns run --env-file, -w/--workdir, and Docker-style memory units

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -428,13 +428,18 @@ pub struct RunArgs {
 
     #[arg(
         long,
+        value_parser = clap::value_parser!(u8).range(1..),
         help = "Number of vCPUs; falls back to the `run.cpus` config default, then 1."
     )]
     pub cpus: Option<u8>,
 
     #[arg(
+        short = 'm',
         long,
-        help = "RAM in MiB; falls back to the `run.mem` config default, then 512."
+        visible_alias = "memory",
+        value_name = "SIZE",
+        value_parser = parse_mem_arg,
+        help = "RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; b/k/m/g, rounded up to MiB); falls back to the `run.mem` config default, then 512."
     )]
     pub mem: Option<usize>,
 
@@ -490,6 +495,15 @@ pub struct RunArgs {
     pub detach_keys: DetachChord,
 
     #[arg(
+        short = 'w',
+        long,
+        value_name = "DIR",
+        value_parser = parse_workdir_arg,
+        help = "Working directory inside the sandbox (absolute path; created if missing). Defaults to the image's WORKDIR."
+    )]
+    pub workdir: Option<String>,
+
+    #[arg(
         short = 'e',
         long = "env",
         value_name = "KEY=VALUE",
@@ -497,6 +511,13 @@ pub struct RunArgs {
         help = "Set a non-secret environment variable in the workload (repeatable). Secrets belong in the credential flow, not -e."
     )]
     pub env: Vec<String>,
+
+    #[arg(
+        long = "env-file",
+        value_name = "FILE",
+        help = "Read KEY=VALUE lines from a file into the workload env (repeatable; later files and -e win; `#` comments and blank lines are skipped)."
+    )]
+    pub env_file: Vec<PathBuf>,
 
     #[arg(
         short = 'p',
@@ -601,6 +622,45 @@ pub(crate) fn parse_env_kv(s: &str) -> Result<String, String> {
         return Err(format!("empty variable name in `{s}`"));
     }
     Ok(s.to_string())
+}
+
+fn parse_workdir_arg(s: &str) -> Result<String, String> {
+    if !s.starts_with('/') {
+        return Err(format!(
+            "workdir must be an absolute path inside the sandbox, got `{s}`"
+        ));
+    }
+    Ok(s.to_string())
+}
+
+const MIB: u128 = 1024 * 1024;
+
+pub(crate) fn parse_mem_arg(s: &str) -> Result<usize, String> {
+    let lower = s.trim().to_ascii_lowercase();
+    let digits_end = lower
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(lower.len());
+    let (digits, suffix) = lower.split_at(digits_end);
+    let value: u128 = digits
+        .parse()
+        .map_err(|_| format!("invalid memory size `{s}`: expected MiB, e.g. `512`, or `2g`"))?;
+    let mib = match suffix {
+        "" | "m" | "mb" | "mib" => value,
+        "b" => value.div_ceil(MIB),
+        "k" | "kb" | "kib" => value.div_ceil(1024),
+        "g" | "gb" | "gib" => value
+            .checked_mul(1024)
+            .ok_or_else(|| format!("memory size `{s}` is out of range"))?,
+        _ => {
+            return Err(format!(
+                "invalid memory size `{s}`: unknown unit `{suffix}` (use b, k, m, or g)"
+            ));
+        }
+    };
+    if mib == 0 {
+        return Err(format!("invalid memory size `{s}`: must be at least 1 MiB"));
+    }
+    usize::try_from(mib).map_err(|_| format!("memory size `{s}` is out of range"))
 }
 
 pub(crate) fn parse_publish_arg(s: &str) -> Result<PortPublish, String> {
@@ -772,6 +832,72 @@ mod tests {
     fn parse_env_kv_rejects_a_bare_key_with_no_equals() {
         let err = parse_env_kv("HOME").unwrap_err();
         assert!(err.contains("KEY=VALUE"), "got {err:?}");
+    }
+
+    #[test]
+    fn parse_workdir_arg_accepts_an_absolute_path() {
+        assert_eq!(parse_workdir_arg("/app").unwrap(), "/app");
+    }
+
+    #[test]
+    fn parse_workdir_arg_rejects_a_relative_path() {
+        for spec in ["app", "./app", "../app", ""] {
+            let err = parse_workdir_arg(spec).unwrap_err();
+            assert!(err.contains("absolute path"), "spec {spec:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn parse_mem_arg_bare_number_is_mib() {
+        assert_eq!(parse_mem_arg("512").unwrap(), 512);
+    }
+
+    #[test]
+    fn parse_mem_arg_m_suffixes_are_mib_passthrough() {
+        for spec in ["512m", "512mb", "512mib", "512M", "512MiB"] {
+            assert_eq!(parse_mem_arg(spec).unwrap(), 512, "spec: {spec}");
+        }
+    }
+
+    #[test]
+    fn parse_mem_arg_g_suffixes_scale_to_mib() {
+        for spec in ["2g", "2gb", "2gib", "2G"] {
+            assert_eq!(parse_mem_arg(spec).unwrap(), 2048, "spec: {spec}");
+        }
+    }
+
+    #[test]
+    fn parse_mem_arg_k_and_b_round_up_to_a_whole_mib() {
+        assert_eq!(parse_mem_arg("1024k").unwrap(), 1);
+        assert_eq!(parse_mem_arg("1500k").unwrap(), 2);
+        assert_eq!(parse_mem_arg("1b").unwrap(), 1);
+        assert_eq!(parse_mem_arg("1048577b").unwrap(), 2);
+    }
+
+    #[test]
+    fn parse_mem_arg_rejects_zero() {
+        for spec in ["0", "0g", "0b"] {
+            let err = parse_mem_arg(spec).unwrap_err();
+            assert!(err.contains("at least 1 MiB"), "spec {spec}: {err}");
+        }
+    }
+
+    #[test]
+    fn parse_mem_arg_rejects_an_unknown_unit() {
+        let err = parse_mem_arg("12parsecs").unwrap_err();
+        assert!(err.contains("unknown unit"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_mem_arg_rejects_a_unit_with_no_number() {
+        let err = parse_mem_arg("g").unwrap_err();
+        assert!(err.contains("expected MiB"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_mem_arg_rejects_a_size_beyond_usize() {
+        let err = parse_mem_arg(&format!("{}g", u128::from(u64::MAX))).unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
     }
 
     #[test]

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -187,8 +187,8 @@ fn list(path: &Path, writer: &mut impl Write) -> Result<i32> {
 
 fn store(cfg: &mut ConfigFile, key: ConfigKey, values: &[String]) -> Result<()> {
     match key {
-        ConfigKey::RunCpus => cfg.run.cpus = Some(parse_number(key, single(key, values)?)?),
-        ConfigKey::RunMem => cfg.run.mem = Some(parse_number(key, single(key, values)?)?),
+        ConfigKey::RunCpus => cfg.run.cpus = Some(parse_cpus(key, single(key, values)?)?),
+        ConfigKey::RunMem => cfg.run.mem = Some(parse_mem(key, single(key, values)?)?),
         ConfigKey::RunEnv => {
             cfg.run.env = validated(key, values, |s| crate::cli::parse_env_kv(s).map(|_| ()))?;
         }
@@ -218,6 +218,18 @@ fn parse_number<N: std::str::FromStr<Err = std::num::ParseIntError>>(
 ) -> Result<N> {
     value
         .parse()
+        .map_err(|e| anyhow!("invalid {} value {value:?}: {e}", key.name()))
+}
+
+fn parse_cpus(key: ConfigKey, value: &str) -> Result<u8> {
+    match parse_number(key, value)? {
+        0 => bail!("invalid {} value {value:?}: must be at least 1", key.name()),
+        n => Ok(n),
+    }
+}
+
+fn parse_mem(key: ConfigKey, value: &str) -> Result<usize> {
+    crate::cli::parse_mem_arg(value)
         .map_err(|e| anyhow!("invalid {} value {value:?}: {e}", key.name()))
 }
 
@@ -264,8 +276,8 @@ pub struct RunDefaults {
 pub fn load_run_defaults(path: &Path) -> Result<RunDefaults> {
     let cfg = load(path)?;
     Ok(RunDefaults {
-        cpus: cfg.run.cpus,
-        mem: cfg.run.mem,
+        cpus: nonzero_default(ConfigKey::RunCpus, cfg.run.cpus, path)?,
+        mem: nonzero_default(ConfigKey::RunMem, cfg.run.mem, path)?,
         env: parsed_defaults(
             ConfigKey::RunEnv,
             &cfg.run.env,
@@ -285,6 +297,20 @@ pub fn load_run_defaults(path: &Path) -> Result<RunDefaults> {
             crate::cli::parse_publish_arg,
         )?,
     })
+}
+
+fn nonzero_default<N>(key: ConfigKey, value: Option<N>, path: &Path) -> Result<Option<N>>
+where
+    N: Copy + PartialEq + From<u8> + std::fmt::Display,
+{
+    if value == Some(N::from(0)) {
+        bail!(
+            "invalid {} default 0 in {}: must be at least 1",
+            key.name(),
+            path.display()
+        );
+    }
+    Ok(value)
 }
 
 fn parsed_defaults<T>(
@@ -580,7 +606,9 @@ mod tests {
             tty: true,
             detach: false,
             detach_keys: crate::cli::DetachChord(vec![0x10, 0x11]),
+            workdir: None,
             env: Vec::new(),
+            env_file: Vec::new(),
             publish: Vec::new(),
             volumes: Vec::new(),
             cmd: Vec::new(),
@@ -620,6 +648,62 @@ mod tests {
         std::fs::write(&path, "run:\n  publish:\n    - nonsense\n").unwrap();
         let err = format!("{:#}", load_run_defaults(&path).unwrap_err());
         assert!(err.contains("run.publish"), "got: {err}");
+    }
+
+    #[test]
+    fn store_rejects_a_zero_cpu_default() {
+        let mut cfg = ConfigFile::default();
+        let err = store(&mut cfg, ConfigKey::RunCpus, &["0".to_string()]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("run.cpus"), "got: {msg}");
+        assert!(msg.contains("at least 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn store_rejects_a_zero_mem_default() {
+        let mut cfg = ConfigFile::default();
+        let err = store(&mut cfg, ConfigKey::RunMem, &["0".to_string()]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("run.mem"), "got: {msg}");
+        assert!(msg.contains("at least 1 MiB"), "got: {msg}");
+    }
+
+    #[test]
+    fn store_accepts_a_mem_unit_suffix_and_normalizes_to_mib() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        let (code, out) = run_ok(&set_cmd(ConfigKey::RunMem, &["2g"]), &path);
+        assert_eq!(code, 0);
+        assert!(out.contains("Set run.mem to 2g"), "got: {out}");
+        assert_eq!(load(&path).unwrap().run.mem, Some(2048));
+        let (_, shown) = run_ok(
+            &ConfigCommand::Get(ConfigKeyArgs {
+                key: ConfigKey::RunMem,
+            }),
+            &path,
+        );
+        assert_eq!(shown, "2048\n");
+    }
+
+    #[test]
+    fn load_run_defaults_rejects_a_hand_edited_zero_cpu_naming_the_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "run:\n  cpus: 0\n").unwrap();
+        let err = format!("{:#}", load_run_defaults(&path).unwrap_err());
+        assert!(err.contains("run.cpus"), "got: {err}");
+        assert!(err.contains("config.yaml"), "got: {err}");
+        assert!(err.contains("at least 1"), "got: {err}");
+    }
+
+    #[test]
+    fn load_run_defaults_rejects_a_hand_edited_zero_mem_naming_the_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "run:\n  mem: 0\n").unwrap();
+        let err = format!("{:#}", load_run_defaults(&path).unwrap_err());
+        assert!(err.contains("run.mem"), "got: {err}");
+        assert!(err.contains("config.yaml"), "got: {err}");
     }
 
     #[test]

--- a/crates/lns-cli/src/lib.rs
+++ b/crates/lns-cli/src/lib.rs
@@ -26,7 +26,8 @@ pub async fn run(cli: Cli) -> Result<i32> {
         let _ = update_check::real::run_announce();
     }
     let code = match cli.command {
-        Command::Run(args) => {
+        Command::Run(mut args) => {
+            args.env = run::env_file::merged_run_env(&args.env_file, &args.env)?;
             let config_path = config::default_config_path()?;
             let defaults = config::load_run_defaults(&config_path)?;
             let args = config::apply_run_defaults(args, defaults);

--- a/crates/lns-cli/src/run/env_file.rs
+++ b/crates/lns-cli/src/run/env_file.rs
@@ -1,0 +1,130 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+pub fn merged_run_env(env_files: &[PathBuf], env_flags: &[String]) -> Result<Vec<String>> {
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for path in env_files {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("reading --env-file {}", path.display()))?;
+        parse_env_file(path, &content, &mut entries)?;
+    }
+    for kv in env_flags {
+        if let Some((key, value)) = kv.split_once('=') {
+            upsert(&mut entries, key, value);
+        }
+    }
+    Ok(entries
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect())
+}
+
+fn parse_env_file(path: &Path, content: &str, entries: &mut Vec<(String, String)>) -> Result<()> {
+    for (idx, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let lineno = idx + 1;
+        let Some((key, value)) = line.split_once('=') else {
+            anyhow::bail!(
+                "{}:{lineno}: `{line}` has no value — host env passthrough is not supported; \
+                 write KEY=VALUE",
+                path.display(),
+            );
+        };
+        if key.is_empty() {
+            anyhow::bail!(
+                "{}:{lineno}: empty variable name in `{line}`; write KEY=VALUE",
+                path.display(),
+            );
+        }
+        upsert(entries, key, value);
+    }
+    Ok(())
+}
+
+fn upsert(entries: &mut Vec<(String, String)>, key: &str, value: &str) {
+    match entries.iter_mut().find(|(k, _)| k == key) {
+        Some(slot) => slot.1 = value.to_string(),
+        None => entries.push((key.to_string(), value.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_file(dir: &tempfile::TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).expect("write env file");
+        path
+    }
+
+    #[test]
+    fn flags_alone_merge_without_any_file() {
+        let env = merged_run_env(&[], &["A=1".into(), "B=2".into()]).unwrap();
+        assert_eq!(env, ["A=1", "B=2"]);
+    }
+
+    #[test]
+    fn a_value_keeps_embedded_equals_signs() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "DSN=user=admin;pw=x\n");
+        let env = merged_run_env(&[f], &[]).unwrap();
+        assert_eq!(env, ["DSN=user=admin;pw=x"]);
+    }
+
+    #[test]
+    fn an_empty_value_is_preserved() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "FEATURE_X=\n");
+        let env = merged_run_env(&[f], &[]).unwrap();
+        assert_eq!(env, ["FEATURE_X="]);
+    }
+
+    #[test]
+    fn crlf_line_endings_do_not_leak_into_values() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "PORT=3003\r\nHOST=db\r\n");
+        let env = merged_run_env(&[f], &[]).unwrap();
+        assert_eq!(env, ["PORT=3003", "HOST=db"]);
+    }
+
+    #[test]
+    fn a_duplicate_key_in_one_file_keeps_the_last_value() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "A=first\nA=last\n");
+        let env = merged_run_env(&[f], &[]).unwrap();
+        assert_eq!(env, ["A=last"]);
+    }
+
+    #[test]
+    fn a_bare_key_fails_with_file_and_line() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "A=1\nHOME\n");
+        let err = format!("{:#}", merged_run_env(&[f], &[]).unwrap_err());
+        assert!(err.contains("a.env:2:"), "got: {err}");
+        assert!(err.contains("KEY=VALUE"), "got: {err}");
+        assert!(err.contains("passthrough"), "got: {err}");
+    }
+
+    #[test]
+    fn an_empty_key_fails_with_file_and_line() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = env_file(&dir, "a.env", "=oops\n");
+        let err = format!("{:#}", merged_run_env(&[f], &[]).unwrap_err());
+        assert!(err.contains("a.env:1:"), "got: {err}");
+        assert!(err.contains("empty variable name"), "got: {err}");
+    }
+
+    #[test]
+    fn an_unreadable_file_fails_naming_the_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let missing = dir.path().join("nope.env");
+        let err = format!("{:#}", merged_run_env(&[missing], &[]).unwrap_err());
+        assert!(err.contains("nope.env"), "got: {err}");
+        assert!(err.contains("--env-file"), "got: {err}");
+    }
+}

--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -1,1 +1,2 @@
+pub mod env_file;
 pub mod summary;

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -77,6 +77,9 @@ pub fn format_summary(
     for vol in &args.volumes {
         writeln!(s, "  Volume:    {}", volume_line(vol)).unwrap();
     }
+    if let Some(dir) = &args.workdir {
+        writeln!(s, "  Workdir:   {dir}").unwrap();
+    }
     writeln!(
         s,
         "  Resources: {} vCPU · {} MiB",
@@ -197,7 +200,9 @@ mod tests {
             tty: true,
             detach: false,
             detach_keys: crate::cli::DetachChord(vec![0x10, 0x11]),
+            workdir: None,
             env: Vec::new(),
+            env_file: Vec::new(),
             publish: Vec::new(),
             volumes: Vec::new(),
             cmd: Vec::new(),
@@ -331,6 +336,30 @@ mod tests {
             s.contains("Volume:    ro-cfg → /cfg (ro)"),
             "missing ro volume line: {s}"
         );
+    }
+
+    #[test]
+    fn summary_lists_the_requested_workdir() {
+        let mut args = run_args(Some("ubuntu"));
+        args.workdir = Some("/app".into());
+        let s = format_summary(
+            &args,
+            &Policy::default(),
+            Path::new("/x/lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(s.contains("Workdir:   /app"), "missing workdir line: {s}");
+    }
+
+    #[test]
+    fn summary_omits_workdir_line_when_unset() {
+        let s = format_summary(
+            &run_args(Some("ubuntu")),
+            &Policy::default(),
+            Path::new("/x/lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(!s.contains("Workdir:"), "no workdir line expected: {s}");
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -80,6 +80,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         sandbox_uid: args.sandbox_uid,
         cmd: args.cmd,
         env: args.env,
+        workdir: args.workdir,
         debug,
         tty,
         stdin,

--- a/crates/lns-cli/tests/behaviours/config_cli.feature
+++ b/crates/lns-cli/tests/behaviours/config_cli.feature
@@ -48,6 +48,18 @@ Feature: lns config stores persistent run defaults
     When the developer sets the default "run.cpus" to "many"
     Then the command fails mentioning "run.cpus"
 
+  Scenario: A memory default may use a unit suffix and is stored in MiB
+    When the developer sets the default "run.mem" to "2g"
+    Then getting "run.mem" prints "2048"
+
+  Scenario: A zero cpu default is rejected when set
+    When the developer sets the default "run.cpus" to "0"
+    Then the command fails mentioning "at least 1"
+
+  Scenario: A zero memory default is rejected when set
+    When the developer sets the default "run.mem" to "0"
+    Then the command fails mentioning "run.mem"
+
   Scenario: A malformed env default is rejected when set
     When the developer sets the default "run.env" to "BARE"
     Then the command fails mentioning "KEY=VALUE"

--- a/crates/lns-cli/tests/behaviours/env_file.feature
+++ b/crates/lns-cli/tests/behaviours/env_file.feature
@@ -1,0 +1,65 @@
+Feature: lns run --env-file loads workload environment variables from a file
+  `lns run --env-file FILE` injects non-secret configuration in bulk,
+  mirroring `docker run --env-file`. Files merge in flag order, `-e`
+  always wins over file entries, and malformed lines fail before any
+  service round-trip. Bare `KEY` lines (host passthrough) are refused
+  for the same reason `-e KEY` is: they would be a silent
+  host-to-workload leak channel.
+
+  Scenario: Variables from an env file reach the run environment
+    Given the working directory contains an env file `app.env`:
+      """
+      PORT=3003
+      NODE_ENV=production
+      """
+    When the run environment is assembled for `lns run --env-file app.env someimage`
+    Then the run environment contains `PORT=3003`
+    And the run environment contains `NODE_ENV=production`
+
+  Scenario: -e overrides the same variable from an env file
+    Given the working directory contains an env file `app.env`:
+      """
+      PORT=3003
+      """
+    When the run environment is assembled for `lns run --env-file app.env -e PORT=4000 someimage`
+    Then the run environment contains `PORT=4000`
+    And the run environment does not contain `PORT=3003`
+
+  Scenario: A later env file overrides an earlier one
+    Given the working directory contains an env file `base.env`:
+      """
+      LOG_LEVEL=info
+      PORT=3003
+      """
+    And the working directory contains an env file `override.env`:
+      """
+      LOG_LEVEL=debug
+      """
+    When the run environment is assembled for `lns run --env-file base.env --env-file override.env someimage`
+    Then the run environment contains `LOG_LEVEL=debug`
+    And the run environment contains `PORT=3003`
+    And the run environment does not contain `LOG_LEVEL=info`
+
+  Scenario: Comment and blank lines are skipped
+    Given the working directory contains an env file `app.env`:
+      """
+      # tuning knobs
+
+      PORT=3003
+      """
+    When the run environment is assembled for `lns run --env-file app.env someimage`
+    Then the run environment contains `PORT=3003`
+
+  Scenario: A bare KEY line is refused (no host passthrough)
+    Given the working directory contains an env file `app.env`:
+      """
+      PORT=3003
+      HOME
+      """
+    When the run environment is assembled for `lns run --env-file app.env someimage`
+    Then the merge fails naming `app.env` line 2
+    And the merge failure requires KEY=VALUE form
+
+  Scenario: A missing env file fails before any run starts
+    When the run environment is assembled for `lns run --env-file nope.env someimage`
+    Then the merge fails with an error mentioning `nope.env`

--- a/crates/lns-cli/tests/behaviours/run_resources.feature
+++ b/crates/lns-cli/tests/behaviours/run_resources.feature
@@ -1,0 +1,30 @@
+Feature: lns run resource limits — vCPU count and memory size flags
+  `lns run --cpus N` and `lns run -m SIZE` bound the microVM's resources,
+  mirroring `docker run --cpus`/`-m`. Memory accepts Docker-style unit
+  suffixes and zero-sized resources are rejected at the CLI boundary, so a
+  typo never boots an unbootable VM.
+
+  Scenario: Zero vCPUs is rejected before the run starts
+    When the user runs `lns run --cpus 0 someimage`
+    Then the command fails with a parse error naming the --cpus flag
+    And no run is started
+
+  Scenario: A memory size with a unit suffix is accepted
+    Given the command is `lns run -m 2g someimage`
+    When the summary is printed
+    Then the summary shows `Resources: 1 vCPU · 2048 MiB`
+
+  Scenario: --memory works as an alias of --mem
+    Given the command is `lns run --memory 1g someimage`
+    When the summary is printed
+    Then the summary shows `Resources: 1 vCPU · 1024 MiB`
+
+  Scenario: Zero memory is rejected before the run starts
+    When the user runs `lns run -m 0 someimage`
+    Then the command fails with a parse error naming the --mem flag
+    And no run is started
+
+  Scenario: A garbled memory size is rejected before the run starts
+    When the user runs `lns run -m 12parsecs someimage`
+    Then the command fails with a parse error naming the --mem flag
+    And no run is started

--- a/crates/lns-cli/tests/behaviours/run_workdir.feature
+++ b/crates/lns-cli/tests/behaviours/run_workdir.feature
@@ -1,0 +1,15 @@
+Feature: lns run -w sets the workload working directory
+  `lns run -w DIR` starts the workload in DIR inside the sandbox,
+  mirroring `docker run -w`. The path is a guest path, so it must be
+  absolute — a relative path is rejected at the CLI boundary before any
+  service round-trip.
+
+  Scenario: A relative workdir is rejected before the run starts
+    When the user runs `lns run -w app someimage`
+    Then the command fails with a parse error naming the --workdir flag
+    And no run is started
+
+  Scenario: The summary shows the requested working directory
+    Given the command is `lns run -w /app someimage`
+    When the summary is printed
+    Then the summary shows `Workdir:   /app`

--- a/crates/lns-cli/tests/behaviours/steps/cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/cli.rs
@@ -94,6 +94,19 @@ fn parse_error_requires_kv_form(world: &mut BehaviourWorld) -> Result<(), String
     }
 }
 
+#[then(regex = r"^the command fails with a parse error naming the (--[a-z-]+) flag$")]
+fn parse_error_names_flag(world: &mut BehaviourWorld, flag: String) -> Result<(), String> {
+    let res = world.result.as_ref().ok_or("no CLI run captured")?;
+    if res.exit_code == 2 && res.output.contains(&flag) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected exit 2 naming {flag}, got code {} (output: {:?})",
+            res.exit_code, res.output
+        ))
+    }
+}
+
 #[then("no run is started")]
 fn no_run_is_started(world: &mut BehaviourWorld) -> Result<(), String> {
     let res = world.result.as_ref().ok_or("no CLI run captured")?;

--- a/crates/lns-cli/tests/behaviours/steps/env_file.rs
+++ b/crates/lns-cli/tests/behaviours/steps/env_file.rs
@@ -1,0 +1,91 @@
+use crate::world::BehaviourWorld;
+use clap::Parser;
+use cucumber::gherkin::Step;
+use cucumber::{given, then, when};
+use lns_cli::cli::{Cli, Command};
+use lns_cli::run::env_file::merged_run_env;
+use std::path::PathBuf;
+
+fn cwd(world: &mut BehaviourWorld) -> PathBuf {
+    world
+        .cwd
+        .get_or_insert_with(|| tempfile::TempDir::new().expect("create tempdir"))
+        .path()
+        .to_path_buf()
+}
+
+fn merged(world: &BehaviourWorld) -> Result<&Result<Vec<String>, String>, String> {
+    world
+        .merged_env
+        .as_ref()
+        .ok_or_else(|| "no merge attempted".to_string())
+}
+
+#[given(regex = r"^the working directory contains an env file `([^`]+)`:$")]
+fn env_file_with_content(world: &mut BehaviourWorld, step: &Step, name: String) {
+    let content = step.docstring().expect("env file step needs a docstring");
+    let dir = cwd(world);
+    std::fs::write(dir.join(&name), content.trim_start_matches('\n')).expect("write env file");
+}
+
+#[when(regex = r"^the run environment is assembled for `lns run ([^`]+)`$")]
+fn assemble_run_env(world: &mut BehaviourWorld, args_after_run: String) {
+    let dir = cwd(world);
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(args_after_run.split_whitespace().map(str::to_string));
+    let cli = Cli::try_parse_from(&argv).expect("argv must parse against the CLI grammar");
+    let Command::Run(args) = cli.command else {
+        panic!("env-file rig only drives `lns run`");
+    };
+    let files: Vec<PathBuf> = args.env_file.iter().map(|p| dir.join(p)).collect();
+    world.merged_env = Some(merged_run_env(&files, &args.env).map_err(|e| format!("{e:#}")));
+}
+
+#[then(regex = r"^the run environment contains `([^`]+)`$")]
+fn run_env_contains(world: &mut BehaviourWorld, entry: String) -> Result<(), String> {
+    match merged(world)? {
+        Ok(env) if env.contains(&entry) => Ok(()),
+        Ok(env) => Err(format!("expected {entry:?} in {env:?}")),
+        Err(e) => Err(format!("merge failed: {e}")),
+    }
+}
+
+#[then(regex = r"^the run environment does not contain `([^`]+)`$")]
+fn run_env_does_not_contain(world: &mut BehaviourWorld, entry: String) -> Result<(), String> {
+    match merged(world)? {
+        Ok(env) if env.contains(&entry) => Err(format!("{entry:?} must not be in {env:?}")),
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("merge failed: {e}")),
+    }
+}
+
+#[then(regex = r"^the merge fails naming `([^`]+)` line (\d+)$")]
+fn merge_fails_naming_file_and_line(
+    world: &mut BehaviourWorld,
+    file: String,
+    line: u32,
+) -> Result<(), String> {
+    match merged(world)? {
+        Ok(env) => Err(format!("expected a failure, got {env:?}")),
+        Err(e) if e.contains(&file) && e.contains(&format!(":{line}:")) => Ok(()),
+        Err(e) => Err(format!("error does not name {file}:{line}: {e}")),
+    }
+}
+
+#[then("the merge failure requires KEY=VALUE form")]
+fn merge_failure_requires_kv(world: &mut BehaviourWorld) -> Result<(), String> {
+    match merged(world)? {
+        Ok(env) => Err(format!("expected a failure, got {env:?}")),
+        Err(e) if e.contains("KEY=VALUE") => Ok(()),
+        Err(e) => Err(format!("error does not require KEY=VALUE form: {e}")),
+    }
+}
+
+#[then(regex = r"^the merge fails with an error mentioning `([^`]+)`$")]
+fn merge_fails_mentioning(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    match merged(world)? {
+        Ok(env) => Err(format!("expected a failure, got {env:?}")),
+        Err(e) if e.contains(&needle) => Ok(()),
+        Err(e) => Err(format!("error does not mention {needle:?}: {e}")),
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod config_cli;
+pub mod env_file;
 pub mod image_cli;
 pub mod integration_cli;
 pub mod policy_cli;

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -177,6 +177,18 @@ async fn drive_canned_sequence(world: &mut BehaviourWorld) {
     }
 }
 
+#[then(regex = r"^the summary shows `([^`]+)`$")]
+fn summary_shows(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    if world.summary_output.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {needle:?} in summary:\n{}",
+            world.summary_output
+        ))
+    }
+}
+
 #[then(regex = r"^a run summary is printed before any service round-trip$")]
 fn summary_is_printed(world: &mut BehaviourWorld) -> Result<(), String> {
     if world.summary_output.is_empty() {

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -25,6 +25,7 @@ pub struct BehaviourWorld {
     pub resolved_run: Option<ResolvedRunView>,
     pub volume: VolumeCliRig,
     pub image: ImageCliRig,
+    pub merged_env: Option<Result<Vec<String>, String>>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -183,6 +183,8 @@ pub struct RunImageArgs {
     pub cmd: Vec<String>,
     #[serde(default)]
     pub env: Vec<String>,
+    #[serde(default)]
+    pub workdir: Option<String>,
     pub debug: bool,
     #[serde(default = "default_tty")]
     pub tty: bool,
@@ -378,6 +380,7 @@ mod tests {
             sandbox_uid: Some(65534),
             cmd: Vec::new(),
             env: Vec::new(),
+            workdir: None,
             debug: false,
             tty: true,
             stdin: true,
@@ -402,6 +405,7 @@ mod tests {
             sandbox_uid: None,
             cmd: vec![],
             env: vec![],
+            workdir: None,
             debug: false,
             tty: true,
             stdin: true,

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -286,6 +286,7 @@ pub(super) fn build_session_params(
     crate::vm::session_client::SessionParams {
         argv: args.argv,
         env: args.env,
+        cwd: None,
         tty: args.tty,
         stdin: args.stdin,
         initial_winsize: args
@@ -355,6 +356,7 @@ mod tests {
                 sandbox_uid: None,
                 cmd: vec![],
                 env: vec![],
+                workdir: None,
                 debug: false,
                 tty: true,
                 stdin: true,
@@ -1066,6 +1068,10 @@ mod tests {
         let params = build_session_params(args);
         assert_eq!(params.argv, vec!["echo".to_string()]);
         assert_eq!(params.env, vec!["A=B".to_string()]);
+        assert_eq!(
+            params.cwd, None,
+            "exec sessions run in the broker's default cwd"
+        );
         let ws = params.initial_winsize.expect("winsize should be mapped");
         assert_eq!((ws.rows, ws.cols), (24, 80));
     }

--- a/crates/lns-service/src/lib.rs
+++ b/crates/lns-service/src/lib.rs
@@ -32,6 +32,7 @@ pub mod upperfs;
 pub mod vm;
 pub mod volume_store;
 pub mod workload_argv;
+pub mod workload_cwd;
 pub mod workload_env;
 
 #[cfg(test)]

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -49,6 +49,7 @@ pub(super) fn exec_env_strings(
     user_env: &[String],
     supervised: bool,
     extra_managed: &[String],
+    workdir: Option<&str>,
 ) -> crate::workload_env::WorkloadEnv {
     let agent_command = supervised.then(|| match image_config {
         Some(cfg) => crate::workload_argv::from_image_config(cfg, override_cmd),
@@ -61,6 +62,7 @@ pub(super) fn exec_env_strings(
         image_env,
         user_env,
         agent_command.as_deref(),
+        workdir,
         extra_managed,
     )
 }
@@ -161,7 +163,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn exec_env_strings_supervised_derives_agent_command_from_the_override_cmd() {
-        let env = exec_env_strings(None, &["echo".into(), "hi".into()], &[], true, &[]);
+        let env = exec_env_strings(None, &["echo".into(), "hi".into()], &[], true, &[], None);
         assert!(
             env.env.contains(&"AGENT_COMMAND=echo hi".to_string()),
             "expected AGENT_COMMAND in supervised env, got: {env:?}"
@@ -181,6 +183,7 @@ mod tests {
             &[],
             true,
             &[],
+            None,
         );
         let agent = env
             .env
@@ -202,6 +205,7 @@ mod tests {
             &["FOO=bar".into()],
             false,
             &[],
+            None,
         );
         assert_eq!(
             env.env,
@@ -242,7 +246,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let env = exec_env_strings(Some(&cfg), &[], &[], true, &[]);
+        let env = exec_env_strings(Some(&cfg), &[], &[], true, &[], None);
         assert!(env.env.contains(&"AGENT_COMMAND=/srv arg".to_string()));
     }
 
@@ -258,7 +262,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let env = exec_env_strings(Some(&cfg), &[], &["PORT=4000".into()], true, &[]);
+        let env = exec_env_strings(Some(&cfg), &[], &["PORT=4000".into()], true, &[], None);
         assert!(
             env.env.contains(&"PORT=4000".to_string()),
             "user overrides image: {env:?}"

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -205,6 +205,10 @@ async fn orchestrate(
             .initial_winsize
             .map(|(rows, cols)| lns_session::Winsize { rows, cols });
         let argv = build_workload_argv(image.config.as_ref(), &args.cmd, session.is_some());
+        let workdir = crate::workload_cwd::resolve(
+            args.workdir.as_deref(),
+            crate::workload_cwd::image_workdir(image.config.as_ref()).as_deref(),
+        );
         let composed = exec_env_strings(
             image.config.as_ref(),
             &args.cmd,
@@ -214,6 +218,7 @@ async fn orchestrate(
                 .as_ref()
                 .map(|s| s.managed_env_vars.as_slice())
                 .unwrap_or(&[]),
+            workdir.as_deref(),
         );
         for refused in &composed.refused {
             let _ = frame_tx
@@ -229,6 +234,7 @@ async fn orchestrate(
         let params = vm::session_client::SessionParams {
             argv,
             env,
+            cwd: workdir,
             tty: args.tty,
             stdin: args.stdin,
             initial_winsize,

--- a/crates/lns-service/src/vm/cloud_hypervisor.rs
+++ b/crates/lns-service/src/vm/cloud_hypervisor.rs
@@ -47,7 +47,6 @@ mod tests {
             debug: false,
             exec: ExecSpec {
                 kernel_env: Vec::new(),
-                workdir: None,
             },
             #[cfg(target_os = "macos")]
             vsock: None,

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -91,8 +91,6 @@ pub struct VsockChannel {
 #[cfg_attr(target_os = "macos", allow(dead_code))]
 pub struct ExecSpec {
     pub kernel_env: Vec<(String, String)>,
-    #[allow(dead_code)]
-    pub workdir: Option<String>,
 }
 
 impl ExecSpec {
@@ -103,7 +101,6 @@ impl ExecSpec {
         token: &str,
         cmd: &[String],
     ) -> Self {
-        let workdir = image_config_workdir(image_config);
         let agent_command = match image_config {
             Some(cfg) => crate::workload_argv::from_image_config(cfg, cmd),
             None => crate::workload_argv::shell_quote_argv(cmd),
@@ -130,10 +127,7 @@ impl ExecSpec {
             "/.lens/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into(),
         ));
 
-        ExecSpec {
-            kernel_env,
-            workdir,
-        }
+        ExecSpec { kernel_env }
     }
 
     pub fn from_image_config(
@@ -144,7 +138,6 @@ impl ExecSpec {
             Some(cfg) => crate::workload_argv::from_image_config(cfg, override_cmd),
             None => crate::workload_argv::shell_quote_argv(override_cmd),
         };
-        let workdir = image_config_workdir(image_config);
 
         ExecSpec {
             kernel_env: vec![
@@ -157,7 +150,6 @@ impl ExecSpec {
                     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into(),
                 ),
             ],
-            workdir,
         }
     }
 
@@ -172,13 +164,6 @@ impl ExecSpec {
             None => Self::from_image_config(image_config, cmd),
         }
     }
-}
-
-fn image_config_workdir(image_config: Option<&oci_client::config::ConfigFile>) -> Option<String> {
-    image_config
-        .and_then(|c| c.config.as_ref())
-        .and_then(|c| c.working_dir.clone())
-        .filter(|s| !s.is_empty())
 }
 
 const DEFAULT_SANDBOX_USER: &str = "sandbox";
@@ -736,12 +721,11 @@ mod tests {
         String::from_utf8(out).ok()
     }
 
-    fn config_with_workdir(workdir: &str) -> oci_client::config::ConfigFile {
+    fn config_with_entrypoint() -> oci_client::config::ConfigFile {
         oci_client::config::ConfigFile {
             architecture: "arm64".into(),
             os: "linux".into(),
             config: Some(oci_client::config::Config {
-                working_dir: Some(workdir.to_string()),
                 entrypoint: Some(vec!["/entry".into()]),
                 cmd: Some(vec!["arg".into()]),
                 ..Default::default()
@@ -751,10 +735,9 @@ mod tests {
     }
 
     #[test]
-    fn from_image_config_with_some_uses_image_entrypoint_and_workdir() {
-        let cfg = config_with_workdir("/work");
+    fn from_image_config_with_some_uses_image_entrypoint() {
+        let cfg = config_with_entrypoint();
         let spec = ExecSpec::from_image_config(Some(&cfg), &[]);
-        assert_eq!(spec.workdir.as_deref(), Some("/work"));
         let b64 = spec
             .kernel_env
             .iter()
@@ -766,8 +749,8 @@ mod tests {
     }
 
     #[test]
-    fn server_with_some_image_config_uses_image_entrypoint_and_workdir() {
-        let cfg = config_with_workdir("/srv");
+    fn server_with_some_image_config_uses_image_entrypoint() {
+        let cfg = config_with_entrypoint();
         let spec = ExecSpec::server(
             Some(&cfg),
             &run_as("sandbox", Some(65534)),
@@ -775,7 +758,6 @@ mod tests {
             "token-xyz",
             &[],
         );
-        assert_eq!(spec.workdir.as_deref(), Some("/srv"));
         let b64 = spec
             .kernel_env
             .iter()

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -27,6 +27,7 @@ pub enum SessionInput {
 pub struct SessionParams {
     pub argv: Vec<String>,
     pub env: Vec<String>,
+    pub cwd: Option<String>,
     pub tty: bool,
     pub stdin: bool,
     pub initial_winsize: Option<Winsize>,

--- a/crates/lns-service/src/vm/session_client/real.rs
+++ b/crates/lns-service/src/vm/session_client/real.rs
@@ -47,6 +47,7 @@ async fn run_session(
     let open = ClientFrame::OpenSession {
         argv: params.argv,
         env: params.env,
+        cwd: params.cwd,
         tty: params.tty,
         stdin: params.stdin,
         winsize: params.initial_winsize,

--- a/crates/lns-service/src/workload_cwd.rs
+++ b/crates/lns-service/src/workload_cwd.rs
@@ -1,0 +1,70 @@
+pub fn resolve(cli_workdir: Option<&str>, image_workdir: Option<&str>) -> Option<String> {
+    cli_workdir.or(image_workdir).map(str::to_string)
+}
+
+pub fn image_workdir(image_config: Option<&oci_client::config::ConfigFile>) -> Option<String> {
+    image_config
+        .and_then(|c| c.config.as_ref())
+        .and_then(|c| c.working_dir.clone())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_the_cli_flag_over_the_image_workdir() {
+        assert_eq!(
+            resolve(Some("/app"), Some("/srv")),
+            Some("/app".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_the_image_workdir() {
+        assert_eq!(resolve(None, Some("/srv")), Some("/srv".to_string()));
+    }
+
+    #[test]
+    fn resolve_is_none_when_neither_is_set() {
+        assert_eq!(resolve(None, None), None);
+    }
+
+    fn config(working_dir: Option<&str>) -> oci_client::config::ConfigFile {
+        oci_client::config::ConfigFile {
+            architecture: "arm64".into(),
+            os: "linux".into(),
+            config: Some(oci_client::config::Config {
+                working_dir: working_dir.map(str::to_string),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn image_workdir_reads_the_oci_working_dir() {
+        assert_eq!(
+            image_workdir(Some(&config(Some("/srv")))),
+            Some("/srv".to_string())
+        );
+    }
+
+    #[test]
+    fn image_workdir_treats_an_empty_working_dir_as_unset() {
+        assert_eq!(image_workdir(Some(&config(Some("")))), None);
+        assert_eq!(image_workdir(Some(&config(None))), None);
+    }
+
+    #[test]
+    fn image_workdir_is_none_without_an_image_config() {
+        assert_eq!(image_workdir(None), None);
+        let bare = oci_client::config::ConfigFile {
+            architecture: "arm64".into(),
+            os: "linux".into(),
+            ..Default::default()
+        };
+        assert_eq!(image_workdir(Some(&bare)), None);
+    }
+}

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -73,13 +73,17 @@ pub fn run_workload_env(
     image_env: Option<&[String]>,
     user_env: &[String],
     agent_command: Option<&str>,
+    workdir: Option<&str>,
     extra_managed: &[String],
 ) -> WorkloadEnv {
     const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
     let mut composed = compose_workload_env(image_env, user_env, extra_managed);
     if let Some(agent_command) = agent_command {
-        // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the supervisor PTY opt-in or the command.
+        // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the supervisor PTY opt-in, the command, or the agent cwd.
         composed.env.push(format!("AGENT_COMMAND={agent_command}"));
+        if let Some(workdir) = workdir {
+            composed.env.push(format!("WORKSPACE_PATH={workdir}"));
+        }
         // nexus-agent-sandbox treats TERM unset or "linux" as "no PTY"; xterm-256color opts it into the PTY path needed for `lns run -it --policy`.
         composed
             .env
@@ -187,13 +191,13 @@ mod tests {
 
     #[test]
     fn run_workload_env_carries_user_env_for_an_unsupervised_run() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None, &[]);
+        let c = run_workload_env(None, &["FOO=bar".into()], None, None, &[]);
         assert_eq!(c.env, ["FOO=bar"], "user -e must reach a policy-less run");
     }
 
     #[test]
     fn run_workload_env_adds_no_supervisor_vars_when_unsupervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None, &[]);
+        let c = run_workload_env(None, &["FOO=bar".into()], None, None, &[]);
         assert!(
             !c.env
                 .iter()
@@ -205,7 +209,7 @@ mod tests {
 
     #[test]
     fn run_workload_env_appends_agent_command_and_term_when_supervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], Some("echo hi"), &[]);
+        let c = run_workload_env(None, &["FOO=bar".into()], Some("echo hi"), None, &[]);
         assert!(c.env.contains(&"FOO=bar".to_string()), "got: {:?}", c.env);
         assert!(c.env.contains(&"AGENT_COMMAND=echo hi".to_string()));
         assert!(c.env.contains(&"TERM=xterm-256color".to_string()));
@@ -213,7 +217,7 @@ mod tests {
 
     #[test]
     fn run_workload_env_keeps_supervisor_term_after_a_user_term_so_it_cannot_be_clobbered() {
-        let c = run_workload_env(None, &["TERM=dumb".into()], Some("sh"), &[]);
+        let c = run_workload_env(None, &["TERM=dumb".into()], Some("sh"), None, &[]);
         let last_term = c.env.iter().rposition(|e| e.starts_with("TERM=")).unwrap();
         assert_eq!(c.env[last_term], "TERM=xterm-256color");
     }
@@ -223,6 +227,7 @@ mod tests {
         let c = run_workload_env(
             None,
             &["SOME_TOKEN=x".into()],
+            None,
             None,
             &["SOME_TOKEN".to_string()],
         );
@@ -236,10 +241,62 @@ mod tests {
             None,
             &["GITLAB_TOKEN=real".into()],
             None,
+            None,
             &["GITLAB_TOKEN".to_string()],
         );
         assert_eq!(c.refused, ["GITLAB_TOKEN"]);
         assert!(c.env.is_empty());
+    }
+
+    #[test]
+    fn run_workload_env_pins_workspace_path_for_a_supervised_run() {
+        let c = run_workload_env(None, &[], Some("sh"), Some("/app"), &[]);
+        assert!(
+            c.env.contains(&"WORKSPACE_PATH=/app".to_string()),
+            "got: {:?}",
+            c.env
+        );
+    }
+
+    #[test]
+    fn run_workload_env_omits_workspace_path_without_a_workdir() {
+        let c = run_workload_env(None, &[], Some("sh"), None, &[]);
+        assert!(
+            !c.env.iter().any(|e| e.starts_with("WORKSPACE_PATH=")),
+            "got: {:?}",
+            c.env
+        );
+    }
+
+    #[test]
+    fn run_workload_env_keeps_the_workdir_workspace_path_after_a_user_override() {
+        let c = run_workload_env(
+            None,
+            &["WORKSPACE_PATH=/evil".into()],
+            Some("sh"),
+            Some("/app"),
+            &[],
+        );
+        let last = c
+            .env
+            .iter()
+            .rposition(|e| e.starts_with("WORKSPACE_PATH="))
+            .unwrap();
+        assert_eq!(
+            c.env[last], "WORKSPACE_PATH=/app",
+            "the broker's last-wins putenv must land on the -w dir: {:?}",
+            c.env
+        );
+    }
+
+    #[test]
+    fn run_workload_env_adds_no_workspace_path_when_unsupervised() {
+        let c = run_workload_env(None, &[], None, Some("/app"), &[]);
+        assert!(
+            c.env.is_empty(),
+            "an unsupervised run's cwd travels via the session, not env: {:?}",
+            c.env
+        );
     }
 
     #[test]

--- a/crates/lns-service/tests/behaviours/steps/env_injection.rs
+++ b/crates/lns-service/tests/behaviours/steps/env_injection.rs
@@ -43,6 +43,7 @@ fn when_user_runs(world: &mut BehaviourWorld, cmd: String) {
         image_env.as_deref(),
         &user_env,
         None,
+        None,
         &managed,
     ));
     world.user_env = user_env;

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -7,3 +7,4 @@ pub mod ipc;
 pub mod oauth_integration;
 pub mod volume_management;
 pub mod volumes;
+pub mod workdir;

--- a/crates/lns-service/tests/behaviours/steps/workdir.rs
+++ b/crates/lns-service/tests/behaviours/steps/workdir.rs
@@ -1,0 +1,102 @@
+use crate::world::BehaviourWorld;
+use cucumber::{given, then, when};
+use lns_service::workload_cwd;
+use lns_service::workload_env::run_workload_env;
+
+fn flag_values(cmd: &str, flags: &[&str]) -> Vec<String> {
+    let toks: Vec<&str> = cmd.split_whitespace().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < toks.len() {
+        if flags.contains(&toks[i]) && i + 1 < toks.len() {
+            out.push(toks[i + 1].to_string());
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+fn cli_workdir(cmd: &str) -> Option<String> {
+    flag_values(cmd, &["-w", "--workdir"]).into_iter().next()
+}
+
+#[given(regex = r"^the image declares WORKDIR (\S+)$")]
+fn image_declares_workdir(world: &mut BehaviourWorld, dir: String) {
+    world.image_workdir = Some(dir);
+}
+
+#[when(regex = r"^the working directory is resolved for `lns run ([^`]+)`$")]
+fn resolve_working_directory(world: &mut BehaviourWorld, cmd: String) {
+    world.resolved_workdir = Some(workload_cwd::resolve(
+        cli_workdir(&cmd).as_deref(),
+        world.image_workdir.as_deref(),
+    ));
+}
+
+#[when(regex = r"^the user runs `lns run ([^`]+)` under a policy$")]
+fn user_runs_supervised(world: &mut BehaviourWorld, cmd: String) {
+    compose_run_env(world, &cmd, Some("some-agent-command"));
+}
+
+#[when(regex = r"^the user runs `lns run ([^`]+)` without a policy$")]
+fn user_runs_unsupervised(world: &mut BehaviourWorld, cmd: String) {
+    compose_run_env(world, &cmd, None);
+}
+
+fn compose_run_env(world: &mut BehaviourWorld, cmd: &str, agent_command: Option<&str>) {
+    let user_env = flag_values(cmd, &["-e", "--env"]);
+    let workdir =
+        workload_cwd::resolve(cli_workdir(cmd).as_deref(), world.image_workdir.as_deref());
+    world.composed_env = Some(run_workload_env(
+        world.image_env.as_deref(),
+        &user_env,
+        agent_command,
+        workdir.as_deref(),
+        &world.managed_vars,
+    ));
+}
+
+#[then(regex = r"^the workload working directory is (\S+)$")]
+fn workdir_is(world: &mut BehaviourWorld, dir: String) -> Result<(), String> {
+    match world.resolved_workdir.as_ref() {
+        Some(Some(got)) if *got == dir => Ok(()),
+        Some(got) => Err(format!("expected {dir:?}, got {got:?}")),
+        None => Err("no working directory was resolved".to_string()),
+    }
+}
+
+#[then("no working directory is forced on the workload")]
+fn workdir_unset(world: &mut BehaviourWorld) -> Result<(), String> {
+    match world.resolved_workdir.as_ref() {
+        Some(None) => Ok(()),
+        Some(Some(got)) => Err(format!("expected no workdir, got {got:?}")),
+        None => Err("no working directory was resolved".to_string()),
+    }
+}
+
+#[then(regex = r#"^the supervised workload env pins WORKSPACE_PATH to "([^"]+)"$"#)]
+fn workspace_path_pinned(world: &mut BehaviourWorld, dir: String) -> Result<(), String> {
+    let env = &world.composed_env.as_ref().ok_or("no composed env")?.env;
+    let last = env
+        .iter()
+        .rev()
+        .find_map(|e| e.strip_prefix("WORKSPACE_PATH="))
+        .ok_or_else(|| format!("no WORKSPACE_PATH in {env:?}"))?;
+    if last == dir {
+        Ok(())
+    } else {
+        Err(format!("WORKSPACE_PATH pinned to {last:?}, want {dir:?}"))
+    }
+}
+
+#[then("the workload env carries no WORKSPACE_PATH entry")]
+fn no_workspace_path(world: &mut BehaviourWorld) -> Result<(), String> {
+    let env = &world.composed_env.as_ref().ok_or("no composed env")?.env;
+    if env.iter().any(|e| e.starts_with("WORKSPACE_PATH=")) {
+        Err(format!("unexpected WORKSPACE_PATH in {env:?}"))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/lns-service/tests/behaviours/workdir.feature
+++ b/crates/lns-service/tests/behaviours/workdir.feature
@@ -1,0 +1,32 @@
+Feature: lns run working directory — image WORKDIR honored, -w overrides
+  The workload starts in the image's WORKDIR by default, mirroring
+  `docker run`. `lns run -w DIR` overrides it. For supervised (policy)
+  runs the agent's cwd is pinned through the supervisor's environment,
+  so a user `-e WORKSPACE_PATH=…` can never redirect where the agent
+  actually starts.
+
+  Scenario: The image WORKDIR is the default working directory
+    Given the image declares WORKDIR /srv
+    When the working directory is resolved for `lns run someimage`
+    Then the workload working directory is /srv
+
+  Scenario: -w overrides the image WORKDIR
+    Given the image declares WORKDIR /srv
+    When the working directory is resolved for `lns run -w /app someimage`
+    Then the workload working directory is /app
+
+  Scenario: No -w and no image WORKDIR leaves the working directory unset
+    When the working directory is resolved for `lns run someimage`
+    Then no working directory is forced on the workload
+
+  Scenario: A supervised agent's cwd is pinned through its environment
+    When the user runs `lns run -w /app someimage` under a policy
+    Then the supervised workload env pins WORKSPACE_PATH to "/app"
+
+  Scenario: -e WORKSPACE_PATH cannot redirect a -w working directory
+    When the user runs `lns run -w /app -e WORKSPACE_PATH=/evil someimage` under a policy
+    Then the supervised workload env pins WORKSPACE_PATH to "/app"
+
+  Scenario: An unsupervised run carries no supervisor cwd variable
+    When the user runs `lns run -w /app someimage` without a policy
+    Then the workload env carries no WORKSPACE_PATH entry

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -24,7 +24,9 @@ pub struct BehaviourWorld {
     pub oauth_id: Option<String>,
 
     pub image_env: Option<Vec<String>>,
+    pub image_workdir: Option<String>,
     pub composed_env: Option<lns_service::workload_env::WorkloadEnv>,
+    pub resolved_workdir: Option<Option<String>>,
     pub user_env: Vec<String>,
     /// Env vars a connected integration manages for the run; `-e` overrides of these are refused.
     pub managed_vars: Vec<String>,

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -22,6 +22,12 @@ pub struct SessionOutcome {
     pub exit_code: i32,
 }
 
+pub(crate) struct WorkloadSpec {
+    pub(crate) argv: Vec<String>,
+    pub(crate) env: Vec<String>,
+    pub(crate) cwd: Option<String>,
+}
+
 #[derive(Debug)]
 pub enum SessionError {
     Io(io::Error),
@@ -173,6 +179,7 @@ mod tests {
         let frame = ClientFrame::OpenSession {
             argv: vec!["/bin/sh".into()],
             env: vec!["A=1".into()],
+            cwd: Some("/app".into()),
             tty: true,
             stdin: false,
             winsize: None,
@@ -185,6 +192,7 @@ mod tests {
         let frame = ClientFrame::OpenSession {
             argv: Vec::new(),
             env: Vec::new(),
+            cwd: None,
             tty: false,
             stdin: false,
             winsize: None,
@@ -217,6 +225,7 @@ mod tests {
         let opener = ClientFrame::OpenSession {
             argv: Vec::new(),
             env: Vec::new(),
+            cwd: None,
             tty: false,
             stdin: false,
             winsize: None,

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -8,8 +8,8 @@ use std::sync::mpsc::SyncSender;
 use lns_session::{ClientFrame, ServerFrame, Winsize, encode_frame};
 
 use super::{
-    LoopAction, SessionError, SessionOutcome, SharedFd, close, dispatch_frame, read_client_frame,
-    signal_target, validate_argv, validate_open_session,
+    LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close, dispatch_frame,
+    read_client_frame, signal_target, validate_argv, validate_open_session,
 };
 use crate::forker::{Fork, Forker};
 use crate::pty;
@@ -59,6 +59,7 @@ pub fn handle_session(
     let ClientFrame::OpenSession {
         argv,
         env,
+        cwd,
         tty,
         stdin,
         winsize,
@@ -66,17 +67,17 @@ pub fn handle_session(
     else {
         unreachable!("validate_open_session guarantees OpenSession");
     };
+    let spec = WorkloadSpec { argv, env, cwd };
     if tty {
-        run_tty_session(conn, argv, env, winsize, stdin, pid_tx, forker)
+        run_tty_session(conn, spec, winsize, stdin, pid_tx, forker)
     } else {
-        run_pipe_session(conn, argv, env, stdin, pid_tx, forker)
+        run_pipe_session(conn, spec, stdin, pid_tx, forker)
     }
 }
 
 fn run_tty_session(
     conn: RawFd,
-    argv: Vec<String>,
-    env: Vec<String>,
+    spec: WorkloadSpec,
     winsize: Option<Winsize>,
     _stdin_enabled: bool,
     pid_tx: Option<SyncSender<libc::pid_t>>,
@@ -90,7 +91,7 @@ fn run_tty_session(
                 let _ = writeln_stderr(&format!("child_setup: {e}"));
                 child_exit(127);
             }
-            exec_child(&argv, &env);
+            exec_child(&spec);
         }
         Err(err) => {
             close(pty.master);
@@ -115,8 +116,7 @@ fn run_tty_session(
 
 fn run_pipe_session(
     conn: RawFd,
-    argv: Vec<String>,
-    env: Vec<String>,
+    spec: WorkloadSpec,
     stdin_enabled: bool,
     pid_tx: Option<SyncSender<libc::pid_t>>,
     forker: &dyn Forker,
@@ -143,7 +143,7 @@ fn run_pipe_session(
             close(stdin_r);
             close(stdout_w);
             close(stderr_w);
-            exec_child(&argv, &env);
+            exec_child(&spec);
         }
         Err(err) => {
             for fd in [stdin_r, stdin_w, stdout_r, stdout_w, stderr_r, stderr_w] {
@@ -369,7 +369,7 @@ fn make_pipe() -> Result<(RawFd, RawFd), SessionError> {
     Ok((fds[0], fds[1]))
 }
 
-fn exec_child(argv: &[String], env: &[String]) -> ! {
+fn exec_child(spec: &WorkloadSpec) -> ! {
     // SAFETY: post-dup2 child; raw close_range (no musl binding) drops every fd>=3 so conn/pty.master/listeners never survive execvp.
     unsafe {
         libc::syscall(
@@ -379,14 +379,15 @@ fn exec_child(argv: &[String], env: &[String]) -> ! {
             0 as c_long,
         )
     };
-    for kv in env {
+    enter_workdir(spec.cwd.as_deref());
+    for kv in &spec.env {
         if let Ok(c) = CString::new(kv.as_str()) {
             let raw = c.into_raw();
             // SAFETY: putenv keeps the pointer; child execs imminently, so the leak ends with the process image.
             unsafe { libc::putenv(raw) };
         }
     }
-    let Some(cargs) = validate_argv(argv) else {
+    let Some(cargs) = validate_argv(&spec.argv) else {
         let _ = writeln_stderr("argv contained interior NUL");
         child_exit(127);
     };
@@ -396,10 +397,19 @@ fn exec_child(argv: &[String], env: &[String]) -> ! {
     unsafe { libc::execvp(argv_ptrs[0], argv_ptrs.as_ptr()) };
     let _ = writeln_stderr(&format!(
         "execvp({:?}): {}",
-        argv[0],
+        spec.argv[0],
         io::Error::last_os_error()
     ));
     child_exit(127);
+}
+
+fn enter_workdir(cwd: Option<&str>) {
+    let Some(dir) = cwd else { return };
+    let entered = std::fs::create_dir_all(dir).and_then(|()| std::env::set_current_dir(dir));
+    if let Err(e) = entered {
+        let _ = writeln_stderr(&format!("workdir {dir:?}: {e}"));
+        child_exit(126);
+    }
 }
 
 #[cfg(test)]
@@ -422,6 +432,7 @@ mod tests {
         let frame = ClientFrame::OpenSession {
             argv,
             env: Vec::new(),
+            cwd: None,
             tty: false,
             stdin: false,
             winsize: None,

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -16,6 +16,7 @@ pub enum ClientFrame {
     OpenSession {
         argv: Vec<String>,
         env: Vec<String>,
+        cwd: Option<String>,
         tty: bool,
         stdin: bool,
         winsize: Option<Winsize>,
@@ -120,6 +121,7 @@ mod tests {
         let frame = ClientFrame::OpenSession {
             argv: vec!["sh".into(), "-c".into(), "echo hi".into()],
             env: vec!["FOO=bar".into()],
+            cwd: Some("/app".into()),
             tty: true,
             stdin: true,
             winsize: Some(Winsize { rows: 24, cols: 80 }),
@@ -127,6 +129,21 @@ mod tests {
         let bytes = encode_frame(&frame).expect("encode");
         let len = decode_length_prefix(&bytes[..4].try_into().unwrap()).expect("len");
         assert_eq!(len, bytes.len() - 4);
+        let back: ClientFrame = decode_frame(&bytes[4..]).expect("decode");
+        assert_eq!(back, frame);
+    }
+
+    #[test]
+    fn open_session_without_a_cwd_round_trips() {
+        let frame = ClientFrame::OpenSession {
+            argv: vec!["sh".into()],
+            env: Vec::new(),
+            cwd: None,
+            tty: false,
+            stdin: false,
+            winsize: None,
+        };
+        let bytes = encode_frame(&frame).expect("encode");
         let back: ClientFrame = decode_frame(&bytes[4..]).expect("decode");
         assert_eq!(back, frame);
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,10 +26,12 @@ run, which requires a `COMMAND` after `--`.
 
 | Option                       | Default          | Meaning                                                                 |
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
-| `--cpus <N>`                 | `1`              | Number of vCPUs; falls back to the `run.cpus` config default.           |
-| `--mem <MiB>`                | `512`            | RAM in MiB; falls back to the `run.mem` config default.                 |
+| `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
+| `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; rounded up to a whole MiB); falls back to the `run.mem` config default. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with `defaultVerdict: ask` if absent.         |
+| `-w`, `--workdir <DIR>`      | image `WORKDIR`  | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
+| `--env-file <FILE>`          |                  | Read `KEY=VALUE` lines from a file into the workload env (repeatable; later files and `-e` win). |
 | `-v`, `--volume <SPEC>`      |                  | Attach a named volume as `name:/path[:ro]` (repeatable); persists across runs. |
 | `-p`, `--publish <SPEC>`     |                  | Publish a guest port as `[host_ip:]hostport:containerport[/proto]` (repeatable). Host bind defaults to `127.0.0.1`. |
 | `-i`, `--interactive`        | `true`           | Keep stdin open and forward host stdin to the workload.                 |
@@ -41,7 +43,8 @@ run, which requires a `COMMAND` after `--`.
 | `-- <COMMAND...>`            |                  | Override the entrypoint and command. Everything after `--`.             |
 
 `--cpus`, `--mem`, `-e`, `-v`, and `-p` fall back to defaults stored with
-[`lns config`](#lns-config); a per-run flag overrides its configured default.
+[`lns config`](#lns-config); a per-run flag overrides its configured default. For
+the environment, the layering is `run.env` < `--env-file` < `-e`.
 
 See [Running workloads](running-workloads.md).
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -74,13 +74,26 @@ lns run -- /bin/sh
 
 ### Resources
 
-| Flag         | Default | Meaning            |
-| ------------ | ------- | ------------------ |
-| `--cpus <N>` | `1`     | Number of vCPUs.   |
-| `--mem <MiB>`| `512`   | RAM in mebibytes.  |
+| Flag                          | Default | Meaning            |
+| ----------------------------- | ------- | ------------------ |
+| `--cpus <N>`                  | `1`     | Number of vCPUs (at least 1). |
+| `-m`, `--mem`, `--memory <SIZE>` | `512` | RAM in mebibytes, or with a unit suffix. |
+
+Memory accepts Docker-style unit suffixes (`b`, `k`, `m`, `g`, plus `kb`/`kib`
+and friends), rounded up to a whole MiB:
 
 ```bash
-lns run --cpus 4 --mem 2048 ghcr.io/acme/builder
+lns run --cpus 4 -m 2g ghcr.io/acme/builder
+lns run --mem 2048 ghcr.io/acme/builder        # same thing, in MiB
+```
+
+### Working directory
+
+The workload starts in the image's `WORKDIR`, like `docker run`. Override it
+with `-w` (an absolute guest path, created inside the sandbox if missing):
+
+```bash
+lns run -w /workspace ghcr.io/acme/agent
 ```
 
 ### Persistent defaults
@@ -109,9 +122,20 @@ Set non-secret environment variables with `-e KEY=VALUE` (repeatable):
 lns run -e NODE_ENV=production -e LOG_LEVEL=debug ghcr.io/acme/agent
 ```
 
-Secrets do **not** belong here — `-e` values are plain environment variables
-visible to the workload. Use the [credential flow](credentials.md) so real secrets
-stay outside the sandbox.
+Load them in bulk from a file with `--env-file` (repeatable):
+
+```bash
+lns run --env-file app.env ghcr.io/acme/agent
+```
+
+An env file holds one `KEY=VALUE` per line; blank lines and `#` comments are
+skipped. When the same variable appears more than once, later files win and
+`-e` beats every file. A bare `KEY` line with no `=` is rejected — passing
+host variables through implicitly would be a silent leak channel.
+
+Secrets do **not** belong in either flag — `-e` and `--env-file` values are
+plain environment variables visible to the workload. Use the
+[credential flow](credentials.md) so real secrets stay outside the sandbox.
 
 ### Volumes
 


### PR DESCRIPTION
Closes the day-one `docker run` ergonomics gaps in `lns run`: bulk env loading, working-directory control, and friendlier resource flags.

## What

- **`--env-file FILE`** — load `KEY=VALUE` lines into the workload env, mirroring `docker run --env-file`. Repeatable; blank lines and `#` comments are skipped; later files override earlier ones and `-e` beats every file. A bare `KEY` line (host passthrough) is rejected with the file and line number — same reasoning as the existing `-e KEY` refusal: implicit host-to-workload env passthrough would be a silent leak channel.
- **`-w`, `--workdir DIR`** — start the workload in `DIR` (absolute guest path, created if missing), mirroring `docker run -w`. The image's `WORKDIR` is now honored as the default — previously it was parsed but never applied, so every workload started in the broker's cwd or the agent's home.
- **`-m`, `--mem`, `--memory SIZE`** — memory now takes Docker-style unit suffixes (`-m 2g`, `-m 512m`; bare numbers stay MiB), rounded up to a whole MiB. `--cpus 0` and zero-sized memory are rejected at the CLI boundary instead of failing inside the VMM.

## How

- `--env-file` is resolved entirely CLI-side (`lns-cli/src/run/env_file.rs`): files are read and upsert-merged with `-e` before the request is built, so the service sees one deduped env list and the existing managed-credential refusal and `run_env` audit cover file-sourced vars for free.
- The effective working directory is resolved in the service (`workload_cwd::resolve`: `-w` wins over image `WORKDIR`) and travels on both legs:
  - supervised (policy) runs append `WORKSPACE_PATH` to the session env after user `-e` vars — the supervisor already prefers it when resolving the agent cwd, and last-wins putenv means `-e WORKSPACE_PATH=…` can never redirect it;
  - the broker's `OpenSession` frame gains a `cwd` field, and the fork child does `create_dir_all` + `chdir` before exec (exit 126 with a stderr line on failure), so unsupervised sessions and the supervisor process itself start in the right place. Both sides of the vsock protocol ship together, so the frame change is skew-safe.
- The dead `ExecSpec.workdir` field (computed from the image config but never delivered anywhere) is removed in favor of the above.
- `lns exec` sessions keep `cwd: None` — exec working-directory support is a separate, smaller change.

## Tests

- Layer 2 Gherkin: `env_file.feature` (merge precedence, comments, bare-KEY refusal, missing file), `run_workdir.feature` + service-side `workdir.feature` (image `WORKDIR` default, `-w` override, `WORKSPACE_PATH` pinning incl. the `-e WORKSPACE_PATH` clobber attempt), `run_resources.feature` (unit suffixes, `--memory` alias, zero rejections).
- Layer 3 units: env-file parser edge cases (CRLF, embedded `=`, duplicate keys, error paths naming file:line), `parse_mem_arg` (suffix table, round-up, overflow), `parse_workdir_arg`, `workload_cwd::resolve`/`image_workdir`, `WORKSPACE_PATH` composition in `workload_env`, and `OpenSession` round-trips with and without `cwd`.
- Guest crates cross-checked with `cargo clippy --target aarch64-unknown-linux-musl` (the broker's session driver is Linux-only and invisible to host clippy).
