### PR TITLE
fix(lns-cli): surface a missing or corrupt audit anchor instead of verifying clean

### DIFF
--- a/crates/lns-cli/src/audit/mod.rs
+++ b/crates/lns-cli/src/audit/mod.rs
@@ -9,6 +9,11 @@ use crate::log;
 pub struct AuditArgs {
     #[arg(help = "Run identifier surfaced by `lns run` as `✓ started run #<id>`.")]
     pub run_id: String,
+    #[arg(
+        long,
+        help = "Treat a missing audit anchor as non-fatal. Without it, an absent anchor exits non-zero because truncation and rollback cannot be detected."
+    )]
+    pub allow_missing_anchor: bool,
 }
 
 pub fn augment(app: clap::Command) -> clap::Command {
@@ -34,14 +39,26 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a>
 pub fn run_verify(args: AuditArgs) -> anyhow::Result<i32> {
     let path = lns_ipc::audit_log_for_run(&args.run_id)?;
     log::info!("Verifying", "audit chain at {}", path.display());
-    Ok(report_outcome(verify::verify_chain(&path)?))
+    Ok(report_outcome(
+        verify::verify_chain(&path)?,
+        args.allow_missing_anchor,
+    ))
 }
 
-fn report_outcome(outcome: verify::VerifyOutcome) -> i32 {
+fn report_outcome(outcome: verify::VerifyOutcome, allow_missing_anchor: bool) -> i32 {
     match outcome {
         verify::VerifyOutcome::Ok { line_count } => {
             println!("Verified {line_count} audit events");
             0
+        }
+        verify::VerifyOutcome::NoAnchor { line_count } => {
+            report_no_anchor(line_count, allow_missing_anchor)
+        }
+        verify::VerifyOutcome::AnchorUnreadable { line_count, reason } => {
+            log::error!(
+                "audit anchor present but unreadable ({reason}) — truncation or rollback cannot be verified for {line_count} events"
+            );
+            1
         }
         verify::VerifyOutcome::Broken { at_line, reason } => {
             log::error!("audit chain TAMPERED at line {at_line}: {reason}");
@@ -52,6 +69,14 @@ fn report_outcome(outcome: verify::VerifyOutcome) -> i32 {
             1
         }
     }
+}
+
+fn report_no_anchor(line_count: usize, allow_missing_anchor: bool) -> i32 {
+    println!("Verified {line_count} audit events");
+    log::warn!(
+        "no audit anchor beside the log — chain integrity was checked, but truncation or rollback cannot be detected"
+    );
+    if allow_missing_anchor { 0 } else { 1 }
 }
 
 #[cfg(test)]
@@ -104,6 +129,11 @@ mod tests {
             payload.push('\n');
         }
         std::fs::write(&path, payload).unwrap();
+        std::fs::write(
+            path.with_file_name("audit.anchor"),
+            chain.anchor().unwrap().to_line(),
+        )
+        .unwrap();
 
         assert_eq!(expect_ok(verify::verify_chain(&path).unwrap()), 3);
     }
@@ -129,11 +159,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_audit_log_verifies_ok() {
+    fn empty_audit_log_without_anchor_reports_no_anchor() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("audit.jsonl");
         std::fs::write(&path, "").unwrap();
-        assert_eq!(expect_ok(verify::verify_chain(&path).unwrap()), 0);
+        assert!(matches!(
+            verify::verify_chain(&path).unwrap(),
+            verify::VerifyOutcome::NoAnchor { line_count: 0 }
+        ));
     }
 
     #[test]
@@ -144,24 +177,54 @@ mod tests {
 
     #[test]
     fn report_outcome_clean_chain_returns_zero() {
-        let code = report_outcome(verify::VerifyOutcome::Ok { line_count: 3 });
+        let code = report_outcome(verify::VerifyOutcome::Ok { line_count: 3 }, false);
         assert_eq!(code, 0);
     }
 
     #[test]
     fn report_outcome_tampered_chain_returns_one() {
-        let code = report_outcome(verify::VerifyOutcome::Broken {
-            at_line: 7,
-            reason: "prev_hash mismatch".into(),
-        });
+        let code = report_outcome(
+            verify::VerifyOutcome::Broken {
+                at_line: 7,
+                reason: "prev_hash mismatch".into(),
+            },
+            false,
+        );
         assert_eq!(code, 1);
     }
 
     #[test]
     fn report_outcome_truncated_chain_returns_one() {
-        let code = report_outcome(verify::VerifyOutcome::Truncated {
-            reason: "tail truncated".into(),
-        });
+        let code = report_outcome(
+            verify::VerifyOutcome::Truncated {
+                reason: "tail truncated".into(),
+            },
+            false,
+        );
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn report_outcome_missing_anchor_fails_by_default() {
+        let code = report_outcome(verify::VerifyOutcome::NoAnchor { line_count: 2 }, false);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn report_outcome_missing_anchor_is_tolerated_when_explicitly_allowed() {
+        let code = report_outcome(verify::VerifyOutcome::NoAnchor { line_count: 2 }, true);
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn report_outcome_unreadable_anchor_returns_one_even_when_missing_is_allowed() {
+        let code = report_outcome(
+            verify::VerifyOutcome::AnchorUnreadable {
+                line_count: 2,
+                reason: "corrupt anchor: trailing data".into(),
+            },
+            true,
+        );
         assert_eq!(code, 1);
     }
 
@@ -186,6 +249,8 @@ mod tests {
                 payload.push('\n');
             }
             std::fs::write(runs_dir.join("audit.jsonl"), payload).unwrap();
+            let anchor = chain.anchor().expect("staged chain has events");
+            std::fs::write(runs_dir.join("audit.anchor"), anchor.to_line()).unwrap();
         }
 
         let _home = crate::test_env::EnvScope::set("HOME", cache_root.path());

--- a/crates/lns-cli/src/audit/verify.rs
+++ b/crates/lns-cli/src/audit/verify.rs
@@ -9,16 +9,31 @@ use std::path::Path;
 #[derive(Debug)]
 pub enum VerifyOutcome {
     Ok { line_count: usize },
+    NoAnchor { line_count: usize },
+    AnchorUnreadable { line_count: usize, reason: String },
     Broken { at_line: usize, reason: String },
     Truncated { reason: String },
+}
+
+enum AnchorState {
+    Present(Anchor),
+    Absent,
+    Unreadable(String),
 }
 
 fn anchor_path_for(path: &Path) -> std::path::PathBuf {
     path.with_file_name("audit.anchor")
 }
 
-fn read_anchor(path: &Path) -> Option<Anchor> {
-    Anchor::parse(&std::fs::read_to_string(path).ok()?).ok()
+fn read_anchor_state(path: &Path) -> AnchorState {
+    match std::fs::read_to_string(path) {
+        Ok(text) => match Anchor::parse(&text) {
+            Ok(anchor) => AnchorState::Present(anchor),
+            Err(e) => AnchorState::Unreadable(format!("corrupt anchor: {e}")),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => AnchorState::Absent,
+        Err(e) => AnchorState::Unreadable(e.to_string()),
+    }
 }
 
 struct ChainWalk {
@@ -92,21 +107,21 @@ fn check_line(line: &str, idx: usize, expected_prev: &str) -> Option<VerifyOutco
 }
 
 pub fn verify_chain(path: &Path) -> Result<VerifyOutcome> {
-    verify_chain_against_anchor(path, read_anchor(&anchor_path_for(path)))
+    verify_chain_against_anchor(path, read_anchor_state(&anchor_path_for(path)))
 }
 
-fn verify_chain_against_anchor(path: &Path, anchor: Option<Anchor>) -> Result<VerifyOutcome> {
+fn verify_chain_against_anchor(path: &Path, anchor: AnchorState) -> Result<VerifyOutcome> {
     let walk = match walk_chain(path)? {
         Ok(w) => w,
         Err(broken) => return Ok(broken),
     };
-    if let Some(anchor) = anchor
-        && let Some(truncated) = check_anchor(&walk, &anchor)
-    {
-        return Ok(truncated);
-    }
-    Ok(VerifyOutcome::Ok {
-        line_count: walk.line_count as usize,
+    let line_count = walk.line_count as usize;
+    Ok(match anchor {
+        AnchorState::Present(anchor) => {
+            check_anchor(&walk, &anchor).unwrap_or(VerifyOutcome::Ok { line_count })
+        }
+        AnchorState::Absent => VerifyOutcome::NoAnchor { line_count },
+        AnchorState::Unreadable(reason) => VerifyOutcome::AnchorUnreadable { line_count, reason },
     })
 }
 
@@ -197,13 +212,14 @@ mod tests {
     fn good_chain_reports_ok_with_count() {
         let d = tempfile::TempDir::new().unwrap();
         let path = d.path().join("audit.jsonl");
-        write_chain_to(
+        let anchor = write_chain_to(
             &path,
             &[
                 r#"{"type":"audit_event","seq":1}"#,
                 r#"{"type":"audit_event","seq":2}"#,
             ],
         );
+        write_anchor_beside(&path, &anchor);
         assert_eq!(expect_ok(verify_chain(&path).unwrap()), 2);
     }
 
@@ -238,11 +254,15 @@ mod tests {
     }
 
     #[test]
-    fn empty_file_is_ok() {
+    fn an_empty_log_without_an_anchor_reports_no_anchor() {
         let d = tempfile::TempDir::new().unwrap();
         let path = d.path().join("audit.jsonl");
         std::fs::write(&path, "").unwrap();
-        assert_eq!(expect_ok(verify_chain(&path).unwrap()), 0);
+        let outcome = verify_chain(&path).unwrap();
+        assert!(
+            matches!(outcome, VerifyOutcome::NoAnchor { line_count: 0 }),
+            "an empty log with no anchor must report NoAnchor: {outcome:?}"
+        );
     }
 
     #[test]
@@ -329,12 +349,45 @@ mod tests {
     }
 
     #[test]
-    fn a_garbage_anchor_file_is_ignored_and_the_chain_still_verifies() {
+    fn a_missing_anchor_is_surfaced_as_no_anchor_not_clean_ok() {
+        let d = tempfile::TempDir::new().unwrap();
+        let path = d.path().join("audit.jsonl");
+        write_chain_to(&path, &[r#"{"type":"audit_event","seq":1}"#]);
+        let outcome = verify_chain(&path).unwrap();
+        assert!(
+            matches!(outcome, VerifyOutcome::NoAnchor { line_count: 1 }),
+            "a chain with no anchor beside it must report NoAnchor: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_anchor_file_is_surfaced_as_anchor_unreadable() {
         let d = tempfile::TempDir::new().unwrap();
         let path = d.path().join("audit.jsonl");
         write_chain_to(&path, &[r#"{"type":"audit_event","seq":1}"#]);
         std::fs::write(anchor_path_for(&path), "not-an-anchor").unwrap();
-        assert_eq!(expect_ok(verify_chain(&path).unwrap()), 1);
+        let outcome = verify_chain(&path).unwrap();
+        assert!(
+            matches!(&outcome, VerifyOutcome::AnchorUnreadable { line_count: 1, reason } if reason.contains("corrupt")),
+            "a garbage anchor must report AnchorUnreadable, never clean Ok: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_anchor_io_error_is_surfaced_as_anchor_unreadable() {
+        let d = tempfile::TempDir::new().unwrap();
+        let path = d.path().join("audit.jsonl");
+        write_chain_to(&path, &[r#"{"type":"audit_event","seq":1}"#]);
+        std::fs::create_dir(anchor_path_for(&path)).unwrap();
+        let outcome = verify_chain(&path).unwrap();
+        let unreadable = matches!(
+            &outcome,
+            VerifyOutcome::AnchorUnreadable { line_count: 1, .. }
+        );
+        assert!(
+            unreadable,
+            "an anchor path that cannot be read must report AnchorUnreadable: {outcome:?}"
+        );
     }
 
     #[test]
@@ -360,6 +413,7 @@ mod tests {
         payload.push_str(std::str::from_utf8(&line2).unwrap());
         payload.push('\n');
         std::fs::write(&path, payload).unwrap();
+        write_anchor_beside(&path, &c.anchor().expect("chain has events"));
         assert_eq!(expect_ok(verify_chain(&path).unwrap()), 2);
     }
 }

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -56,8 +56,12 @@ rollback to an earlier prefix), it reports the mismatch and exits non-zero:
 audit chain TRUNCATED: <reason>
 ```
 
-An empty log verifies successfully (zero events) only when no anchor records a
-longer history. A missing log is reported distinctly from an empty one.
+The anchor is what makes truncation and rollback detectable, so `lns audit` does
+not treat its absence as success. If the anchor is present but corrupt or
+unreadable, it exits non-zero. If no anchor is found beside the log, it prints the
+event count, warns that truncation and rollback cannot be checked, and exits
+non-zero; pass `--allow-missing-anchor` to accept that degraded check with exit
+`0`. A missing log is reported distinctly from an empty one.
 
 ## Where logs live
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -147,11 +147,13 @@ as hidden aliases; the `lns sandbox` forms are the documented ones.
 Verify the audit chain of a run.
 
 ```bash
-lns audit <RUN_ID>
+lns audit <RUN_ID> [--allow-missing-anchor]
 ```
 
 `RUN_ID` is the identifier surfaced by `lns run` as `✓ started run #<id>`. Exits `0`
-on an intact chain, non-zero if tampering is detected. See [Audit](audit.md).
+on an intact chain, non-zero if tampering is detected, or if the anchor that guards
+against truncation is missing, corrupt, or unreadable. `--allow-missing-anchor`
+accepts a missing anchor (chain-only check) with exit `0`. See [Audit](audit.md).
 
 ## `lns service`
 


### PR DESCRIPTION
## What

`lns audit <run_id>` collapsed every audit-anchor failure mode — file absent, unreadable, or corrupt — into a chain-only check that still printed `Verified N audit events` and exited `0`. The anchor is the only thing that lets `lns audit` detect a truncated tail or a rollback to an earlier prefix, so a log whose anchor had been deleted or damaged was reported as fully intact.

## Change

`read_anchor` becomes `read_anchor_state`, returning a tri-state:

- **Present** — anchor parsed; truncation/rollback checks run as before.
- **Absent** (`NotFound`) — `VerifyOutcome::NoAnchor`: prints the event count, warns that truncation/rollback cannot be detected, and exits non-zero. `--allow-missing-anchor` downgrades this to exit `0` for callers that knowingly accept a chain-only check.
- **Unreadable** (I/O error or unparseable content) — `VerifyOutcome::AnchorUnreadable`: exits non-zero unconditionally; an anchor that exists but cannot be trusted is a stronger signal than none at all.

A real run always writes an anchor, so the common path is unchanged. The behavior change is limited to anomalous states that previously read as clean.

## Tests

Layer 3 unit tests in `audit/verify.rs` pin each anchor state (present-match, absent, corrupt content, unreadable I/O via a directory at the anchor path) and in `audit/mod.rs` pin the exit codes for each outcome including both sides of `--allow-missing-anchor`. The pre-existing dispatch test now stages an anchor so it exercises the real clean path. `docs/audit.md` and `docs/cli-reference.md` updated to match.

`make lint`, cognitive-complexity, and the lns-cli per-file coverage gate (100%) all pass locally.