### PR TITLE
feat(run): Overlap prepare phases and stream live progress to the CLI

### DIFF
--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -1,2 +1,3 @@
 pub mod env_file;
+pub mod progress;
 pub mod summary;

--- a/crates/lns-cli/src/run/progress.rs
+++ b/crates/lns-cli/src/run/progress.rs
@@ -38,21 +38,26 @@ impl ProgressRenderer {
         if !self.enabled {
             return Ok(());
         }
-        self.active = Some(ActiveProgress {
+        let active = ActiveProgress {
             verb: verb.to_string(),
             message: message.to_string(),
             current,
             total,
-        });
-        self.render(writer)
+        };
+        let line = progress_line(SPINNER_FRAMES[self.spin], &active);
+        self.active = Some(active);
+        self.write_line(&line, writer)
     }
 
+    // `active` is only ever set by update(), so a disabled renderer never has a line to animate.
     pub fn tick(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
-        if !self.enabled || self.active.is_none() {
-            return Ok(());
-        }
-        self.spin = (self.spin + 1) % SPINNER_FRAMES.len();
-        self.render(writer)
+        let next_spin = (self.spin + 1) % SPINNER_FRAMES.len();
+        let line = match &self.active {
+            Some(active) => progress_line(SPINNER_FRAMES[next_spin], active),
+            None => return Ok(()),
+        };
+        self.spin = next_spin;
+        self.write_line(&line, writer)
     }
 
     pub fn clear(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
@@ -67,11 +72,7 @@ impl ProgressRenderer {
         Ok(())
     }
 
-    fn render(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
-        let Some(active) = &self.active else {
-            return Ok(());
-        };
-        let line = progress_line(SPINNER_FRAMES[self.spin], active);
+    fn write_line(&mut self, line: &str, writer: &mut impl Write) -> std::io::Result<()> {
         let width = line.chars().count();
         let pad = " ".repeat(self.rendered_width.saturating_sub(width));
         write!(writer, "\r{line}{pad}")?;

--- a/crates/lns-cli/src/run/progress.rs
+++ b/crates/lns-cli/src/run/progress.rs
@@ -132,10 +132,10 @@ mod tests {
         r.update("Pulling", "", 5, 10, &mut buf).unwrap();
         r.tick(&mut buf).unwrap();
         r.clear(&mut buf).unwrap();
+        let rendered = text(&buf);
         assert!(
-            buf.is_empty(),
-            "non-tty output must stay machine-readable: {:?}",
-            text(&buf),
+            rendered.is_empty(),
+            "non-tty output must stay machine-readable: {rendered:?}"
         );
     }
 

--- a/crates/lns-cli/src/run/progress.rs
+++ b/crates/lns-cli/src/run/progress.rs
@@ -1,0 +1,274 @@
+use std::io::Write;
+
+const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const BAR_WIDTH: usize = 20;
+
+pub struct ProgressRenderer {
+    enabled: bool,
+    active: Option<ActiveProgress>,
+    spin: usize,
+    rendered_width: usize,
+}
+
+struct ActiveProgress {
+    verb: String,
+    message: String,
+    current: u64,
+    total: u64,
+}
+
+impl ProgressRenderer {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            active: None,
+            spin: 0,
+            rendered_width: 0,
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        verb: &str,
+        message: &str,
+        current: u64,
+        total: u64,
+        writer: &mut impl Write,
+    ) -> std::io::Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        self.active = Some(ActiveProgress {
+            verb: verb.to_string(),
+            message: message.to_string(),
+            current,
+            total,
+        });
+        self.render(writer)
+    }
+
+    pub fn tick(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
+        if !self.enabled || self.active.is_none() {
+            return Ok(());
+        }
+        self.spin = (self.spin + 1) % SPINNER_FRAMES.len();
+        self.render(writer)
+    }
+
+    pub fn clear(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
+        self.active = None;
+        if self.rendered_width == 0 {
+            return Ok(());
+        }
+        let blank = " ".repeat(self.rendered_width);
+        write!(writer, "\r{blank}\r")?;
+        writer.flush()?;
+        self.rendered_width = 0;
+        Ok(())
+    }
+
+    fn render(&mut self, writer: &mut impl Write) -> std::io::Result<()> {
+        let Some(active) = &self.active else {
+            return Ok(());
+        };
+        let line = progress_line(SPINNER_FRAMES[self.spin], active);
+        let width = line.chars().count();
+        let pad = " ".repeat(self.rendered_width.saturating_sub(width));
+        write!(writer, "\r{line}{pad}")?;
+        writer.flush()?;
+        self.rendered_width = width;
+        Ok(())
+    }
+}
+
+fn progress_line(spinner: char, p: &ActiveProgress) -> String {
+    let phrase = p.verb.to_lowercase();
+    if p.total > 0 {
+        let capped = p.current.min(p.total);
+        let ratio = capped as f64 / p.total as f64;
+        let filled = (ratio * BAR_WIDTH as f64).round() as usize;
+        let bar: String = "█".repeat(filled) + &"░".repeat(BAR_WIDTH - filled);
+        let pct = (ratio * 100.0).round() as u64;
+        let cur = fmt_bytes(capped);
+        let tot = fmt_bytes(p.total);
+        format!("{spinner} {phrase}  {bar}  {cur} / {tot}  {pct}%")
+    } else if p.current > 0 {
+        format!("{spinner} {phrase}  {}", fmt_bytes(p.current))
+    } else if p.message.is_empty() {
+        format!("{spinner} {phrase}…")
+    } else {
+        format!("{spinner} {phrase} {}…", p.message)
+    }
+}
+
+fn fmt_bytes(n: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+    if n >= GIB {
+        format!("{:.1} GiB", n as f64 / GIB as f64)
+    } else if n >= MIB {
+        format!("{:.1} MiB", n as f64 / MIB as f64)
+    } else if n >= KIB {
+        format!("{:.1} KiB", n as f64 / KIB as f64)
+    } else {
+        format!("{n} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(buf: &[u8]) -> String {
+        String::from_utf8(buf.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn disabled_renderer_writes_nothing_for_any_call() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(false);
+        r.update("Pulling", "", 5, 10, &mut buf).unwrap();
+        r.tick(&mut buf).unwrap();
+        r.clear(&mut buf).unwrap();
+        assert!(
+            buf.is_empty(),
+            "non-tty output must stay machine-readable: {:?}",
+            text(&buf),
+        );
+    }
+
+    #[test]
+    fn determinate_update_renders_a_bar_with_sizes_and_percent() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Pulling", "", 26 * 1024 * 1024, 52 * 1024 * 1024, &mut buf)
+            .unwrap();
+        let s = text(&buf);
+        assert!(s.starts_with('\r'), "line must overwrite in place: {s:?}");
+        assert!(s.contains("pulling"), "{s:?}");
+        assert!(s.contains(&"█".repeat(10)), "{s:?}");
+        assert!(s.contains(&"░".repeat(10)), "{s:?}");
+        assert!(s.contains("26.0 MiB / 52.0 MiB"), "{s:?}");
+        assert!(s.contains("50%"), "{s:?}");
+    }
+
+    #[test]
+    fn determinate_update_at_zero_and_full_render_empty_and_full_bars() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Pulling", "", 0, 100, &mut buf).unwrap();
+        assert!(text(&buf).contains(&"░".repeat(BAR_WIDTH)));
+        buf.clear();
+        r.update("Pulling", "", 100, 100, &mut buf).unwrap();
+        let s = text(&buf);
+        assert!(s.contains(&"█".repeat(BAR_WIDTH)), "{s:?}");
+        assert!(s.contains("100%"), "{s:?}");
+    }
+
+    #[test]
+    fn overshoot_beyond_total_clamps_to_one_hundred_percent() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Pulling", "", 250, 100, &mut buf).unwrap();
+        let s = text(&buf);
+        assert!(s.contains("100%"), "{s:?}");
+        assert!(s.contains("100 B / 100 B"), "{s:?}");
+        assert!(!s.contains("250"), "{s:?}");
+    }
+
+    #[test]
+    fn indeterminate_update_with_message_renders_a_spinner_phrase() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Booting", "microVM", 0, 0, &mut buf).unwrap();
+        let s = text(&buf);
+        assert!(s.contains("booting microVM…"), "{s:?}");
+        assert!(!s.contains('█'), "{s:?}");
+    }
+
+    #[test]
+    fn indeterminate_update_without_message_renders_just_the_phrase() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Assembling", "", 0, 0, &mut buf).unwrap();
+        assert!(text(&buf).contains("assembling…"));
+    }
+
+    #[test]
+    fn unknown_total_with_bytes_renders_a_byte_counter() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Pulling", "", 3 * 1024, 0, &mut buf).unwrap();
+        let s = text(&buf);
+        assert!(s.contains("pulling  3.0 KiB"), "{s:?}");
+        assert!(!s.contains('%'), "{s:?}");
+    }
+
+    #[test]
+    fn tick_advances_the_spinner_glyph_on_the_active_line() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Booting", "microVM", 0, 0, &mut buf).unwrap();
+        let first = text(&buf).chars().nth(1).unwrap();
+        buf.clear();
+        r.tick(&mut buf).unwrap();
+        let second = text(&buf).chars().nth(1).unwrap();
+        assert_ne!(first, second, "the spinner must visibly animate");
+        assert!(SPINNER_FRAMES.contains(&second));
+    }
+
+    #[test]
+    fn tick_with_no_active_progress_writes_nothing() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.tick(&mut buf).unwrap();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn clear_blanks_the_rendered_line_and_returns_the_cursor() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Booting", "microVM", 0, 0, &mut buf).unwrap();
+        let width = text(&buf).trim_start_matches('\r').chars().count();
+        buf.clear();
+        r.clear(&mut buf).unwrap();
+        assert_eq!(text(&buf), format!("\r{}\r", " ".repeat(width)));
+    }
+
+    #[test]
+    fn clear_before_any_render_writes_nothing() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.clear(&mut buf).unwrap();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn a_shorter_line_pads_over_the_previous_longer_one() {
+        let mut buf = Vec::new();
+        let mut r = ProgressRenderer::new(true);
+        r.update("Pulling", "", 50, 100, &mut buf).unwrap();
+        let long_width = text(&buf).trim_start_matches('\r').chars().count();
+        buf.clear();
+        r.update("Booting", "microVM", 0, 0, &mut buf).unwrap();
+        let s = text(&buf);
+        let short_width = "⠋ booting microVM…".chars().count();
+        assert_eq!(
+            s.chars().count(),
+            1 + long_width.max(short_width),
+            "stale glyphs from the longer line must be overwritten: {s:?}",
+        );
+        assert!(s.ends_with(&" ".repeat(long_width - short_width)));
+    }
+
+    #[test]
+    fn fmt_bytes_picks_largest_unit_at_1024_boundary() {
+        assert_eq!(fmt_bytes(0), "0 B");
+        assert_eq!(fmt_bytes(1023), "1023 B");
+        assert_eq!(fmt_bytes(1024), "1.0 KiB");
+        assert_eq!(fmt_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(fmt_bytes(1024 * 1024 * 1024), "1.0 GiB");
+    }
+}

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -104,8 +104,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         other => anyhow::bail!("expected RunStarted, got {other:?}"),
     };
 
