### PR TITLE
feat(cli): consolidate ls, exec, and kill under lns sandbox

### DIFF
--- a/crates/e2e-tests/features/sandbox_lifecycle.feature
+++ b/crates/e2e-tests/features/sandbox_lifecycle.feature
@@ -13,6 +13,24 @@ Feature: sandbox lifecycle verbs reach the service end to end
     And the output contains "inspect"
     And the output contains "stats"
 
+  Scenario: sandbox ls answers with the runs table end to end
+    Given the Lens Sandbox service is running
+    When I run sandbox command "ls" against the service
+    Then the exit code is 0
+    And the output contains "ID"
+
+  Scenario: the flat ls alias still reaches the service
+    Given the Lens Sandbox service is running
+    When I run lns "ls" against the service
+    Then the exit code is 0
+    And the output contains "ID"
+
+  Scenario: sandbox kill of an unknown run reports the daemon's error
+    Given the Lens Sandbox service is running
+    When I run sandbox command "kill 4242" against the service
+    Then the exit code is non-zero
+    And the output contains "4242"
+
   Scenario: stopping an unknown run reports the daemon's error
     Given the Lens Sandbox service is running
     When I run sandbox command "stop 4242" against the service

--- a/crates/e2e-tests/tests/steps/sandbox.rs
+++ b/crates/e2e-tests/tests/steps/sandbox.rs
@@ -9,3 +9,10 @@ fn run_sandbox_command(world: &mut E2eWorld, cmd_line: String) {
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
     world.result = Some(world.run_with_service_env(&arg_refs));
 }
+
+#[when(regex = r#"^I run lns "([^"]*)" against the service$"#)]
+fn run_lns_command(world: &mut E2eWorld, cmd_line: String) {
+    let args = split_args(&cmd_line);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    world.result = Some(world.run_with_service_env(&arg_refs));
+}

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -36,13 +36,15 @@ pub struct Cli {
 pub enum Command {
     #[command(about = "Run an OCI image in a microVM.")]
     Run(RunArgs),
-    #[command(about = "Open a new session (`docker exec`-style) against a running run.")]
+    #[command(hide = true)]
     Exec(ExecArgs),
-    #[command(about = "Send a signal to a running run (`docker kill`-style).")]
+    #[command(hide = true)]
     Kill(KillArgs),
-    #[command(about = "List active runs (`docker ps`-style).")]
+    #[command(hide = true)]
     Ls,
-    #[command(about = "Manage running sandboxes: stop, logs, attach, inspect, stats.")]
+    #[command(
+        about = "Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats."
+    )]
     Sandbox(SandboxArgs),
     #[command(about = "Verify the audit chain of a completed run.")]
     Audit(AuditArgs),
