### PR TITLE
feat(integrations): add Amazon Bedrock as a bearer-token integration

### DIFF
--- a/crates/lns-policy/src/integrations.rs
+++ b/crates/lns-policy/src/integrations.rs
@@ -595,6 +595,26 @@ mod tests {
     }
 
     #[test]
+    fn bundled_bedrock_injects_a_bearer_header_on_the_regional_runtime_and_control_planes() {
+        let bedrock = bundled_integrations()
+            .iter()
+            .find(|i| i.id == "bedrock")
+            .expect("bedrock is bundled");
+        assert_eq!(bedrock.auth_kind, AuthKind::Credential);
+        let cred = bedrock.credential.as_ref().unwrap();
+        assert_eq!(cred.env_var, "AWS_BEARER_TOKEN_BEDROCK");
+        for domain in ["bedrock-runtime.*.amazonaws.com", "bedrock.*.amazonaws.com"] {
+            assert!(
+                cred.injections
+                    .iter()
+                    .any(|i| i.kind == InjectionKind::BearerHeader && i.domain == domain),
+                "the Bedrock API key rides as Authorization: Bearer to {domain}, got: {:?}",
+                cred.injections
+            );
+        }
+    }
+
+    #[test]
     fn bundled_linear_injects_a_bearer_header() {
         let linear = bundled_integrations()
             .iter()

--- a/crates/lns-policy/src/integrations.yaml
+++ b/crates/lns-policy/src/integrations.yaml
@@ -68,6 +68,20 @@ integrations:
           header: x-api-key
         - kind: bearer_header
           domain: api.anthropic.com
+  - id: bedrock
+    name: Amazon Bedrock
+    authKind: credential
+    routes:
+      - match: bedrock-runtime.*.amazonaws.com
+      - match: bedrock.*.amazonaws.com
+    credential:
+      envVar: AWS_BEARER_TOKEN_BEDROCK
+      placeholder: ABSKLNSPLACEHOLDER000000000000000000000000000000
+      injections:
+        - kind: bearer_header
+          domain: bedrock-runtime.*.amazonaws.com
+        - kind: bearer_header
+          domain: bedrock.*.amazonaws.com
   - id: linear
     authKind: credential
     routes:

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -444,11 +444,16 @@ impl ApprovalSession {
     }
 }
 
-/// Matches a request host against an integration route pattern: exact, or a `*.suffix` wildcard covering the apex and any subdomain.
+/// Matches a request host against an integration route pattern: exact, a leading `*.suffix` wildcard covering the apex and any subdomain, or a mid-segment `prefix.*.suffix` wildcard covering one variable label.
 fn host_matches_pattern(pattern: &str, host: &str) -> bool {
-    match pattern.strip_prefix("*.") {
-        Some(suffix) => host == suffix || host.ends_with(&format!(".{suffix}")),
-        None => pattern == host,
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        host == suffix || host.ends_with(&format!(".{suffix}"))
+    } else if let Some((prefix, suffix)) = pattern.split_once('*') {
+        host.starts_with(prefix)
+            && host[prefix.len()..].ends_with(suffix)
+            && host.len() > prefix.len() + suffix.len()
+    } else {
+        pattern == host
     }
 }
 
@@ -1599,6 +1604,22 @@ pub(crate) mod tests {
         assert!(!host_matches_pattern(
             "*.huggingface.co",
             "huggingface.co.evil.com"
+        ));
+    }
+
+    #[test]
+    fn host_matches_pattern_mid_segment_wildcard_covers_a_variable_label() {
+        assert!(host_matches_pattern(
+            "bedrock-runtime.*.amazonaws.com",
+            "bedrock-runtime.us-east-1.amazonaws.com"
+        ));
+        assert!(!host_matches_pattern(
+            "bedrock-runtime.*.amazonaws.com",
+            "bedrock-runtime.us-east-1amazonaws.com"
+        ));
+        assert!(!host_matches_pattern(
+            "bedrock-runtime.*.amazonaws.com",
+            "bedrock.us-east-1.amazonaws.com"
         ));
     }
 }

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -25,9 +25,9 @@ isn't configured for is not rewritten — the placeholder goes nowhere useful.
 
 Every credential provider is an [integration](integrations.md): a named service that
 bundles its placeholder, environment variable, and per-domain injection with the