-    let mut progress =
-        crate::run::progress::ProgressRenderer::new(std::io::stderr().is_terminal());
+    let mut progress = crate::run::progress::ProgressRenderer::new(std::io::stderr().is_terminal());
     let outcome = drive_pre_phase(&mut stream, &mut std::io::stderr(), &mut progress).await?;
     if let PrePhaseOutcome::EarlyExit(code) = outcome {
         return Ok(code);
@@ -882,7 +881,9 @@ mod tests {
             write_response(&mut server, run_log("SessionReady", "")).await;
         });
         let mut buf = Vec::<u8>::new();
-        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress()).await.unwrap();
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress())
+            .await
+            .unwrap();
         assert_eq!(outcome, PrePhaseOutcome::SessionReady);
         let s = String::from_utf8(buf).unwrap();
         assert!(
@@ -902,7 +903,9 @@ mod tests {
             write_response(&mut server, Response::RunExit { code: 42 }).await;
         });
         let mut buf = Vec::<u8>::new();
-        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress()).await.unwrap();
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress())
+            .await
+            .unwrap();
         assert_eq!(outcome, PrePhaseOutcome::EarlyExit(42));
     }
 

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -104,7 +104,9 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         other => anyhow::bail!("expected RunStarted, got {other:?}"),
     };
 
-    let outcome = drive_pre_phase(&mut stream, &mut std::io::stderr()).await?;
+    let mut progress =
+        crate::run::progress::ProgressRenderer::new(std::io::stderr().is_terminal());
+    let outcome = drive_pre_phase(&mut stream, &mut std::io::stderr(), &mut progress).await?;
     if let PrePhaseOutcome::EarlyExit(code) = outcome {
         return Ok(code);
     }
@@ -325,6 +327,7 @@ where
                     WireFrame::Json(Response::RunLog { level, verb, message }) => {
                         render_attached_run_log(level, verb.as_deref(), &message, stderr).await?;
                     }
+                    WireFrame::Json(Response::RunProgress { .. }) => {}
                     WireFrame::Json(Response::RunExit { code }) => break code,
                     WireFrame::Json(Response::Error { message }) => {
                         anyhow::bail!("daemon error: {message}")
@@ -655,15 +658,26 @@ pub enum PrePhaseStep {
     EarlyExit(i32),
 }
 
-pub async fn pre_phase_step<S, W>(stream: &mut S, writer: &mut W) -> Result<PrePhaseStep>
+pub fn pre_phase_step<W>(
+    bytes: &[u8],
+    writer: &mut W,
+    progress: &mut crate::run::progress::ProgressRenderer,
+) -> Result<PrePhaseStep>
 where
-    S: AsyncReadExt + Unpin,
     W: std::io::Write,
 {
-    let bytes = read_frame_bytes_async(stream)
-        .await
-        .context("reading pre-phase frame")?;
-    let wire = decode_wire_frame_from_bytes(&bytes).context("decoding pre-phase frame")?;
+    let wire = decode_wire_frame_from_bytes(bytes).context("decoding pre-phase frame")?;
+    if let WireFrame::Json(Response::RunProgress {
+        verb,
+        message,
+        current,
+        total,
+    }) = wire
+    {
+        progress.update(&verb, &message, current, total, writer)?;
+        return Ok(PrePhaseStep::Continue);
+    }
+    progress.clear(writer)?;
     match wire {
         WireFrame::Json(Response::RunLog {
             level,
@@ -685,13 +699,30 @@ where
     }
 }
 
-pub async fn drive_pre_phase<S, W>(stream: &mut S, writer: &mut W) -> Result<PrePhaseOutcome>
+const PROGRESS_TICK: Duration = Duration::from_millis(100);
+
+pub async fn drive_pre_phase<S, W>(
+    stream: &mut S,
+    writer: &mut W,
+    progress: &mut crate::run::progress::ProgressRenderer,
+) -> Result<PrePhaseOutcome>
 where
     S: AsyncReadExt + Unpin,
     W: std::io::Write,
 {
+    let mut ticker = tokio::time::interval(PROGRESS_TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
-        match pre_phase_step(stream, writer).await? {
+        let read = read_frame_bytes_async(stream);
+        tokio::pin!(read);
+        let bytes = loop {
+            tokio::select! {
+                r = &mut read => break r,
+                _ = ticker.tick() => progress.tick(writer)?,
+            }
+        }
+        .context("reading pre-phase frame")?;
+        match pre_phase_step(&bytes, writer, progress)? {
             PrePhaseStep::Continue => {}
             PrePhaseStep::SessionReady => return Ok(PrePhaseOutcome::SessionReady),
             PrePhaseStep::EarlyExit(code) => return Ok(PrePhaseOutcome::EarlyExit(code)),
@@ -828,6 +859,19 @@ mod tests {
         server.write_all(&frame).await.expect("write");
     }
 
+    fn no_progress() -> crate::run::progress::ProgressRenderer {
+        crate::run::progress::ProgressRenderer::new(false)
+    }
+
+    fn run_progress(verb: &str, message: &str, current: u64, total: u64) -> Response {
+        Response::RunProgress {
+            verb: verb.to_string(),
+            message: message.to_string(),
+            current,
+            total,
+        }
+    }
+
     #[tokio::test]
     async fn drive_pre_phase_renders_log_frames_and_returns_session_ready() {
         let (mut client, mut server) = tokio::io::duplex(4096);
@@ -838,7 +882,7 @@ mod tests {
             write_response(&mut server, run_log("SessionReady", "")).await;
         });
         let mut buf = Vec::<u8>::new();
-        let outcome = drive_pre_phase(&mut client, &mut buf).await.unwrap();
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress()).await.unwrap();
         assert_eq!(outcome, PrePhaseOutcome::SessionReady);
         let s = String::from_utf8(buf).unwrap();
         assert!(
@@ -858,7 +902,7 @@ mod tests {
             write_response(&mut server, Response::RunExit { code: 42 }).await;
         });
         let mut buf = Vec::<u8>::new();
-        let outcome = drive_pre_phase(&mut client, &mut buf).await.unwrap();
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress()).await.unwrap();
         assert_eq!(outcome, PrePhaseOutcome::EarlyExit(42));
     }
 
@@ -875,7 +919,7 @@ mod tests {
             .await;
         });
         let mut buf = Vec::<u8>::new();
-        let err = drive_pre_phase(&mut client, &mut buf)
+        let err = drive_pre_phase(&mut client, &mut buf, &mut no_progress())
             .await
             .expect_err("daemon Error must surface");
         assert!(format!("{err:#}").contains("no such image"));
@@ -890,10 +934,96 @@ mod tests {
             server.write_all(&frame).await.expect("write");
         });
         let mut buf = Vec::<u8>::new();
-        let err = drive_pre_phase(&mut client, &mut buf)
+        let err = drive_pre_phase(&mut client, &mut buf, &mut no_progress())
             .await
             .expect_err("stdout before SessionReady is a protocol violation");
         assert!(format!("{err:#}").contains("unexpected frame"));
+    }
+
+    #[tokio::test]
+    async fn drive_pre_phase_ignores_progress_frames_when_stderr_is_not_a_tty() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            write_response(&mut server, run_progress("Pulling", "", 5, 10)).await;
+            write_response(&mut server, run_progress("Booting", "microVM", 0, 0)).await;
+            write_response(&mut server, run_log("SessionReady", "")).await;
+        });
+        let mut buf = Vec::<u8>::new();
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress())
+            .await
+            .unwrap();
+        assert_eq!(outcome, PrePhaseOutcome::SessionReady);
+        let s = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            s, "✓ session ready\n",
+            "piped output must contain only final status lines",
+        );
+    }
+
+    #[tokio::test]
+    async fn drive_pre_phase_renders_then_clears_progress_before_the_next_status_line() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            write_response(&mut server, run_progress("Pulling", "", 5, 10)).await;
+            write_response(&mut server, run_log("Pulled", "2 layers")).await;
+            write_response(&mut server, run_log("SessionReady", "")).await;
+        });
+        let mut buf = Vec::<u8>::new();
+        let mut progress = crate::run::progress::ProgressRenderer::new(true);
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut progress)
+            .await
+            .unwrap();
+        assert_eq!(outcome, PrePhaseOutcome::SessionReady);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("pulling"), "live bar must render: {s:?}");
+        assert!(s.contains("50%"), "{s:?}");
+        let check_idx = s.find('✓').unwrap();
+        assert!(
+            s[..check_idx].ends_with('\r'),
+            "the bar must be erased so the status line starts at column 0: {s:?}",
+        );
+        assert!(s.contains("✓ pulled 2 layers"), "{s:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_pre_phase_animates_the_spinner_while_waiting_between_frames() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            write_response(&mut server, run_progress("Booting", "microVM", 0, 0)).await;
+            tokio::time::sleep(Duration::from_millis(350)).await;
+            write_response(&mut server, run_log("SessionReady", "")).await;
+        });
+        let mut buf = Vec::<u8>::new();
+        let mut progress = crate::run::progress::ProgressRenderer::new(true);
+        let outcome = drive_pre_phase(&mut client, &mut buf, &mut progress)
+            .await
+            .unwrap();
+        assert_eq!(outcome, PrePhaseOutcome::SessionReady);
+        let s = String::from_utf8(buf).unwrap();
+        let spinner_glyphs: std::collections::HashSet<char> = s
+            .chars()
+            .filter(|c| ('\u{2800}'..='\u{28FF}').contains(c))
+            .collect();
+        assert!(
+            spinner_glyphs.len() >= 2,
+            "the spinner must visibly animate while the service is silent: {s:?}",
+        );
+        assert!(s.contains("✓ session ready"), "{s:?}");
+    }
+
+    #[tokio::test]
+    async fn drive_attached_session_tolerates_progress_frames_after_session_ready() {
+        let (client, mut server) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            let progress = encode_frame(&run_progress("Pulling", "", 1, 2)).expect("encode");
+            server.write_all(&progress).await.expect("write progress");
+            let exit = encode_frame(&Response::RunExit { code: 0 }).expect("encode RunExit");
+            server.write_all(&exit).await.expect("write RunExit");
+        });
+        let code = drive_attached_session(client, None, 42, false, Vec::new())
+            .await
+            .expect("a stray progress frame must not kill an attached session");
+        assert_eq!(code, 0);
     }
 
     #[tokio::test]

--- a/crates/lns-cli/tests/behaviours/run_visibility.feature
+++ b/crates/lns-cli/tests/behaviours/run_visibility.feature
@@ -49,6 +49,12 @@ Feature: users see what `lns run` is doing from the moment they hit Enter
     Then `✓ session ready` is printed
     And finally `✓ started run #N` is printed before the attached session takes over
 
