### PR TITLE
fix: cap HTTP download bodies before buffering them into memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "cucumber",
  "dirs 5.0.1",
  "flate2",
+ "futures-util",
  "httpmock",
  "libc",
  "lns-ipc",

--- a/crates/lns-cli/Cargo.toml
+++ b/crates/lns-cli/Cargo.toml
@@ -39,6 +39,7 @@ anstyle = "1"
 # shape (reqwest with rustls + stream features, tar+flate2 for the
 # release tarball, sha2 for the manifest-pinned checksum).
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+futures-util = "0.3"
 flate2  = "1"
 tar     = "0.4"
 

--- a/crates/lns-cli/src/update.rs
+++ b/crates/lns-cli/src/update.rs
@@ -4,6 +4,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use futures_util::StreamExt;
 use lns_ipc::{Method, PlatformInfo};
 
 use crate::command::{CommandSpec, subcommand};
@@ -47,6 +48,7 @@ pub const SPEC: CommandSpec = CommandSpec {
 
 pub(in crate::update) const DEFAULT_CDN_BASE: &str = "https://get.lns.run";
 const MANIFEST_NAME: &str = "lns-latest.json";
+const MAX_DOWNLOAD_BYTES: u64 = 256 * 1024 * 1024;
 const SERVICE_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const SERVICE_START_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -292,6 +294,10 @@ fn http_client(running_version: &str, platform: &PlatformInfo) -> Result<reqwest
 }
 
 async fn http_get_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> {
+    http_get_bytes_capped(client, url, MAX_DOWNLOAD_BYTES).await
+}
+
+async fn http_get_bytes_capped(client: &reqwest::Client, url: &str, max: u64) -> Result<Vec<u8>> {
     let resp = client
         .get(url)
         .send()
@@ -299,11 +305,52 @@ async fn http_get_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> 
         .with_context(|| format!("downloading {url}"))?
         .error_for_status()
         .with_context(|| format!("HTTP error from {url}"))?;
-    let bytes = resp
-        .bytes()
-        .await
-        .with_context(|| format!("reading body from {url}"))?;
-    Ok(bytes.to_vec())
+    let mut buf = CappedBuffer::new(resp.content_length(), max, url)?;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        buf.push(chunk.map(|b| b.to_vec()), url)?;
+    }
+    Ok(buf.into_inner())
+}
+
+#[derive(Debug)]
+struct CappedBuffer {
+    buf: Vec<u8>,
+    max: u64,
+}
+
+impl CappedBuffer {
+    fn new(content_length: Option<u64>, max: u64, url: &str) -> Result<Self> {
+        if let Some(len) = content_length
+            && len > max
+        {
+            bail!("{url} declared {len} bytes, over the {max}-byte download cap");
+        }
+        Ok(Self {
+            buf: Vec::new(),
+            max,
+        })
+    }
+
+    fn push<E: std::fmt::Display>(
+        &mut self,
+        chunk: std::result::Result<Vec<u8>, E>,
+        url: &str,
+    ) -> Result<()> {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(e) => bail!("reading body from {url}: {e}"),
+        };
+        if self.buf.len() as u64 + chunk.len() as u64 > self.max {
+            bail!("{url} body exceeded the {}-byte download cap", self.max);
+        }
+        self.buf.extend_from_slice(&chunk);
+        Ok(())
+    }
+
+    fn into_inner(self) -> Vec<u8> {
+        self.buf
+    }
 }
 
 async fn stop_running_service(service: &impl ServiceClient) -> Result<()> {
@@ -1602,5 +1649,63 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("downloading"), "msg: {msg}");
         assert!(msg.contains(&url), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn http_get_bytes_rejects_a_body_whose_declared_length_is_over_the_cap() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET);