@@ -64,6 +66,12 @@ pub struct SandboxArgs {
 
 #[derive(Subcommand)]
 pub enum SandboxCommand {
+    #[command(about = "List active runs (`docker ps`-style).")]
+    Ls,
+    #[command(about = "Open a new session (`docker exec`-style) against a running run.")]
+    Exec(ExecArgs),
+    #[command(about = "Send a signal to a running run (`docker kill`-style).")]
+    Kill(KillArgs),
     #[command(about = "Stop a run gracefully: SIGTERM, then SIGKILL once the timeout passes.")]
     Stop(SandboxStopArgs),
     #[command(about = "Print a run's captured output; `-f` streams until the run exits.")]

--- a/crates/lns-cli/src/lib.rs
+++ b/crates/lns-cli/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn run(cli: Cli) -> Result<i32> {
         }
         Command::Sandbox(args) => {
             service::require_running().await;
-            sandbox::real::dispatch(&args).await?
+            sandbox::real::dispatch(args).await?
         }
         Command::Audit(args) => audit::run_verify(args)?,
         Command::Service(args) => {

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -8,8 +8,8 @@ use lns_ipc::{
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 use crate::cli::{
-    SandboxAttachArgs, SandboxCommand, SandboxInspectArgs, SandboxLogsArgs, SandboxStatsArgs,
-    SandboxStopArgs,
+    KillArgs, SandboxAttachArgs, SandboxCommand, SandboxInspectArgs, SandboxLogsArgs,
+    SandboxStatsArgs, SandboxStopArgs,
 };
 use crate::service::client::BoxFuture;
 
@@ -44,11 +44,49 @@ where
     E: AsyncWriteExt + Unpin,
 {
     match cmd {
+        SandboxCommand::Ls => ls(svc, out).await,
+        SandboxCommand::Kill(args) => kill(svc, args, out).await,
+        SandboxCommand::Exec(_) => bail!("sandbox exec is dispatched on its own interactive path"),
         SandboxCommand::Stop(args) => stop(svc, args, out).await,
         SandboxCommand::Inspect(args) => inspect(svc, args, out).await,
         SandboxCommand::Stats(args) => stats(svc, args, out).await,
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
+    }
+}
+
+async fn ls<W: std::io::Write>(svc: &impl SandboxService, out: &mut W) -> Result<i32> {
+    let response = svc.one_shot(Request::ListRuns).await?;
+    match response {
+        Response::RunList { mut runs } => {
+            runs.sort_by(|a, b| b.started.cmp(&a.started));
+            crate::service::render_ls_table(out, &runs)?;
+            Ok(0)
+        }
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+async fn kill<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &KillArgs,
+    out: &mut W,
+) -> Result<i32> {
+    let signal = crate::service::parse_signal_name(&args.signal)?;
+    let response = svc
+        .one_shot(Request::Kill {
+            run_id: args.run_id,
+            signal,
+        })
+        .await?;
+    match response {
+        Response::Acknowledged => {
+            writeln!(out, "killed run #{}", args.run_id)?;
+            Ok(0)
+        }
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
 
@@ -118,25 +156,41 @@ fn render_inspect<W: std::io::Write>(
     policy: Option<serde_json::Value>,
     out: &mut W,
 ) -> Result<()> {
-    let doc = serde_json::json!({
-        "id": details.summary.id,
-        "image": details.summary.image,
-        "command": details.summary.command,
-        "status": details.summary.status,
-        "started": details.summary.started,
-        "config": {
-            "cpus": details.config.cpus,
-            "memMib": details.config.mem_mib,
-            "env": details.config.env,
-            "publishedPorts": details.config.published_ports,
-            "volumes": details.config.volumes,
-            "sandboxUser": details.config.sandbox_user,
-            "sandboxUid": details.config.sandbox_uid,
-            "detached": details.config.detached,
-        },
-        "policy": policy,
-    });
-    writeln!(out, "{}", serde_json::to_string_pretty(&doc)?)?;
+    let mut config = serde_json::Map::new();
+    config.insert("cpus".into(), details.config.cpus.into());
+    config.insert("memMib".into(), details.config.mem_mib.into());
+    config.insert("env".into(), serde_json::to_value(&details.config.env)?);
+    config.insert(
+        "publishedPorts".into(),
+        serde_json::to_value(&details.config.published_ports)?,
+    );
+    config.insert(
+        "volumes".into(),
+        serde_json::to_value(&details.config.volumes)?,
+    );
+    config.insert(
+        "sandboxUser".into(),
+        serde_json::to_value(&details.config.sandbox_user)?,
+    );
+    config.insert(
+        "sandboxUid".into(),
+        serde_json::to_value(details.config.sandbox_uid)?,
+    );
+    config.insert("detached".into(), details.config.detached.into());
+
+    let mut doc = serde_json::Map::new();
+    doc.insert("id".into(), details.summary.id.into());
+    doc.insert("image".into(), details.summary.image.clone().into());
+    doc.insert("command".into(), details.summary.command.clone().into());
+    doc.insert(
+        "status".into(),
+        serde_json::to_value(details.summary.status)?,
+    );
+    doc.insert("started".into(), details.summary.started.clone().into());
+    doc.insert("config".into(), config.into());
+    doc.insert("policy".into(), policy.unwrap_or(serde_json::Value::Null));
+    let rendered = serde_json::to_string_pretty(&serde_json::Value::Object(doc))?;
+    writeln!(out, "{rendered}")?;
     Ok(())
 }
 
@@ -340,6 +394,86 @@ mod tests {
             run_id,
             timeout: 10,
         }
+    }
+
+    #[tokio::test]
+    async fn run_with_writers_refuses_the_interactive_exec_verb() {
+        let svc = CannedService::new(Response::Pong);
+        let cmd = SandboxCommand::Exec(crate::cli::ExecArgs {
+            run_id: 1,
+            interactive: false,
+            tty: false,
+            detach_keys: crate::cli::DetachChord(Vec::new()),
+            cmd: vec!["echo".into()],
+        });
+        let mut out = Vec::new();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let err = run_with_writers(
+            &cmd,
+            &svc,
+            TermInfo::default(),
+            &mut out,
+            &mut stdout,
+            &mut stderr,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("interactive"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn ls_surfaces_a_daemon_error() {
+        let svc = CannedService::new(Response::Error {
+            message: "registry poisoned".into(),
+        });
+        let mut out = Vec::new();
+        let err = ls(&svc, &mut out).await.unwrap_err();
+        assert!(format!("{err:#}").contains("registry poisoned"));
+    }
+
+    #[tokio::test]
+    async fn ls_rejects_an_unrelated_response_variant() {
+        let svc = CannedService::new(Response::Pong);
+        let mut out = Vec::new();
+        let err = ls(&svc, &mut out).await.unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[tokio::test]
+    async fn kill_surfaces_a_daemon_error() {
+        let svc = CannedService::new(Response::Error {
+            message: "no active session for run 1".into(),
+        });
+        let mut out = Vec::new();
+        let err = kill(
+            &svc,
+            &crate::cli::KillArgs {
+                run_id: 1,
+                signal: "TERM".into(),
+            },
+            &mut out,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("no active session"));
+    }
+
+    #[tokio::test]
+    async fn kill_rejects_an_unrelated_response_variant() {
+        let svc = CannedService::new(Response::Pong);
+        let mut out = Vec::new();
+        let err = kill(
+            &svc,
+            &crate::cli::KillArgs {
+                run_id: 1,
+                signal: "TERM".into(),
+            },
+            &mut out,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -52,7 +52,13 @@ impl SandboxService for RealSandboxService {
     }
 }
 
-pub async fn dispatch(args: &crate::cli::SandboxArgs) -> Result<i32> {
+pub async fn dispatch(args: crate::cli::SandboxArgs) -> Result<i32> {
+    let command = match args.command {
+        crate::cli::SandboxCommand::Exec(exec_args) => {
+            return crate::service::exec_image(exec_args).await;
+        }
+        other => other,
+    };
     let svc = RealSandboxService {
         socket: crate::service::socket_path()?,
     };
@@ -63,13 +69,5 @@ pub async fn dispatch(args: &crate::cli::SandboxArgs) -> Result<i32> {
     let mut out = std::io::stdout();
     let mut stdout = tokio::io::stdout();
     let mut stderr = tokio::io::stderr();
-    run_with_writers(
-        &args.command,
-        &svc,
-        term,
-        &mut out,
-        &mut stdout,
-        &mut stderr,
-    )
-    .await
+    run_with_writers(&command, &svc, term, &mut out, &mut stdout, &mut stderr).await
 }

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -186,7 +186,7 @@ pub(crate) fn parse_signal_name(name: &str) -> Result<SignalKind> {
         }
     })
 }
-pub(super) fn render_ls_table<W: std::io::Write>(
+pub(crate) fn render_ls_table<W: std::io::Write>(
     out: &mut W,
     rows: &[RunSummary],
 ) -> std::io::Result<()> {

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -6,11 +6,49 @@ Feature: managing running sandboxes from the CLI
   Scenario: the sandbox family lists its verbs in help
     When I run "lns sandbox --help"
     Then the exit code is 0
+    And the output contains "ls"
+    And the output contains "exec"
+    And the output contains "kill"
     And the output contains "stop"
     And the output contains "logs"
     And the output contains "attach"
     And the output contains "inspect"
     And the output contains "stats"
+
+  Scenario: the flat ls, exec, and kill verbs stay usable but leave the front page
+    When I run "lns --help"
+    Then the exit code is 0
+    And the output does not contain "docker ps"
+    And the output does not contain "docker exec"
+    And the output does not contain "docker kill"
+    When I run "lns ls"
+    Then the exit code is 0
+    When I run "lns kill 3"
+    Then the exit code is 0
+    When I run "lns exec 3 -- echo hi"
+    Then the exit code is 0
+
+  Scenario: sandbox ls renders the runs table
+    Given the service reports a run listing with run 3 of image "some-image" running
+    When the user runs sandbox command "ls"
+    Then the exit code is 0
+    And the output contains "ID"
+    And the output contains "some-image"
+    And the output contains "running"
+    And the service received a ListRuns request
+
+  Scenario: sandbox kill sends the requested signal
+    Given the service will answer Acknowledged
+    When the user runs sandbox command "kill 3 --signal KILL"
+    Then the exit code is 0
+    And the output contains "killed run #3"
+    And the service received a Kill request for run 3 with signal KILL
+
+  Scenario: sandbox kill rejects an unknown signal name
+    Given the service will answer Acknowledged
+    When the user runs sandbox command "kill 3 --signal NOPE"
+    Then the command fails with an exit code other than 0
+    And the output contains "unknown signal"
 
   Scenario: stopping a run reports a graceful stop
     Given the service will answer RunStopped without force

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -98,6 +98,60 @@ fn service_unreachable(w: &mut BehaviourWorld) {
     w.sandbox.unreachable = true;
 }
 
+#[given(regex = r"^the service will answer Acknowledged$")]
+fn canned_acknowledged(w: &mut BehaviourWorld) {
+    w.sandbox.response = Some(Response::Acknowledged);
+}
+
+#[given(regex = r#"^the service reports a run listing with run (\d+) of image "([^"]+)" running$"#)]
+fn canned_run_listing(w: &mut BehaviourWorld, run_id: u32, image: String) {
+    w.sandbox.response = Some(Response::RunList {
+        runs: vec![RunSummary {
+            id: run_id,
+            image,
+            command: "some-command".into(),
+            status: RunStatus::Running,
+            started: "2026-01-01T00:00:00Z".into(),
+        }],
+    });
+}
+
+#[then("the service received a ListRuns request")]
+fn then_list_runs_request(w: &mut BehaviourWorld) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    if requests.contains(&Request::ListRuns) {
+        Ok(())
+    } else {
+        Err(format!("expected ListRuns among {requests:?}"))
+    }
+}
+
+#[then(regex = r"^the service received a Kill request for run (\d+) with signal KILL$")]
+fn then_kill_request(w: &mut BehaviourWorld, run_id: u32) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    let expected = Request::Kill {
+        run_id,
+        signal: lns_ipc::SignalKind::Kill,
+    };
+    if requests.contains(&expected) {
+        Ok(())
+    } else {
+        Err(format!("expected {expected:?} among {requests:?}"))
+    }
+}
+
+#[then(regex = r#"^the output does not contain "([^"]*)"$"#)]
+fn then_output_does_not_contain(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let output = &w.result.as_ref().ok_or("no CLI run captured")?.output;
+    if output.contains(&needle) {
+        Err(format!(
+            "expected output not to contain {needle:?}, got {output:?}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 #[given(
     regex = r#"^the service reports run (\d+) of image "([^"]+)" running with (\d+) cpus and (\d+) MiB$"#
 )]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,46 +42,14 @@ run, which requires a `COMMAND` after `--`.
 
 See [Running workloads](running-workloads.md).
 
-## `lns exec`
-
-Open a new session against a running run (`docker exec`-style).
-
-```bash
-lns exec [OPTIONS] <RUN_ID> -- <COMMAND...>
-```
-
-| Option                  | Default         | Meaning                                                       |
-| ----------------------- | --------------- | ------------------------------------------------------------- |
-| `-i`, `--interactive`   | `true`          | Keep stdin open.                                              |
-| `-t`, `--tty`           | `true`          | Allocate a PTY for the session.                               |
-| `--detach-keys <CHORD>` | `ctrl-p,ctrl-q` | Detach chord; closes only this session, leaving the run alive.|
-| `-- <COMMAND...>`       |                 | Command to run. Required. Everything after `--`.              |
-
-## `lns kill`
-
-Send a signal to a running run (`docker kill`-style).
-
-```bash
-lns kill <RUN_ID> [--signal <SIG>]
-```
-
-| Option            | Default | Meaning                                                                 |
-| ----------------- | ------- | ----------------------------------------------------------------------- |
-| `--signal <SIG>`  | `TERM`  | Signal name, bare or `SIG`-prefixed, case-insensitive. Supported: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`. |
-
-## `lns ls`
-
-List active runs (`docker ps`-style).
-
-```bash
-lns ls
-```
-
 ## `lns sandbox`
 
-Manage running sandboxes: stop, logs, attach, inspect, stats.
+Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats.
 
 ```bash
+lns sandbox ls
+lns sandbox exec [OPTIONS] <RUN_ID> -- <COMMAND...>
+lns sandbox kill <RUN_ID> [--signal <SIG>]
 lns sandbox stop <RUN_ID> [-t <SECONDS>]
 lns sandbox logs [-f] <RUN_ID>
 lns sandbox attach <RUN_ID> [--detach-keys <CHORD>]
@@ -91,11 +59,17 @@ lns sandbox stats <RUN_ID>
 
 | Subcommand | Meaning |
 | ---------- | ------- |
+| `ls`       | List active runs (`docker ps`-style). |
+| `exec`     | Open a new session against a running run (`docker exec`-style). `-i`/`-t` and `--detach-keys` work as for `lns run`; detaching closes only the exec session. |
+| `kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
-| `logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, and only while the run is listed by `lns ls`. |
+| `logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, and only while the run is listed by `lns sandbox ls`. |
 | `attach`   | Re-join a run's live output, most useful after `lns run -d`. The detach chord (`ctrl-p,ctrl-q` by default) behaves exactly like `lns run`'s. Stdin reaches the workload only if the run was started with stdin open. |
 | `inspect`  | Print the run's state and launch configuration as JSON, with the policy file's parsed contents embedded when it is readable. |
 | `stats`    | Sample the sandbox's CPU share and memory over one second, via the guest's `/proc`. |
+
+The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working
+as hidden aliases; the `lns sandbox` forms are the documented ones.
 
 ## `lns audit`
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -1,8 +1,8 @@
 # Running workloads
 
-Everything that runs inside a sandbox goes through `lns run`. Once a run is up you
-can open extra sessions into it with `lns exec`, list active runs with `lns ls`,
-and signal them with `lns kill`. The model is deliberately close to `docker`.
+Everything that runs inside a sandbox goes through `lns run`. Once a run is up,
+the `lns sandbox` family manages it: list runs, open extra sessions, read logs,
+and stop them. The model is deliberately close to `docker`.
 
 The background service must be running first (`lns service start`).
 
@@ -113,7 +113,7 @@ lns run -d ghcr.io/acme/long-job
 # prints: run #7
 ```
 
-A detached run is reachable later via `lns exec`, `lns ls`, `lns kill`, and the
+A detached run is reachable later via the
 [`lns sandbox` lifecycle verbs](#lns-sandbox--managing-runs-youve-started).
 `-d` cannot be combined with `-i`/`-t`.
 
@@ -128,50 +128,14 @@ lns run --detach-keys ctrl-x,ctrl-x ghcr.io/acme/agent
 
 The value is a comma-separated chord of single characters or `ctrl-X` tokens.
 
-## `lns exec`
-
-Open another session inside a running run, like `docker exec`:
-
-```bash
-lns exec 7 -- bash
-```
-
-The first argument is the run id (shown by `lns run -d` and `lns ls`). `-i`, `-t`,
-and `--detach-keys` work as they do for `lns run`. Detaching from an exec session
-closes only that session — the run and any other sessions keep going.
-
-This is also how you open a debugging shell alongside a misbehaving workload
-without disturbing it.
-
-## `lns ls`
-
-List active runs:
-
-```bash
-lns ls
-```
-
-## `lns kill`
-
-Send a signal to a run (default `SIGTERM`), like `docker kill`:
-
-```bash
-lns kill 7                 # SIGTERM
-lns kill 7 --signal KILL   # SIGKILL
-```
-
-Signal names are case-insensitive and may be bare or `SIG`-prefixed. Supported
-signals: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`.
-
-For a graceful shutdown that waits and escalates for you, prefer
-`lns sandbox stop`.
-
 ## `lns sandbox` — managing runs you've started
 
-The `lns sandbox` family extends `ls`/`exec`/`kill` with the rest of the
-lifecycle:
+Everything you do to a run after starting it lives under `lns sandbox`:
 
 ```bash
+lns sandbox ls                 # list active runs
+lns sandbox exec 7 -- bash     # open another session inside a run
+lns sandbox kill 7             # send one signal (default SIGTERM)
 lns sandbox stop 7             # SIGTERM, wait up to 10s, then SIGKILL
 lns sandbox stop 7 -t 30       # give it longer to clean up
 lns sandbox logs 7             # print the captured output so far
@@ -181,19 +145,33 @@ lns sandbox inspect 7          # state + launch config as JSON
 lns sandbox stats 7            # CPU share and memory, sampled over 1s
 ```
 
+The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working
+as hidden aliases.
+
+### Exec — another session inside a run
+
+`lns sandbox exec 7 -- bash` opens a second session, like `docker exec`. The
+run id is shown by `lns run -d` and `lns sandbox ls`. `-i`, `-t`, and
+`--detach-keys` work as they do for `lns run`; detaching from an exec session
+closes only that session — the run and any other sessions keep going. This is
+also how you open a debugging shell alongside a misbehaving workload without
+disturbing it.
+
 ### Stopping vs killing
 
-`lns kill` sends one signal and returns. `lns sandbox stop` owns the whole
-shutdown: it sends `SIGTERM`, waits up to the timeout for the workload to exit,
-and only then sends `SIGKILL`. The command reports which of the two happened —
-`stopped run #7` for a graceful exit, `killed run #7` when it had to escalate.
+`lns sandbox kill` sends one signal (case-insensitive, bare or
+`SIG`-prefixed: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and returns.
+`lns sandbox stop` owns the whole shutdown: it sends `SIGTERM`, waits up to
+the timeout for the workload to exit, and only then sends `SIGKILL`. The
+command reports which of the two happened — `stopped run #7` for a graceful
+exit, `killed run #7` when it had to escalate.
 
 ### Logs
 
 The service keeps a rolling capture of every run's stdout and stderr — the most
-recent 2 MiB — for as long as the run is listed by `lns ls`. `lns sandbox logs`
+recent 2 MiB — for as long as the run is listed by `lns sandbox ls`. `lns sandbox logs`
 prints what's buffered; `-f` streams new output until the run exits. Output of
-`lns exec` sessions is not captured, only the run's primary session.
+exec sessions is not captured, only the run's primary session.
 
 ### Attaching
 


### PR DESCRIPTION
## What

Migrates the flat workload verbs into the `lns sandbox` namespace, making the nested forms the documented house style (matching `lns service` / `lns policy`):

- **`lns sandbox ls`**, **`lns sandbox exec`**, **`lns sandbox kill`** become the canonical spellings, listed in `lns sandbox --help` alongside stop/logs/attach/inspect/stats.
- The flat `lns ls` / `lns exec` / `lns kill` keep working as **hidden aliases** (`#[command(hide = true)]`) so existing scripts and habits don't break; they just leave the front page of `lns --help`.
- `sandbox ls` and `sandbox kill` answer through the `SandboxService` seam, so both gained Layer 2 behavioural coverage that the flat forms never had (table rendering, signal mapping, unknown-signal rejection, request assertions). `sandbox exec` dispatches through the existing interactive exec path unchanged.

## Docs

`cli-reference.md` folds the three verbs into the `lns sandbox` table with an alias note; `running-workloads.md` now presents the whole post-start lifecycle under one section.

## Tests

- Behaviours: help lists all eight verbs; flat aliases parse and stay hidden; `sandbox ls` renders the runs table; `sandbox kill` forwards the requested signal and rejects unknown names.
- E2E: `sandbox ls` and the flat `ls` alias answer end to end; `sandbox kill` of an unknown run surfaces the daemon's error.

Stacked on #56 — diff is against the `lifecycle` branch; retarget to `main` once #56 lands.