+  Scenario: Layer downloads show a live in-place progress bar on a terminal
+    Given the image is not in the local cache
+    When the service streams pull progress halfway through the download
+    Then the terminal shows an in-place pull progress bar at 50%
+    And the pulled completion line erases the bar and starts at column 0
+
   Scenario: Warm image cache collapses the resolve+pull phases
     Given the image is already cached locally
     When the run starts

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -6,7 +6,10 @@ use lns_cli::run::summary::print_run_summary;
 use lns_cli::service::{
     PrePhaseStep, drive_attached_session_with_writers, pre_phase_step, render_started_run,
 };
-use lns_ipc::{LogLevel, Response, WireFrame, encode_frame, encode_wire_frame};
+use lns_cli::run::progress::ProgressRenderer;
+use lns_ipc::{
+    LogLevel, Response, WireFrame, encode_frame, encode_wire_frame, read_frame_bytes_async,
+};
 use lns_policy::{Policy, RouteRule, Transport, Verdict};
 use std::io::Write as _;
 use tokio::io::AsyncWriteExt;
@@ -18,6 +21,17 @@ fn pipe_mut(world: &mut BehaviourWorld) -> &mut PhasePipe {
     world.pipe.as_mut().unwrap()
 }
 
+async fn step_from_pipe(
+    pipe: &mut PhasePipe,
+    writer: &mut Vec<u8>,
+    progress: &mut ProgressRenderer,
+) -> PrePhaseStep {
+    let bytes = read_frame_bytes_async(&mut pipe.client)
+        .await
+        .expect("read frame");
+    pre_phase_step(&bytes, writer, progress).expect("pre_phase_step")
+}
+
 async fn send_and_step(world: &mut BehaviourWorld, resp: Response) -> PrePhaseStep {
     let frame = encode_frame(&resp).expect("encode response");
     {
@@ -26,9 +40,7 @@ async fn send_and_step(world: &mut BehaviourWorld, resp: Response) -> PrePhaseSt
     }
     let mut writer = std::mem::take(&mut world.phase_output);
     let pipe = pipe_mut(world);
-    let step = pre_phase_step(&mut pipe.client, &mut writer)
-        .await
-        .expect("pre_phase_step");
+    let step = step_from_pipe(pipe, &mut writer, &mut ProgressRenderer::new(false)).await;
     world.phase_output = writer;
     step
 }
@@ -38,6 +50,65 @@ fn run_log(verb: &str, message: &str) -> Response {
         level: LogLevel::Info,
         verb: Some(verb.to_string()),
         message: message.to_string(),
+    }
+}
+
+#[when("the service streams pull progress halfway through the download")]
+async fn stream_pull_progress_halfway(world: &mut BehaviourWorld) {
+    let progress_frame = encode_frame(&Response::RunProgress {
+        verb: "Pulling".to_string(),
+        message: String::new(),
+        current: 5 * 1024 * 1024,
+        total: 10 * 1024 * 1024,
+    })
+    .expect("encode progress");
+    let pulled_frame = encode_frame(&run_log("Pulled", "1 layer   (0.42s · 10.0 MiB)"))
+        .expect("encode pulled");
+    {
+        let pipe = pipe_mut(world);
+        pipe.server
+            .write_all(&progress_frame)
+            .await
+            .expect("write progress");
+        pipe.server
+            .write_all(&pulled_frame)
+            .await
+            .expect("write pulled");
+    }
+    let mut writer = std::mem::take(&mut world.phase_output);
+    let pipe = pipe_mut(world);
+    let mut renderer = ProgressRenderer::new(true);
+    let _ = step_from_pipe(pipe, &mut writer, &mut renderer).await;
+    let _ = step_from_pipe(pipe, &mut writer, &mut renderer).await;
+    world.phase_output = writer;
+}
+
+#[then("the terminal shows an in-place pull progress bar at 50%")]
+fn terminal_shows_bar_at_half(world: &mut BehaviourWorld) -> Result<(), String> {
+    let s = String::from_utf8_lossy(&world.phase_output);
+    if !s.contains("\r") {
+        return Err(format!("bar must redraw in place via carriage return: {s:?}"));
+    }
+    if s.contains("pulling") && s.contains("50%") && s.contains("5.0 MiB / 10.0 MiB") {
+        Ok(())
+    } else {
+        Err(format!("no 50% pull bar in: {s:?}"))
+    }
+}
+
+#[then("the pulled completion line erases the bar and starts at column 0")]
+fn pulled_line_erases_bar(world: &mut BehaviourWorld) -> Result<(), String> {
+    let s = String::from_utf8_lossy(&world.phase_output);
+    let idx = s
+        .find('✓')
+        .ok_or_else(|| format!("no completion line in: {s:?}"))?;
+    if !s[..idx].ends_with('\r') {
+        return Err(format!("bar not erased before the ✓ line: {s:?}"));
+    }
+    if s.contains("✓ pulled 1 layer") {
+        Ok(())
+    } else {
+        Err(format!("missing pulled line: {s:?}"))
     }
 }
 
@@ -459,12 +530,9 @@ async fn resolution_fails(world: &mut BehaviourWorld) {
     }
     let mut writer = std::mem::take(&mut world.phase_output);
     let pipe = pipe_mut(world);
-    let _ = pre_phase_step(&mut pipe.client, &mut writer)
-        .await
-        .expect("step 1");
-    let outcome = pre_phase_step(&mut pipe.client, &mut writer)
-        .await
-        .expect("step 2");
+    let mut progress = ProgressRenderer::new(false);
+    let _ = step_from_pipe(pipe, &mut writer, &mut progress).await;
+    let outcome = step_from_pipe(pipe, &mut writer, &mut progress).await;
     world.phase_output = writer;
     if let PrePhaseStep::EarlyExit(code) = outcome {
         world.early_exit_code = Some(code);

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -2,11 +2,11 @@ use crate::world::{BehaviourWorld, CannedSequence, PhasePipe};
 use clap::Parser;
 use cucumber::{given, then, when};
 use lns_cli::cli::{Cli, Command};
+use lns_cli::run::progress::ProgressRenderer;
 use lns_cli::run::summary::print_run_summary;
 use lns_cli::service::{
     PrePhaseStep, drive_attached_session_with_writers, pre_phase_step, render_started_run,
 };
-use lns_cli::run::progress::ProgressRenderer;
 use lns_ipc::{
     LogLevel, Response, WireFrame, encode_frame, encode_wire_frame, read_frame_bytes_async,
 };
@@ -62,8 +62,8 @@ async fn stream_pull_progress_halfway(world: &mut BehaviourWorld) {
         total: 10 * 1024 * 1024,
     })
     .expect("encode progress");
