### PR TITLE
fix(run): honest exit reporting, arch guard, and PTY drain

### DIFF
--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -303,6 +303,7 @@ where
             _ = early_exit_rx.recv() => {
                 break exit_code_after_detach(
                     detach,
+                    tty,
                     &mut stream,
                     stdout,
                     stderr,
@@ -324,7 +325,8 @@ where
                         stderr.flush().await.ok();
                     }
                     WireFrame::Json(Response::RunLog { level, verb, message }) => {
-                        render_attached_run_log(level, verb.as_deref(), &message, stderr).await?;
+                        render_attached_run_log(level, verb.as_deref(), &message, tty, stderr)
+                            .await?;
                     }
                     WireFrame::Json(Response::RunProgress { .. }) => {}
                     WireFrame::Json(Response::RunExit { code }) => break code,
@@ -362,6 +364,7 @@ async fn render_attached_run_log<E>(
     level: LogLevel,
     verb: Option<&str>,
     message: &str,
+    tty: bool,
     stderr: &mut E,
 ) -> Result<()>
 where
@@ -373,13 +376,28 @@ where
     }
     let mut line = Vec::<u8>::new();
     render_status_line(level, verb, message, &mut line)?;
+    if tty {
+        line = lf_to_crlf(&line);
+    }
     stderr.write_all(&line).await?;
     stderr.flush().await.ok();
     Ok(())
 }
 
