### PR TITLE
feat(sandbox): Address runs by name across the lifecycle

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -38,6 +38,12 @@ pub struct RunArgs {
 
     #[arg(
         long,
+        help = "Name the run, addressable in place of its id by every `lns sandbox` verb. Auto-generated (adjective_noun) when omitted; must not be all digits."
+    )]
+    pub name: Option<String>,
+
+    #[arg(
+        long,
         help = "Registry to qualify a bare image reference (e.g. ghcr.io); falls back to the `run.registry` config default. A fully-qualified reference is used as-is."
     )]
     pub registry: Option<String>,
@@ -173,8 +179,11 @@ impl RunArgs {
 
 #[derive(clap::Args)]
 pub struct ExecArgs {
-    #[arg(help = "Target run id surfaced by `lns ls` or `lns run -d`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 
     #[arg(
         short = 'i',
@@ -209,8 +218,8 @@ pub struct ExecArgs {
 
 #[derive(clap::Args)]
 pub struct KillArgs {
-    #[arg(help = "Target run id.")]
-    pub run_id: u32,
+    #[arg(value_name = "RUN", help = "Target run id or name.")]
+    pub run: String,
 
     #[arg(
         long,

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -726,6 +726,7 @@ mod tests {
     fn bare_run_args() -> RunArgs {
         RunArgs {
             image: Some("alpine".to_string()),
+            name: None,
             registry: None,
             cpus: None,
             mem: None,

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -191,6 +191,7 @@ mod tests {
     fn run_args(image: Option<&str>) -> RunArgs {
         RunArgs {
             image: image.map(str::to_string),
+            name: None,
             registry: None,
             cpus: None,
             mem: None,

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -41,14 +41,19 @@ pub enum SandboxCommand {
         about = "Remove a finished run from the list (`docker rm`-style; refuses running runs)."
     )]
     Rm(SandboxRmArgs),
+    #[command(about = "Rename a run (`docker rename`-style); the new name resolves immediately.")]
+    Rename(SandboxRenameArgs),
     #[command(about = "Remove all finished runs from the list (`docker container prune`-style).")]
     Prune,
 }
 
 #[derive(clap::Args)]
 pub struct SandboxStopArgs {
-    #[arg(help = "Target run id surfaced by `lns ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 
     #[arg(
         short = 't',
@@ -61,8 +66,11 @@ pub struct SandboxStopArgs {
 
 #[derive(clap::Args)]
 pub struct SandboxLogsArgs {
-    #[arg(help = "Target run id surfaced by `lns ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 
     #[arg(
         short = 'f',
@@ -75,8 +83,11 @@ pub struct SandboxLogsArgs {
 
 #[derive(clap::Args)]
 pub struct SandboxAttachArgs {
-    #[arg(help = "Target run id surfaced by `lns ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 
     #[arg(
         long,
@@ -89,25 +100,46 @@ pub struct SandboxAttachArgs {
 
 #[derive(clap::Args)]
 pub struct SandboxInspectArgs {
-    #[arg(help = "Target run id surfaced by `lns ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 }
 
 #[derive(clap::Args)]
 pub struct SandboxStatsArgs {
-    #[arg(help = "Target run id surfaced by `lns ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
 }
 
 #[derive(clap::Args)]
 pub struct SandboxRmArgs {
-    #[arg(help = "Target finished run id surfaced by `lns sandbox ls`.")]
-    pub run_id: u32,
+    #[arg(
+        value_name = "RUN",
+        help = "Target finished run id or name surfaced by `lns sandbox ls`."
+    )]
+    pub run: String,
+}
+
+#[derive(clap::Args)]
+pub struct SandboxRenameArgs {
+    #[arg(value_name = "RUN", help = "Run to rename, by current id or name.")]
+    pub run: String,
+
+    #[arg(
+        value_name = "NEW_NAME",
+        help = "New name; must not be all digits and must be unique among listed runs."
+    )]
+    pub new_name: String,
 }
 
 pub fn augment(app: clap::Command) -> clap::Command {
     app.subcommand(subcommand::<SandboxArgs>("sandbox").about(
-        "Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, prune.",
+        "Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.",
     ))
 }
 
@@ -156,7 +188,16 @@ where
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
+        SandboxCommand::Rename(args) => rename(svc, args, out).await,
         SandboxCommand::Prune => prune(svc, out).await,
+    }
+}
+
+pub(crate) fn run_label(run: &str) -> String {
+    if !run.is_empty() && run.bytes().all(|b| b.is_ascii_digit()) {
+        format!("#{run}")
+    } else {
+        run.to_string()
     }
 }
 
@@ -181,13 +222,13 @@ async fn kill<W: std::io::Write>(
     let signal = crate::service::parse_signal_name(&args.signal)?;
     let response = svc
         .one_shot(Request::Kill {
-            run_id: args.run_id,
+            run: args.run.clone(),
             signal,
         })
         .await?;
     match response {
         Response::Acknowledged => {
-            writeln!(out, "killed run #{}", args.run_id)?;
+            writeln!(out, "killed run {}", run_label(&args.run))?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -202,20 +243,21 @@ async fn stop<W: std::io::Write>(
 ) -> Result<i32> {
     let response = svc
         .one_shot(Request::StopRun {
-            run_id: args.run_id,
+            run: args.run.clone(),
             timeout_secs: args.timeout,
         })
         .await?;
     match response {
         Response::RunStopped { forced: false } => {
-            writeln!(out, "stopped run #{}", args.run_id)?;
+            writeln!(out, "stopped run {}", run_label(&args.run))?;
             Ok(0)
         }
         Response::RunStopped { forced: true } => {
             writeln!(
                 out,
-                "killed run #{} after the {}s timeout",
-                args.run_id, args.timeout
+                "killed run {} after the {}s timeout",
+                run_label(&args.run),
+                args.timeout
             )?;
             Ok(0)
         }
@@ -231,12 +273,38 @@ async fn rm<W: std::io::Write>(
 ) -> Result<i32> {
     let response = svc
         .one_shot(Request::RemoveRun {
-            run_id: args.run_id,
+            run: args.run.clone(),
         })
         .await?;
     match response {
         Response::Acknowledged => {
-            writeln!(out, "removed run #{}", args.run_id)?;
+            writeln!(out, "removed run {}", run_label(&args.run))?;
+            Ok(0)
+        }
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+async fn rename<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &SandboxRenameArgs,
+    out: &mut W,
+) -> Result<i32> {
+    let response = svc
+        .one_shot(Request::RenameRun {
+            run: args.run.clone(),
+            new_name: args.new_name.clone(),
+        })
+        .await?;
+    match response {
+        Response::Acknowledged => {
+            writeln!(
+                out,
+                "renamed run {} to {}",
+                run_label(&args.run),
+                args.new_name
+            )?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -270,7 +338,7 @@ async fn inspect<W: std::io::Write>(
 ) -> Result<i32> {
     let response = svc
         .one_shot(Request::InspectRun {
-            run_id: args.run_id,
+            run: args.run.clone(),
         })
         .await?;
     match response {
@@ -345,7 +413,7 @@ async fn stats<W: std::io::Write>(
 ) -> Result<i32> {
     let response = svc
         .one_shot(Request::RunStats {
-            run_id: args.run_id,
+            run: args.run.clone(),
         })
         .await?;
     match response {
@@ -402,7 +470,7 @@ where
 {
     let mut stream = svc
         .open_stream(Request::RunLogs {
-            run_id: args.run_id,
+            run: args.run.clone(),
             follow: args.follow,
         })
         .await?;
@@ -424,7 +492,7 @@ where
 {
     let mut stream = svc
         .open_stream(Request::AttachRun {
-            run_id: args.run_id,
+            run: args.run.clone(),
         })
         .await?;
     let run_id = expect_run_started(&mut stream).await?;
@@ -536,7 +604,7 @@ mod tests {
 
     fn stop_args(run_id: u32) -> SandboxStopArgs {
         SandboxStopArgs {
-            run_id,
+            run: run_id.to_string(),
             timeout: 10,
         }
     }
@@ -545,7 +613,7 @@ mod tests {
     async fn run_with_writers_refuses_the_interactive_exec_verb() {
         let svc = CannedService::new(Response::Pong);
         let cmd = SandboxCommand::Exec(crate::cli::ExecArgs {
-            run_id: 1,
+            run: "1".into(),
             interactive: false,
             tty: false,
             detach_keys: crate::cli::DetachChord(Vec::new()),
@@ -594,7 +662,7 @@ mod tests {
         let err = kill(
             &svc,
             &crate::cli::KillArgs {
-                run_id: 1,
+                run: "1".into(),
                 signal: "TERM".into(),
             },
             &mut out,
@@ -611,7 +679,7 @@ mod tests {
         let err = kill(
             &svc,
             &crate::cli::KillArgs {
-                run_id: 1,
+                run: "1".into(),
                 signal: "TERM".into(),
             },
             &mut out,
@@ -633,7 +701,7 @@ mod tests {
     async fn inspect_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = inspect(&svc, &SandboxInspectArgs { run_id: 1 }, &mut out)
+        let err = inspect(&svc, &SandboxInspectArgs { run: "1".into() }, &mut out)
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
@@ -645,7 +713,7 @@ mod tests {
             message: "no active run with id 1".into(),
         });
         let mut out = Vec::new();
-        let err = inspect(&svc, &SandboxInspectArgs { run_id: 1 }, &mut out)
+        let err = inspect(&svc, &SandboxInspectArgs { run: "1".into() }, &mut out)
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("no active run with id 1"));
@@ -655,7 +723,7 @@ mod tests {
     async fn stats_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = stats(&svc, &SandboxStatsArgs { run_id: 1 }, &mut out)
+        let err = stats(&svc, &SandboxStatsArgs { run: "1".into() }, &mut out)
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
@@ -667,7 +735,7 @@ mod tests {
             message: "macOS-only".into(),
         });
         let mut out = Vec::new();
-        let err = stats(&svc, &SandboxStatsArgs { run_id: 1 }, &mut out)
+        let err = stats(&svc, &SandboxStatsArgs { run: "1".into() }, &mut out)
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("macOS-only"));
@@ -677,10 +745,48 @@ mod tests {
     async fn rm_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = rm(&svc, &SandboxRmArgs { run_id: 1 }, &mut out)
+        let err = rm(&svc, &SandboxRmArgs { run: "1".into() }, &mut out)
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[tokio::test]
+    async fn rename_rejects_an_unrelated_response_variant() {
+        let svc = CannedService::new(Response::Pong);
+        let mut out = Vec::new();
+        let err = rename(
+            &svc,
+            &SandboxRenameArgs {
+                run: "reviewer".into(),
+                new_name: "auditor".into(),
+            },
+            &mut out,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[tokio::test]
+    async fn rename_confirms_with_the_handle_and_new_name() {
+        let svc = CannedService::new(Response::Acknowledged);
+        let mut out = Vec::new();
+        let code = rename(
+            &svc,
+            &SandboxRenameArgs {
+                run: "reviewer".into(),
+                new_name: "auditor".into(),
+            },
+            &mut out,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "renamed run reviewer to auditor\n"
+        );
     }
 
     #[tokio::test]
@@ -783,7 +889,7 @@ mod tests {
         let err = logs(
             &svc,
             &SandboxLogsArgs {
-                run_id: 1,
+                run: "1".into(),
                 follow: false,
             },
             &mut stdout,
@@ -806,7 +912,7 @@ mod tests {
         let code = attach(
             &svc,
             &SandboxAttachArgs {
-                run_id: 9,
+                run: "9".into(),
                 detach_keys: crate::cli::DetachChord(Vec::new()),
             },
             TermInfo::default(),
@@ -829,6 +935,7 @@ mod tests {
             details: Box::new(RunDetails {
                 summary: lns_ipc::RunSummary {
                     id: 1,
+                    name: "reviewer".into(),
                     image: "some-image".into(),
                     command: String::new(),
                     status: lns_ipc::RunStatus::Running,
@@ -841,7 +948,7 @@ mod tests {
             }),
         });
         let mut out = Vec::new();
-        let code = inspect(&svc, &SandboxInspectArgs { run_id: 1 }, &mut out)
+        let code = inspect(&svc, &SandboxInspectArgs { run: "1".into() }, &mut out)
             .await
             .unwrap();
         assert_eq!(code, 0);

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -257,6 +257,9 @@ pub(crate) fn render_ls_table<W: std::io::Write>(
     let id_w = "ID"
         .len()
         .max(rows.iter().map(|r| count_digits(r.id)).max().unwrap_or(0));
+    let name_w = "NAME"
+        .len()
+        .max(rows.iter().map(|r| r.name.len()).max().unwrap_or(0));
     let status_w = "STATUS".len().max(
         rows.iter()
             .map(|r| status_str(r.status).len())
@@ -272,12 +275,14 @@ pub(crate) fn render_ls_table<W: std::io::Write>(
 
     writeln!(
         out,
-        "{:<id_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  STARTED",
+        "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  STARTED",
         "ID",
+        "NAME",
         "STATUS",
         "IMAGE",
         "COMMAND",
         id_w = id_w,
+        name_w = name_w,
         status_w = status_w,
         image_w = image_w,
         cmd_w = cmd_w,
@@ -285,13 +290,15 @@ pub(crate) fn render_ls_table<W: std::io::Write>(
     for r in rows {
         writeln!(
             out,
-            "{:<id_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  {}",
+            "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  {}",
             r.id,
+            r.name,
             status_str(r.status),
             r.image,
             r.command,
             friendly_started(&r.started),
             id_w = id_w,
+            name_w = name_w,
             status_w = status_w,
             image_w = image_w,
             cmd_w = cmd_w,
@@ -667,6 +674,7 @@ exit 0
     fn render_ls_table_emits_header_and_one_row_per_run() {
         let rows = vec![RunSummary {
             id: 7,
+            name: "reviewer".into(),
             image: "alpine:3.20".into(),
             command: "echo hi".into(),
             started: "2024-03-15T08:30:00Z".into(),
@@ -675,13 +683,14 @@ exit 0
         let mut buf: Vec<u8> = Vec::new();
         render_ls_table(&mut buf, &rows).expect("render");
         let out = String::from_utf8(buf).unwrap();
-        for tok in ["ID", "STATUS", "STARTED", "IMAGE", "COMMAND"] {
+        for tok in ["ID", "NAME", "STATUS", "STARTED", "IMAGE", "COMMAND"] {
             assert!(
                 out.contains(tok),
                 "expected header token {tok:?} in {out:?}"
             );
         }
         assert!(out.contains("7"), "id 7 missing in {out:?}");
+        assert!(out.contains("reviewer"), "name missing in {out:?}");
         assert!(out.contains("alpine:3.20"), "image missing in {out:?}");
     }
 
@@ -697,6 +706,7 @@ exit 0
     fn render_ls_table_renders_exited_status_with_code() {
         let rows = vec![RunSummary {
             id: 42,
+            name: "auditor".into(),
             image: "<imageless>".into(),
             command: "true".into(),
             started: "2024-03-15T08:30:00Z".into(),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -123,6 +123,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         cpus: args.effective_cpus(),
         mem: args.effective_mem(),
         image: args.image,
+        name: args.name,
         policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user: args.sandbox_user,
         sandbox_uid: args.sandbox_uid,
@@ -185,7 +186,7 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
         .await
         .with_context(|| format!("connecting to {}", socket.display()))?;
 
-    let target_run_id = args.run_id;
+    let target_run = args.run;
     let tty = args.tty && crate::raw_mode::stdin_is_tty();
     let stdin = args.interactive;
     let initial_winsize = if tty {
@@ -196,7 +197,7 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     let detach_chord = args.detach_keys.0.clone();
 
     let request = Request::ExecImage(ExecImageArgs {
-        run_id: target_run_id,
+        run: target_run,
         argv: args.cmd,
         env: Vec::new(),
         tty,
@@ -228,7 +229,7 @@ pub async fn kill(args: KillArgs) -> Result<()> {
     let response = real::send_request(
         &socket,
         &Request::Kill {
-            run_id: args.run_id,
+            run: args.run.clone(),
             signal,
         },
     )
@@ -236,7 +237,7 @@ pub async fn kill(args: KillArgs) -> Result<()> {
     .ok_or_else(|| anyhow::anyhow!("no response from lns-service (is it running?)"))?;
     match response {
         Response::Acknowledged => {
-            println!("killed run #{}", args.run_id);
+            println!("killed run {}", crate::sandbox::run_label(&args.run));
             Ok(())
         }
         Response::Error { message } => anyhow::bail!("daemon error: {message}"),

--- a/crates/lns-cli/tests/behaviours/run_naming.feature
+++ b/crates/lns-cli/tests/behaviours/run_naming.feature
@@ -1,0 +1,39 @@
+Feature: addressing runs by name from the CLI
+  `lns run --name` gives a run a human handle, and every `lns sandbox`
+  verb takes that name wherever it takes a numeric run id. The CLI stays
+  thin: it forwards whatever handle the user typed and lets the service
+  resolve it, so numeric-id addressing keeps working unchanged.
+
+  Scenario: a lifecycle verb forwards a name as the run handle
+    Given the service will answer RunStopped without force
+    When the user runs sandbox command "stop reviewer"
+    Then the exit code is 0
+    And the output contains "stopped run reviewer"
+    And the service received a StopRun request for run "reviewer" with timeout 10
+
+  Scenario: numeric-id addressing is unchanged
+    Given the service will answer RunStopped without force
+    When the user runs sandbox command "stop 3"
+    Then the exit code is 0
+    And the output contains "stopped run #3"
+    And the service received a StopRun request for run "3" with timeout 10
+
+  Scenario: the run list shows a NAME column with each run's name
+    Given the service reports a run listing with run 3 named "reviewer" of image "some-image" running
+    When the user runs sandbox command "ls"
+    Then the exit code is 0
+    And the output contains "NAME"
+    And the output contains "reviewer"
+
+  Scenario: rename forwards the old and new names to the service
+    Given the service will answer Acknowledged
+    When the user runs sandbox command "rename reviewer auditor"
+    Then the exit code is 0
+    And the output contains "renamed run reviewer to auditor"
+    And the service received a RenameRun request for run "reviewer" to "auditor"
+
+  Scenario: a naming error from the service is surfaced verbatim
+    Given the service will answer an error "name reviewer already in use by run #7"
+    When the user runs sandbox command "rename auditor reviewer"
+    Then the command fails with an exit code other than 0
+    And the output contains "already in use by run #7"

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -15,6 +15,7 @@ Feature: managing running sandboxes from the CLI
     And the output contains "inspect"
     And the output contains "stats"
     And the output contains "rm"
+    And the output contains "rename"
     And the output contains "prune"
 
   Scenario: the flat ls, exec, and kill verbs stay usable but leave the front page

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -68,6 +68,7 @@ fn details_with(image: &str, config: RunConfig) -> Response {
         details: Box::new(RunDetails {
             summary: RunSummary {
                 id: 3,
+                name: "reviewer".into(),
                 image: image.to_string(),
                 command: "some-command".into(),
                 status: RunStatus::Running,
@@ -118,7 +119,9 @@ fn canned_pruned_empty(w: &mut BehaviourWorld) {
 #[then(regex = r"^the service received a RemoveRun request for run (\d+)$")]
 fn then_remove_request(w: &mut BehaviourWorld, run_id: u32) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
-    let expected = Request::RemoveRun { run_id };
+    let expected = Request::RemoveRun {
+        run: run_id.to_string(),
+    };
     if requests.contains(&expected) {
         Ok(())
     } else {
@@ -141,6 +144,7 @@ fn canned_run_listing(w: &mut BehaviourWorld, run_id: u32, image: String) {
     w.sandbox.response = Some(Response::RunList {
         runs: vec![RunSummary {
             id: run_id,
+            name: String::new(),
             image,
             command: "some-command".into(),
             status: RunStatus::Running,
@@ -163,7 +167,7 @@ fn then_list_runs_request(w: &mut BehaviourWorld) -> Result<(), String> {
 fn then_kill_request(w: &mut BehaviourWorld, run_id: u32) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
     let expected = Request::Kill {
-        run_id,
+        run: run_id.to_string(),
         signal: lns_ipc::SignalKind::Kill,
     };
     if requests.contains(&expected) {
@@ -297,7 +301,7 @@ async fn run_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
 fn then_stop_request(w: &mut BehaviourWorld, run_id: u32, timeout: u64) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
     let expected = Request::StopRun {
-        run_id,
+        run: run_id.to_string(),
         timeout_secs: timeout,
     };
     if requests.contains(&expected) {
@@ -311,7 +315,7 @@ fn then_stop_request(w: &mut BehaviourWorld, run_id: u32, timeout: u64) -> Resul
 fn then_logs_request(w: &mut BehaviourWorld, run_id: u32, mode: String) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
     let expected = Request::RunLogs {
-        run_id,
+        run: run_id.to_string(),
         follow: mode == "with",
     };
     if requests.contains(&expected) {
@@ -324,7 +328,9 @@ fn then_logs_request(w: &mut BehaviourWorld, run_id: u32, mode: String) -> Resul
 #[then(regex = r"^the service received an AttachRun request for run (\d+)$")]
 fn then_attach_request(w: &mut BehaviourWorld, run_id: u32) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
-    let expected = Request::AttachRun { run_id };
+    let expected = Request::AttachRun {
+        run: run_id.to_string(),
+    };
     if requests.contains(&expected) {
         Ok(())
     } else {
@@ -341,5 +347,54 @@ fn then_workload_stdout(w: &mut BehaviourWorld, needle: String) -> Result<(), St
         Err(format!(
             "expected workload stdout to contain {needle:?}, got {text:?}"
         ))
+    }
+}
+
+#[given(
+    regex = r#"^the service reports a run listing with run (\d+) named "([^"]+)" of image "([^"]+)" running$"#
+)]
+fn canned_named_run_listing(w: &mut BehaviourWorld, run_id: u32, name: String, image: String) {
+    w.sandbox.response = Some(Response::RunList {
+        runs: vec![RunSummary {
+            id: run_id,
+            name,
+            image,
+            command: "some-command".into(),
+            status: RunStatus::Running,
+            started: "2026-01-01T00:00:00Z".into(),
+        }],
+    });
+}
+
+#[then(regex = r#"^the service received a StopRun request for run "([^"]+)" with timeout (\d+)$"#)]
+fn then_stop_request_by_handle(
+    w: &mut BehaviourWorld,
+    run: String,
+    timeout: u64,
+) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    let expected = Request::StopRun {
+        run,
+        timeout_secs: timeout,
+    };
+    if requests.contains(&expected) {
+        Ok(())
+    } else {
+        Err(format!("expected {expected:?} among {requests:?}"))
+    }
+}
+
+#[then(regex = r#"^the service received a RenameRun request for run "([^"]+)" to "([^"]+)"$"#)]
+fn then_rename_request(
+    w: &mut BehaviourWorld,
+    run: String,
+    new_name: String,
+) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    let expected = Request::RenameRun { run, new_name };
+    if requests.contains(&expected) {
+        Ok(())
+    } else {
+        Err(format!("expected {expected:?} among {requests:?}"))
     }
 }

--- a/crates/lns-ipc/src/codec.rs
+++ b/crates/lns-ipc/src/codec.rs
@@ -245,6 +245,7 @@ mod tests {
             runs: vec![
                 crate::RunSummary {
                     id: 7,
+                    name: "reviewer".into(),
                     image: "alpine:latest".into(),
                     command: "sleep 30".into(),
                     status: crate::RunStatus::Running,
@@ -252,6 +253,7 @@ mod tests {
                 },
                 crate::RunSummary {
                     id: 8,
+                    name: "auditor".into(),
                     image: "<imageless>".into(),
                     command: String::new(),
                     status: crate::RunStatus::Exited { code: 143 },

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -17,7 +17,8 @@ pub use paths::{CachePathError, audit_anchor_for_run, audit_log_for_run, cache_r
 pub use protocol::{
     ExecImageArgs, ImageInfo, LogLevel, PortPublish, Protocol, Request, Response, RunConfig,
     RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SignalKind, StatusInfo,
-    VolumeInfo, VolumeMount, VolumePruneFailure, validate_volume_name, validate_volume_target,
+    VolumeInfo, VolumeMount, VolumePruneFailure, validate_run_name, validate_volume_name,
+    validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -30,29 +30,33 @@ pub enum Request {
     },
     ExecImage(ExecImageArgs),
     Kill {
-        run_id: u32,
+        run: String,
         signal: SignalKind,
     },
     ListRuns,
     StopRun {
-        run_id: u32,
+        run: String,
         timeout_secs: u64,
     },
     InspectRun {
-        run_id: u32,
+        run: String,
     },
     RunLogs {
-        run_id: u32,
+        run: String,
         follow: bool,
     },
     AttachRun {
-        run_id: u32,
+        run: String,
     },
     RunStats {
-        run_id: u32,
+        run: String,
     },
     RemoveRun {
-        run_id: u32,
+        run: String,
+    },
+    RenameRun {
+        run: String,
+        new_name: String,
     },
     PruneRuns,
     BeginIntegrationSignIn {
@@ -213,6 +217,7 @@ pub struct ImageInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunSummary {
     pub id: u32,
+    pub name: String,
     pub image: String,
     pub command: String,
     pub status: RunStatus,
@@ -293,6 +298,8 @@ pub struct PortPublish {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunImageArgs {
     pub image: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
     pub cpus: u8,
     pub mem: usize,
     pub policy_path: Option<String>,
@@ -389,6 +396,23 @@ fn name_char_allowed(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-')
 }
 
+pub fn validate_run_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("invalid run name: must not be empty".to_string());
+    }
+    if name.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!(
+            "invalid run name {name:?}: a name must not be all digits (those address a run by id)"
+        ));
+    }
+    match name.chars().find(|c| !name_char_allowed(*c)) {
+        Some(bad) => Err(format!(
+            "invalid run name {name:?}: character {bad:?} not allowed"
+        )),
+        None => Ok(()),
+    }
+}
+
 fn default_tty() -> bool {
     true
 }
@@ -399,7 +423,7 @@ fn default_stdin() -> bool {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecImageArgs {
-    pub run_id: u32,
+    pub run: String,
     pub argv: Vec<String>,
     pub env: Vec<String>,
     #[serde(default = "default_tty")]
@@ -426,7 +450,7 @@ mod tests {
     #[test]
     fn exec_image_args_tty_defaults_to_true_when_missing() {
         let frame = serde_json::json!({
-            "run_id": 1,
+            "run": "1",
             "argv": ["sh"],
             "env": []
         });
@@ -493,6 +517,7 @@ mod tests {
         };
         let req = Request::RunImage(RunImageArgs {
             image: Some("prism".into()),
+            name: None,
             cpus: 1,
             mem: 512,
             policy_path: None,
@@ -518,6 +543,7 @@ mod tests {
     fn run_image_args_volumes_survive_postcard_round_trip() {
         let args = RunImageArgs {
             image: Some("ubuntu".into()),
+            name: None,
             cpus: 1,
             mem: 512,
             policy_path: None,
@@ -619,7 +645,7 @@ mod tests {
     #[test]
     fn stop_run_survives_a_request_round_trip() {
         let req = Request::StopRun {
-            run_id: 7,
+            run: "7".into(),
             timeout_secs: 10,
         };
         let frame = crate::encode_frame(&req).unwrap();
@@ -630,6 +656,7 @@ mod tests {
     fn sample_run_args() -> RunImageArgs {
         RunImageArgs {
             image: Some("some-image:1".into()),
+            name: None,
             cpus: 2,
             mem: 1024,
             policy_path: Some("/work/lns-policy.yaml".into()),
@@ -674,7 +701,7 @@ mod tests {
 
     #[test]
     fn inspect_run_survives_a_request_round_trip() {
-        let req = Request::InspectRun { run_id: 3 };
+        let req = Request::InspectRun { run: "3".into() };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
         assert_eq!(decoded, req);
@@ -683,7 +710,10 @@ mod tests {
     #[test]
     fn run_logs_survives_a_request_round_trip() {
         for follow in [false, true] {
-            let req = Request::RunLogs { run_id: 3, follow };
+            let req = Request::RunLogs {
+                run: "3".into(),
+                follow,
+            };
             let frame = crate::encode_frame(&req).unwrap();
             let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
             assert_eq!(decoded, req);
@@ -692,7 +722,7 @@ mod tests {
 
     #[test]
     fn attach_run_survives_a_request_round_trip() {
-        let req = Request::AttachRun { run_id: 3 };
+        let req = Request::AttachRun { run: "3".into() };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
         assert_eq!(decoded, req);
@@ -700,7 +730,7 @@ mod tests {
 
     #[test]
     fn run_stats_survives_a_request_and_response_round_trip() {
-        let req = Request::RunStats { run_id: 3 };
+        let req = Request::RunStats { run: "3".into() };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
         assert_eq!(decoded, req);
@@ -723,6 +753,7 @@ mod tests {
             details: Box::new(RunDetails {
                 summary: RunSummary {
                     id: 3,
+                    name: "reviewer".into(),
                     image: "some-image:1".into(),
                     command: "echo hi".into(),
                     status: RunStatus::Running,
@@ -770,10 +801,41 @@ mod tests {
 
     #[test]
     fn remove_run_survives_a_request_round_trip() {
-        let req = Request::RemoveRun { run_id: 7 };
+        let req = Request::RemoveRun { run: "7".into() };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
         assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn rename_run_survives_a_request_round_trip() {
+        let req = Request::RenameRun {
+            run: "reviewer".into(),
+            new_name: "auditor".into(),
+        };
+        let frame = crate::encode_frame(&req).unwrap();
+        let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn run_image_args_name_survives_a_round_trip_and_defaults_to_none() {
+        let mut args = sample_run_args();
+        args.name = Some("reviewer".into());
+        let frame = crate::encode_frame(&args).unwrap();
+        let decoded: RunImageArgs = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded.name.as_deref(), Some("reviewer"));
+
+        let frame = serde_json::json!({
+            "image": "alpine",
+            "cpus": 1,
+            "mem": 512,
+            "policy_path": null,
+            "cmd": [],
+            "debug": false
+        });
+        let parsed: RunImageArgs = serde_json::from_value(frame).unwrap();
+        assert_eq!(parsed.name, None);
     }
 
     #[test]
@@ -958,6 +1020,29 @@ mod tests {
     fn volume_mount_parse_rejects_target_with_a_double_quote() {
         let err = VolumeMount::parse(r#"data:/d"x"#).unwrap_err();
         assert!(err.contains("must not contain whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_run_name_accepts_the_volume_charset() {
+        for ok in ["reviewer", "build-cache", "agent.v2_3", "a", "x7"] {
+            validate_run_name(ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_run_name_rejects_all_digit_names_so_ids_stay_unambiguous() {
+        let err = validate_run_name("7").unwrap_err();
+        assert!(err.contains("all digits"), "got: {err}");
+        validate_run_name("0042").unwrap_err();
+    }
+
+    #[test]
+    fn validate_run_name_rejects_empty_and_illegal_characters() {
+        validate_run_name("").unwrap_err();
+        let err = validate_run_name("has space").unwrap_err();
+        assert!(err.contains("not allowed"), "got: {err}");
+        validate_run_name("a/b").unwrap_err();
+        validate_run_name("a:b").unwrap_err();
     }
 
     #[test]

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -404,6 +404,7 @@ mod tests {
     fn running(id: u32, image: &str) -> lns_ipc::RunSummary {
         lns_ipc::RunSummary {
             id,
+            name: String::new(),
             image: image.to_string(),
             command: String::new(),
             status: lns_ipc::RunStatus::Running,

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -150,16 +150,23 @@ async fn handle_connection(
     match request {
         Request::RunImage(args) => handle_run(stream, args).await,
         Request::ExecImage(args) => handle_exec(stream, args).await,
-        Request::RunLogs { run_id, follow } => handle_logs(stream, run_id, follow).await,
-        Request::AttachRun { run_id } => handle_attach(stream, run_id).await,
-        Request::RunStats { run_id } => handle_stats(stream, run_id).await,
+        Request::RunLogs { run, follow } => handle_logs(stream, run, follow).await,
+        Request::AttachRun { run } => handle_attach(stream, run).await,
+        Request::RunStats { run } => handle_stats(stream, run).await,
         Request::BeginIntegrationSignIn { id } => handle_integration_sign_in(stream, id).await,
         other => handle_one_shot(stream, other, shutdown, started_at).await,
     }
 }
 
 #[cfg(target_os = "macos")]
-async fn handle_stats(mut stream: UnixStream, run_id: u32) -> anyhow::Result<()> {
+async fn handle_stats(mut stream: UnixStream, run: String) -> anyhow::Result<()> {
+    let run_id = match crate::run_registry::resolve(&run) {
+        Ok(id) => id,
+        Err(message) => {
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
     let response = match crate::run_registry::connector(run_id) {
         None => Response::Error {
             message: format!("no active run with id {run_id}"),
@@ -178,16 +185,23 @@ async fn handle_stats(mut stream: UnixStream, run_id: u32) -> anyhow::Result<()>
 }
 
 #[cfg(not(target_os = "macos"))]
-async fn handle_stats(mut stream: UnixStream, run_id: u32) -> anyhow::Result<()> {
+async fn handle_stats(mut stream: UnixStream, run: String) -> anyhow::Result<()> {
     let _ = write_error(
         &mut stream,
-        format!("sampling stats for run {run_id} is macOS-only in this build"),
+        format!("sampling stats for run {run} is macOS-only in this build"),
     )
     .await;
     Ok(())
 }
 
-async fn handle_logs(mut stream: UnixStream, run_id: u32, follow: bool) -> anyhow::Result<()> {
+async fn handle_logs(mut stream: UnixStream, run: String, follow: bool) -> anyhow::Result<()> {
+    let run_id = match crate::run_registry::resolve(&run) {
+        Ok(id) => id,
+        Err(message) => {
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
     let Some(buffer) = crate::run_registry::log_buffer(run_id) else {
         let _ = write_error(&mut stream, format!("no active run with id {run_id}")).await;
         return Ok(());
@@ -197,7 +211,14 @@ async fn handle_logs(mut stream: UnixStream, run_id: u32, follow: bool) -> anyho
     crate::run_log::stream_to(&buffer, &mut stream, follow, 0).await
 }
 
-async fn handle_attach(mut stream: UnixStream, run_id: u32) -> anyhow::Result<()> {
+async fn handle_attach(mut stream: UnixStream, run: String) -> anyhow::Result<()> {
+    let run_id = match crate::run_registry::resolve(&run) {
+        Ok(id) => id,
+        Err(message) => {
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
     let Some(buffer) = crate::run_registry::log_buffer(run_id) else {
         let _ = write_error(&mut stream, format!("no active run with id {run_id}")).await;
         return Ok(());
@@ -406,6 +427,13 @@ async fn handle_one_shot(
 const FRAME_CHAN_BUF: usize = 512;
 
 async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyhow::Result<()> {
+    if let Some(name) = &args.name
+        && let Err(message) = crate::run_registry::ensure_name_available(name)
+    {
+        let _ = write_error(&mut stream, message).await;
+        return Ok(());
+    }
+
     let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(FRAME_CHAN_BUF);
     let (cancel_tx, cancel_rx) = oneshot::channel::<i32>();
 
@@ -421,6 +449,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
         .unwrap_or_else(|| "<imageless>".to_string());
     let command_label = args.cmd.join(" ");
     let started_label = rfc3339_now();
+    let requested_name = args.name.clone();
     let config = lns_ipc::RunConfig::from_run_args(&args);
 
     let logs = Arc::new(crate::run_log::RunLogBuffer::default());
@@ -442,8 +471,10 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
         }
     });
 
-    crate::run_registry::register(
+    let abort = run_task.abort_handle();
+    let registered = crate::run_registry::register_named(
         run_id,
+        requested_name,
         crate::run_registry::RunHandle {
             cancel_tx,
             task: run_task,
@@ -451,6 +482,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             input_tx: Some(input_tx),
             #[cfg(target_os = "macos")]
             connector: None,
+            name: String::new(),
             image: image_label,
             command: command_label,
             started: started_label,
@@ -459,6 +491,11 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             config,
         },
     );
+    if let Err(message) = registered {
+        abort.abort();
+        let _ = write_error(&mut stream, message).await;
+        return Ok(());
+    }
 
     drop(frame_tx);
 
@@ -505,7 +542,13 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
 
 #[cfg(target_os = "macos")]
 async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> anyhow::Result<()> {
-    let target_run_id = args.run_id;
+    let target_run_id = match crate::run_registry::resolve(&args.run) {
+        Ok(id) => id,
+        Err(message) => {
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
     let Some(connector) = crate::run_registry::connector(target_run_id) else {
         let _ = write_error(
             &mut stream,

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -123,9 +123,7 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
         Request::RunSignal { run_id, signal } => {
             forward_session_input(*run_id, session_input_from_signal(*signal), "RunSignal").await
         }
-        Request::Kill { run_id, signal } => {
-            forward_session_input(*run_id, session_input_from_signal(*signal), "Kill").await
-        }
+        Request::Kill { run, signal } => kill_request(run, *signal).await,
         Request::ListRuns => Response::RunList {
             runs: crate::run_registry::snapshot(),
         },
@@ -191,37 +189,12 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             username,
             secret,
         } => login_response(crate::image::verify_login(registry, username, secret).await),
-        Request::StopRun {
-            run_id,
-            timeout_secs,
-        } => {
-            let id = *run_id;
-            stop_run_with(
-                id,
-                std::time::Duration::from_secs(*timeout_secs),
-                KILL_GRACE,
-                |signal| forward_session_input(id, session_input_from_signal(signal), "StopRun"),
-            )
-            .await
-        }
-        Request::InspectRun { run_id } => match crate::run_registry::inspect(*run_id) {
-            Some(details) => Response::RunInspect {
-                details: Box::new(details),
-            },
-            None => Response::Error {
-                message: format!("no active run with id {run_id}"),
-            },
-        },
-        Request::RemoveRun { run_id } => match crate::run_registry::remove_if_exited(*run_id) {
-            crate::run_registry::RemoveOutcome::Removed => Response::Acknowledged,
-            crate::run_registry::RemoveOutcome::Running => Response::Error {
-                message: format!(
-                    "run {run_id} is still running; stop it first with `lns sandbox stop {run_id}`"
-                ),
-            },
-            crate::run_registry::RemoveOutcome::NotFound => Response::Error {
-                message: format!("no run with id {run_id}"),
-            },
+        Request::StopRun { run, timeout_secs } => stop_run_request(run, *timeout_secs).await,
+        Request::InspectRun { run } => inspect_run_request(run),
+        Request::RemoveRun { run } => remove_run_request(run),
+        Request::RenameRun { run, new_name } => match crate::run_registry::rename(run, new_name) {
+            Ok(()) => Response::Acknowledged,
+            Err(message) => Response::Error { message },
         },
         Request::PruneRuns => Response::RunsPruned {
             removed: crate::run_registry::prune_exited(),
@@ -241,6 +214,59 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
         }
         Request::Unknown { method } => Response::Error {
             message: format!("unknown method: {method}"),
+        },
+    }
+}
+
+async fn kill_request(run: &str, signal: lns_ipc::SignalKind) -> Response {
+    match crate::run_registry::resolve(run) {
+        Ok(id) => forward_session_input(id, session_input_from_signal(signal), "Kill").await,
+        Err(message) => Response::Error { message },
+    }
+}
+
+async fn stop_run_request(run: &str, timeout_secs: u64) -> Response {
+    let id = match crate::run_registry::resolve(run) {
+        Ok(id) => id,
+        Err(message) => return Response::Error { message },
+    };
+    stop_run_with(
+        id,
+        std::time::Duration::from_secs(timeout_secs),
+        KILL_GRACE,
+        |signal| forward_session_input(id, session_input_from_signal(signal), "StopRun"),
+    )
+    .await
+}
+
+fn inspect_run_request(run: &str) -> Response {
+    match crate::run_registry::resolve(run) {
+        Ok(id) => match crate::run_registry::inspect(id) {
+            Some(details) => Response::RunInspect {
+                details: Box::new(details),
+            },
+            None => Response::Error {
+                message: format!("no active run with id {id}"),
+            },
+        },
+        Err(message) => Response::Error { message },
+    }
+}
+
+fn remove_run_request(run: &str) -> Response {
+    let id = match crate::run_registry::resolve(run) {
+        Ok(id) => id,
+        Err(message) => return Response::Error { message },
+    };
+    match crate::run_registry::remove_if_exited(id) {
+        crate::run_registry::RemoveOutcome::Removed => Response::Acknowledged,
+        crate::run_registry::RemoveOutcome::Running => Response::Error {
+            message: format!(
+                "run {id} is still running; stop it first with `lns sandbox stop {id}`"
+            ),
+        },
+        crate::run_registry::RemoveOutcome::NotFound => Response::Error {
+            message: format!("no run with id {id}"),
         },
     }
 }
@@ -391,7 +417,7 @@ pub(super) fn validate_exec(args: &lns_ipc::ExecImageArgs) -> Result<(), String>
             "lns exec -t/-i against run #{} is not yet supported (input \
              routing for exec sessions awaits an IPC discriminator); for now lns exec \
              supports non-interactive commands only",
-            args.run_id
+            args.run
         ));
     }
     Ok(())
@@ -478,6 +504,7 @@ mod tests {
         let _ = handle_request(
             &Request::RunImage(lns_ipc::RunImageArgs {
                 image: None,
+                name: None,
                 cpus: 1,
                 mem: 0,
                 policy_path: None,
@@ -734,6 +761,7 @@ mod tests {
                 task,
                 input_tx: Some(input_tx),
                 connector: None,
+                name: String::new(),
                 image: String::new(),
                 command: String::new(),
                 started: String::new(),
@@ -956,7 +984,7 @@ mod tests {
     async fn handle_request_kill_for_unregistered_run_returns_error() {
         let response = handle_request(
             &Request::Kill {
-                run_id: 999_999,
+                run: "999999".into(),
                 signal: lns_ipc::SignalKind::Kill,
             },
             Instant::now(),
@@ -966,10 +994,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_request_addressing_an_unknown_name_reports_no_such_run() {
+        for req in [
+            Request::Kill {
+                run: "ghost".into(),
+                signal: lns_ipc::SignalKind::Term,
+            },
+            Request::InspectRun {
+                run: "ghost".into(),
+            },
+            Request::RemoveRun {
+                run: "ghost".into(),
+            },
+        ] {
+            match handle_request(&req, Instant::now()).await {
+                Response::Error { message } => {
+                    assert!(message.contains("no such run: ghost"), "got: {message}");
+                }
+                other => unreachable!("expected Error for {req:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
     #[should_panic(expected = "ExecImage must be dispatched via handle_exec")]
     async fn exec_image_via_handle_request_panics() {
         let req = Request::ExecImage(lns_ipc::ExecImageArgs {
-            run_id: 1,
+            run: "1".into(),
             argv: vec![],
             env: vec![],
             tty: false,
@@ -1021,6 +1072,7 @@ mod tests {
             input_tx: None,
             #[cfg(target_os = "macos")]
             connector: None,
+            name: String::new(),
             image: "test-image".into(),
             command: "".into(),
             started: "1970-01-01T00:00:00Z".into(),
@@ -1049,6 +1101,7 @@ mod tests {
             task,
             input_tx: Some(input_tx),
             connector: None,
+            name: String::new(),
             image: "closed-channel-test".into(),
             command: "".into(),
             started: "1970-01-01T00:00:00Z".into(),
@@ -1165,6 +1218,7 @@ mod tests {
                 input_tx: None,
                 #[cfg(target_os = "macos")]
                 connector: None,
+                name: "reviewer".into(),
                 image: "stop-test".into(),
                 command: String::new(),
                 started: "1970-01-01T00:00:00Z".into(),
@@ -1199,7 +1253,7 @@ mod tests {
     async fn run_logs_via_handle_request_panics() {
         let _ = handle_request(
             &Request::RunLogs {
-                run_id: 1,
+                run: "1".into(),
                 follow: false,
             },
             Instant::now(),
@@ -1210,18 +1264,24 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "Request::AttachRun must be dispatched via handle_attach")]
     async fn attach_run_via_handle_request_panics() {
-        let _ = handle_request(&Request::AttachRun { run_id: 1 }, Instant::now()).await;
+        let _ = handle_request(&Request::AttachRun { run: "1".into() }, Instant::now()).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "Request::RunStats must be dispatched via handle_stats")]
     async fn run_stats_via_handle_request_panics() {
-        let _ = handle_request(&Request::RunStats { run_id: 1 }, Instant::now()).await;
+        let _ = handle_request(&Request::RunStats { run: "1".into() }, Instant::now()).await;
     }
 
     #[tokio::test]
     async fn handle_request_inspect_run_for_unknown_run_returns_error() {
-        let resp = handle_request(&Request::InspectRun { run_id: 999_998 }, Instant::now()).await;
+        let resp = handle_request(
+            &Request::InspectRun {
+                run: "999998".into(),
+            },
+            Instant::now(),
+        )
+        .await;
         match resp {
             Response::Error { message } => {
                 assert!(message.contains("no active run"), "got: {message}");
@@ -1235,7 +1295,13 @@ mod tests {
         let id = crate::run_registry::allocate_run_id();
         register_running(id);
 
-        let resp = handle_request(&Request::InspectRun { run_id: id }, Instant::now()).await;
+        let resp = handle_request(
+            &Request::InspectRun {
+                run: id.to_string(),
+            },
+            Instant::now(),
+        )
+        .await;
 
         match resp {
             Response::RunInspect { details } => {
@@ -1273,7 +1339,7 @@ mod tests {
     async fn handle_request_stop_run_for_unknown_run_returns_error() {
         let resp = handle_request(
             &Request::StopRun {
-                run_id: 999_999,
+                run: "999999".into(),
                 timeout_secs: 1,
             },
             Instant::now(),
@@ -1451,6 +1517,7 @@ mod tests {
                 task,
                 input_tx: Some(input_tx),
                 connector: None,
+                name: String::new(),
                 image: String::new(),
                 command: String::new(),
                 started: String::new(),
@@ -1471,7 +1538,7 @@ mod tests {
 
         let resp = handle_request(
             &Request::StopRun {
-                run_id: id,
+                run: id.to_string(),
                 timeout_secs: 10,
             },
             Instant::now(),
@@ -1491,7 +1558,7 @@ mod tests {
 
         let resp = handle_request(
             &Request::StopRun {
-                run_id: id,
+                run: id.to_string(),
                 timeout_secs: 1,
             },
             Instant::now(),
@@ -1510,7 +1577,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn exec_args(argv: Vec<String>, tty: bool, stdin: bool) -> lns_ipc::ExecImageArgs {
         lns_ipc::ExecImageArgs {
-            run_id: 42,
+            run: "42".into(),
             argv,
             env: Vec::new(),
             tty,
@@ -1548,7 +1615,7 @@ mod tests {
     #[test]
     fn build_session_params_maps_fields_and_winsize() {
         let args = lns_ipc::ExecImageArgs {
-            run_id: 1,
+            run: "1".into(),
             argv: vec!["echo".into()],
             env: vec!["A=B".into()],
             tty: false,

--- a/crates/lns-service/src/lib.rs
+++ b/crates/lns-service/src/lib.rs
@@ -24,6 +24,7 @@ pub mod paths;
 pub mod relay;
 pub mod run;
 pub mod run_log;
+pub mod run_name;
 pub mod run_registry;
 pub mod runtime_layer;
 pub mod shutdown;

--- a/crates/lns-service/src/run_name.rs
+++ b/crates/lns-service/src/run_name.rs
@@ -1,0 +1,58 @@
+const ADJECTIVES: &[&str] = &[
+    "amber", "bold", "calm", "dapper", "eager", "fuzzy", "gentle", "hardy", "ivory", "jolly",
+    "keen", "lucid", "mellow", "nimble", "olive", "plucky", "quiet", "rapid", "sleek", "tidy",
+    "upbeat", "vivid", "witty", "zesty",
+];
+
+const NOUNS: &[&str] = &[
+    "otter", "falcon", "maple", "comet", "harbor", "lynx", "quartz", "willow", "ember", "badger",
+    "cedar", "marlin", "puffin", "ridge", "sparrow", "thistle", "walrus", "yak", "zephyr",
+    "beacon", "cypress", "delta", "grove", "heron",
+];
+
+pub fn name_for_index(i: usize) -> String {
+    let adjective = ADJECTIVES[i % ADJECTIVES.len()];
+    let noun = NOUNS[(i / ADJECTIVES.len()) % NOUNS.len()];
+    format!("{adjective}_{noun}")
+}
+
+pub fn pool_size() -> usize {
+    ADJECTIVES.len() * NOUNS.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_for_index_is_adjective_underscore_noun() {
+        let name = name_for_index(0);
+        let (adj, noun) = name.split_once('_').expect("adjective_noun shape");
+        assert!(ADJECTIVES.contains(&adj));
+        assert!(NOUNS.contains(&noun));
+    }
+
+    #[test]
+    fn consecutive_indices_vary_the_adjective_before_repeating_a_noun() {
+        assert_ne!(name_for_index(0), name_for_index(1));
+        assert_eq!(
+            name_for_index(0),
+            name_for_index(ADJECTIVES.len() * NOUNS.len())
+        );
+    }
+
+    #[test]
+    fn an_auto_name_is_never_all_digits() {
+        for i in [0, 1, 7, 23, 24, 600] {
+            assert!(lns_ipc::validate_run_name(&name_for_index(i)).is_ok());
+        }
+    }
+
+    #[test]
+    fn the_pool_holds_pool_size_distinct_names_before_repeating() {
+        let names: std::collections::HashSet<String> =
+            (0..pool_size()).map(name_for_index).collect();
+        assert_eq!(names.len(), pool_size());
+        assert_eq!(name_for_index(0), name_for_index(pool_size()));
+    }
+}

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
-use lns_ipc::RunStatus;
+use lns_ipc::{RunStatus, validate_run_name};
+
+use crate::run_name;
 #[cfg(target_os = "macos")]
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -16,6 +18,8 @@ use crate::vm::session_client::SessionInput;
 
 static NEXT_RUN_ID: AtomicU32 = AtomicU32::new(1);
 
+static NEXT_NAME_SEQ: AtomicUsize = AtomicUsize::new(0);
+
 static ACTIVE: Mutex<Option<HashMap<u32, RunHandle>>> = Mutex::new(None);
 
 pub struct RunHandle {
@@ -25,6 +29,7 @@ pub struct RunHandle {
     pub input_tx: Option<mpsc::Sender<SessionInput>>,
     #[cfg(target_os = "macos")]
     pub connector: Option<std::sync::Arc<VsockConnector>>,
+    pub name: String,
     pub image: String,
     pub command: String,
     pub started: String,
@@ -56,6 +61,110 @@ fn max_run_id_in(runs_dir: &Path) -> u32 {
 pub fn register(run_id: u32, handle: RunHandle) {
     let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
     g.get_or_insert_with(HashMap::new).insert(run_id, handle);
+}
+
+pub fn register_named(
+    run_id: u32,
+    requested: Option<String>,
+    handle: RunHandle,
+) -> Result<String, String> {
+    let mut next_name = || run_name::name_for_index(NEXT_NAME_SEQ.fetch_add(1, Ordering::Relaxed));
+    let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
+    let map = g.get_or_insert_with(HashMap::new);
+    register_named_in(map, run_id, requested, handle, &mut next_name)
+}
+
+fn register_named_in(
+    map: &mut HashMap<u32, RunHandle>,
+    run_id: u32,
+    requested: Option<String>,
+    mut handle: RunHandle,
+    next_name: &mut dyn FnMut() -> String,
+) -> Result<String, String> {
+    let name = match requested {
+        Some(requested) => {
+            check_name_available(Some(&*map), &requested)?;
+            requested
+        }
+        None => unique_auto_name(map, next_name),
+    };
+    handle.name = name.clone();
+    map.insert(run_id, handle);
+    Ok(name)
+}
+
+pub fn ensure_name_available(name: &str) -> Result<(), String> {
+    let g = ACTIVE.lock().expect("ACTIVE poisoned");
+    check_name_available(g.as_ref(), name)
+}
+
+fn check_name_available(map: Option<&HashMap<u32, RunHandle>>, name: &str) -> Result<(), String> {
+    validate_run_name(name)?;
+    match map.and_then(|m| name_holder(m, name)) {
+        Some(holder) => Err(format!("name {name:?} already in use by run #{holder}")),
+        None => Ok(()),
+    }
+}
+
+fn unique_auto_name(
+    map: &HashMap<u32, RunHandle>,
+    next_name: &mut dyn FnMut() -> String,
+) -> String {
+    for _ in 0..run_name::pool_size() {
+        let candidate = next_name();
+        if name_holder(map, &candidate).is_none() {
+            return candidate;
+        }
+    }
+    let base = next_name();
+    (0..=map.len() as u32)
+        .map(|n| format!("{base}_{n}"))
+        .find(|name| name_holder(map, name).is_none())
+        .expect("more distinct suffixes than names in use")
+}
+
+fn name_holder(map: &HashMap<u32, RunHandle>, name: &str) -> Option<u32> {
+    map.iter().find(|(_, h)| h.name == name).map(|(id, _)| *id)
+}
+
+pub fn resolve(handle: &str) -> Result<u32, String> {
+    let g = ACTIVE.lock().expect("ACTIVE poisoned");
+    resolve_in(g.as_ref(), handle)
+}
+
+fn resolve_in(map: Option<&HashMap<u32, RunHandle>>, handle: &str) -> Result<u32, String> {
+    if let Ok(id) = handle.parse::<u32>() {
+        return Ok(id);
+    }
+    map.and_then(|m| name_holder(m, handle))
+        .ok_or_else(|| format!("no such run: {handle}"))
+}
+
+pub fn rename(handle: &str, new_name: &str) -> Result<(), String> {
+    let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
+    rename_in(g.as_mut(), handle, new_name)
+}
+
+fn rename_in(
+    map: Option<&mut HashMap<u32, RunHandle>>,
+    handle: &str,
+    new_name: &str,
+) -> Result<(), String> {
+    validate_run_name(new_name)?;
+    let map = map.ok_or_else(|| format!("no such run: {handle}"))?;
+    let target = resolve_in(Some(&*map), handle)?;
+    if let Some(holder) = name_holder(map, new_name)
+        && holder != target
+    {
+        return Err(format!("name {new_name:?} already in use by run #{holder}"));
+    }
+    match map.get_mut(&target) {
+        Some(h) => {
+            h.name = new_name.to_string();
+            Ok(())
+        }
+        None => Err(format!("no such run: {handle}")),
+    }
 }
 
 pub fn deregister(run_id: u32) {
@@ -138,6 +247,7 @@ fn summary_of(id: u32, h: &RunHandle) -> lns_ipc::RunSummary {
     let status = h.status.lock().map(|s| *s).unwrap_or(RunStatus::Running);
     lns_ipc::RunSummary {
         id,
+        name: h.name.clone(),
         image: h.image.clone(),
         command: h.command.clone(),
         status,
@@ -233,6 +343,7 @@ mod tests {
                 input_tx: None,
                 #[cfg(target_os = "macos")]
                 connector: None,
+                name: String::new(),
                 image: String::new(),
                 command: String::new(),
                 started: String::new(),
@@ -242,6 +353,198 @@ mod tests {
             },
             cancel_rx,
         )
+    }
+
+    fn gen_amber() -> String {
+        "amber_otter".to_string()
+    }
+
+    async fn named_handle(map: &mut HashMap<u32, RunHandle>, id: u32, name: &str) {
+        let (mut h, _rx) = make_handle();
+        h.name = name.to_string();
+        map.insert(id, h);
+    }
+
+    #[tokio::test]
+    async fn register_named_in_keeps_an_explicit_valid_name() {
+        let mut map = HashMap::new();
+        let (h, _rx) = make_handle();
+        let name = register_named_in(
+            &mut map,
+            1,
+            Some("reviewer".into()),
+            h,
+            &mut (gen_amber as fn() -> String),
+        )
+        .unwrap();
+        assert_eq!(name, "reviewer");
+        assert_eq!(map.get(&1).unwrap().name, "reviewer");
+    }
+
+    #[tokio::test]
+    async fn register_named_in_rejects_a_name_held_by_a_listed_run() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 7, "reviewer").await;
+        let (h, _rx) = make_handle();
+        let err = register_named_in(
+            &mut map,
+            8,
+            Some("reviewer".into()),
+            h,
+            &mut (gen_amber as fn() -> String),
+        )
+        .unwrap_err();
+        assert!(err.contains("already in use by run #7"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn register_named_in_rejects_an_invalid_explicit_name() {
+        let mut map = HashMap::new();
+        let (h, _rx) = make_handle();
+        register_named_in(
+            &mut map,
+            1,
+            Some("7".into()),
+            h,
+            &mut (gen_amber as fn() -> String),
+        )
+        .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn register_named_in_auto_generates_when_no_name_is_requested() {
+        let mut map = HashMap::new();
+        let (h, _rx) = make_handle();
+        let name =
+            register_named_in(&mut map, 1, None, h, &mut (gen_amber as fn() -> String)).unwrap();
+        assert_eq!(name, "amber_otter");
+    }
+
+    #[tokio::test]
+    async fn register_named_in_regenerates_until_the_auto_name_is_unique() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 7, "amber_otter").await;
+        let (h, _rx) = make_handle();
+        let mut seq = ["amber_otter", "amber_otter", "bold_falcon"].into_iter();
+        let mut next_name = || seq.next().unwrap().to_string();
+        let name = register_named_in(&mut map, 8, None, h, &mut next_name).unwrap();
+        assert_eq!(name, "bold_falcon");
+    }
+
+    #[tokio::test]
+    async fn register_named_in_suffixes_a_name_when_the_pretty_pool_is_exhausted() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 7, "amber_otter").await;
+        let (h, _rx) = make_handle();
+        let mut next_name = || "amber_otter".to_string();
+        let name = register_named_in(&mut map, 8, None, h, &mut next_name).unwrap();
+        assert_eq!(name, "amber_otter_0");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(global_runs)]
+    async fn ensure_name_available_rejects_taken_or_invalid_names_and_accepts_free_ones() {
+        let id = allocate_run_id();
+        let (h, _rx) = make_handle();
+        register_named(id, Some(format!("rev-{id}")), h).unwrap();
+        assert!(ensure_name_available(&format!("rev-{id}")).is_err());
+        assert!(ensure_name_available("7").is_err());
+        assert!(ensure_name_available(&format!("free-{id}")).is_ok());
+        deregister(id);
+    }
+
+    #[tokio::test]
+    async fn resolve_in_passes_numeric_ids_through_and_looks_up_names() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        assert_eq!(resolve_in(Some(&map), "3"), Ok(3));
+        assert_eq!(resolve_in(Some(&map), "reviewer"), Ok(3));
+        // Numeric handles pass through unchecked; the downstream id-op is the existence gate.
+        assert_eq!(resolve_in(Some(&map), "9"), Ok(9));
+        assert_eq!(resolve_in(None, "5"), Ok(5));
+        assert!(
+            resolve_in(Some(&map), "ghost")
+                .unwrap_err()
+                .contains("no such run: ghost")
+        );
+        assert!(
+            resolve_in(None, "reviewer")
+                .unwrap_err()
+                .contains("no such run")
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_in_changes_the_name_in_place() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        rename_in(Some(&mut map), "reviewer", "auditor").unwrap();
+        assert_eq!(map.get(&3).unwrap().name, "auditor");
+        assert_eq!(resolve_in(Some(&map), "auditor"), Ok(3));
+        assert!(
+            resolve_in(Some(&map), "reviewer")
+                .unwrap_err()
+                .contains("no such run")
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_in_to_a_held_name_is_refused() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        named_handle(&mut map, 4, "auditor").await;
+        let err = rename_in(Some(&mut map), "auditor", "reviewer").unwrap_err();
+        assert!(err.contains("already in use by run #3"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rename_in_to_the_runs_own_name_is_a_noop_success() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        rename_in(Some(&mut map), "reviewer", "reviewer").unwrap();
+        assert_eq!(map.get(&3).unwrap().name, "reviewer");
+    }
+
+    #[tokio::test]
+    async fn rename_in_rejects_an_invalid_new_name() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        rename_in(Some(&mut map), "reviewer", "7").unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn rename_in_reports_no_such_run_for_unknown_name_id_or_empty_registry() {
+        let mut map = HashMap::new();
+        named_handle(&mut map, 3, "reviewer").await;
+        let err = rename_in(Some(&mut map), "ghost", "auditor").unwrap_err();
+        assert!(err.contains("no such run: ghost"), "got: {err}");
+        let err = rename_in(Some(&mut map), "999", "auditor").unwrap_err();
+        assert!(err.contains("no such run: 999"), "got: {err}");
+        let err = rename_in(None, "ghost", "auditor").unwrap_err();
+        assert!(err.contains("no such run: ghost"), "got: {err}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(global_runs)]
+    async fn register_named_assigns_an_auto_name_and_resolves_by_name_and_id() {
+        let id = allocate_run_id();
+        let (h, _rx) = make_handle();
+        let name = register_named(id, None, h).unwrap();
+        assert!(!name.is_empty());
+        assert_eq!(resolve(&name), Ok(id));
+        assert_eq!(resolve(&id.to_string()), Ok(id));
+        deregister(id);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(global_runs)]
+    async fn rename_via_the_global_registry_updates_the_name() {
+        let id = allocate_run_id();
+        let (h, _rx) = make_handle();
+        register_named(id, Some(format!("rev-{id}")), h).unwrap();
+        rename(&format!("rev-{id}"), &format!("aud-{id}")).unwrap();
+        assert_eq!(resolve(&format!("aud-{id}")), Ok(id));
+        deregister(id);
     }
 
     #[tokio::test]

--- a/crates/lns-service/tests/behaviours/image_rig.rs
+++ b/crates/lns-service/tests/behaviours/image_rig.rs
@@ -162,6 +162,7 @@ impl ImageRig {
         self.holder_run_id = Some(run_id);
         self.active.push(lns_ipc::RunSummary {
             id: run_id,
+            name: String::new(),
             image: reference.to_string(),
             command: String::new(),
             status: lns_ipc::RunStatus::Running,

--- a/crates/lns-service/tests/behaviours/run_naming.feature
+++ b/crates/lns-service/tests/behaviours/run_naming.feature
@@ -1,0 +1,78 @@
+@serial
+Feature: naming runs — the service owns names and resolution
+  Every run carries a numeric id and a name. `--name` sets the name;
+  omitting it auto-generates an adjective_noun one. Names are unique
+  among listed runs, are addressable in place of the id, and are freed
+  for reuse once their run is removed. `lns sandbox rename` changes a
+  run's name in place.
+
+  Scenario: a run registered without a name is auto-assigned an adjective_noun name
+    Given a fresh service handler
+    When a run is registered without a name
+    Then the run is assigned a non-empty name
+    And the assigned name is not all digits
+
+  Scenario: a run registered with a name keeps that name
+    Given a fresh service handler
+    When a run is registered with the name "reviewer"
+    Then the run's name is "reviewer"
+
+  Scenario: a name already held by a listed run is rejected
+    Given a registered run named "reviewer"
+    When a run is registered with the name "reviewer"
+    Then registration is refused
+    And the refusal contains "already in use by run"
+
+  Scenario: auto-generation regenerates until the name is unique among listed runs
+    Given a registered run whose name is the generator's first pick
+    When a run is registered without a name
+    Then the auto-assigned name differs from every listed run's name
+
+  Scenario: a name resolves to its run, as does the numeric id
+    Given a registered run named "reviewer" that has already exited
+    When a StopRun request for run "reviewer" arrives
+    Then the response is RunStopped without force
+    When a StopRun request for that run's numeric id arrives
+    Then the response is RunStopped without force
+
+  Scenario: an unknown name surfaces a "no such run" error
+    Given a fresh service handler
+    When a StopRun request for run "ghost" arrives
+    Then the response is Error
+    And the error message contains "no such run: ghost"
+
+  Scenario: a name frees up once its run is removed and can be reused
+    Given a registered run named "reviewer" that has already exited
+    When a RemoveRun request for run "reviewer" arrives
+    Then the response is Acknowledged
+    And a run can then be registered with the name "reviewer"
+
+  Scenario: an all-digit name is rejected
+    Given a fresh service handler
+    When a run is registered with the name "7"
+    Then registration is refused
+    And the refusal explains a name must not be all digits
+
+  Scenario: a name with an illegal character is rejected
+    Given a fresh service handler
+    When a run is registered with the name "has space"
+    Then registration is refused
+
+  Scenario: rename changes the name in place
+    Given a registered run named "reviewer"
+    When a RenameRun request renames "reviewer" to "auditor"
+    Then the response is Acknowledged
+    And the run resolves by the name "auditor"
+    And the run no longer resolves by the name "reviewer"
+
+  Scenario: rename to a held name is refused
+    Given a registered run named "reviewer"
+    And a registered run named "auditor"
+    When a RenameRun request renames "auditor" to "reviewer"
+    Then the response is Error
+    And the error message contains "already in use"
+
+  Scenario: rename to an all-digit name is refused
+    Given a registered run named "reviewer"
+    When a RenameRun request renames "reviewer" to "7"
+    Then the response is Error

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -7,6 +7,7 @@ pub mod ipc;
 pub mod oauth_integration;
 pub mod pkce_integration;
 pub mod run_lifecycle;
+pub mod run_naming;
 pub mod volume_management;
 pub mod volumes;
 pub mod workdir;

--- a/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
@@ -7,26 +7,31 @@ pub fn register_run(run_id: u32) {
     register_run_with(run_id, "some-image", lns_ipc::RunConfig::default());
 }
 
-pub fn register_run_with(run_id: u32, image: &str, config: lns_ipc::RunConfig) {
+pub fn fresh_handle(
+    image: &str,
+    config: lns_ipc::RunConfig,
+) -> lns_service::run_registry::RunHandle {
     let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
     let task = tokio::spawn(async {});
-    lns_service::run_registry::register(
-        run_id,
-        lns_service::run_registry::RunHandle {
-            cancel_tx,
-            task,
-            #[cfg(target_os = "macos")]
-            input_tx: None,
-            #[cfg(target_os = "macos")]
-            connector: None,
-            image: image.into(),
-            command: "some-command".into(),
-            started: "2026-01-01T00:00:00Z".into(),
-            status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
-            logs: std::sync::Arc::new(lns_service::run_log::RunLogBuffer::default()),
-            config,
-        },
-    );
+    lns_service::run_registry::RunHandle {
+        cancel_tx,
+        task,
+        #[cfg(target_os = "macos")]
+        input_tx: None,
+        #[cfg(target_os = "macos")]
+        connector: None,
+        name: String::new(),
+        image: image.into(),
+        command: "some-command".into(),
+        started: "2026-01-01T00:00:00Z".into(),
+        status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
+        logs: std::sync::Arc::new(lns_service::run_log::RunLogBuffer::default()),
+        config,
+    }
+}
+
+pub fn register_run_with(run_id: u32, image: &str, config: lns_ipc::RunConfig) {
+    lns_service::run_registry::register(run_id, fresh_handle(image, config));
 }
 
 #[given("a registered run that has already exited")]
@@ -46,13 +51,29 @@ async fn registered_running_run(world: &mut BehaviourWorld) {
 
 #[when(regex = r#"^a RemoveRun request for run (\d+) arrives$"#)]
 async fn remove_unknown_run(world: &mut BehaviourWorld, run_id: u32) {
-    world.response = Some(run_one_shot(&Request::RemoveRun { run_id }, world.started_at()).await);
+    world.response = Some(
+        run_one_shot(
+            &Request::RemoveRun {
+                run: run_id.to_string(),
+            },
+            world.started_at(),
+        )
+        .await,
+    );
 }
 
 #[when("a RemoveRun request for that run arrives")]
 async fn remove_registered_run(world: &mut BehaviourWorld) {
     let run_id = world.lifecycle_run.expect("a run must be registered first");
-    world.response = Some(run_one_shot(&Request::RemoveRun { run_id }, world.started_at()).await);
+    world.response = Some(
+        run_one_shot(
+            &Request::RemoveRun {
+                run: run_id.to_string(),
+            },
+            world.started_at(),
+        )
+        .await,
+    );
     lns_service::run_registry::deregister(run_id);
 }
 
@@ -61,7 +82,7 @@ async fn stop_unknown_run(world: &mut BehaviourWorld, run_id: u32) {
     world.response = Some(
         run_one_shot(
             &Request::StopRun {
-                run_id,
+                run: run_id.to_string(),
                 timeout_secs: 1,
             },
             world.started_at(),
@@ -76,7 +97,7 @@ async fn stop_registered_run(world: &mut BehaviourWorld) {
     world.response = Some(
         run_one_shot(
             &Request::StopRun {
-                run_id,
+                run: run_id.to_string(),
                 timeout_secs: 1,
             },
             world.started_at(),
@@ -118,13 +139,29 @@ async fn registered_run_with_config(
 
 #[when(regex = r#"^an InspectRun request for run (\d+) arrives$"#)]
 async fn inspect_unknown_run(world: &mut BehaviourWorld, run_id: u32) {
-    world.response = Some(run_one_shot(&Request::InspectRun { run_id }, world.started_at()).await);
+    world.response = Some(
+        run_one_shot(
+            &Request::InspectRun {
+                run: run_id.to_string(),
+            },
+            world.started_at(),
+        )
+        .await,
+    );
 }
 
 #[when("an InspectRun request for that run arrives")]
 async fn inspect_registered_run(world: &mut BehaviourWorld) {
     let run_id = world.lifecycle_run.expect("a run must be registered first");
-    world.response = Some(run_one_shot(&Request::InspectRun { run_id }, world.started_at()).await);
+    world.response = Some(
+        run_one_shot(
+            &Request::InspectRun {
+                run: run_id.to_string(),
+            },
+            world.started_at(),
+        )
+        .await,
+    );
     lns_service::run_registry::deregister(run_id);
 }
 

--- a/crates/lns-service/tests/behaviours/steps/run_naming.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_naming.rs
@@ -1,0 +1,203 @@
+use crate::runner::run_one_shot;
+use crate::steps::run_lifecycle::fresh_handle;
+use crate::world::BehaviourWorld;
+use cucumber::{given, then, when};
+use lns_ipc::Request;
+use lns_service::run_registry;
+
+fn clear_name(name: &str) {
+    if let Ok(id) = run_registry::resolve(name) {
+        run_registry::deregister(id);
+    }
+}
+
+fn do_register(world: &mut BehaviourWorld, requested: Option<String>) {
+    let id = run_registry::allocate_run_id();
+    match run_registry::register_named(
+        id,
+        requested,
+        fresh_handle("some-image", lns_ipc::RunConfig::default()),
+    ) {
+        Ok(name) => {
+            world.naming_run = Some(id);
+            world.naming_name = Some(name);
+            world.naming_error = None;
+        }
+        Err(message) => world.naming_error = Some(message),
+    }
+}
+
+#[when("a run is registered without a name")]
+async fn register_without_name(world: &mut BehaviourWorld) {
+    do_register(world, None);
+}
+
+#[when(regex = r#"^a run is registered with the name "([^"]+)"$"#)]
+async fn register_with_name(world: &mut BehaviourWorld, name: String) {
+    do_register(world, Some(name));
+}
+
+#[given(regex = r#"^a registered run named "([^"]+)"$"#)]
+async fn given_registered_named(world: &mut BehaviourWorld, name: String) {
+    clear_name(&name);
+    do_register(world, Some(name));
+}
+
+#[given(regex = r#"^a registered run named "([^"]+)" that has already exited$"#)]
+async fn given_registered_named_exited(world: &mut BehaviourWorld, name: String) {
+    clear_name(&name);
+    do_register(world, Some(name));
+    if let Some(id) = world.naming_run {
+        run_registry::set_exit_code(id, 0);
+    }
+}
+
+#[given("a registered run whose name is the generator's first pick")]
+async fn given_auto_named(world: &mut BehaviourWorld) {
+    do_register(world, None);
+    world.naming_first_name = world.naming_name.clone();
+}
+
+#[then("the run is assigned a non-empty name")]
+fn then_non_empty_name(world: &mut BehaviourWorld) -> Result<(), String> {
+    match world.naming_name.as_deref() {
+        Some(n) if !n.is_empty() => Ok(()),
+        other => Err(format!("expected a non-empty name, got {other:?}")),
+    }
+}
+
+#[then("the assigned name is not all digits")]
+fn then_not_all_digits(world: &mut BehaviourWorld) -> Result<(), String> {
+    let name = world.naming_name.as_deref().ok_or("no name assigned")?;
+    if name.bytes().all(|b| b.is_ascii_digit()) {
+        Err(format!("name {name:?} is all digits"))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^the run's name is "([^"]+)"$"#)]
+fn then_run_name_is(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    match world.naming_name.as_deref() {
+        Some(n) if n == expected => Ok(()),
+        other => Err(format!("expected name {expected:?}, got {other:?}")),
+    }
+}
+
+#[then("registration is refused")]
+fn then_registration_refused(world: &mut BehaviourWorld) -> Result<(), String> {
+    if world.naming_error.is_some() {
+        Ok(())
+    } else {
+        Err("expected registration to be refused".into())
+    }
+}
+
+#[then(regex = r#"^the refusal contains "([^"]+)"$"#)]
+fn then_refusal_contains(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let err = world.naming_error.as_deref().ok_or("no refusal captured")?;
+    if err.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected refusal to contain {needle:?}, got {err:?}"
+        ))
+    }
+}
+
+#[then("the refusal explains a name must not be all digits")]
+fn then_refusal_all_digits(world: &mut BehaviourWorld) -> Result<(), String> {
+    let err = world.naming_error.as_deref().ok_or("no refusal captured")?;
+    if err.contains("all digits") {
+        Ok(())
+    } else {
+        Err(format!("expected an all-digits explanation, got {err:?}"))
+    }
+}
+
+#[then("the auto-assigned name differs from every listed run's name")]
+fn then_auto_name_differs(world: &mut BehaviourWorld) -> Result<(), String> {
+    let first = world
+        .naming_first_name
+        .as_deref()
+        .ok_or("no first auto name")?;
+    let second = world.naming_name.as_deref().ok_or("no second auto name")?;
+    if first != second {
+        Ok(())
+    } else {
+        Err(format!("auto names collided: {first:?}"))
+    }
+}
+
+#[when(regex = r#"^a StopRun request for run "([^"]+)" arrives$"#)]
+async fn stop_by_handle(world: &mut BehaviourWorld, run: String) {
+    world.response = Some(
+        run_one_shot(
+            &Request::StopRun {
+                run,
+                timeout_secs: 1,
+            },
+            world.started_at(),
+        )
+        .await,
+    );
+}
+
+#[when("a StopRun request for that run's numeric id arrives")]
+async fn stop_by_numeric_id(world: &mut BehaviourWorld) {
+    let id = world.naming_run.expect("a run must be registered first");
+    world.response = Some(
+        run_one_shot(
+            &Request::StopRun {
+                run: id.to_string(),
+                timeout_secs: 1,
+            },
+            world.started_at(),
+        )
+        .await,
+    );
+}
+
+#[when(regex = r#"^a RemoveRun request for run "([^"]+)" arrives$"#)]
+async fn remove_by_handle(world: &mut BehaviourWorld, run: String) {
+    world.response = Some(run_one_shot(&Request::RemoveRun { run }, world.started_at()).await);
+}
+
+#[then(regex = r#"^a run can then be registered with the name "([^"]+)"$"#)]
+fn then_can_register_name(world: &mut BehaviourWorld, name: String) -> Result<(), String> {
+    let _ = world;
+    let id = run_registry::allocate_run_id();
+    let result = run_registry::register_named(
+        id,
+        Some(name.clone()),
+        fresh_handle("some-image", lns_ipc::RunConfig::default()),
+    );
+    let outcome = match &result {
+        Ok(assigned) if *assigned == name => Ok(()),
+        Ok(other) => Err(format!("registered under {other:?}, expected {name:?}")),
+        Err(e) => Err(format!("expected reuse to succeed, got {e:?}")),
+    };
+    run_registry::deregister(id);
+    outcome
+}
+
+#[when(regex = r#"^a RenameRun request renames "([^"]+)" to "([^"]+)"$"#)]
+async fn rename_request(world: &mut BehaviourWorld, run: String, new_name: String) {
+    world.response =
+        Some(run_one_shot(&Request::RenameRun { run, new_name }, world.started_at()).await);
+}
+
+#[then(regex = r#"^the run resolves by the name "([^"]+)"$"#)]
+fn then_resolves_by_name(_world: &mut BehaviourWorld, name: String) -> Result<(), String> {
+    run_registry::resolve(&name)
+        .map(|_| ())
+        .map_err(|e| format!("expected {name:?} to resolve, got {e}"))
+}
+
+#[then(regex = r#"^the run no longer resolves by the name "([^"]+)"$"#)]
+fn then_not_resolves_by_name(_world: &mut BehaviourWorld, name: String) -> Result<(), String> {
+    match run_registry::resolve(&name) {
+        Err(_) => Ok(()),
+        Ok(id) => Err(format!("expected {name:?} not to resolve, but got id {id}")),
+    }
+}

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -48,6 +48,15 @@ pub struct BehaviourWorld {
 
     /// Run id registered by a lifecycle scenario (stop / inspect / logs).
     pub lifecycle_run: Option<u32>,
+
+    /// Run id registered by a naming scenario, addressable later by name or id.
+    pub naming_run: Option<u32>,
+    /// Name a naming scenario last assigned or observed.
+    pub naming_name: Option<String>,
+    /// First auto-generated name captured when comparing auto-name uniqueness.
+    pub naming_first_name: Option<String>,
+    /// Refusal message from the last registration / rename in a naming scenario.
+    pub naming_error: Option<String>,
 }
 
 impl BehaviourWorld {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,6 +28,7 @@ run, which requires a `COMMAND` after `--`.
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
 | `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
 | `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; rounded up to a whole MiB); falls back to the `run.mem` config default. |
+| `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `docker.io`      | Registry to qualify a bare image reference (e.g. `ghcr.io`); falls back to the `run.registry` config default. A fully-qualified reference is used as-is. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with `defaultVerdict: ask` if absent.         |
 | `-w`, `--workdir <DIR>`      | image `WORKDIR`  | Working directory inside the sandbox (absolute path; created if missing). |
@@ -111,20 +112,24 @@ a per-user file (`~/.lns-registry-auth.json`, `0600`; override with
 
 ## `lns sandbox`
 
-Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, prune.
+Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.
 
 ```bash
 lns sandbox ls
-lns sandbox exec [OPTIONS] <RUN_ID> -- <COMMAND...>
-lns sandbox kill <RUN_ID> [--signal <SIG>]
-lns sandbox stop <RUN_ID> [-t <SECONDS>]
-lns sandbox logs [-f] <RUN_ID>
-lns sandbox attach <RUN_ID> [--detach-keys <CHORD>]
-lns sandbox inspect <RUN_ID>
-lns sandbox stats <RUN_ID>
-lns sandbox rm <RUN_ID>
+lns sandbox exec [OPTIONS] <RUN> -- <COMMAND...>
+lns sandbox kill <RUN> [--signal <SIG>]
+lns sandbox stop <RUN> [-t <SECONDS>]
+lns sandbox logs [-f] <RUN>
+lns sandbox attach <RUN> [--detach-keys <CHORD>]
+lns sandbox inspect <RUN>
+lns sandbox stats <RUN>
+lns sandbox rm <RUN>
+lns sandbox rename <RUN> <NEW_NAME>
 lns sandbox prune
 ```
+
+`<RUN>` is a run's numeric id (`7`) or its name (`reviewer`) — the two are
+interchangeable everywhere a run is addressed.
 
 | Subcommand | Meaning |
 | ---------- | ------- |
@@ -137,6 +142,7 @@ lns sandbox prune
 | `inspect`  | Print the run's state and launch configuration as JSON, with the policy file's parsed contents embedded when it is readable. |
 | `stats`    | Sample the sandbox's CPU share and memory over one second, via the guest's `/proc`. |
 | `rm`       | Remove a single finished run from the list (`docker rm`-style). Refuses a run that is still running — stop it first. |
+| `rename`   | Give a run a name or change it (`docker rename`-style); the new name resolves immediately and must be unique among listed runs. |
 | `prune`    | Remove every finished run from the list at once (`docker container prune`-style); running runs are left untouched. |
 
 The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -96,6 +96,23 @@ with `-w` (an absolute guest path, created inside the sandbox if missing):
 lns run -w /workspace ghcr.io/acme/agent
 ```
 
+### Naming a run
+
+Every run has a numeric id (`run #7`) **and** a name. Pass `--name` to choose
+one; omit it and Lens Sandbox assigns a memorable `adjective_noun` name. Either
+handle works anywhere a run id is accepted:
+
+```bash
+lns run -d --name reviewer ghcr.io/acme/agent
+lns sandbox logs reviewer
+lns sandbox stop reviewer
+```
+
+A name may contain letters, digits, `_`, `.`, and `-`, and must not be all
+digits (so it is never mistaken for an id). Names are unique among the runs
+`lns sandbox ls` shows, and free up once the run is removed. Rename a run at any
+time with `lns sandbox rename <run> <new-name>`.
+
 ### Persistent defaults
 
 Settings you'd otherwise repeat on every run can be stored once with
@@ -231,12 +248,14 @@ lns sandbox logs -f 7          # ...and keep following until it exits
 lns sandbox attach 7           # re-join a detached run live
 lns sandbox inspect 7          # state + launch config as JSON
 lns sandbox stats 7            # CPU share and memory, sampled over 1s
+lns sandbox rename 7 reviewer  # name a run (or rename it), docker-rename style
 lns sandbox rm 7               # drop one finished run from the list
 lns sandbox prune              # drop every finished run from the list
 ```
 
-The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working
-as hidden aliases.
+Every verb takes a run's **name** as readily as its numeric id — `lns sandbox
+stop reviewer` and `lns sandbox stop 7` are equivalent. The pre-namespace
+spellings `lns ls`, `lns exec`, and `lns kill` keep working as hidden aliases.
 
 ### Exec — another session inside a run
 


### PR DESCRIPTION
## Summary

Until now every `lns sandbox` verb and the wire protocol only accepted a numeric run id. This PR adds Docker-style **run names** — a human-readable handle you can use anywhere a run id is accepted today.

### 1. Name assignment

Every run now carries both a numeric id and a name. Pass `--name reviewer` to `lns run` to choose one; omit it and the service auto-assigns an `adjective_noun` name (e.g. `amber_otter`). Names follow the same character set as volumes — letters, digits, `_`, `.`, `-` — and must not be all-digits (which would be indistinguishable from an id).

```bash
lns run -d --name reviewer ghcr.io/acme/agent
lns run -d ghcr.io/acme/agent   # auto-assigned, e.g. "bold_falcon"
```

### 2. Transparent resolution everywhere

The wire protocol's `run_id: u32` fields become `run: String` across all run-addressing requests (`Kill`, `StopRun`, `InspectRun`, `RunLogs`, `AttachRun`, `RunStats`, `RemoveRun`, `ExecImage`). The service resolves the handle in `run_registry::resolve`: numeric strings pass through as-is; non-numeric strings are looked up in the name map. This means old numeric addressing keeps working unchanged — the CLI is a thin forwarder.

```bash
lns sandbox stop reviewer    # same as lns sandbox stop 7
lns sandbox logs bold_falcon # same as lns sandbox logs 12
```

### 3. Rename command

New `lns sandbox rename <RUN> <NEW_NAME>` changes a run's name in place. The new name resolves immediately; the old one is freed. Rename to the run's own name is a no-op success (idempotent). Renaming to a name held by a different run is refused.

### 4. `lns sandbox ls` NAME column

The run list gains a `NAME` column between `ID` and `STATUS`, auto-sized to fit the widest name.

### 5. Service owns identity, CLI stays thin

Name uniqueness, auto-generation, and resolution all live in `lns-service/run_registry.rs`. The new `run_name.rs` module holds the adjective/noun pools (24×24 = 576 distinct names) and the index-to-name mapping. The CLI never inspects the string it receives as a `run` handle — it forwards it and surfaces whatever error the service returns.

## Docs

- `docs/cli-reference.md`: updated `lns run` flag table, `lns sandbox` command table, synopsis block (`<RUN>` instead of `<RUN_ID>`), added `rename` entry.
- `docs/running-workloads.md`: added "Naming a run" subsection; updated lifecycle example block to show `rename`; clarified name/id equivalence.

## Test instructions

1. `lns run -d --name reviewer <image>` — run starts; `lns sandbox ls` shows `reviewer` in the NAME column; `lns sandbox stop reviewer` stops it; `lns sandbox rm reviewer` cleans up.
2. `lns run -d <image>` (no `--name`) — run gets an auto-generated `adjective_noun` name visible in `lns sandbox ls`.
3. Try to start a second run with the same `--name reviewer` while the first is still listed — expect an error "already in use by run #N".
4. `lns sandbox rename <id-or-name> newname` while the run is running — `lns sandbox ls` reflects the new name; the old name no longer resolves.
5. `lns sandbox rename reviewer reviewer` (no-op rename) — exits 0, no error.
6. `lns sandbox rename reviewer <existing-other-name>` — refused with "already in use".
7. Every lifecycle verb with the name handle: `logs`, `attach`, `inspect`, `stats`, `stop`, `rm`, `exec`, `kill` — each should behave identically to using the numeric id.
8. Numeric id addressing unchanged: `lns sandbox stop 7` still works for any run whose id is 7.