-    let pulled_frame = encode_frame(&run_log("Pulled", "1 layer   (0.42s · 10.0 MiB)"))
-        .expect("encode pulled");
+    let pulled_frame =
+        encode_frame(&run_log("Pulled", "1 layer   (0.42s · 10.0 MiB)")).expect("encode pulled");
     {
         let pipe = pipe_mut(world);
         pipe.server
@@ -87,7 +87,9 @@ async fn stream_pull_progress_halfway(world: &mut BehaviourWorld) {
 fn terminal_shows_bar_at_half(world: &mut BehaviourWorld) -> Result<(), String> {
     let s = String::from_utf8_lossy(&world.phase_output);
     if !s.contains("\r") {
-        return Err(format!("bar must redraw in place via carriage return: {s:?}"));
+        return Err(format!(
+            "bar must redraw in place via carriage return: {s:?}"
+        ));
     }
     if s.contains("pulling") && s.contains("50%") && s.contains("5.0 MiB / 10.0 MiB") {
         Ok(())

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -124,6 +124,13 @@ pub enum Response {
         removed: Vec<String>,
         reclaimed_bytes: u64,
     },
+    RunProgress {
+        verb: String,
+        message: String,
+        current: u64,
+        /// 0 means the size of the work is unknown (render as indeterminate).
+        total: u64,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -681,6 +688,28 @@ mod tests {
     fn run_stopped_survives_a_response_round_trip() {
         for forced in [false, true] {
             let resp = Response::RunStopped { forced };
+            let frame = crate::encode_frame(&resp).unwrap();
+            let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();
+            assert_eq!(decoded, resp);
+        }
+    }
+
+    #[test]
+    fn run_progress_survives_round_trips_for_determinate_and_indeterminate() {
+        for resp in [
+            Response::RunProgress {
+                verb: "Pulling".into(),
+                message: String::new(),
+                current: 12 * 1024 * 1024,
+                total: 51 * 1024 * 1024,
+            },
+            Response::RunProgress {
+                verb: "Booting".into(),
+                message: "microVM".into(),
+                current: 0,
+                total: 0,
+            },
+        ] {
             let frame = crate::encode_frame(&resp).unwrap();
             let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();
             assert_eq!(decoded, resp);

--- a/crates/lns-service/src/composefs/descriptor.rs
+++ b/crates/lns-service/src/composefs/descriptor.rs
@@ -32,6 +32,12 @@ impl DescriptorBuilder {
         Self { root: root.into() }
     }
 
+    pub fn cached(&self, req: &DescriptorRequest<'_>) -> Result<Option<BuiltDescriptor>> {
+        let runtime_digest = req.runtime_layer.map(|r| r.digest());
+        let merge_hash = compute_merge_hash(req.layer_digests, runtime_digest);
+        self.try_cached(&merge_hash)
+    }
+
     pub fn build(
         &self,
         content_store: &ContentStore,
@@ -39,21 +45,10 @@ impl DescriptorBuilder {
     ) -> Result<BuiltDescriptor> {
         let runtime_digest = req.runtime_layer.map(|r| r.digest());
         let merge_hash = compute_merge_hash(req.layer_digests, runtime_digest);
-        let dir = self.root.join("composefs").join(&merge_hash);
-        let path = dir.join("descriptor.erofs");
-
-        if let Ok(meta) = std::fs::metadata(&path)
-            && meta.is_file()
-        {
-            let bytes = std::fs::read(&path)
-                .with_context(|| format!("re-reading cached {}", path.display()))?;
-            return Ok(BuiltDescriptor {
-                merge_hash,
-                path,
-                descriptor_sha256: format!("sha256:{}", hex::encode(Sha256::digest(&bytes))),
-                size: meta.len(),
-            });
+        if let Some(hit) = self.try_cached(&merge_hash)? {
+            return Ok(hit);
         }
+        let path = self.path_for(&merge_hash);
 
         let mut fs = oci::build_filesystem_from_layer_bytes(content_store, req.layers)
             .context("expanding OCI layers into composefs tree")?;
@@ -73,6 +68,7 @@ impl DescriptorBuilder {
 
         atomic_install(&path, &bytes)
             .with_context(|| format!("installing composefs descriptor at {}", path.display()))?;
+        write_sha_sidecar(&path, &descriptor_sha256);
 
         Ok(BuiltDescriptor {
             merge_hash,
@@ -80,6 +76,63 @@ impl DescriptorBuilder {
             descriptor_sha256,
             size: bytes.len() as u64,
         })
+    }
+
+    fn path_for(&self, merge_hash: &str) -> PathBuf {
+        self.root
+            .join("composefs")
+            .join(merge_hash)
+            .join("descriptor.erofs")
+    }
+
+    fn try_cached(&self, merge_hash: &str) -> Result<Option<BuiltDescriptor>> {
+        let path = self.path_for(merge_hash);
+        let Ok(meta) = std::fs::metadata(&path) else {
+            return Ok(None);
+        };
+        if !meta.is_file() {
+            return Ok(None);
+        }
+        let descriptor_sha256 = match read_sha_sidecar(&path) {
+            Some(sha) => sha,
+            None => {
+                let bytes = std::fs::read(&path)
+                    .with_context(|| format!("re-reading cached {}", path.display()))?;
+                let sha = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+                write_sha_sidecar(&path, &sha);
+                sha
+            }
+        };
+        Ok(Some(BuiltDescriptor {
+            merge_hash: merge_hash.to_string(),
+            path,
+            descriptor_sha256,
+            size: meta.len(),
+        }))
+    }
+}
+
+fn sidecar_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".sha256");
+    PathBuf::from(s)
+}
+
+fn read_sha_sidecar(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(sidecar_path(path)).ok()?;
+    let text = text.trim();
+    let hex_part = text.strip_prefix("sha256:")?;
+    let valid = hex_part.len() == 64 && hex_part.chars().all(|c| c.is_ascii_hexdigit());
+    valid.then(|| text.to_string())
+}
+
+fn write_sha_sidecar(path: &Path, sha: &str) {
+    let sidecar = sidecar_path(path);
+    if let Err(e) = std::fs::write(&sidecar, sha) {
+        let sidecar_str = sidecar.display();
+        crate::log::warn!(
+            "descriptor sha sidecar write failed at {sidecar_str} ({e}); next run will re-hash"
+        );
     }
 }
 
@@ -344,6 +397,111 @@ mod tests {
         let bytes = std::fs::read(&r.path).unwrap();
         assert!(bytes.len() > 1024);
         assert_eq!(&bytes[1024..1028], &[0xe2, 0xe1, 0xf5, 0xe0]);
+    }
+
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        store: ContentStore,
+        builder: DescriptorBuilder,
+        digests: Vec<String>,
+        layers: Vec<Vec<u8>>,
+    }
+
+    fn fixture(layer_digest: &str) -> Fixture {
+        let dir = tempdir();
+        let store = ContentStore::new(dir.path().join("content"));
+        let builder = DescriptorBuilder::new(dir.path());
+        Fixture {
+            _dir: dir,
+            store,
+            builder,
+            digests: vec![layer_digest.repeat(32)],
+            layers: vec![tiny_tar("hello", b"world")],
+        }
+    }
+
+    impl Fixture {
+        fn request(&self) -> DescriptorRequest<'_> {
+            DescriptorRequest {
+                layer_digests: &self.digests,
+                layers: &self.layers,
+                runtime_layer: None,
+            }
+        }
+    }
+
+    #[test]
+    fn build_writes_a_sha_sidecar_next_to_the_descriptor() {
+        let f = fixture("sha256:1a");
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let sidecar = sidecar_path(&built.path);
+        assert_eq!(
+            std::fs::read_to_string(sidecar).unwrap(),
+            built.descriptor_sha256,
+        );
+    }
+
+    #[test]
+    fn cached_returns_none_before_build_and_the_built_descriptor_after() {
+        let f = fixture("sha256:2b");
+        assert!(f.builder.cached(&f.request()).unwrap().is_none());
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        assert_eq!(f.builder.cached(&f.request()).unwrap(), Some(built));
+    }
+
+    #[test]
+    fn cached_hit_serves_sha_from_sidecar_without_rehashing_the_descriptor() {
+        let f = fixture("sha256:3c");
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        std::fs::write(&built.path, b"corrupted on disk after install").unwrap();
+        let hit = f.builder.cached(&f.request()).unwrap().expect("cache hit");
+        assert_eq!(
+            hit.descriptor_sha256, built.descriptor_sha256,
+            "a warm hit must trust the sidecar instead of re-reading the descriptor",
+        );
+    }
+
+    #[test]
+    fn cached_falls_back_to_hashing_and_self_heals_when_sidecar_is_missing() {
+        let f = fixture("sha256:4d");
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let sidecar = sidecar_path(&built.path);
+        std::fs::remove_file(&sidecar).unwrap();
+        let hit = f.builder.cached(&f.request()).unwrap().expect("cache hit");
+        assert_eq!(hit.descriptor_sha256, built.descriptor_sha256);
+        assert_eq!(
+            std::fs::read_to_string(&sidecar).unwrap(),
+            built.descriptor_sha256,
+            "the fallback hash must be persisted so the next run skips it",
+        );
+    }
+
+    #[test]
+    fn cached_rejects_a_corrupt_sidecar_and_rehashes() {
+        let f = fixture("sha256:5e");
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let sidecar = sidecar_path(&built.path);
+        for garbage in ["not a digest", "sha256:zz", "sha256:abc"] {
+            std::fs::write(&sidecar, garbage).unwrap();
+            let hit = f.builder.cached(&f.request()).unwrap().expect("cache hit");
+            assert_eq!(
+                hit.descriptor_sha256, built.descriptor_sha256,
+                "garbage sidecar {garbage:?} must be ignored and re-derived",
+            );
+        }
+    }
+
+    #[test]
+    fn a_directory_squatting_on_the_sidecar_path_does_not_fail_the_build() {
+        let f = fixture("sha256:6f");
+        assert!(f.builder.cached(&f.request()).unwrap().is_none());
+        let path = f.builder.path_for(&compute_merge_hash(&f.digests, None));
+        std::fs::create_dir_all(sidecar_path(&path)).unwrap();
+        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        assert!(
+            built.path.is_file(),
+            "descriptor must land despite the sidecar failure",
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/composefs/descriptor.rs
+++ b/crates/lns-service/src/composefs/descriptor.rs
@@ -492,6 +492,18 @@ mod tests {
     }
 
     #[test]
+    fn a_directory_squatting_on_the_descriptor_path_reads_as_a_cache_miss() {
+        let f = fixture("sha256:7a");
+        let path = f.builder.path_for(&compute_merge_hash(&f.digests, None));
+        std::fs::create_dir_all(&path).unwrap();
+        assert_eq!(
+            f.builder.cached(&f.request()).unwrap(),
+            None,
+            "a non-file at the descriptor path must not be served as a hit",
+        );
+    }
+
+    #[test]
     fn a_directory_squatting_on_the_sidecar_path_does_not_fail_the_build() {
         let f = fixture("sha256:6f");
         assert!(f.builder.cached(&f.request()).unwrap().is_none());

--- a/crates/lns-service/src/image/manifest_cache.rs
+++ b/crates/lns-service/src/image/manifest_cache.rs
@@ -90,8 +90,9 @@ impl<R: Registry> Registry for CachingRegistry<R> {
         &self,
         reference: &Reference,
         descriptor: &oci_client::manifest::OciDescriptor,
+        on_chunk: &(dyn Fn(u64) + Send + Sync),
     ) -> Result<Vec<u8>> {
-        self.inner.pull_blob(reference, descriptor).await
+        self.inner.pull_blob(reference, descriptor, on_chunk).await
     }
 }
 
@@ -211,6 +212,7 @@ mod tests {
             &self,
             _reference: &Reference,
             _descriptor: &OciDescriptor,
+            _on_chunk: &(dyn Fn(u64) + Send + Sync),
         ) -> Result<Vec<u8>> {
             Ok(vec![])
         }
@@ -300,7 +302,7 @@ mod tests {
         };
         assert!(
             caching
-                .pull_blob(&reference, &descriptor)
+                .pull_blob(&reference, &descriptor, &|_| {})
                 .await
                 .unwrap()
                 .is_empty()

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -306,7 +306,9 @@ pub(crate) async fn pull_inner<R: Registry>(
                                 p.add(bytes);
                             }
                         };
-                        client.pull_blob(reference_ref, &descriptor, &on_chunk).await
+                        client
+                            .pull_blob(reference_ref, &descriptor, &on_chunk)
+                            .await
                     })
                     .await
                     .with_context(|| format!("resolving layer {i} (digest {digest})"))?;
@@ -560,8 +562,7 @@ mod tests {
         let guard = tracing::subscriber::set_default(subscriber);
         f();
         drop(guard);
-        let points = capture.points.lock().unwrap().clone();
-        points
+        capture.points.lock().unwrap().clone()
     }
 
     async fn capture_progress<F, Fut, R>(f: F) -> (R, Vec<(u64, u64)>)

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -283,29 +283,50 @@ pub(crate) async fn pull_inner<R: Registry>(
     let layers_owned: Vec<(usize, oci_client::manifest::OciDescriptor)> =
         manifest.layers.iter().cloned().enumerate().collect();
     let bytes_per_layer: Vec<Vec<u8>> = stream::iter(layers_owned)
-        .map(|(i, descriptor)| async move {
-            let layer_idx = i + 1;
-            let short = short_digest(&descriptor.digest);
-            let size = descriptor.size;
-            log::debug!(
-                layer = layer_idx,
-                of = n,
-                digest = short,
-                size = size,
-                "fetch-or-cache",
-            );
-            let digest = descriptor.digest.clone();
-            layer_cache
-                .get_or_install(&digest, || async move {
-                    let on_chunk = move |bytes: u64| {
-                        if let Some(p) = progress {
-                            p.add(bytes);
-                        }
-                    };
-                    client.pull_blob(reference_ref, &descriptor, &on_chunk).await
+        .map(|(i, descriptor)| {
+            // Cached layers were DiffID-verified on their cold pull; their decompressed content is pinned by the already-verified compressed digest, so re-decompressing them every run is pure waste.
+            let expected_diff_id = (!was_cached[i]).then(|| config.rootfs.diff_ids[i].clone());
+            async move {
+                let layer_idx = i + 1;
+                let short = short_digest(&descriptor.digest);
+                let size = descriptor.size;
+                log::debug!(
+                    layer = layer_idx,
+                    of = n,
+                    digest = short,
+                    size = size,
+                    "fetch-or-cache",
+                );
+                let digest = descriptor.digest.clone();
+                let media_type = descriptor.media_type.clone();
+                let bytes = layer_cache
+                    .get_or_install(&digest, || async move {
+                        let on_chunk = move |bytes: u64| {
+                            if let Some(p) = progress {
+                                p.add(bytes);
+                            }
+                        };
+                        client.pull_blob(reference_ref, &descriptor, &on_chunk).await
+                    })
+                    .await
+                    .with_context(|| format!("resolving layer {i} (digest {digest})"))?;
+                let Some(expected_diff_id) = expected_diff_id else {
+                    return Ok(bytes);
+                };
+                let (bytes, actual_diff_id) = tokio::task::spawn_blocking(move || {
+                    let actual = compute_diff_id(&bytes, &media_type)
+                        .with_context(|| format!("computing DiffID for layer {i}"))?;
+                    Ok::<_, anyhow::Error>((bytes, actual))
                 })
-                .await
-                .with_context(|| format!("resolving layer {i} (digest {digest})"))
+                .await??;
+                if !ct_digest_eq(&actual_diff_id, &expected_diff_id) {
+                    anyhow::bail!(
+                        "layer {i} DiffID mismatch: image config says {expected_diff_id}, \
+                         actual {actual_diff_id}"
+                    );
+                }
+                Ok(bytes)
+            }
         })
         .buffered(MAX_CONCURRENT_LAYER_FETCHES)
         .try_collect()
@@ -318,28 +339,6 @@ pub(crate) async fn pull_inner<R: Registry>(
             "{n} layer{plural}   ({elapsed_s:.2}s · {total_bytes_fmt})"
         );
     }
-
-    // Cached layers were DiffID-verified on their cold pull; their decompressed content is pinned by the already-verified compressed digest, so re-decompressing them every run is pure waste.
-    let diff_id_futures = bytes_per_layer
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !was_cached[*i])
-        .map(|(i, bytes)| {
-            let descriptor = &manifest.layers[i];
-            let expected_diff_id = config.rootfs.diff_ids[i].clone();
-            async move {
-                let actual_diff_id = compute_diff_id(bytes, &descriptor.media_type)
-                    .with_context(|| format!("computing DiffID for layer {i}"))?;
-                if !ct_digest_eq(&actual_diff_id, &expected_diff_id) {
-                    anyhow::bail!(
-                        "layer {i} DiffID mismatch: image config says {expected_diff_id}, \
-                     actual {actual_diff_id}"
-                    );
-                }
-                Ok::<(), anyhow::Error>(())
-            }
-        });
-    futures_util::future::try_join_all(diff_id_futures).await?;
 
     let mut layers: Vec<oci_client::client::ImageLayer> = Vec::with_capacity(n);
     let mut layer_digests: Vec<String> = Vec::with_capacity(n);

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -22,7 +22,88 @@ pub(crate) trait Registry: Send + Sync {
         &self,
         reference: &Reference,
         descriptor: &OciDescriptor,
+        on_chunk: &(dyn Fn(u64) + Send + Sync),
     ) -> impl std::future::Future<Output = Result<Vec<u8>>> + Send;
+}
+
+pub(crate) struct CountingSink<'a> {
+    buf: Vec<u8>,
+    on_chunk: &'a (dyn Fn(u64) + Send + Sync),
+}
+
+impl<'a> CountingSink<'a> {
+    pub(crate) fn new(on_chunk: &'a (dyn Fn(u64) + Send + Sync)) -> Self {
+        Self {
+            buf: Vec::new(),
+            on_chunk,
+        }
+    }
+
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+impl tokio::io::AsyncWrite for CountingSink<'_> {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let sink = self.get_mut();
+        (sink.on_chunk)(buf.len() as u64);
+        sink.buf.extend_from_slice(buf);
+        std::task::Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+const MIN_PROGRESS_STEP_BYTES: u64 = 256 * 1024;
+
+struct PullProgress {
+    total: u64,
+    step: u64,
+    received: std::sync::atomic::AtomicU64,
+    logged: std::sync::Mutex<u64>,
+}
+
+impl PullProgress {
+    fn start(total: u64) -> Self {
+        log::progress("Pulling", "", 0, total);
+        Self {
+            total,
+            step: (total / 100).max(MIN_PROGRESS_STEP_BYTES),
+            received: std::sync::atomic::AtomicU64::new(0),
+            logged: std::sync::Mutex::new(0),
+        }
+    }
+
+    fn add(&self, n: u64) {
+        let cur = self
+            .received
+            .fetch_add(n, std::sync::atomic::Ordering::Relaxed)
+            + n;
+        let mut logged = self.logged.lock().expect("pull-progress mutex");
+        let crossed_step = cur / self.step > *logged / self.step;
+        let reached_total = self.total > 0 && cur >= self.total && *logged < self.total;
+        if cur > *logged && (crossed_step || reached_total) {
+            *logged = cur;
+            log::progress("Pulling", "", cur, self.total);
+        }
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -184,6 +265,15 @@ pub(crate) async fn pull_inner<R: Registry>(
             "{image} ({n} layer{plural}, {total_bytes_fmt})"
         );
     }
+    let missing_total: u64 = manifest
+        .layers
+        .iter()
+        .zip(&was_cached)
+        .filter(|(_, cached)| !**cached)
+        .map(|(d, _)| d.size.max(0) as u64)
+        .fold(0u64, u64::saturating_add);
+    let progress = any_missing.then(|| PullProgress::start(missing_total));
+    let progress = progress.as_ref();
     let pull_start = std::time::Instant::now();
 
     // `buffered` preserves manifest order — `buffer_unordered` caused the digest-mismatch bug fixed in 608bda56.
@@ -207,7 +297,12 @@ pub(crate) async fn pull_inner<R: Registry>(
             let digest = descriptor.digest.clone();
             layer_cache
                 .get_or_install(&digest, || async move {
-                    client.pull_blob(reference_ref, &descriptor).await
+                    let on_chunk = move |bytes: u64| {
+                        if let Some(p) = progress {
+                            p.add(bytes);
+                        }
+                    };
+                    client.pull_blob(reference_ref, &descriptor, &on_chunk).await
                 })
                 .await
                 .with_context(|| format!("resolving layer {i} (digest {digest})"))
@@ -414,6 +509,78 @@ mod tests {
         (result, verbs)
     }
 
+    #[derive(Default)]
+    struct ProgressCapture {
+        points: Mutex<Vec<(u64, u64)>>,
+    }
+
+    struct ProgressPointVisitor {
+        current: u64,
+        total: u64,
+    }
+
+    impl tracing::field::Visit for ProgressPointVisitor {
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            match field.name() {
+                "current" => self.current = value,
+                "total" => self.total = value,
+                _ => {}
+            }
+        }
+        fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}
+    }
+
+    struct ProgressLayer(std::sync::Arc<ProgressCapture>);
+
+    impl<S> tracing_subscriber::Layer<S> for ProgressLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().target() != crate::log::PROGRESS_TARGET {
+                return;
+            }
+            let mut v = ProgressPointVisitor {
+                current: 0,
+                total: 0,
+            };
+            event.record(&mut v);
+            self.0.points.lock().unwrap().push((v.current, v.total));
+        }
+    }
+
+    fn capture_progress_sync(f: impl FnOnce()) -> Vec<(u64, u64)> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let capture = std::sync::Arc::new(ProgressCapture::default());
+        let subscriber =
+            tracing_subscriber::registry().with(ProgressLayer(std::sync::Arc::clone(&capture)));
+        let guard = tracing::subscriber::set_default(subscriber);
+        f();
+        drop(guard);
+        let points = capture.points.lock().unwrap().clone();
+        points
+    }
+
+    async fn capture_progress<F, Fut, R>(f: F) -> (R, Vec<(u64, u64)>)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = R>,
+    {
+        use tracing_subscriber::layer::SubscriberExt;
+        let capture = std::sync::Arc::new(ProgressCapture::default());
+        let subscriber =
+            tracing_subscriber::registry().with(ProgressLayer(std::sync::Arc::clone(&capture)));
+        let guard = tracing::subscriber::set_default(subscriber);
+        let result = f().await;
+        drop(guard);
+        let points = capture.points.lock().unwrap().clone();
+        (result, points)
+    }
+
     fn build_two_layer_image() -> FakeImage {
         let layer_a_raw = b"layer-a-tarball-bytes".to_vec();
         let layer_b_raw = b"layer-b-tarball-bytes".to_vec();
@@ -501,6 +668,7 @@ mod tests {
             &self,
             _reference: &Reference,
             descriptor: &OciDescriptor,
+            on_chunk: &(dyn Fn(u64) + Send + Sync),
         ) -> Result<Vec<u8>> {
             self.calls
                 .lock()
@@ -511,7 +679,12 @@ mod tests {
                 .iter()
                 .find(|(d, _)| d == &descriptor.digest)
                 .map(|(_, b)| b.clone());
-            blob.ok_or_else(|| anyhow::anyhow!("no canned blob for {}", descriptor.digest))
+            let blob =
+                blob.ok_or_else(|| anyhow::anyhow!("no canned blob for {}", descriptor.digest))?;
+            let mid = blob.len() / 2;
+            on_chunk(mid as u64);
+            on_chunk((blob.len() - mid) as u64);
+            Ok(blob)
         }
     }
 
@@ -1021,6 +1194,134 @@ mod tests {
             verbs,
             vec!["ImageCached".to_string()],
             "warm cache must emit only ImageCached (no Resolved, no Pulled)",
+        );
+    }
+
+    #[test]
+    fn pull_progress_emits_start_then_step_crossings_then_completion() {
+        let total = MIN_PROGRESS_STEP_BYTES * 4;
+        let points = capture_progress_sync(|| {
+            let p = PullProgress::start(total);
+            p.add(MIN_PROGRESS_STEP_BYTES - 1);
+            p.add(2);
+            p.add(MIN_PROGRESS_STEP_BYTES);
+            p.add(2 * MIN_PROGRESS_STEP_BYTES - 1);
+        });
+        assert_eq!(
+            points,
+            vec![
+                (0, total),
+                (MIN_PROGRESS_STEP_BYTES + 1, total),
+                (2 * MIN_PROGRESS_STEP_BYTES + 1, total),
+                (total, total),
+            ],
+            "sub-step chunks must stay silent; boundary crossings and completion must emit",
+        );
+    }
+
+    #[test]
+    fn pull_progress_small_pull_emits_only_start_and_completion() {
+        let points = capture_progress_sync(|| {
+            let p = PullProgress::start(10);
+            p.add(4);
+            p.add(6);
+        });
+        assert_eq!(points, vec![(0, 10), (10, 10)]);
+    }
+
+    #[test]
+    fn pull_progress_overshoot_beyond_declared_total_still_reports_monotonically() {
+        let points = capture_progress_sync(|| {
+            let p = PullProgress::start(10);
+            p.add(25);
+        });
+        assert_eq!(
+            points,
+            vec![(0, 10), (25, 10)],
+            "a registry sending more bytes than the manifest declared must not wedge progress",
+        );
+    }
+
+    #[test]
+    fn pull_progress_zero_total_reports_byte_counter_on_step_crossings() {
+        let points = capture_progress_sync(|| {
+            let p = PullProgress::start(0);
+            p.add(MIN_PROGRESS_STEP_BYTES + 5);
+        });
+        assert_eq!(points, vec![(0, 0), (MIN_PROGRESS_STEP_BYTES + 5, 0)]);
+    }
+
+    #[tokio::test]
+    async fn counting_sink_reports_each_chunk_and_accumulates_bytes() {
+        use tokio::io::AsyncWriteExt;
+        let seen = Mutex::new(Vec::<u64>::new());
+        let on_chunk = |n: u64| seen.lock().unwrap().push(n);
+        let mut sink = CountingSink::new(&on_chunk);
+        sink.write_all(b"hello ").await.unwrap();
+        sink.write_all(b"world").await.unwrap();
+        sink.flush().await.unwrap();
+        sink.shutdown().await.unwrap();
+        assert_eq!(sink.into_bytes(), b"hello world");
+        assert_eq!(*seen.lock().unwrap(), vec![6, 5]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pull_inner_cold_cache_streams_progress_from_zero_to_missing_total() {
+        let image = build_two_layer_image();
+        let total: u64 = image.manifest.layers.iter().map(|l| l.size as u64).sum();
+        let (_dir, cache) = cache();
+        let registry = image.into_registry();
+        let (result, points) =
+            capture_progress(|| pull_inner(&registry, "alpine:3.20", &cache)).await;
+        result.expect("cold pull");
+        assert_eq!(
+            points.first(),
+            Some(&(0, total)),
+            "the bar must appear at 0% as soon as the pull starts",
+        );
+        assert_eq!(
+            points.last(),
+            Some(&(total, total)),
+            "the bar must reach 100% when the last byte lands",
+        );
+        assert!(
+            points.windows(2).all(|w| w[0].0 < w[1].0),
+            "progress must be monotone: {points:?}",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pull_inner_partial_cache_reports_progress_against_missing_bytes_only() {
+        let image = build_two_layer_image();
+        let (_dir, cache) = cache();
+        let (digest0, bytes0) = image.blobs[0].clone();
+        cache.install_from_bytes(&digest0, &bytes0).unwrap();
+        let missing = image.manifest.layers[1].size as u64;
+        let registry = image.into_registry();
+        let (result, points) =
+            capture_progress(|| pull_inner(&registry, "alpine:3.20", &cache)).await;
+        result.expect("partial pull");
+        assert!(
+            points.iter().all(|(_, t)| *t == missing),
+            "total must count only bytes that actually need fetching: {points:?}",
+        );
+        assert_eq!(points.last(), Some(&(missing, missing)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pull_inner_warm_cache_emits_no_progress_frames() {
+        let image = build_two_layer_image();
+        let (_dir, cache) = cache();
+        for (digest, bytes) in &image.blobs {
+            cache.install_from_bytes(digest, bytes).unwrap();
+        }
+        let registry = image.into_registry();
+        let (result, points) =
+            capture_progress(|| pull_inner(&registry, "alpine:3.20", &cache)).await;
+        result.expect("warm pull");
+        assert!(
+            points.is_empty(),
+            "a fully cached image has no wait to report: {points:?}",
         );
     }
 

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -522,10 +522,11 @@ mod tests {
 
     impl tracing::field::Visit for ProgressPointVisitor {
         fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-            match field.name() {
-                "current" => self.current = value,
-                "total" => self.total = value,
-                _ => {}
+            if field.name() == "current" {
+                self.current = value;
+            }
+            if field.name() == "total" {
+                self.total = value;
             }
         }
         fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}

--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -10,8 +10,8 @@ use crate::oci_layer_cache::LayerCache;
 
 use super::manifest_cache::{CachingRegistry, ManifestCache};
 use super::{
-    PulledImage, Registry, enforce_manifest_doc_size, linux_platform_resolver, pull_inner,
-    serialized_len,
+    CountingSink, PulledImage, Registry, enforce_manifest_doc_size, linux_platform_resolver,
+    pull_inner, serialized_len,
 };
 
 pub struct RealRegistry {
@@ -57,13 +57,14 @@ impl Registry for RealRegistry {
         &self,
         reference: &Reference,
         descriptor: &OciDescriptor,
+        on_chunk: &(dyn Fn(u64) + Send + Sync),
     ) -> Result<Vec<u8>> {
-        let mut out = Vec::new();
+        let mut out = CountingSink::new(on_chunk);
         self.client
             .pull_blob(reference, descriptor, &mut out)
             .await
             .map_err(|e| anyhow::anyhow!("pull_blob {}: {e}", descriptor.digest))?;
-        Ok(out)
+        Ok(out.into_bytes())
     }
 }
 

--- a/crates/lns-service/src/log.rs
+++ b/crates/lns-service/src/log.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 pub const TARGET: &str = "lns.log";
 
-const PROGRESS_TARGET: &str = "lns.progress";
+pub(crate) const PROGRESS_TARGET: &str = "lns.progress";
 
 /// Emits a transient progress update for the CLI's live status line; total 0 means indeterminate.
 pub fn progress(verb: &str, message: &str, current: u64, total: u64) {

--- a/crates/lns-service/src/log.rs
+++ b/crates/lns-service/src/log.rs
@@ -16,6 +16,13 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 pub const TARGET: &str = "lns.log";
 
+const PROGRESS_TARGET: &str = "lns.progress";
+
+/// Emits a transient progress update for the CLI's live status line; total 0 means indeterminate.
+pub fn progress(verb: &str, message: &str, current: u64, total: u64) {
+    tracing::debug!(target: PROGRESS_TARGET, verb, message, current, total);
+}
+
 #[derive(Clone)]
 pub(crate) struct RunFrameTx(pub Sender<WireFrame>);
 
@@ -231,6 +238,44 @@ fn format_extras(extras: &[(String, String)]) -> String {
     out
 }
 
+#[derive(Default)]
+struct ProgressVisitor {
+    verb: String,
+    message: String,
+    current: u64,
+    total: u64,
+}
+
+impl Visit for ProgressVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "verb" => self.verb = value.to_string(),
+            "message" => self.message = value.to_string(),
+            _ => {}
+        }
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "current" => self.current = value,
+            "total" => self.total = value,
+            _ => {}
+        }
+    }
+    fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+}
+
+fn run_frame_tx<S>(
+    event: &Event<'_>,
+    ctx: &tracing_subscriber::layer::Context<'_, S>,
+) -> Option<RunFrameTx>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    ctx.event_scope(event)?
+        .from_root()
+        .find_map(|span| span.extensions().get::<RunFrameTx>().cloned())
+}
+
 // `try_send` rather than `send` because `on_event` is synchronous; log frames are dropped on full rather than blocking the emitter.
 struct FrameForwardLayer;
 
@@ -239,6 +284,20 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_event(&self, event: &Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        if event.metadata().target() == PROGRESS_TARGET {
+            let Some(tx) = run_frame_tx(event, &ctx) else {
+                return;
+            };
+            let mut v = ProgressVisitor::default();
+            event.record(&mut v);
+            let _ = tx.0.try_send(WireFrame::Json(Response::RunProgress {
+                verb: v.verb,
+                message: v.message,
+                current: v.current,
+                total: v.total,
+            }));
+            return;
+        }
         if event.metadata().target() != TARGET {
             return;
         }
@@ -250,13 +309,7 @@ where
             _ => return,
         };
 
-        let Some(scope) = ctx.event_scope(event) else {
-            return;
-        };
-        let Some(tx) = scope
-            .from_root()
-            .find_map(|span| span.extensions().get::<RunFrameTx>().cloned())
-        else {
+        let Some(tx) = run_frame_tx(event, &ctx) else {
             return;
         };
 
@@ -687,6 +740,133 @@ mod tests {
                 s.extensions_mut().insert(RunFrameTx(tx.clone()));
             }
         });
+    }
+
+    #[tokio::test]
+    async fn progress_in_run_scope_forwards_a_run_progress_frame() {
+        use tokio::sync::mpsc;
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        with_default(subscriber, || {
+            let span = tracing::info_span!("run", run_id = 1u32);
+            attach_tx_to_span(&span, tx);
+            let _g = span.enter();
+            progress("Pulling", "", 12, 100);
+        });
+        match rx.try_recv().expect("RunProgress frame emitted") {
+            WireFrame::Json(Response::RunProgress {
+                verb,
+                message,
+                current,
+                total,
+            }) => {
+                assert_eq!(verb, "Pulling");
+                assert_eq!(message, "");
+                assert_eq!(current, 12);
+                assert_eq!(total, 100);
+            }
+            other => panic!("expected WireFrame::Json(RunProgress), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn progress_with_message_carries_it_for_indeterminate_phases() {
+        use tokio::sync::mpsc;
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        with_default(subscriber, || {
+            let span = tracing::info_span!("run", run_id = 1u32);
+            attach_tx_to_span(&span, tx);
+            let _g = span.enter();
+            progress("Booting", "microVM", 0, 0);
+        });
+        match rx.try_recv().expect("RunProgress frame emitted") {
+            WireFrame::Json(Response::RunProgress {
+                verb,
+                message,
+                current,
+                total,
+            }) => {
+                assert_eq!(verb, "Booting");
+                assert_eq!(message, "microVM");
+                assert_eq!(current, 0);
+                assert_eq!(total, 0, "indeterminate phases report total 0");
+            }
+            other => panic!("expected WireFrame::Json(RunProgress), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn progress_outside_run_scope_is_dropped() {
+        use tokio::sync::mpsc;
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        let (_tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        with_default(subscriber, || {
+            progress("Pulling", "", 1, 2);
+        });
+        assert!(
+            rx.try_recv().is_err(),
+            "progress without a run span must not produce a frame",
+        );
+    }
+
+    #[tokio::test]
+    async fn progress_in_a_span_without_tx_is_dropped() {
+        use tokio::sync::mpsc;
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        let (_tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        with_default(subscriber, || {
+            let span = tracing::info_span!("run");
+            let _g = span.enter();
+            progress("Pulling", "", 1, 2);
+        });
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn progress_never_renders_to_the_local_human_layer() {
+        let buf = TestBuf::new();
+        let local = tsfmt::layer()
+            .event_format(LogFormat { color: false })
+            .with_writer(buf.clone())
+            .with_filter(local_log_filter(false));
+        let subscriber = tracing_subscriber::registry().with(local);
+        with_default(subscriber, || {
+            progress("Pulling", "", 1, 2);
+        });
+        assert!(
+            buf.contents().is_empty(),
+            "progress frames are CLI-rendering data, not log lines: {:?}",
+            buf.text(),
+        );
+    }
+
+    #[tokio::test]
+    async fn progress_visitor_ignores_fields_it_does_not_know() {
+        use tokio::sync::mpsc;
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        with_default(subscriber, || {
+            let span = tracing::info_span!("run");
+            attach_tx_to_span(&span, tx);
+            let _g = span.enter();
+            tracing::debug!(
+                target: PROGRESS_TARGET,
+                verb = "Pulling",
+                message = "",
+                current = 5u64,
+                total = 10u64,
+                stray_str = "ignored",
+                stray_u64 = 7u64,
+                stray_debug = ?std::time::Duration::from_secs(1),
+            );
+        });
+        match rx.try_recv().expect("RunProgress frame emitted") {
+            WireFrame::Json(Response::RunProgress { current, total, .. }) => {
+                assert_eq!((current, total), (5, 10));
+            }
+            other => panic!("expected RunProgress, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -3,6 +3,7 @@ use lns_ipc::{Response, WireFrame};
 use tokio::sync::mpsc::Sender;
 
 mod orchestrator;
+mod scratch;
 mod shutdown;
 pub use orchestrator::handle;
 

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -76,7 +76,10 @@ async fn orchestrate(
     let cache_dir = cache::root()?;
     let layer_cache = oci_layer_cache::LayerCache::new(cache_dir.join("layers"));
     let content_store = content_store::ContentStore::new(cache_dir.join("content"));
+    let run_scratch_dir = cache_dir.join("runs").join(run_id.to_string());
     let descriptor_builder = composefs::descriptor::DescriptorBuilder::new(cache_dir);
+    let mut run_scratch =
+        super::scratch::RunScratchGuard::new(run_scratch_dir, super::scratch::RealRemoveDir);
     let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
 
     let tools_then_session = async {
@@ -119,19 +122,19 @@ async fn orchestrate(
         Ok::<_, anyhow::Error>(resolved)
     };
 
-    let (
-        (guest_tools, session, initrd),
-        mut image,
-        kernel_path,
-        upper_disk_path,
-        (volume_attachments, volume_leases),
-    ) = tokio::try_join!(
+    // join! rather than try_join! so the detached spawn_blocking inside upperfs::provision always settles before the scratch guard can fire — a cancelled provision would keep writing and re-orphan the run dir we just cleaned.
+    let (tools_res, image_res, kernel_res, upper_res, volumes_res) = tokio::join!(
         tools_then_session,
         image_fut,
         kernel_fut,
         upper_fut,
         volumes_fut
-    )?;
+    );
+    let (guest_tools, session, initrd) = tools_res?;
+    let mut image = image_res?;
+    let kernel_path = kernel_res?;
+    let upper_disk_path = upper_res?;
+    let (volume_attachments, volume_leases) = volumes_res?;
     log::debug!(path = %upper_disk_path.display(), "upper disk provisioned");
     for vol in &args.volumes {
         crate::audit::record_volume_attached(run_id, &vol.name, &vol.target)?;
@@ -311,6 +314,7 @@ async fn orchestrate(
         let fd = connector
             .connect(lns_session::BROKER_PORT, std::time::Duration::from_secs(30))
             .await?;
+        run_scratch.keep();
         log::debug!("connected broker in {:.2?}", connect_started.elapsed());
         let session_started = std::time::Instant::now();
         let session_code =
@@ -334,6 +338,7 @@ async fn orchestrate(
     {
         let _volume_leases = volume_leases;
         vm::boot(spec, None).await?;
+        run_scratch.keep();
         log::info!("Finished", "in {:.2?}", started.elapsed());
         Ok(0)
     }

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -98,7 +98,8 @@ async fn orchestrate(
         Ok::<_, anyhow::Error>((guest_tools, session, initrd))
     };
     let image_fut = async {
-        let image = ingest::run(args.image.as_deref(), &args.cmd, &layer_cache, image::pull).await?;
+        let image =
+            ingest::run(args.image.as_deref(), &args.cmd, &layer_cache, image::pull).await?;
         log::debug!("image layers ready at +{:.2?}", prepare_started.elapsed());
         Ok::<_, anyhow::Error>(image)
     };
@@ -124,7 +125,13 @@ async fn orchestrate(
         kernel_path,
         upper_disk_path,
         (volume_attachments, volume_leases),
-    ) = tokio::try_join!(tools_then_session, image_fut, kernel_fut, upper_fut, volumes_fut)?;
+    ) = tokio::try_join!(
+        tools_then_session,
+        image_fut,
+        kernel_fut,
+        upper_fut,
+        volumes_fut
+    )?;
     log::debug!(path = %upper_disk_path.display(), "upper disk provisioned");
     for vol in &args.volumes {
         crate::audit::record_volume_attached(run_id, &vol.name, &vol.target)?;

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -71,33 +71,64 @@ async fn orchestrate(
     }
 
     let started = std::time::Instant::now();
-    let mut phase = std::time::Instant::now();
-    let mut lap = move || {
-        let elapsed = phase.elapsed();
-        phase = std::time::Instant::now();
-        elapsed
-    };
-    let guest_tools = guest_tools::ensure().await?;
-    log::debug!("prepared guest tools in {:.2?}", lap());
+    let prepare_started = std::time::Instant::now();
 
     let cache_dir = cache::root()?;
     let layer_cache = oci_layer_cache::LayerCache::new(cache_dir.join("layers"));
     let content_store = content_store::ContentStore::new(cache_dir.join("content"));
     let descriptor_builder = composefs::descriptor::DescriptorBuilder::new(cache_dir);
-
-    let mut image =
-        ingest::run(args.image.as_deref(), &args.cmd, &layer_cache, image::pull).await?;
-    log::debug!("prepared image layers in {:.2?}", lap());
-
     let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
-    let session = supervisor::SupervisorSession::start_if_policy(
-        run_id,
-        policy.as_deref().map(Path::new),
-        guest_tools.root.clone(),
-        args.env.clone(),
-    )
-    .await?;
-    log::debug!("prepared supervisor session in {:.2?}", lap());
+
+    let tools_then_session = async {
+        let guest_tools = guest_tools::ensure().await?;
+        log::debug!("guest tools ready at +{:.2?}", prepare_started.elapsed());
+        let (session, initrd) = tokio::try_join!(
+            supervisor::SupervisorSession::start_if_policy(
+                run_id,
+                policy.as_deref().map(Path::new),
+                guest_tools.root.clone(),
+                args.env.clone(),
+            ),
+            initramfs::build(&guest_tools),
+        )?;
+        log::debug!(
+            "supervisor session and initramfs ready at +{:.2?}",
+            prepare_started.elapsed()
+        );
+        Ok::<_, anyhow::Error>((guest_tools, session, initrd))
+    };
+    let image_fut = async {
+        let image = ingest::run(args.image.as_deref(), &args.cmd, &layer_cache, image::pull).await?;
+        log::debug!("image layers ready at +{:.2?}", prepare_started.elapsed());
+        Ok::<_, anyhow::Error>(image)
+    };
+    let kernel_fut = async {
+        let kernel_path = kernel::ensure().await?;
+        log::debug!("kernel ready at +{:.2?}", prepare_started.elapsed());
+        Ok::<_, anyhow::Error>(kernel_path)
+    };
+    let upper_fut = async {
+        let upper_disk_path = upperfs::provision(run_id).await?;
+        log::debug!("upper disk ready at +{:.2?}", prepare_started.elapsed());
+        Ok::<_, anyhow::Error>(upper_disk_path)
+    };
+    let volumes_fut = async {
+        let resolved = crate::volume_store::resolve(&args.volumes, run_id).await?;
+        log::debug!("volumes ready at +{:.2?}", prepare_started.elapsed());
+        Ok::<_, anyhow::Error>(resolved)
+    };
+
+    let (
+        (guest_tools, session, initrd),
+        mut image,
+        kernel_path,
+        upper_disk_path,
+        (volume_attachments, volume_leases),
+    ) = tokio::try_join!(tools_then_session, image_fut, kernel_fut, upper_fut, volumes_fut)?;
+    log::debug!(path = %upper_disk_path.display(), "upper disk provisioned");
+    for vol in &args.volumes {
+        crate::audit::record_volume_attached(run_id, &vol.name, &vol.target)?;
+    }
 
     let imageless = args.image.is_none();
     let runtime_layer = runtime_layer::for_run(
@@ -106,24 +137,38 @@ async fn orchestrate(
         &guest_tools,
         session.as_ref().map(|s| &s.assets),
     )?;
-    log::debug!("prepared runtime layer in {:.2?}", lap());
 
     let layers = std::mem::take(&mut image.bytes);
     let layer_digests = std::mem::take(&mut image.digests);
-    let descriptor_cs = content_store.clone();
-    let descriptor = tokio::task::spawn_blocking(move || {
-        descriptor_builder.build(
-            &descriptor_cs,
-            &composefs::descriptor::DescriptorRequest {
-                layer_digests: &layer_digests,
-                layers: &layers,
-                runtime_layer: runtime_layer.as_ref(),
-            },
-        )
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("composefs descriptor build task panicked: {e}"))??;
-    log::debug!("prepared composefs descriptor in {:.2?}", lap());
+    let probe = composefs::descriptor::DescriptorRequest {
+        layer_digests: &layer_digests,
+        layers: &layers,
+        runtime_layer: runtime_layer.as_ref(),
+    };
+    let cached_descriptor = descriptor_builder.cached(&probe)?;
+    let descriptor = match cached_descriptor {
+        Some(hit) => hit,
+        None => {
+            log::progress("Assembling", "rootfs", 0, 0);
+            let descriptor_cs = content_store.clone();
+            tokio::task::spawn_blocking(move || {
+                descriptor_builder.build(
+                    &descriptor_cs,
+                    &composefs::descriptor::DescriptorRequest {
+                        layer_digests: &layer_digests,
+                        layers: &layers,
+                        runtime_layer: runtime_layer.as_ref(),
+                    },
+                )
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("composefs descriptor build task panicked: {e}"))??
+        }
+    };
+    log::debug!(
+        "composefs descriptor ready at +{:.2?}",
+        prepare_started.elapsed()
+    );
     log::debug!(
         path = %descriptor.path.display(),
         size = descriptor.size,
@@ -142,22 +187,6 @@ async fn orchestrate(
         imageless,
     );
     let exec = vm::ExecSpec::for_run(&run_as, &args.cmd, image.config.as_ref(), session.as_ref());
-
-    let kernel_path = kernel::ensure().await?;
-    log::debug!("prepared kernel in {:.2?}", lap());
-    let initrd = initramfs::build(&guest_tools).await?;
-    log::debug!("prepared initramfs in {:.2?}", lap());
-
-    let upper_disk_path = upperfs::provision(run_id).await?;
-    log::debug!("prepared upper disk in {:.2?}", lap());
-    log::debug!(path = %upper_disk_path.display(), "upper disk provisioned");
-
-    let (volume_attachments, volume_leases) =
-        crate::volume_store::resolve(&args.volumes, run_id).await?;
-    log::debug!("prepared volumes in {:.2?}", lap());
-    for vol in &args.volumes {
-        crate::audit::record_volume_attached(run_id, &vol.name, &vol.target)?;
-    }
 
     #[cfg(target_os = "macos")]
     let console_fd = {
@@ -241,6 +270,7 @@ async fn orchestrate(
         };
 
         let frame_tx_for_session = frame_tx.clone();
+        log::progress("Booting", "microVM", 0, 0);
         let boot_start = std::time::Instant::now();
         let mut vm_task = tokio::spawn(async move {
             let _volume_leases = volume_leases;
@@ -269,14 +299,17 @@ async fn orchestrate(
         crate::run_registry::set_connector(run_id, connector.clone());
         let _vm_stop_guard = vm::VmStopGuard::new(connector.clone());
 
+        log::progress("Connecting", "session", 0, 0);
+        let connect_started = std::time::Instant::now();
         let fd = connector
             .connect(lns_session::BROKER_PORT, std::time::Duration::from_secs(30))
             .await?;
-        log::debug!("connected broker in {:.2?}", lap());
+        log::debug!("connected broker in {:.2?}", connect_started.elapsed());
+        let session_started = std::time::Instant::now();
         let session_code =
             vm::session_client::run_session_on_fd(fd, params, frame_tx_for_session, input_rx)
                 .await?;
-        log::debug!("workload ran for {:.2?}", lap());
+        log::debug!("workload ran for {:.2?}", session_started.elapsed());
         log::debug!(code = session_code, "broker session ended");
         crate::run_registry::set_exit_code(run_id, session_code);
 

--- a/crates/lns-service/src/run/scratch.rs
+++ b/crates/lns-service/src/run/scratch.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+
+pub(super) trait RemoveDir {
+    fn remove_dir_all(&self, dir: &Path) -> std::io::Result<()>;
+}
+
+pub(super) struct RealRemoveDir;
+
+impl RemoveDir for RealRemoveDir {
+    fn remove_dir_all(&self, dir: &Path) -> std::io::Result<()> {
+        std::fs::remove_dir_all(dir)
+    }
+}
+
+/// Removes a run's scratch dir on drop unless `keep()` is called, so prep that fails before boot can't orphan its upper.img.
+pub(super) struct RunScratchGuard<R: RemoveDir> {
+    dir: PathBuf,
+    armed: bool,
+    remover: R,
+}
+
+impl<R: RemoveDir> RunScratchGuard<R> {
+    pub(super) fn new(dir: PathBuf, remover: R) -> Self {
+        Self {
+            dir,
+            armed: true,
+            remover,
+        }
+    }
+
+    pub(super) fn keep(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<R: RemoveDir> Drop for RunScratchGuard<R> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        match self.remover.remove_dir_all(&self.dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                let dir = self.dir.display();
+                crate::log::warn!(
+                    "run scratch cleanup failed at {dir} ({e}); orphaned until prune"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+    use std::sync::{Arc, Mutex};
+
+    struct FakeRemover {
+        calls: Arc<Mutex<Vec<PathBuf>>>,
+        err: Option<ErrorKind>,
+    }
+
+    impl FakeRemover {
+        fn returning(err: Option<ErrorKind>) -> (Self, Arc<Mutex<Vec<PathBuf>>>) {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    calls: Arc::clone(&calls),
+                    err,
+                },
+                calls,
+            )
+        }
+    }
+
+    impl RemoveDir for FakeRemover {
+        fn remove_dir_all(&self, dir: &Path) -> std::io::Result<()> {
+            self.calls.lock().unwrap().push(dir.to_path_buf());
+            match self.err {
+                None => Ok(()),
+                Some(kind) => Err(std::io::Error::new(kind, "fake remover")),
+            }
+        }
+    }
+
+    #[test]
+    fn an_armed_guard_removes_the_run_dir_on_drop() {
+        let dir = PathBuf::from("/cache/runs/7");
+        let (remover, calls) = FakeRemover::returning(None);
+        drop(RunScratchGuard::new(dir.clone(), remover));
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![dir],
+            "a prep failure must reclaim the scratch dir",
+        );
+    }
+
+    #[test]
+    fn a_kept_guard_leaves_the_run_dir_in_place() {
+        let (remover, calls) = FakeRemover::returning(None);
+        let mut guard = RunScratchGuard::new(PathBuf::from("/cache/runs/7"), remover);
+        guard.keep();
+        drop(guard);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "a started run owns its dir — logs and audit must survive",
+        );
+    }
+
+    #[test]
+    fn an_already_gone_dir_is_a_silent_no_op() {
+        let (remover, calls) = FakeRemover::returning(Some(ErrorKind::NotFound));
+        drop(RunScratchGuard::new(
+            PathBuf::from("/cache/runs/7"),
+            remover,
+        ));
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "removal is attempted, and a missing dir is not an error",
+        );
+    }
+
+    #[test]
+    fn a_removal_failure_is_logged_not_panicked() {
+        let (remover, calls) = FakeRemover::returning(Some(ErrorKind::PermissionDenied));
+        drop(RunScratchGuard::new(
+            PathBuf::from("/cache/runs/7"),
+            remover,
+        ));
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn the_real_remover_deletes_a_populated_run_dir() {
+        let base = tempfile::tempdir().unwrap();
+        let run_dir = base.path().join("runs").join("9");
+        std::fs::create_dir_all(run_dir.join("sub")).unwrap();
+        std::fs::write(run_dir.join("upper.img"), b"scratch").unwrap();
+        RealRemoveDir.remove_dir_all(&run_dir).unwrap();
+        assert!(!run_dir.exists());
+    }
+}

--- a/crates/lns-service/src/vm/vz.rs
+++ b/crates/lns-service/src/vm/vz.rs
@@ -13,13 +13,18 @@ pub(crate) trait ConnectOnce {
     fn connect_once(&self, port: u32) -> impl Future<Output = Result<RawFd>> + Send;
 }
 
+const CONNECT_INITIAL_DELAY: Duration = Duration::from_millis(10);
+
+// Capped low because every ms spent past guest readiness is added to every single run's boot time, while a refused vsock connect costs near nothing.
+const CONNECT_MAX_DELAY: Duration = Duration::from_millis(100);
+
 pub(crate) async fn connect_with<C: ConnectOnce + Sync>(
     connector: &C,
     port: u32,
     timeout: Duration,
 ) -> Result<RawFd> {
     let deadline = Instant::now() + timeout;
-    let mut delay = Duration::from_millis(50);
+    let mut delay = CONNECT_INITIAL_DELAY;
     loop {
         match connector.connect_once(port).await {
             Ok(fd) => return Ok(fd),
@@ -30,7 +35,7 @@ pub(crate) async fn connect_with<C: ConnectOnce + Sync>(
                     });
                 }
                 tokio::time::sleep(delay).await;
-                delay = (delay * 2).min(Duration::from_millis(500));
+                delay = (delay * 2).min(CONNECT_MAX_DELAY);
             }
         }
     }
@@ -97,5 +102,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fd, 7);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connect_with_polls_tightly_enough_to_catch_readiness_fast() {
+        let fake = FakeConnect {
+            fails_before_ok: AtomicI32::new(6),
+            always_fail: false,
+            fd: 3,
+        };
+        let started = tokio::time::Instant::now();
+        let fd = connect_with(&fake, 9, Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert_eq!(fd, 3);
+        let waited = started.elapsed();
+        assert_eq!(
+            waited,
+            Duration::from_millis(10 + 20 + 40 + 80 + 100 + 100),
+            "backoff schedule regressed — a guest ready after the 6th probe \
+             must be reached in 350ms, not the old 1.27s",
+        );
     }
 }


### PR DESCRIPTION
## Summary

`lns run` spends its startup in a strictly serial prepare pipeline — guest tools → image ingest → supervisor → runtime layer → composefs descriptor → kernel → initramfs → upper disk → volumes → boot — and the only feedback during the longest waits (layer pull, cold rootfs assembly, microVM boot) is silence until each phase's final `✓` line. This PR overlaps the independent prepare phases, removes per-run rework on warm paths, and streams live progress to the terminal so no wait is ever silent.

```
✓ resolved ubuntu:latest @ sha256:…
⠼ pulling  ████████░░░░░░░░░░░░  12.3 MiB / 29.8 MiB  41%     ← live, redrawn in place
✓ pulled 2 layers   (3.41s · 29.8 MiB)
⠧ booting microVM…                                            ← spinner animates while waiting
✓ booted microVM   (1.92s)
✓ session ready
```

### 1. Concurrent prepare phases

Image ingest, kernel ensure, upper-disk ext4 provisioning, volume resolution, and the guest-tools → (supervisor session ‖ initramfs) chain now run under one `tokio::try_join!` in the run orchestrator. Warm-run prepare time collapses to the slowest single phase (typically the registry manifest round-trip); on a first run the ~17 MiB kernel download overlaps the layer pull instead of following it.

### 2. DiffID verification overlaps fetches

Gunzip + sha256 of each freshly pulled layer moved from a serial post-pull pass into the per-layer fetch stream on `spawn_blocking` — layer N verifies while layer N+1 is still downloading, using multiple cores. Cached layers still skip re-verification.

### 3. No descriptor re-hash on warm runs

The composefs descriptor's sha256 is persisted in a `descriptor.erofs.sha256` sidecar at install; warm runs read the sidecar instead of re-reading and re-hashing the whole erofs. Pre-existing caches (no sidecar) fall back to hashing once and self-heal; corrupt sidecars are rejected and re-derived. A new `DescriptorBuilder::cached()` probe lets the orchestrator skip the blocking-pool hop entirely on a hit.

### 4. Tighter guest vsock connect backoff

The post-boot connect poll backed off 50 ms → 500 ms cap; now 10 ms → 100 ms cap, trimming up to ~400 ms of dead tail latency off every boot (a refused vsock connect costs near nothing). Pinned by a paused-time test: a guest ready after the 6th probe is reached in 350 ms vs 1.27 s before.

### 5. Live progress frames end to end

- New `Response::RunProgress { verb, message, current, total }` frame in `lns-ipc` (`total == 0` ⇒ indeterminate), emitted through a dedicated `lns.progress` tracing target that the service's frame layer forwards only inside a run scope — it never lands in service logs.
- `Registry::pull_blob` streams chunk counts; the service aggregates across the 4 concurrent layer fetches and emits throttled, monotone `Pulling` updates (step = max(total/100, 256 KiB)). The total counts only bytes that actually need fetching, so a partially cached image reports honestly.
- Indeterminate markers for the remaining waits: `Assembling` (cold composefs build), `Booting`, `Connecting`.
- The CLI renders an animated spinner + 20-char bar with byte counts and percentage, redrawn with `\r` and erased before each `✓` line. Strictly TTY-gated: piped output is byte-for-byte unchanged (pinned by a Gherkin scenario). The spinner animates on a 100 ms tick even while the service is silent, via a cancel-safe pinned-read select loop. Attached sessions tolerate stray progress frames.

## Screenshots
<!-- Add a terminal recording of a cold `lns run` showing the live pull bar and boot spinner -->

## Test instructions

1. Cold pull with a bar: clear the layer cache (`lns image prune` or a fresh cache dir), then `lns run ubuntu -- true` in a terminal. Expected: a `pulling` bar with bytes/percent updates in place, then `✓ pulled …`, a `booting microVM…` spinner that visibly animates, `✓ booted`, `✓ session ready`.
2. Warm run: repeat the same command. Expected: `✓ image cached …` (no bar), noticeably faster total time than before this branch (prepare ≈ manifest round-trip), and no `assembling` flash since the descriptor cache hits.
3. Piped output stays log-safe: `lns run ubuntu -- true 2>&1 | cat`. Expected: only complete `✓` lines, no `\r`, no spinner glyphs, no partial lines.
4. Partial cache honesty: remove one layer of a multi-layer image from the cache, re-run. Expected: the bar total equals only the missing bytes and ends at 100%.
5. First-ever run on a machine (no kernel cached): expected `fetching guest kernel` line while the pull bar keeps updating — the kernel download overlaps the pull instead of following it.
6. Backoff regression guard: `cargo test -p lns-service connect_with_polls_tightly` passes.

## Notes

- `run/orchestrator.rs` (service) and the stream-coupled CLI tail remain Layer-1/E2E territory per the IGNORES policy; everything else added here is gated at 100% (`make lint && make complexity && make coverage` green locally, full workspace).
- Tag references still re-resolve against the registry on every run (deliberate freshness semantics from the manifest-cache work). Docker-style `--pull=missing` semantics would be the next big warm-start win if we want it.
- A live microVM smoke (`lns run ubuntu` cold + warm) is recommended before release; not executed on this branch.

Closes #4 
