### PR TITLE
feat(integrations): add Google as a device-flow oauth integration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -154,6 +154,12 @@ jobs:
       # true secret) is baked into the official binary; fork builds ship
       # without it and fall back to a pasted PAT.
       LNS_OAUTH_CLIENT_ID_GITHUB: ${{ secrets.OAUTH_CLIENT_ID_GITHUB }}
+      # Google's device flow is a confidential client: its id AND secret
+      # are baked into the official binary (extractable, treated as a
+      # public client per RFC 8252). Fork builds ship without them and
+      # fall back to a pasted token.
+      LNS_OAUTH_CLIENT_ID_GOOGLE: ${{ secrets.OAUTH_CLIENT_ID_GOOGLE }}
+      LNS_OAUTH_CLIENT_SECRET_GOOGLE: ${{ secrets.OAUTH_CLIENT_SECRET_GOOGLE }}
       # build.rs already defaults to rust-lld; pinning here documents
       # intent and survives an org-level env override that picks a
       # nonexistent toolchain like `aarch64-linux-musl-gcc`.

--- a/crates/lns-cli/src/integration/mod.rs
+++ b/crates/lns-cli/src/integration/mod.rs
@@ -474,6 +474,7 @@ mod tests {
             oauth: Some(OauthAuth {
                 flow: OauthFlow::Device,
                 client_id: Some("Iv1.somesaas".into()),
+                client_secret: None,
                 scopes: vec!["repo".into()],
                 device_authorization_endpoint: Some(
                     "https://api.somesaas.com/login/device/code".into(),

--- a/crates/lns-cli/tests/behaviours/steps/integration_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/integration_cli.rs
@@ -106,6 +106,7 @@ fn given_user_oauth_integration(world: &mut BehaviourWorld, id: String) {
             oauth: Some(OauthAuth {
                 flow: OauthFlow::Device,
                 client_id: Some("Iv1.some-oauth".into()),
+                client_secret: None,
                 scopes: vec!["repo".into()],
                 device_authorization_endpoint: Some("https://example.com/device/code".into()),
                 authorization_endpoint: None,
@@ -149,6 +150,7 @@ fn given_user_pkce_integration(world: &mut BehaviourWorld, id: String) {
             oauth: Some(OauthAuth {
                 flow: OauthFlow::Pkce,
                 client_id: None,
+                client_secret: None,
                 scopes: Vec::new(),
                 device_authorization_endpoint: None,
                 authorization_endpoint: Some("https://api.some-pkce.example/auth".into()),

--- a/crates/lns-policy/src/integrations.rs
+++ b/crates/lns-policy/src/integrations.rs
@@ -71,7 +71,7 @@ impl OauthFlow {
     }
 }
 
-/// Interactive sign-in configuration for an `oauth` integration: `flow` selects device (RFC 8628) or pkce, alongside the same env/placeholder/injection wiring a credential carries; `clientId` is optional (community builds ship none and fall back to a pasted token), with `deviceAuthorizationEndpoint` required for device and `authorizationEndpoint` for pkce.
+/// Interactive sign-in configuration for an `oauth` integration: `flow` selects device (RFC 8628) or pkce, alongside the same env/placeholder/injection wiring a credential carries; `clientId` is optional (community builds ship none and fall back to a pasted token), with `deviceAuthorizationEndpoint` required for device and `authorizationEndpoint` for pkce; `clientSecret` is set only for confidential device clients (e.g. Google) that require it in the token exchange.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OauthAuth {
@@ -79,6 +79,8 @@ pub struct OauthAuth {
     pub flow: OauthFlow,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -291,6 +293,7 @@ mod tests {
         OauthAuth {
             flow: OauthFlow::Device,
             client_id: Some("Iv1.example0000".into()),
+            client_secret: None,
             scopes: vec!["repo".into()],
             device_authorization_endpoint: Some("https://example.com/login/device/code".into()),
             authorization_endpoint: None,
@@ -309,6 +312,7 @@ mod tests {
         OauthAuth {
             flow: OauthFlow::Pkce,
             client_id: None,
+            client_secret: None,
             scopes: Vec::new(),
             device_authorization_endpoint: None,
             authorization_endpoint: Some("https://example.com/auth".into()),
@@ -502,6 +506,28 @@ mod tests {
         );
         let parsed: Integration = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, i);
+    }
+
+    #[test]
+    fn an_oauth_integration_round_trips_an_optional_client_secret() {
+        let mut i = oauth_integration();
+        i.oauth.as_mut().unwrap().client_secret = Some("some-client-secret".into());
+        let yaml = serde_yaml::to_string(&i).unwrap();
+        assert!(
+            yaml.contains("clientSecret: some-client-secret"),
+            "got: {yaml}"
+        );
+        let parsed: Integration = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, i);
+    }
+
+    #[test]
+    fn an_oauth_integration_without_a_client_secret_omits_it_from_yaml() {
+        let yaml = serde_yaml::to_string(&oauth_integration()).unwrap();
+        assert!(
+            !yaml.contains("clientSecret"),
+            "a public-client oauth entry must not serialize an empty client secret: {yaml}"
+        );
     }
 
     #[test]
@@ -931,6 +957,45 @@ mod tests {
     }
 
     #[test]
+    fn bundled_google_signs_in_via_oauth_device_flow_with_a_client_secret_and_injects_a_bearer_header()
+     {
+        let google = bundled_integrations()
+            .iter()
+            .find(|i| i.id == "google")
+            .expect("google is bundled");
+        assert_eq!(google.auth_kind, AuthKind::Oauth);
+        let oauth = google.oauth.as_ref().expect("oauth block present");
+        assert_eq!(oauth.flow, OauthFlow::Device);
+        assert_eq!(oauth.env_var, "GOOGLE_OAUTH_ACCESS_TOKEN");
+        assert_eq!(
+            oauth.device_authorization_endpoint.as_deref(),
+            Some("https://oauth2.googleapis.com/device/code")
+        );
+        assert_eq!(oauth.token_endpoint, "https://oauth2.googleapis.com/token");
+        assert!(
+            oauth.client_secret.is_some(),
+            "Google's device flow requires a client secret in the token exchange"
+        );
+        assert!(
+            oauth
+                .injections
+                .iter()
+                .any(|i| i.kind == InjectionKind::BearerHeader && i.domain == "www.googleapis.com"),
+            "Google APIs take Authorization: Bearer, got: {:?}",
+            oauth.injections
+        );
+        assert!(
+            google
+                .token_fallback
+                .as_ref()
+                .and_then(|f| f.help.as_deref())
+                .is_some_and(|h| h.starts_with("https://")),
+            "an unconfigured build must let the user pivot to a pasted token, got: {:?}",
+            google.token_fallback
+        );
+    }
+
+    #[test]
     fn no_bundled_integration_commits_a_literal_oauth_client_id() {
         let raw = include_str!("integrations.yaml");
         for line in raw.lines() {
@@ -939,6 +1004,20 @@ mod tests {
                 assert!(
                     value.starts_with("\"${") && value.ends_with("}\""),
                     "clientId must be a build-time env reference, never a committed literal: {line:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_bundled_integration_commits_a_literal_oauth_client_secret() {
+        let raw = include_str!("integrations.yaml");
+        for line in raw.lines() {
+            if let Some(rest) = line.trim_start().strip_prefix("clientSecret:") {
+                let value = rest.trim();
+                assert!(
+                    value.starts_with("\"${") && value.ends_with("}\""),
+                    "clientSecret must be a build-time env reference, never a committed literal: {line:?}"
                 );
             }
         }

--- a/crates/lns-policy/src/integrations.yaml
+++ b/crates/lns-policy/src/integrations.yaml
@@ -45,6 +45,27 @@ integrations:
           domain: github.com
     tokenFallback:
       help: https://github.com/settings/personal-access-tokens/new
+  - id: google
+    name: Google
+    authKind: oauth
+    routes:
+      - match: www.googleapis.com
+    oauth:
+      clientId: "${LNS_OAUTH_CLIENT_ID_GOOGLE}"
+      clientSecret: "${LNS_OAUTH_CLIENT_SECRET_GOOGLE}"
+      scopes:
+        - openid
+        - email
+        - profile
+      deviceAuthorizationEndpoint: https://oauth2.googleapis.com/device/code
+      tokenEndpoint: https://oauth2.googleapis.com/token
+      envVar: GOOGLE_OAUTH_ACCESS_TOKEN
+      placeholder: ya29.LNSPLACEHOLDER000000000000000000000000
+      injections:
+        - kind: bearer_header
+          domain: www.googleapis.com
+    tokenFallback:
+      help: https://developers.google.com/oauthplayground
   - id: openai
     authKind: credential
     routes:

--- a/crates/lns-service/src/credential_flow/integrations.rs
+++ b/crates/lns-service/src/credential_flow/integrations.rs
@@ -217,6 +217,7 @@ mod tests {
             oauth: Some(OauthAuth {
                 flow: OauthFlow::Device,
                 client_id: Some(format!("Iv1.{id}")),
+                client_secret: None,
                 scopes: vec!["repo".into()],
                 device_authorization_endpoint: Some(format!("https://{domain}/login/device/code")),
                 authorization_endpoint: None,
@@ -249,6 +250,7 @@ mod tests {
             oauth: Some(OauthAuth {
                 flow: OauthFlow::Pkce,
                 client_id: None,
+                client_secret: None,
                 scopes: Vec::new(),
                 device_authorization_endpoint: None,
                 authorization_endpoint: Some(format!("https://{domain}/auth")),

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -1537,6 +1537,7 @@ mod tests {
             "some-oauth".to_string(),
             crate::oauth::OauthConfig {
                 client_id: "Iv1.test".into(),
+                client_secret: String::new(),
                 scopes: vec![],
                 device_authorization_endpoint: "https://example.com/device/code".into(),
                 token_endpoint: "https://example.com/oauth/token".into(),
@@ -1678,6 +1679,7 @@ mod tests {
         let flow = FakeFlow::polling(vec![]);
         let cfg = crate::oauth::OauthConfig {
             client_id: "Iv1.test".into(),
+            client_secret: String::new(),
             scopes: vec![],
             device_authorization_endpoint: "https://example.com/device/code".into(),
             token_endpoint: "https://example.com/oauth/token".into(),
@@ -1712,6 +1714,7 @@ mod tests {
             "some-oauth".to_string(),
             crate::oauth::OauthConfig {
                 client_id: "Iv1.test".into(),
+                client_secret: String::new(),
                 scopes: vec!["repo".into()],
                 device_authorization_endpoint: "https://example.com/device/code".into(),
                 token_endpoint: "https://example.com/oauth/token".into(),

--- a/crates/lns-service/src/oauth/mod.rs
+++ b/crates/lns-service/src/oauth/mod.rs
@@ -357,6 +357,7 @@ mod tests {
     fn sample_cfg() -> OauthConfig {
         OauthConfig {
             client_id: "Iv1.test".into(),
+            client_secret: String::new(),
             scopes: vec!["repo".into()],
             device_authorization_endpoint: "https://example.com/device/code".into(),
             token_endpoint: "https://example.com/oauth/token".into(),

--- a/crates/lns-service/src/oauth/real.rs
+++ b/crates/lns-service/src/oauth/real.rs
@@ -32,6 +32,7 @@ pub struct RealDeviceFlow;
 struct DeviceCodeResp {
     device_code: String,
     user_code: String,
+    #[serde(alias = "verification_url")]
     verification_uri: String,
     interval: Option<u64>,
     expires_in: Option<u64>,
@@ -75,6 +76,17 @@ fn parse_json<T: DeserializeOwned>(
         .with_context(|| format!("parsing response from {url} (HTTP {status})"))
 }
 
+/// Confidential device clients (e.g. Google) must send `client_secret` in the token exchange; public clients (e.g. GitHub) leave it empty and omit it.
+fn with_client_secret<'a>(
+    mut form: Vec<(&'a str, &'a str)>,
+    secret: &'a str,
+) -> Vec<(&'a str, &'a str)> {
+    if !secret.is_empty() {
+        form.push(("client_secret", secret));
+    }
+    form
+}
+
 impl DeviceFlow for RealDeviceFlow {
     fn request_device_code<'a>(
         &'a self,
@@ -113,11 +125,14 @@ impl DeviceFlow for RealDeviceFlow {
         Box::pin(async move {
             let (status, bytes) = post_form_bytes(
                 &cfg.token_endpoint,
-                &[
-                    ("client_id", cfg.client_id.as_str()),
-                    ("device_code", device_code),
-                    ("grant_type", DEVICE_CODE_GRANT),
-                ],
+                &with_client_secret(
+                    vec![
+                        ("client_id", cfg.client_id.as_str()),
+                        ("device_code", device_code),
+                        ("grant_type", DEVICE_CODE_GRANT),
+                    ],
+                    &cfg.client_secret,
+                ),
             )
             .await?;
             let t: TokenResp = parse_json(&cfg.token_endpoint, status, &bytes)?;
@@ -149,11 +164,14 @@ impl DeviceFlow for RealDeviceFlow {
         Box::pin(async move {
             let (status, bytes) = post_form_bytes(
                 &cfg.token_endpoint,
-                &[
-                    ("client_id", cfg.client_id.as_str()),
-                    ("grant_type", "refresh_token"),
-                    ("refresh_token", refresh_token),
-                ],
+                &with_client_secret(
+                    vec![
+                        ("client_id", cfg.client_id.as_str()),
+                        ("grant_type", "refresh_token"),
+                        ("refresh_token", refresh_token),
+                    ],
+                    &cfg.client_secret,
+                ),
             )
             .await?;
             let t: TokenResp = parse_json(&cfg.token_endpoint, status, &bytes)?;
@@ -294,5 +312,39 @@ impl CallbackHandle for RealCallbackHandle {
             let _ = write_half.flush().await;
             params
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_confidential_client_appends_its_secret_to_the_token_form() {
+        let form = with_client_secret(vec![("client_id", "some-id")], "some-secret");
+        assert_eq!(
+            form,
+            vec![("client_id", "some-id"), ("client_secret", "some-secret")]
+        );
+    }
+
+    #[test]
+    fn a_public_client_omits_the_secret_from_the_token_form() {
+        let form = with_client_secret(vec![("client_id", "some-id")], "");
+        assert_eq!(form, vec![("client_id", "some-id")]);
+    }
+
+    #[test]
+    fn a_device_code_response_accepts_a_providers_nonstandard_verification_url_key() {
+        let body = r#"{"device_code":"some-device","user_code":"SOME-CODE","verification_url":"https://example.com/device"}"#;
+        let d: DeviceCodeResp = serde_json::from_str(body).unwrap();
+        assert_eq!(d.verification_uri, "https://example.com/device");
+    }
+
+    #[test]
+    fn a_device_code_response_accepts_the_rfc8628_verification_uri_key() {
+        let body = r#"{"device_code":"some-device","user_code":"SOME-CODE","verification_uri":"https://example.com/device"}"#;
+        let d: DeviceCodeResp = serde_json::from_str(body).unwrap();
+        assert_eq!(d.verification_uri, "https://example.com/device");
     }
 }

--- a/crates/lns-service/src/oauth/traits.rs
+++ b/crates/lns-service/src/oauth/traits.rs
@@ -9,6 +9,7 @@ use lns_policy::integrations::OauthAuth;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OauthConfig {
     pub client_id: String,
+    pub client_secret: String,
     pub scopes: Vec<String>,
     pub device_authorization_endpoint: String,
     pub token_endpoint: String,
@@ -18,6 +19,7 @@ impl From<&OauthAuth> for OauthConfig {
     fn from(o: &OauthAuth) -> Self {
         Self {
             client_id: o.client_id.clone().unwrap_or_default(),
+            client_secret: o.client_secret.clone().unwrap_or_default(),
             scopes: o.scopes.clone(),
             device_authorization_endpoint: o
                 .device_authorization_endpoint

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -1132,6 +1132,7 @@ mod tests {
             oauth: Some(OauthAuth {
                 flow: lns_policy::integrations::OauthFlow::Device,
                 client_id: Some("Iv1.x".into()),
+                client_secret: None,
                 scopes: vec![],
                 device_authorization_endpoint: Some("https://example.com/device/code".into()),
                 authorization_endpoint: None,
@@ -1433,6 +1434,7 @@ mod tests {
             "acme".to_string(),
             crate::oauth::OauthConfig {
                 client_id: "Iv1.acme".into(),
+                client_secret: String::new(),
                 scopes: vec![],
                 device_authorization_endpoint: "https://example.com/device/code".into(),
                 token_endpoint: "https://example.com/oauth/token".into(),
@@ -1499,6 +1501,7 @@ mod tests {
             "acme".to_string(),
             crate::oauth::OauthConfig {
                 client_id: "Iv1.acme".into(),
+                client_secret: String::new(),
                 scopes: vec![],
                 device_authorization_endpoint: "https://example.com/device/code".into(),
                 token_endpoint: "https://example.com/oauth/token".into(),
@@ -1574,6 +1577,7 @@ mod tests {
             "acme".to_string(),
             crate::oauth::OauthConfig {
                 client_id: "Iv1.acme".into(),
+                client_secret: String::new(),
                 scopes: vec![],
                 device_authorization_endpoint: "https://example.com/device/code".into(),
                 token_endpoint: "https://example.com/oauth/token".into(),
@@ -1629,6 +1633,7 @@ mod tests {
         use crate::oauth::DeviceFlow;
         let cfg = crate::oauth::OauthConfig {
             client_id: "x".into(),
+            client_secret: String::new(),
             scopes: vec![],
             device_authorization_endpoint: "https://example.com/device/code".into(),
             token_endpoint: "https://example.com/oauth/token".into(),

--- a/crates/lns-service/tests/behaviours/credential_rig.rs
+++ b/crates/lns-service/tests/behaviours/credential_rig.rs
@@ -255,6 +255,7 @@ impl CredentialRig {
             id.to_string(),
             OauthConfig {
                 client_id: format!("Iv1.{id}"),
+                client_secret: String::new(),
                 scopes: vec!["repo".into()],
                 device_authorization_endpoint: format!("https://example.com/{id}/device/code"),
                 token_endpoint: format!("https://example.com/{id}/oauth/token"),


### PR DESCRIPTION
## Summary

The existing OAuth device-flow plumbing assumed public clients (GitHub-style: `client_id` only). Google's RFC 8628 device flow is a *confidential* client — its token poll and refresh require a `client_secret` alongside `client_id`, and its device-code response uses the non-standard `verification_url` key — so it couldn't be expressed at all.

This PR threads the missing pieces and ships a bundled `google` entry.

### 1. Optional `client_secret` on `OauthAuth` / `OauthConfig`

Adds `client_secret: Option<String>` to `OauthAuth` (serialised as `clientSecret`, omitted when absent) and the derived `OauthConfig` (an empty string for public clients). A `with_client_secret` helper appends the field to the token/refresh POST form only when non-empty, so public clients (GitHub) are unaffected.

The secret is added to `poll_token` and `refresh` but deliberately **omitted** from `request_device_code`, matching Google's actual contract.

### 2. `verification_url` alias

Google's device-code response uses `verification_url` rather than the RFC 8628 `verification_uri`. A `#[serde(alias = "verification_url")]` on `DeviceCodeResp` handles both without any runtime branching.

### 3. Bundled `google` entry

```yaml
- id: google
  name: Google
  authKind: oauth
  routes:
    - match: www.googleapis.com
  oauth:
    clientId: "${LNS_OAUTH_CLIENT_ID_GOOGLE}"
    clientSecret: "${LNS_OAUTH_CLIENT_SECRET_GOOGLE}"
    scopes: [openid, email, profile]
    deviceAuthorizationEndpoint: https://oauth2.googleapis.com/device/code
    tokenEndpoint: https://oauth2.googleapis.com/token
    envVar: GOOGLE_OAUTH_ACCESS_TOKEN
    placeholder: ya29.LNSPLACEHOLDER000000000000000000000000
    injections:
      - kind: bearer_header
        domain: www.googleapis.com
  tokenFallback:
    help: https://developers.google.com/oauthplayground
```

Both id and secret are sourced from build-env refs (scanned generically by `build.rs`). Fork/unconfigured builds get empty strings and degrade to the `tokenFallback` pasted-token path. The binary-baked secret is treated as effectively public per RFC 8252.

### 4. CI secrets

`LNS_OAUTH_CLIENT_ID_GOOGLE` and `LNS_OAUTH_CLIENT_SECRET_GOOGLE` wired into the release build job, matching the existing GitHub pattern.

## Test instructions

1. **Bundled entry shape** — `make test` passes; the `bundled_google_signs_in_via_oauth_device_flow_with_a_client_secret_and_injects_a_bearer_header` test pinpoints the key invariants.
2. **No secret committed** — `no_bundled_integration_commits_a_literal_oauth_client_secret` asserts every `clientSecret:` line is a `"${...}"` ref.
3. **Fork build degrades cleanly** — build without the env vars set; `lns integration connect google` should offer the `tokenFallback` pasted-token path rather than starting a device flow with an empty client id.
4. **GitHub unaffected** — `lns integration connect github` device flow unchanged (no secret appended to its token POST).
5. **Live smoke (official build)** — with `LNS_OAUTH_CLIENT_ID_GOOGLE` and `LNS_OAUTH_CLIENT_SECRET_GOOGLE` set at build time, `lns integration connect google` displays a device-code URL + user code, completes the Google consent flow, and injects `GOOGLE_OAUTH_ACCESS_TOKEN` into workloads that hit `www.googleapis.com`.

## Screenshots
<!-- Add screenshot or recording demonstrating the new feature -->