+fn lf_to_crlf(line: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(line.len() + 2);
+    for &b in line {
+        if b == b'\n' {
+            out.push(b'\r');
+        }
+        out.push(b);
+    }
+    out
+}
+
 async fn exit_code_after_detach<S, O, E>(
     detach: DetachBehaviour,
+    tty: bool,
     stream: &mut S,
     stdout: &mut O,
     stderr: &mut E,
@@ -392,7 +410,7 @@ where
 {
     match detach {
         DetachBehaviour::SignalAndDrain => {
-            drain_after_chord(stream, stdout, stderr, last_stdout_byte).await
+            drain_after_chord(stream, tty, stdout, stderr, last_stdout_byte).await
         }
         DetachBehaviour::LeaveRunning => 0,
     }
@@ -400,6 +418,7 @@ where
 
 async fn drain_after_chord<S, O, E>(
     stream: &mut S,
+    tty: bool,
     stdout: &mut O,
     stderr: &mut E,
     last_stdout_byte: &mut Option<u8>,
@@ -411,7 +430,7 @@ where
 {
     match timeout(
         Duration::from_secs(5),
-        drain_to_exit(stream, stdout, stderr, last_stdout_byte),
+        drain_to_exit(stream, tty, stdout, stderr, last_stdout_byte),
     )
     .await
     {
@@ -429,6 +448,7 @@ where
 
 async fn drain_to_exit<S, O, E>(
     stream: &mut S,
+    tty: bool,
     stdout: &mut O,
     stderr: &mut E,
     last_stdout_byte: &mut Option<u8>,
@@ -457,7 +477,7 @@ where
                 verb,
                 message,
             }) => {
-                render_attached_run_log(level, verb.as_deref(), &message, stderr).await?;
+                render_attached_run_log(level, verb.as_deref(), &message, tty, stderr).await?;
             }
             WireFrame::Json(Response::RunExit { code }) => return Ok(code),
             WireFrame::Json(Response::Error { message }) => {
@@ -1122,9 +1142,15 @@ mod tests {
     #[tokio::test]
     async fn render_attached_run_log_keeps_debug_frames_off_the_user_writer() {
         let mut stderr = Vec::<u8>::new();
-        render_attached_run_log(LogLevel::Debug, None, "broker handshake", &mut stderr)
-            .await
-            .expect("render debug");
+        render_attached_run_log(
+            LogLevel::Debug,
+            None,
+            "broker handshake",
+            false,
+            &mut stderr,
+        )
+        .await
+        .expect("render debug");
         assert!(
             stderr.is_empty(),
             "debug run-log must not reach the user's status writer: {stderr:?}",
@@ -1134,10 +1160,45 @@ mod tests {
     #[tokio::test]
     async fn render_attached_run_log_writes_info_status_to_the_writer() {
         let mut stderr = Vec::<u8>::new();
-        render_attached_run_log(LogLevel::Info, Some("Finished"), "in 1.10s", &mut stderr)
-            .await
-            .expect("render info");
+        render_attached_run_log(
+            LogLevel::Info,
+            Some("Finished"),
+            "in 1.10s",
+            false,
+            &mut stderr,
+        )
+        .await
+        .expect("render info");
         assert_eq!(stderr, b"\xe2\x9c\x93 finished in 1.10s\n");
+    }
+
+    #[tokio::test]
+    async fn render_attached_run_log_uses_crlf_when_the_terminal_is_raw() {
+        let mut stderr = Vec::<u8>::new();
+        render_attached_run_log(
+            LogLevel::Warn,
+            None,
+            "workload exited with code 1",
+            true,
+            &mut stderr,
+        )
+        .await
+        .expect("render warn");
+        let rendered = String::from_utf8(stderr).expect("utf8");
+        assert!(
+            rendered.ends_with("\r\n"),
+            "in raw mode a status line must carriage-return so the next line starts at column 0: {rendered:?}",
+        );
+        assert!(
+            !rendered.contains("\n\r") && rendered.matches('\n').count() == 1,
+            "exactly one CRLF, no stray bare LF: {rendered:?}",
+        );
+    }
+
+    #[test]
+    fn lf_to_crlf_expands_every_newline_and_leaves_other_bytes() {
+        assert_eq!(lf_to_crlf(b"a\nb\n"), b"a\r\nb\r\n");
+        assert_eq!(lf_to_crlf(b"no newline"), b"no newline");
     }
 
     #[test]
@@ -1199,6 +1260,7 @@ mod tests {
         let mut last = None;
         let code = exit_code_after_detach(
             DetachBehaviour::LeaveRunning,
+            false,
             &mut client,
             &mut captured,
             &mut status,
@@ -1231,6 +1293,7 @@ mod tests {
         let mut last = None;
         let code = exit_code_after_detach(
             DetachBehaviour::SignalAndDrain,
+            true,
             &mut client,
             &mut captured,
             &mut status,

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -107,12 +107,12 @@ impl PullProgress {
 }
 
 #[cfg(target_arch = "aarch64")]
-fn want_arch() -> oci_spec::image::Arch {
+pub(crate) fn want_arch() -> oci_spec::image::Arch {
     oci_spec::image::Arch::ARM64
 }
 
 #[cfg(not(target_arch = "aarch64"))]
-fn want_arch() -> oci_spec::image::Arch {
+pub(crate) fn want_arch() -> oci_spec::image::Arch {
     oci_spec::image::Arch::Amd64
 }
 

--- a/crates/lns-service/src/ingest.rs
+++ b/crates/lns-service/src/ingest.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use oci_spec::image::{Arch, Os};
 
 use crate::image::PulledImage;
 use crate::oci_layer_cache::LayerCache;
@@ -13,12 +14,14 @@ pub struct IngestedImage {
 pub async fn run(
     image: Option<&str>,
     cmd: &[String],
+    guest_arch: &Arch,
     layer_cache: &LayerCache,
     pull: impl AsyncFnOnce(&str, &LayerCache) -> Result<PulledImage>,
 ) -> Result<IngestedImage> {
     match image {
         Some(image) => {
             let pulled = pull(image, layer_cache).await?;
+            ensure_runnable_here(&pulled.config, guest_arch)?;
             let bytes: Vec<Vec<u8>> = pulled
                 .layers
                 .into_iter()
@@ -43,6 +46,18 @@ pub async fn run(
             })
         }
     }
+}
+
+fn ensure_runnable_here(config: &oci_client::config::ConfigFile, guest_arch: &Arch) -> Result<()> {
+    if config.architecture == *guest_arch && config.os == Os::Linux {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "image is {}/{} but this sandbox runs linux/{guest_arch}; \
+         use a multi-arch image or one built for linux/{guest_arch}",
+        config.os,
+        config.architecture,
+    )
 }
 
 #[cfg(test)]
@@ -92,7 +107,9 @@ mod tests {
     #[tokio::test]
     async fn imageless_with_empty_cmd_bails_with_actionable_hint() {
         let (_dir, cache) = empty_cache();
-        let err = run(None, &[], &cache, failing_puller).await.unwrap_err();
+        let err = run(None, &[], &Arch::ARM64, &cache, failing_puller)
+            .await
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("imageless mode requires a command"),
@@ -108,7 +125,9 @@ mod tests {
     async fn imageless_with_non_empty_cmd_returns_empty_ingest() {
         let (_dir, cache) = empty_cache();
         let cmd = vec!["echo".to_string(), "hello".to_string()];
-        let ingested = run(None, &cmd, &cache, failing_puller).await.unwrap();
+        let ingested = run(None, &cmd, &Arch::ARM64, &cache, failing_puller)
+            .await
+            .unwrap();
         assert!(ingested.digests.is_empty(), "imageless has no digests");
         assert!(ingested.bytes.is_empty(), "imageless has no payloads");
         assert!(
@@ -136,6 +155,7 @@ mod tests {
         let ingested = run(
             Some("alpine:3.20"),
             &[],
+            &Arch::ARM64,
             &cache,
             async |img: &str, c: &LayerCache| {
                 capturing_puller(&captured, &pulled_cell, img, c).await
@@ -167,9 +187,78 @@ mod tests {
     #[tokio::test]
     async fn oci_branch_propagates_puller_error_unchanged() {
         let (_dir, cache) = empty_cache();
-        let err = run(Some("alpine:3.20"), &[], &cache, failing_puller)
-            .await
-            .unwrap_err();
+        let err = run(
+            Some("alpine:3.20"),
+            &[],
+            &Arch::ARM64,
+            &cache,
+            failing_puller,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(format!("{err}"), "registry timeout");
+    }
+
+    #[tokio::test]
+    async fn oci_branch_bails_when_image_arch_does_not_match_the_guest() {
+        let (_dir, cache) = empty_cache();
+        let pulled_cell: Mutex<Option<PulledImage>> = Mutex::new(Some(sample_pulled()));
+        // sample_pulled() is linux/arm64; ask for an amd64 sandbox so the architectures disagree.
+        let err = run(
+            Some("alpine:3.20"),
+            &[],
+            &Arch::Amd64,
+            &cache,
+            async |_img: &str, _c: &LayerCache| Ok(pulled_cell.lock().unwrap().take().unwrap()),
+        )
+        .await
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("image is linux/arm64") && msg.contains("sandbox runs linux/amd64"),
+            "mismatch error must name both architectures, got: {msg}"
+        );
+        assert!(
+            msg.contains("multi-arch"),
+            "error should point at the multi-arch fix, got: {msg}"
+        );
+    }
+
+    fn cfg(arch: &str, os: &str) -> oci_client::config::ConfigFile {
+        oci_client::config::ConfigFile {
+            architecture: arch.into(),
+            os: os.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ensure_runnable_here_accepts_a_matching_linux_arch() {
+        ensure_runnable_here(&cfg("arm64", "linux"), &Arch::ARM64).expect("exact match runs");
+        ensure_runnable_here(&cfg("amd64", "linux"), &Arch::Amd64).expect("exact match runs");
+    }
+
+    #[test]
+    fn ensure_runnable_here_rejects_a_foreign_arch() {
+        let err = format!(
+            "{:#}",
+            ensure_runnable_here(&cfg("amd64", "linux"), &Arch::ARM64).unwrap_err()
+        );
+        assert!(
+            err.contains("image is linux/amd64") && err.contains("linux/arm64"),
+            "mismatch must name both architectures: {err}"
+        );
+    }
+
+    #[test]
+    fn ensure_runnable_here_rejects_a_non_linux_os() {
+        let err = format!(
+            "{:#}",
+            ensure_runnable_here(&cfg("arm64", "windows"), &Arch::ARM64).unwrap_err()
+        );
+        assert!(
+            err.contains("windows/arm64"),
+            "a non-linux os must surface in the message: {err}"
+        );
     }
 }

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -9,7 +9,18 @@ pub use orchestrator::handle;
 
 pub(super) async fn emit_completion(frame_tx: &Sender<WireFrame>, result: Result<i32>) -> i32 {
     let code = match result {
-        Ok(code) => code,
+        Ok(code) => {
+            if code != 0 {
+                let _ = frame_tx
+                    .send(WireFrame::Json(Response::RunLog {
+                        level: lns_ipc::LogLevel::Warn,
+                        verb: None,
+                        message: format!("workload exited with code {code}"),
+                    }))
+                    .await;
+            }
+            code
+        }
         Err(e) => {
             let _ = frame_tx
                 .send(WireFrame::Json(Response::RunLog {
@@ -106,11 +117,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn emit_completion_forwards_nonzero_workload_exit() {
+    async fn emit_completion_nonzero_ok_warns_before_run_exit() {
         for code in [1_i32, 42, 130, 143] {
             let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
             let returned = emit_completion(&tx, Ok(code)).await;
             assert_eq!(returned, code, "return value should mirror input");
+            match rx.recv().await {
+                Some(WireFrame::Json(Response::RunLog {
+                    level: LogLevel::Warn,
+                    verb,
+                    message,
+                })) => {
+                    assert!(verb.is_none(), "the exit announcement carries no verb");
+                    assert!(
+                        message.contains("exited"),
+                        "announcement must say the workload exited: {message}"
+                    );
+                    assert!(
+                        message.contains(&code.to_string()),
+                        "announcement must name the exit code: {message}"
+                    );
+                }
+                other => panic!("expected a RunLog{{Warn}} announcement, got {other:?}"),
+            }
             match rx.recv().await {
                 Some(WireFrame::Json(Response::RunExit { code: c })) => {
                     assert_eq!(c, code, "frame must carry workload's exit code");

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -101,8 +101,14 @@ async fn orchestrate(
         Ok::<_, anyhow::Error>((guest_tools, session, initrd))
     };
     let image_fut = async {
-        let image =
-            ingest::run(args.image.as_deref(), &args.cmd, &layer_cache, image::pull).await?;
+        let image = ingest::run(
+            args.image.as_deref(),
+            &args.cmd,
+            &image::want_arch(),
+            &layer_cache,
+            image::pull,
+        )
+        .await?;
         log::debug!("image layers ready at +{:.2?}", prepare_started.elapsed());
         Ok::<_, anyhow::Error>(image)
     };

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -2,8 +2,6 @@
 
 use crate::log;
 use std::io;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicI32, Ordering};
 
 use anyhow::{Context, Result};
 use lns_ipc::WireFrame;
@@ -67,28 +65,36 @@ async fn read_one_frame<R: tokio::io::AsyncRead + Unpin>(
 pub(super) async fn read_server_frames<R: tokio::io::AsyncRead + Unpin>(
     mut reader: R,
     frame_tx: mpsc::Sender<WireFrame>,
-    exit_code: Arc<AtomicI32>,
-) -> Result<()> {
+) -> Result<Option<i32>> {
     while let Some(frame) = read_one_frame(&mut reader).await? {
         match frame {
             ServerFrame::StdoutBytes(bytes) => {
                 if frame_tx.send(WireFrame::Stdout(bytes)).await.is_err() {
-                    return Ok(());
+                    return Ok(None);
                 }
             }
             ServerFrame::StderrBytes(bytes) => {
                 if frame_tx.send(WireFrame::Stderr(bytes)).await.is_err() {
-                    return Ok(());
+                    return Ok(None);
                 }
             }
             ServerFrame::ExitStatus(code) => {
                 log::debug!(code, "broker reported workload ExitStatus");
-                exit_code.store(code, Ordering::SeqCst);
-                return Ok(());
+                return Ok(Some(code));
             }
         }
     }
-    Ok(())
+    Ok(None)
+}
+
+pub(super) fn session_exit_code(outcome: Result<Option<i32>>) -> Result<i32> {
+    match outcome {
+        Ok(Some(code)) => Ok(code),
+        Ok(None) => Err(anyhow::anyhow!(
+            "broker session ended before the workload reported an exit status; the guest terminated unexpectedly (crash before exec, or teardown) — re-run with `--log-level debug` to capture the guest console"
+        )),
+        Err(e) => Err(e.context("reading broker session frames")),
+    }
 }
 
 #[cfg(test)]
@@ -98,10 +104,6 @@ mod tests {
 
     fn framed(frame: &ServerFrame) -> Vec<u8> {
         encode_frame(frame).unwrap()
-    }
-
-    fn exit_cell() -> Arc<AtomicI32> {
-        Arc::new(AtomicI32::new(137))
     }
 
     #[test]
@@ -168,47 +170,91 @@ mod tests {
         );
     }
 
+    #[test]
+    fn session_exit_code_passes_through_a_reported_status() {
+        assert_eq!(session_exit_code(Ok(Some(0))).unwrap(), 0);
+        assert_eq!(session_exit_code(Ok(Some(137))).unwrap(), 137);
+    }
+
+    #[test]
+    fn session_exit_code_errs_when_no_status_was_reported() {
+        let rendered = format!("{:#}", session_exit_code(Ok(None)).unwrap_err());
+        assert!(
+            rendered.contains("before the workload reported an exit status"),
+            "got {rendered}"
+        );
+        assert!(
+            rendered.contains("--log-level debug"),
+            "the message must point at the debug console: {rendered}"
+        );
+    }
+
+    #[test]
+    fn session_exit_code_wraps_a_reader_error_with_context() {
+        let rendered = format!(
+            "{:#}",
+            session_exit_code(Err(anyhow::anyhow!("frame decode blew up"))).unwrap_err()
+        );
+        assert!(
+            rendered.contains("reading broker session frames"),
+            "missing context: {rendered}"
+        );
+        assert!(
+            rendered.contains("frame decode blew up"),
+            "missing cause: {rendered}"
+        );
+    }
+
     #[tokio::test]
-    async fn forwards_stdout_stderr_and_captures_exit() {
+    async fn forwards_stdout_stderr_and_returns_exit_status() {
         let mut bytes = framed(&ServerFrame::StdoutBytes(b"out".to_vec()));
         bytes.extend(framed(&ServerFrame::StderrBytes(b"err".to_vec())));
         bytes.extend(framed(&ServerFrame::ExitStatus(42)));
         let (tx, mut rx) = mpsc::channel(8);
-        let exit = exit_cell();
-        read_server_frames(io::Cursor::new(bytes), tx, exit.clone())
+        let code = read_server_frames(io::Cursor::new(bytes), tx)
             .await
             .unwrap();
         assert!(matches!(rx.recv().await, Some(WireFrame::Stdout(b)) if b == b"out"));
         assert!(matches!(rx.recv().await, Some(WireFrame::Stderr(b)) if b == b"err"));
-        assert_eq!(exit.load(Ordering::SeqCst), 42);
+        assert_eq!(
+            code,
+            Some(42),
+            "an explicit ExitStatus is reported as Some(code)"
+        );
     }
 
     #[tokio::test]
-    async fn loop_exits_cleanly_when_stream_closes_without_exit_status() {
+    async fn returns_none_when_stream_closes_without_exit_status() {
         let bytes = framed(&ServerFrame::StdoutBytes(b"out".to_vec()));
         let (tx, _rx) = mpsc::channel(8);
-        read_server_frames(io::Cursor::new(bytes), tx, exit_cell())
+        let code = read_server_frames(io::Cursor::new(bytes), tx)
             .await
             .expect("EOF after a frame ends the loop cleanly");
+        assert_eq!(
+            code, None,
+            "EOF before any ExitStatus must be reported as None, not a fabricated code"
+        );
     }
 
     #[tokio::test]
-    async fn stops_when_stdout_receiver_is_gone() {
+    async fn stops_with_none_when_stdout_receiver_is_gone() {
         let bytes = framed(&ServerFrame::StdoutBytes(b"out".to_vec()));
         let (tx, rx) = mpsc::channel(8);
         drop(rx);
-        read_server_frames(io::Cursor::new(bytes), tx, exit_cell())
+        let code = read_server_frames(io::Cursor::new(bytes), tx)
             .await
             .expect("dropped stdout receiver ends the loop cleanly");
+        assert_eq!(code, None);
     }
 
     #[tokio::test]
-    async fn stops_when_stderr_receiver_is_gone() {
+    async fn stops_with_none_when_stderr_receiver_is_gone() {
         let bytes = framed(&ServerFrame::StderrBytes(b"err".to_vec()));
         let (tx, rx) = mpsc::channel(8);
         drop(rx);
-        read_server_frames(io::Cursor::new(bytes), tx, exit_cell())
+        let code = read_server_frames(io::Cursor::new(bytes), tx)
             .await
             .expect("dropped stderr receiver ends the loop cleanly");
+        assert_eq!(code, None);
     }
 }

--- a/crates/lns-service/src/vm/session_client/real.rs
+++ b/crates/lns-service/src/vm/session_client/real.rs
@@ -3,7 +3,6 @@
 use crate::log;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI32, Ordering};
 
 use anyhow::{Context, Result};
 use lns_ipc::WireFrame;
@@ -57,24 +56,24 @@ async fn run_session(
         .context("send OpenSession to broker")?;
     log::debug!("OpenSession sent; waiting for ExitStatus");
 
-    let exit_code = Arc::new(AtomicI32::new(137));
     let (stop_tx, _) = tokio::sync::broadcast::channel::<()>(1);
 
-    let frame_tx_for_reader = frame_tx.clone();
-    let exit_for_reader = exit_code.clone();
     let stop_for_reader = stop_tx.clone();
     let reader_handle = tokio::spawn(async move {
-        let _ = read_server_frames(read_half, frame_tx_for_reader, exit_for_reader).await;
+        let outcome = read_server_frames(read_half, frame_tx).await;
         // Without an explicit wake-up, detached-run input loops hang because nobody else closes input_rx.
         let _ = stop_for_reader.send(());
+        outcome
     });
 
     log::info!("SessionReady", "");
 
     pump_session_input(writer.clone(), input_rx, stop_tx.subscribe()).await;
 
-    let _ = reader_handle.await;
-    Ok(exit_code.load(Ordering::SeqCst))
+    let outcome = reader_handle
+        .await
+        .map_err(|e| anyhow::anyhow!("broker session reader task panicked: {e}"))?;
+    super::session_exit_code(outcome)
 }
 
 const CAPTURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -4,8 +4,11 @@ use std::os::fd::RawFd;
 use std::os::raw::{c_char, c_long, c_uint};
 use std::ptr;
 use std::sync::mpsc::SyncSender;
+use std::time::Duration;
 
 use lns_session::{ClientFrame, ServerFrame, Winsize, encode_frame};
+
+const PTY_DRAIN_GRACE: Duration = Duration::from_millis(500);
 
 use super::{
     LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close, dispatch_frame,
@@ -188,9 +191,11 @@ fn drive_session_tty(
         return Err(SessionError::Io(io::Error::last_os_error()));
     }
 
+    let (drained_tx, drained_rx) = std::sync::mpsc::channel::<()>();
     let conn_for_out = conn.clone();
     let out_thread = std::thread::spawn(move || {
         pump_fd_to_vsock_stdout(out_dup, conn_for_out);
+        let _ = drained_tx.send(());
     });
 
     let conn_for_ctrl = conn.clone();
@@ -200,12 +205,13 @@ fn drive_session_tty(
 
     let exit_code = forker.wait(child_pid)?;
 
+    // Wait for the pump to flush the workload's final output, bounded because a daemonized child holding the slave open never EOFs the master and an unbounded join would hang.
+    let _ = drained_rx.recv_timeout(PTY_DRAIN_GRACE);
+
     send_exit(&conn, exit_code);
 
     shutdown_read(conn.raw());
     let _ = ctrl_thread.join();
-
-    // A daemonized child can keep the PTY slave open, so read(out_dup) would block forever; drop the handle rather than join to avoid hanging teardown.
     drop(out_thread);
 
     Ok(SessionOutcome { exit_code })


### PR DESCRIPTION
## Summary

The run surface had four related honesty gaps: the exit code could be fabricated, the final output of a fast-failing workload could be dropped, a wrong-arch image would boot and crash instead of failing early, and the warning that a workload exited nonzero was missing entirely. This PR closes all four.

### 1. Honest exit code — replace fabricated 137

`session_client::read_server_frames` used a shared `Arc<AtomicI32>` defaulting to `137` to carry the exit status across threads. If the broker session ended before sending `ExitStatus` (guest crash, teardown), that default silently became the reported code.

`read_server_frames` now returns `Result<Option<i32>>` and a new pure helper `session_exit_code` maps it to a `Result<i32>`:

| Outcome | Before | After |
|---------|--------|-------|
| Normal exit | correct code | correct code |
| Session ended without `ExitStatus` | fabricated `137` | actionable error with `--log-level debug` hint |
| Reader I/O error | swallowed | propagated with context |

The task-panic path (`reader_handle.await` failing) is also now surfaced rather than swallowed.

### 2. PTY drain before announcing exit

In the TTY path, `drive_session_tty` sent `ExitStatus` immediately after `waitpid` returned. A fast-failing workload's last output bytes were still in flight through the stdout pump, and the host would see the exit announcement before those bytes arrived — dropping the final output.

The fix signals the pump thread via a `mpsc::channel` and waits up to `PTY_DRAIN_GRACE` (500 ms) before calling `send_exit`. A normal child's PTY master EOFs the instant the child exits, so the pump completes well within the grace period. The cap prevents a daemonized child (one that inherits the slave fd and keeps it open) from blocking teardown indefinitely.

### 3. Arch/OS guard at ingest time

`ingest::run` now accepts a `guest_arch: &Arch` parameter and calls `ensure_runnable_here` immediately after pulling an image. If the image's `architecture` or `os` doesn't match the guest, the run fails with a clear message naming both sides and pointing at the multi-arch fix:

```
image is windows/amd64 but this sandbox runs linux/arm64;
use a multi-arch image or one built for linux/arm64
```

`image::want_arch()` was already `pub(crate)` and is threaded through `ingest::run` at the call site in `run/orchestrator.rs`. An imageless run skips the check.

### 4. Warn on nonzero workload exit

`emit_completion` now emits a `RunLog { level: Warn }` frame before `RunExit` whenever the workload's exit code is nonzero, so attached sessions surface the exit code in the status line rather than just terminating silently.

### 5. CRLF for status lines in raw TTY mode

When the host terminal is in raw mode (`tty: true`), the kernel doesn't translate `\n` to `\r\n`, so `lns`-generated status lines (arch errors, nonzero exit warnings) were leaving the cursor mid-line. `render_attached_run_log` now passes each line through `lf_to_crlf` when `tty` is set.

## Screenshots
### Before
<!-- Add screenshot or recording showing the bug -->

### After
<!-- Add screenshot or recording showing the fix -->

## Test instructions

1. **Honest exit code** — `lns run alpine:3.20 -- sh -c 'exit 42'`; observe the warning `⚠ workload exited with code 42` on stderr and `lns` itself exits 42.
2. **Arch guard** — on an arm64 host, attempt `lns run --platform linux/amd64 alpine -- true` (or push a single-arch amd64 image); expect an immediate error naming both architectures and no VM boot.
3. **No fabricated 137** — if the guest crashes before exec (simulate by providing a broken binary), verify the error message says "broker session ended before the workload reported an exit status" rather than exiting 137.
4. **PTY drain** — `lns run -it alpine -- sh -c 'echo last-words; exit 1'`; confirm "last-words" appears before the exit warning and the cursor is at column 0 on the next line.
5. **CRLF in raw mode** — same command as above; confirm the `⚠ workload exited with code 1` line starts at the left edge (no staircase effect).