+                then.status(200).body("xxxxxxxxxx");
+            })
+            .await;
+        let url = format!("{}/blob", server.base_url());
+        let client = http_client("0.3.0", &darwin_arm()).unwrap();
+        let err = http_get_bytes_capped(&client, &url, 4).await.unwrap_err();
+        assert!(format!("{err:#}").contains("download cap"), "{err:#}");
+    }
+
+    #[test]
+    fn capped_buffer_rejects_an_oversized_declared_length() {
+        let err = CappedBuffer::new(Some(101), 100, "https://h/x").unwrap_err();
+        assert!(format!("{err:#}").contains("over the 100-byte download cap"));
+    }
+
+    #[test]
+    fn capped_buffer_accepts_within_cap_and_absent_length() {
+        assert!(CappedBuffer::new(None, 100, "https://h/x").is_ok());
+        assert!(CappedBuffer::new(Some(100), 100, "https://h/x").is_ok());
+    }
+
+    #[test]
+    fn capped_buffer_accumulates_chunks_in_order() {
+        let mut b = CappedBuffer::new(None, 10, "https://h/x").unwrap();
+        b.push(Ok::<_, String>(vec![1, 2, 3]), "https://h/x")
+            .unwrap();
+        b.push(Ok::<_, String>(vec![4, 5]), "https://h/x").unwrap();
+        assert_eq!(b.into_inner(), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn capped_buffer_refuses_a_chunk_that_would_cross_the_cap() {
+        let mut b = CappedBuffer::new(None, 4, "https://h/x").unwrap();
+        b.push(Ok::<_, String>(vec![1, 2, 3]), "https://h/x")
+            .unwrap();
+        let err = b
+            .push(Ok::<_, String>(vec![4, 5]), "https://h/x")
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("exceeded the 4-byte download cap"));
+    }
+
+    #[test]
+    fn capped_buffer_surfaces_a_transport_error_chunk() {
+        let mut b = CappedBuffer::new(None, 100, "https://h/x").unwrap();
+        let err = b
+            .push(Err::<Vec<u8>, _>("connection reset"), "https://h/x")
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("reading body from https://h/x"), "{msg}");
+        assert!(msg.contains("connection reset"), "{msg}");
     }
 }

--- a/crates/lns-service/src/http_cap.rs
+++ b/crates/lns-service/src/http_cap.rs
@@ -1,0 +1,89 @@
+use anyhow::{Result, bail};
+
+#[derive(Debug)]
+pub(crate) struct CappedBuffer {
+    buf: Vec<u8>,
+    max: u64,
+}
+
+impl CappedBuffer {
+    pub(crate) fn new(content_length: Option<u64>, max: u64, url: &str) -> Result<Self> {
+        if let Some(len) = content_length
+            && len > max
+        {
+            bail!("{url} declared {len} bytes, over the {max}-byte download cap");
+        }
+        Ok(Self {
+            buf: Vec::new(),
+            max,
+        })
+    }
+
+    pub(crate) fn push<E: std::fmt::Display>(
+        &mut self,
+        chunk: std::result::Result<Vec<u8>, E>,
+        url: &str,
+    ) -> Result<()> {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(e) => bail!("reading body from {url}: {e}"),
+        };
+        if self.buf.len() as u64 + chunk.len() as u64 > self.max {
+            bail!("{url} body exceeded the {}-byte download cap", self.max);
+        }
+        self.buf.extend_from_slice(&chunk);
+        Ok(())
+    }
+
+    pub(crate) fn into_inner(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_declared_length_over_the_cap_is_refused_before_any_body_is_read() {
+        let err = CappedBuffer::new(Some(101), 100, "https://h/x").unwrap_err();
+        assert!(format!("{err:#}").contains("over the 100-byte download cap"));
+    }
+
+    #[test]
+    fn an_absent_or_within_cap_declared_length_is_accepted() {
+        assert!(CappedBuffer::new(None, 100, "https://h/x").is_ok());
+        assert!(CappedBuffer::new(Some(100), 100, "https://h/x").is_ok());
+    }
+
+    #[test]
+    fn chunks_within_the_cap_accumulate_in_order() {
+        let mut b = CappedBuffer::new(None, 10, "https://h/x").unwrap();
+        b.push(Ok::<_, String>(vec![1, 2, 3]), "https://h/x")
+            .unwrap();
+        b.push(Ok::<_, String>(vec![4, 5]), "https://h/x").unwrap();
+        assert_eq!(b.into_inner(), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn a_chunk_that_would_cross_the_cap_is_refused_even_with_no_declared_length() {
+        let mut b = CappedBuffer::new(None, 4, "https://h/x").unwrap();
+        b.push(Ok::<_, String>(vec![1, 2, 3]), "https://h/x")
+            .unwrap();
+        let err = b
+            .push(Ok::<_, String>(vec![4, 5]), "https://h/x")
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("exceeded the 4-byte download cap"));
+    }
+
+    #[test]
+    fn a_transport_error_chunk_is_surfaced_with_the_url() {
+        let mut b = CappedBuffer::new(None, 100, "https://h/x").unwrap();
+        let err = b
+            .push(Err::<Vec<u8>, _>("connection reset"), "https://h/x")
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("reading body from https://h/x"), "{msg}");
+        assert!(msg.contains("connection reset"), "{msg}");
+    }
+}

--- a/crates/lns-service/src/kernel.rs
+++ b/crates/lns-service/src/kernel.rs
@@ -15,6 +15,8 @@ const ARCH: &str = "x86_64";
 
 const CDN_BASE: &str = "https://get.lns.run";
 
+pub(super) const MAX_KERNEL_BYTES: u64 = 64 * 1024 * 1024;
+
 mod real;
 mod traits;
 use real::{RealFetcher, RealFs};

--- a/crates/lns-service/src/kernel/real.rs
+++ b/crates/lns-service/src/kernel/real.rs
@@ -2,7 +2,10 @@ use anyhow::{Context, Result};
 use std::io;
 use std::path::Path;
 
