### PR TITLE
fix(policy): redact stored credential secrets from Debug output

### DIFF
--- a/crates/lns-policy/src/credentials.rs
+++ b/crates/lns-policy/src/credentials.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum CredentialEntry {
     HostDetect,
@@ -24,6 +24,25 @@ pub enum CredentialEntry {
 }
 
 pub type CredentialStateFile = HashMap<String, CredentialEntry>;
+
+impl std::fmt::Debug for CredentialEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CredentialEntry::HostDetect => f.write_str("HostDetect"),
+            CredentialEntry::Stored { .. } => f
+                .debug_struct("Stored")
+                .field("value", &"<redacted>")
+                .finish(),
+            CredentialEntry::Deny => f.write_str("Deny"),
+            CredentialEntry::Oauth { expires_at, .. } => f
+                .debug_struct("Oauth")
+                .field("access_token", &"<redacted>")
+                .field("refresh_token", &"<redacted>")
+                .field("expires_at", expires_at)
+                .finish(),
+        }
+    }
+}
 
 pub trait CredentialStore: Send + Sync {
     fn load(&self) -> io::Result<CredentialStateFile>;
@@ -90,6 +109,38 @@ mod tests {
         let entry = CredentialEntry::HostDetect;
         let v = serde_json::to_value(&entry).unwrap();
         assert_eq!(v, json!({"kind": "host-detect"}));
+    }
+
+    #[test]
+    fn debug_redacts_secret_values_for_every_variant() {
+        let stored = format!(
+            "{:?}",
+            CredentialEntry::Stored {
+                value: "sk-secret".into()
+            }
+        );
+        assert!(!stored.contains("sk-secret"), "{stored}");
+        assert!(stored.contains("redacted"), "{stored}");
+
+        let oauth = format!(
+            "{:?}",
+            CredentialEntry::Oauth {
+                access_token: "gho_secret".into(),
+                refresh_token: "ghr_secret".into(),
+                expires_at: 123,
+            }
+        );
+        assert!(
+            !oauth.contains("gho_secret") && !oauth.contains("ghr_secret"),
+            "{oauth}"
+        );
+        assert!(
+            oauth.contains("123"),
+            "a non-secret expiry stays visible: {oauth}"
+        );
+
+        assert_eq!(format!("{:?}", CredentialEntry::HostDetect), "HostDetect");
+        assert_eq!(format!("{:?}", CredentialEntry::Deny), "Deny");
     }
 
     #[test]


### PR DESCRIPTION
## What

`CredentialEntry` derived `Debug` while holding plaintext secrets — the stored credential `value` and the OAuth `access_token` / `refresh_token`. Any `{:?}` rendering of an entry, or of a `CredentialStateFile` map containing them (in a trace line, an `assert_eq!` failure message, or a panic), would print the live secret.

## Change

`Debug` is now hand-written to mask the secret fields (`value`, `access_token`, `refresh_token` → `<redacted>`) while keeping the variant name and the non-secret `expires_at` visible for diagnostics. Serialization to the on-disk credentials file is unchanged (that file is the intended at-rest store, `0600`).

## Tests

Layer 3 unit test asserts each variant's `Debug` output omits the secret and keeps the non-secret expiry. `make lint`, complexity, and the lns-policy per-file coverage gate (100%) pass locally.