-routes it needs. `openai`, `anthropic`, `linear`, `telegram`, `gitlab`, and
-`huggingface` ship in the bundled catalog; `github` ships as an `oauth` integration
-(device sign-in). Declare your own for an internal API with `lns integration add`
+routes it needs. `openai`, `anthropic`, `bedrock`, `linear`, `telegram`, `gitlab`,
+and `huggingface` ship in the bundled catalog; `github` ships as an `oauth`
+integration (device sign-in). Declare your own for an internal API with `lns integration add`
 (see [Integrations](integrations.md)). Connect one to a project with
 `lns integration connect <id>`, which records it under `integrations:` in that
 directory's `lns-policy.yaml`.


### PR DESCRIPTION
## Summary

Until now, agents needing Amazon Bedrock had no integration to connect — there was no catalog entry, no offer card, and no credential injection for Bedrock endpoints. This PR adds `bedrock` as a bundled credential integration using the Bedrock API key path (`AWS_BEARER_TOKEN_BEDROCK` + `Authorization: Bearer`), and fixes a gap in the offer-card matcher that would have silently swallowed the connect card.

### 1. Offer-card matcher didn't handle mid-segment wildcards

`host_matches_pattern` in `approval_flow/session.rs` (which drives the \"connect Amazon Bedrock?\" card) only understood leading `*.` wildcards. Bedrock's regional endpoints use a mid-segment shape — `bedrock-runtime.us-east-1.amazonaws.com` — so the connect card would never have fired.

`lens-sandbox-core`'s `domain_matches`/`injection_matches` (which drives the actual network gate and credential injection) already handles mid-segment wildcards and even ships a test asserting `bedrock-runtime.*.amazonaws.com` matches regional hosts. This PR brings the offer-card matcher to parity by adding the same mid-segment branch.

**Before / after:**
```rust
// before — leading wildcard only
fn host_matches_pattern(pattern: &str, host: &str) -> bool {
    match pattern.strip_prefix("*.") {
        Some(suffix) => host == suffix || host.ends_with(&format!(".{suffix}")),
        None => pattern == host,
    }
}

// after — also handles prefix.*.suffix
fn host_matches_pattern(pattern: &str, host: &str) -> bool {
    if let Some(suffix) = pattern.strip_prefix("*.") {
        host == suffix || host.ends_with(&format!(".{suffix}"))
    } else if let Some((prefix, suffix)) = pattern.split_once('*') {
        host.starts_with(prefix)
            && host[prefix.len()..].ends_with(suffix)
            && host.len() > prefix.len() + suffix.len()
    } else {
        pattern == host
    }
}
```

### 2. `bedrock` catalog entry

Added to `integrations.yaml` as a `credential` integration:

| Field | Value |
|-------|-------|
| `id` | `bedrock` |
| `name` | Amazon Bedrock |
| `envVar` | `AWS_BEARER_TOKEN_BEDROCK` |
| Injection | `bearer_header` on runtime + control-plane |
| Routes | `bedrock-runtime.*.amazonaws.com` + `bedrock.*.amazonaws.com` |

This is the Bedrock API key path — `AWS_BEARER_TOKEN_BEDROCK` is what AWS SDKs read for it, and the key rides as `Authorization: Bearer` to both the regional inference endpoint (`bedrock-runtime.*`) and the control plane (`bedrock.*`), covering `InvokeModel`/`Converse` as well as `ListFoundationModels` and agent/guardrail operations.

Note: the core already ships a full AWS SigV4 re-signer (`aws_resign.rs`) for the traditional-credentials path — that's a separate future integration if needed.

## Docs

Updated `docs/credentials.md` to include `bedrock` in the list of bundled credential integrations.

## Screenshots
<!-- Add screenshot or recording demonstrating the new feature -->

## Test instructions

1. `lns integration ls` — verify `bedrock` appears with `authKind: credential` and `envVar: AWS_BEARER_TOKEN_BEDROCK`.
2. In a directory with no `lns-policy.yaml`, run an agent that calls `bedrock-runtime.us-east-1.amazonaws.com` — confirm the \"connect Amazon Bedrock?\" offer card appears.
3. Accept the card, set an API key when prompted — verify the key is injected as `Authorization: Bearer <key>` on subsequent Bedrock requests (can confirm via request logs or a failing call that gets an auth error rather than a connection-denied error).
4. Repeat step 2 with a `bedrock.us-west-2.amazonaws.com` (control-plane) call — confirm the offer card fires for that endpoint too.
5. Decline the connect card — confirm the request is denied and no credential is injected.