-use super::{Fetcher, Fs, WritableFile};
+use futures_util::StreamExt;
+
+use super::{Fetcher, Fs, MAX_KERNEL_BYTES, WritableFile};
+use crate::http_cap::CappedBuffer;
 
 pub(super) struct RealFetcher;
 
@@ -13,11 +16,12 @@ impl Fetcher for RealFetcher {
             .with_context(|| format!("downloading {url}"))?
             .error_for_status()
             .with_context(|| format!("HTTP error from {url}"))?;
-        let bytes = resp
-            .bytes()
-            .await
-            .with_context(|| format!("reading body from {url}"))?;
-        Ok(bytes.to_vec())
+        let mut buf = CappedBuffer::new(resp.content_length(), MAX_KERNEL_BYTES, url)?;
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            buf.push(chunk.map(|b| b.to_vec()), url)?;
+        }
+        Ok(buf.into_inner())
     }
 }
 

--- a/crates/lns-service/src/lib.rs
+++ b/crates/lns-service/src/lib.rs
@@ -10,6 +10,7 @@ pub mod credential_flow;
 pub mod forward;
 pub mod guest_stats;
 pub mod guest_tools;
+mod http_cap;
 pub mod image;
 pub mod image_store;
 pub mod ingest;

--- a/crates/lns-service/src/update_check.rs
+++ b/crates/lns-service/src/update_check.rs
@@ -11,6 +11,7 @@ use traits::{Clock, Fetcher, StateStore};
 
 const CDN_BASE: &str = "https://get.lns.run";
 const MANIFEST_NAME: &str = "lns-latest.json";
+pub(super) const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 const LNS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);

--- a/crates/lns-service/src/update_check/real.rs
+++ b/crates/lns-service/src/update_check/real.rs
@@ -1,7 +1,9 @@
 use super::UpdateStatus;
 use super::traits::{Clock, Fetcher, StateStore};
+use crate::http_cap::CappedBuffer;
 use crate::shutdown::Shutdown;
 use anyhow::{Context, Result};
+use futures_util::StreamExt;
 use lns_ipc::{Method, PlatformInfo, Uname, shell_basename_from, uname_fields_with};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -57,7 +59,7 @@ impl Clock for RealClock {
 struct RealFetcher;
 impl Fetcher for RealFetcher {
     async fn get_manifest(&self, url: &str, user_agent: &str, install_id: &str) -> Result<Vec<u8>> {
-        let bytes = reqwest::Client::new()
+        let resp = reqwest::Client::new()
             .get(url)
             .timeout(FETCH_TIMEOUT)
             .header("user-agent", user_agent)
@@ -66,11 +68,13 @@ impl Fetcher for RealFetcher {
             .await
             .with_context(|| format!("checking {url}"))?
             .error_for_status()
-            .with_context(|| format!("HTTP error from {url}"))?
-            .bytes()
-            .await
-            .with_context(|| format!("reading body from {url}"))?;
-        Ok(bytes.to_vec())
+            .with_context(|| format!("HTTP error from {url}"))?;
+        let mut buf = CappedBuffer::new(resp.content_length(), super::MAX_MANIFEST_BYTES, url)?;
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            buf.push(chunk.map(|b| b.to_vec()), url)?;
+        }
+        Ok(buf.into_inner())
     }
 }
 


### PR DESCRIPTION
## What

Three download paths read the entire HTTP response body into RAM with no size ceiling:

- kernel download (`kernel::RealFetcher::fetch`)
- update-check manifest fetch (`update_check::RealFetcher::get_manifest`)
- CLI self-update manifest + release tarball (`update::http_get_bytes`)

A malicious or compromised CDN — or a MITM that gets past TLS — could stream an arbitrarily large body and exhaust host memory before the post-download SHA-256 verification ever runs.

## Change

Each download now streams the body through a small `CappedBuffer`:

- a declared `Content-Length` over the cap is rejected before any body bytes are read;
- the running total is checked on every chunk, so a lying or absent `Content-Length` still can't grow the buffer past the cap.

Caps: kernel 64 MiB, update-check manifest 1 MiB, CLI download 256 MiB (sized for the release tarball). Post-download checksum verification is unchanged — the cap is an independent pre-OOM guard.

The cap decision (`CappedBuffer::new` / `push`) is pure and unit-tested for every branch (oversized declared length, mid-stream overflow, transport-error chunk, in-order accumulation); the async `bytes_stream()` wiring lives in the e2e-covered fetch leaves. `lns-service` shares one `http_cap` module across its two leaves.

## Tests

Layer 3 unit tests for `CappedBuffer` in both crates, plus an httpmock test that an over-cap declared length is rejected. `make lint`, complexity, and the lns-cli + lns-service per-file coverage gates (100%) pass locally.