### PR TITLE
fix(lns-cli): don't hold std stdin/stdout locks across interactive run/exec

### DIFF
--- a/crates/lns-cli/src/audit/mod.rs
+++ b/crates/lns-cli/src/audit/mod.rs
@@ -27,6 +27,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn run<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {

--- a/crates/lns-cli/src/command.rs
+++ b/crates/lns-cli/src/command.rs
@@ -33,6 +33,8 @@ pub struct CommandSpec {
     pub augment: fn(clap::Command) -> clap::Command,
     pub run: for<'a> fn(&'a ArgMatches, RunCtx<'a>) -> RunFuture<'a>,
     pub announces_update_check: bool,
+    /// True for commands that drive the tty over async tokio stdin/stdout, so the dispatcher must not hold the blocking std stdin/stdout locks.
+    pub owns_terminal: bool,
 }
 
 /// Add a derive-`Args` subcommand named `name` to `app`.
@@ -163,5 +165,24 @@ mod tests {
     fn spec_for_finds_a_registered_command_and_rejects_an_unknown_one() {
         assert!(spec_for("volume").is_some());
         assert!(spec_for("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn only_run_and_exec_own_the_terminal() {
+        for spec in registry() {
+            if matches!(spec.name, "run" | "exec") {
+                assert!(
+                    spec.owns_terminal,
+                    "{} drives the tty over tokio stdin/stdout; the dispatcher must not hold the std locks for it",
+                    spec.name
+                );
+            } else {
+                assert!(
+                    !spec.owns_terminal,
+                    "{} runs synchronously and relies on the dispatcher holding the std stdin/stdout locks",
+                    spec.name
+                );
+            }
+        }
     }
 }

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -178,6 +178,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: run_command,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {

--- a/crates/lns-cli/src/image/mod.rs
+++ b/crates/lns-cli/src/image/mod.rs
@@ -58,6 +58,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: real::run,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 /// Sends one image request to the running service; `None` means the service did not answer.

--- a/crates/lns-cli/src/integration/mod.rs
+++ b/crates/lns-cli/src/integration/mod.rs
@@ -156,6 +156,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: real::run,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub async fn run(

--- a/crates/lns-cli/src/lib.rs
+++ b/crates/lns-cli/src/lib.rs
@@ -31,6 +31,18 @@ pub async fn run_from_matches(matches: clap::ArgMatches, debug: bool) -> Result<
     if spec.announces_update_check && update_check::announce_enabled(|k| std::env::var(k).ok()) {
         let _ = update_check::real::run_announce();
     }
+    if spec.owns_terminal {
+        // run/exec drive the tty over tokio stdin/stdout, whose blocking threads take the std stdin/stdout locks; holding those locks here would deadlock the interactive session.
+        let mut input = std::io::empty();
+        let mut out = std::io::sink();
+        let ctx = command::RunCtx {
+            debug,
+            cwd: None,
+            input: &mut input,
+            out: &mut out,
+        };
+        return (spec.run)(sub, ctx).await;
+    }
     let stdin = std::io::stdin();
     let mut input = stdin.lock();
     let stdout = std::io::stdout();

--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -79,6 +79,7 @@ pub const LOGIN_SPEC: CommandSpec = CommandSpec {
     augment: augment_login,
     run: real::run_login,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn augment_logout(app: clap::Command) -> clap::Command {
@@ -92,6 +93,7 @@ pub const LOGOUT_SPEC: CommandSpec = CommandSpec {
     augment: augment_logout,
     run: real::run_logout,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub async fn run(

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -82,6 +82,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: run_command,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {

--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -13,6 +13,7 @@ pub const RUN_SPEC: CommandSpec = CommandSpec {
     augment,
     run: crate::service::run_command,
     announces_update_check: true,
+    owns_terminal: true,
 };
 
 pub fn augment_exec(app: clap::Command) -> clap::Command {
@@ -24,4 +25,5 @@ pub const EXEC_SPEC: CommandSpec = CommandSpec {
     augment: augment_exec,
     run: crate::service::exec_command,
     announces_update_check: true,
+    owns_terminal: true,
 };

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -148,6 +148,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: real::run,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub trait SandboxService: Send + Sync {

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -56,6 +56,7 @@ pub const KILL_SPEC: CommandSpec = CommandSpec {
     augment: augment_kill,
     run: orchestrator::kill_command,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn augment_ls(app: clap::Command) -> clap::Command {
@@ -67,6 +68,7 @@ pub const LS_SPEC: CommandSpec = CommandSpec {
     augment: augment_ls,
     run: orchestrator::ls_command,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 pub fn augment(app: clap::Command) -> clap::Command {
@@ -80,6 +82,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: orchestrator::service_command,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 fn require_running_check(alive: bool) -> Result<(), &'static str> {

--- a/crates/lns-cli/src/update.rs
+++ b/crates/lns-cli/src/update.rs
@@ -44,6 +44,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: real::run_command,
     announces_update_check: false,
+    owns_terminal: false,
 };
 
 pub(in crate::update) const DEFAULT_CDN_BASE: &str = "https://get.lns.run";

--- a/crates/lns-cli/src/volume/mod.rs
+++ b/crates/lns-cli/src/volume/mod.rs
@@ -67,6 +67,7 @@ pub const SPEC: CommandSpec = CommandSpec {
     augment,
     run: real::run,
     announces_update_check: true,
+    owns_terminal: false,
 };
 
 /// Sends one volume request to the running service; `None` means the service did not answer.


### PR DESCRIPTION
## Summary

`lns run -it` / `lns exec -it` hung reliably on interactive sessions. The dispatcher in `run_from_matches` called `std::io::stdin().lock()` / `std::io::stdout().lock()` and held those locks for the entire lifetime of the command. The attached-session driver relays I/O via `tokio::io::stdin()` / `tokio::io::stdout()`, whose backing blocking threads must acquire the same std locks — from a different thread — so they blocked forever.

### Fix

Added an `owns_terminal: bool` field to `CommandSpec`. Commands that drive the tty over async tokio stdio set it to `true`; all other commands set it to `false`. The dispatcher checks the flag before taking the std locks:

- `owns_terminal = false` (all non-interactive commands): behaviour unchanged — dispatcher locks stdin/stdout and passes them through `RunCtx` as before.
- `owns_terminal = true` (`run`, `exec`): dispatcher supplies `std::io::empty()` / `std::io::sink()` as the `RunCtx` I/O, so no std lock is held while the tokio worker threads drive the session.

The `run_command` path only reads `ctx.debug` from `RunCtx`; `exec_command` ignores `ctx` entirely. Neither relied on `ctx.input` or `ctx.out`, so the substitution is behaviour-preserving.

### Guard

A new invariant test (`only_run_and_exec_own_the_terminal`) walks the full `registry()` and asserts `owns_terminal` is `true` for `run`/`exec` and `false` for everything else. Adding a new command that drives the tty will fail this test until the author sets the flag, preventing a silent regression.

## Test instructions

1. **Interactive shell (was: hangs forever):** `lns run -it alpine -- sh` — a shell prompt appears; typing `exit` returns control cleanly.
2. **Exec into running run:** `lns exec -it <run-id> -- sh` — attaches successfully; exit returns the exec exit code.
3. **Non-interactive run unaffected:** `lns run alpine -- echo hello` — outputs `hello` and exits 0 with no hang.
4. **Detached run unaffected:** `lns run -d alpine -- sleep 30` — prints the run ID immediately and exits 0.
5. **All other commands unaffected:** `lns ls`, `lns service status`, etc. continue to work normally (no I/O regression from the `RunCtx` change).

## Screenshots
### Before
<!-- Recording showing `lns run -it` hanging -->

### After
<!-- Recording showing interactive shell working -->