### PR TITLE
fix(lns-service): run headless when no display is present

### DIFF
--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -55,7 +55,7 @@ async fn main() {
 
     E2eWorld::cucumber()
         .fail_on_skipped()
-        .filter_run(features_dir, |feat, _, sc| {
+        .filter_run_and_exit(features_dir, |feat, _, sc| {
             let headless_excluded = |t: &String| t == "gui" || t == "microvm";
             !feat.tags.iter().any(headless_excluded) && !sc.tags.iter().any(headless_excluded)
         })

--- a/crates/e2e-tests/tests/specutil/mod.rs
+++ b/crates/e2e-tests/tests/specutil/mod.rs
@@ -148,13 +148,6 @@ pub fn assert_contains(haystack: &str, needle: &str, label: &str) -> Result<(), 
     }
 }
 
-pub const VALID_AUDIT_CHAIN: &str = concat!(
-    r#"{"prev_hash":"0000000000000000000000000000000000000000000000000000000000000000","seq":1,"type":"audit_event"}"#,
-    "\n",
-    r#"{"prev_hash":"11fa0b79ccf362f88562d142feac7c5cd5866e21b097b1b05a1c3816c8395c3f","seq":2,"type":"audit_event"}"#,
-    "\n",
-);
-
 pub const TAMPERED_AUDIT_CHAIN: &str = concat!(
     r#"{"prev_hash":"0000000000000000000000000000000000000000000000000000000000000000","seq":1,"type":"audit_event"}"#,
     "\n",

--- a/crates/e2e-tests/tests/steps/audit.rs
+++ b/crates/e2e-tests/tests/steps/audit.rs
@@ -1,24 +1,39 @@
 use crate::E2eWorld;
-use crate::specutil::{TAMPERED_AUDIT_CHAIN, VALID_AUDIT_CHAIN, cache_runs_dir};
+use crate::specutil::{TAMPERED_AUDIT_CHAIN, cache_runs_dir};
 use cucumber::given;
 use std::fs;
+use std::path::PathBuf;
 
 #[given(regex = r#"^a run "([^"]+)" with a valid audit chain$"#)]
 fn valid_chain(world: &mut E2eWorld, run_id: String) {
-    write_fixture(world, &run_id, VALID_AUDIT_CHAIN);
+    let run_dir = run_dir(world, &run_id);
+    let mut chain = lns_ipc::AuditChain::new();
+    let mut payload = String::new();
+    for event in [
+        r#"{"type":"audit_event","seq":1}"#,
+        r#"{"type":"audit_event","seq":2}"#,
+    ] {
+        let augmented = chain.augment(event).expect("augment audit event");
+        payload.push_str(std::str::from_utf8(&augmented).expect("augmented line is utf8"));
+        payload.push('\n');
+    }
+    fs::write(run_dir.join("audit.jsonl"), payload).expect("write audit.jsonl");
+    let anchor = chain.anchor().expect("a non-empty chain anchors its head");
+    fs::write(run_dir.join("audit.anchor"), anchor.to_line()).expect("write audit.anchor");
 }
 
 #[given(regex = r#"^a run "([^"]+)" with a tampered audit chain$"#)]
 fn tampered_chain(world: &mut E2eWorld, run_id: String) {
-    write_fixture(world, &run_id, TAMPERED_AUDIT_CHAIN);
+    let run_dir = run_dir(world, &run_id);
+    fs::write(run_dir.join("audit.jsonl"), TAMPERED_AUDIT_CHAIN).expect("write audit.jsonl");
 }
 
-fn write_fixture(world: &E2eWorld, run_id: &str, contents: &str) {
+fn run_dir(world: &E2eWorld, run_id: &str) -> PathBuf {
     let home = world
         .home
         .as_ref()
         .expect("Given a clean lns cache home before writing a fixture");
-    let run_dir = cache_runs_dir(home.path()).join(run_id);
-    fs::create_dir_all(&run_dir).expect("create run dir");
-    fs::write(run_dir.join("audit.jsonl"), contents).expect("write audit.jsonl");
+    let dir = cache_runs_dir(home.path()).join(run_id);
+    fs::create_dir_all(&dir).expect("create run dir");
+    dir
 }

--- a/crates/e2e-tests/tests/steps/service.rs
+++ b/crates/e2e-tests/tests/steps/service.rs
@@ -20,10 +20,22 @@ pub(crate) fn start_service(world: &mut E2eWorld) {
     let result = run_cli_with_env(["service", "start"], envs);
     assert!(
         result.exit_code == 0,
-        "lns service start failed: stdout={:?} stderr={:?}",
+        "lns service start failed: stdout={:?} stderr={:?}\n--- service.log ---\n{}",
         result.stdout,
-        result.stderr
+        result.stderr,
+        read_service_log(world),
     );
+}
+
+fn read_service_log(world: &E2eWorld) -> String {
+    let Some(socket) = &world.service_socket else {
+        return "(no socket path on the world)".to_string();
+    };
+    let Some(log_path) = socket.parent().map(|dir| dir.join("service.log")) else {
+        return "(socket path has no parent directory)".to_string();
+    };
+    std::fs::read_to_string(&log_path)
+        .unwrap_or_else(|e| format!("(could not read {}: {e})", log_path.display()))
 }
 
 fn parse_pid(output: &str) -> Option<u64> {

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -223,10 +223,13 @@ async fn kill_request(run: &str, signal: lns_ipc::SignalKind) -> Response {
         Ok(id) => id,
         Err(message) => return Response::Error { message },
     };
-    if crate::run_registry::status(id).is_none() {
+    let Some(status) = crate::run_registry::status(id) else {
         return Response::Error {
             message: format!("no active run with id {id}"),
         };
+    };
+    if matches!(status, lns_ipc::RunStatus::Exited { .. }) {
+        return Response::Acknowledged;
     }
     forward_session_input(id, session_input_from_signal(signal), "Kill").await
 }
@@ -1027,6 +1030,28 @@ mod tests {
                 "expected a forwarding outcome for a sessionless registered run, got {other:?}"
             ),
         }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(global_runs)]
+    async fn handle_request_kill_of_an_already_exited_run_succeeds_without_forwarding() {
+        let id = crate::run_registry::allocate_run_id();
+        register_running(id);
+        crate::run_registry::set_exit_code(id, 0);
+        let response = handle_request(
+            &Request::Kill {
+                run: id.to_string(),
+                signal: lns_ipc::SignalKind::Kill,
+            },
+            Instant::now(),
+        )
+        .await;
+        crate::run_registry::deregister(id);
+        assert_eq!(
+            response,
+            Response::Acknowledged,
+            "killing an exited run is already satisfied and must not forward to a dead session"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -219,10 +219,16 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
 }
 
 async fn kill_request(run: &str, signal: lns_ipc::SignalKind) -> Response {
-    match crate::run_registry::resolve(run) {
-        Ok(id) => forward_session_input(id, session_input_from_signal(signal), "Kill").await,
-        Err(message) => Response::Error { message },
+    let id = match crate::run_registry::resolve(run) {
+        Ok(id) => id,
+        Err(message) => return Response::Error { message },
+    };
+    if crate::run_registry::status(id).is_none() {
+        return Response::Error {
+            message: format!("no active run with id {id}"),
+        };
     }
+    forward_session_input(id, session_input_from_signal(signal), "Kill").await
 }
 
 async fn stop_run_request(run: &str, timeout_secs: u64) -> Response {
@@ -990,7 +996,37 @@ mod tests {
             Instant::now(),
         )
         .await;
-        assert!(matches!(response, Response::Error { .. }));
+        match response {
+            Response::Error { message } => assert!(
+                message.contains("no active run with id 999999"),
+                "an unknown run must report no-active-run, not a capability error; got: {message}"
+            ),
+            other => panic!("expected an unknown-run error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_request_kill_for_a_registered_run_passes_existence_and_forwards() {
+        let id = 557799;
+        register_running(id);
+        let response = handle_request(
+            &Request::Kill {
+                run: id.to_string(),
+                signal: lns_ipc::SignalKind::Kill,
+            },
+            Instant::now(),
+        )
+        .await;
+        crate::run_registry::deregister(id);
+        match response {
+            Response::Error { message } => assert!(
+                !message.contains("no active run with id"),
+                "a registered run clears the existence check and reaches forwarding; got: {message}"
+            ),
+            other => panic!(
+                "expected a forwarding outcome for a sessionless registered run, got {other:?}"
+            ),
+        }
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/main.rs
+++ b/crates/lns-service/src/main.rs
@@ -29,7 +29,11 @@ fn main() -> anyhow::Result<()> {
     let ipc_socket = socket.clone();
     let ipc_handle = thread::spawn(move || run_ipc_runtime(ipc_socket, ipc_shutdown, started_at));
 
-    tray::run_tray(shutdown, ipc_handle, window_state)
+    if tray::display_present() {
+        tray::run_tray(shutdown, ipc_handle, window_state)
+    } else {
+        tray::run_headless(shutdown, ipc_handle)
+    }
 }
 
 fn run_ipc_runtime(

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -78,6 +78,33 @@ pub fn run_tray(
     result.map_err(|e| anyhow::anyhow!("eframe run_native failed: {e}"))
 }
 
+/// Whether a desktop session the tray can attach to is present: macOS always has a window server, while Linux needs Wayland or X11 — whose absence (headless servers, CI, plain SSH) means winit cannot create an event loop.
+pub fn display_present() -> bool {
+    if cfg!(target_os = "macos") {
+        return true;
+    }
+    has_linux_display(|key| std::env::var_os(key).is_some())
+}
+
+fn has_linux_display(present: impl Fn(&str) -> bool) -> bool {
+    present("WAYLAND_DISPLAY") || present("WAYLAND_SOCKET") || present("DISPLAY")
+}
+
+/// Run the service without the tray UI — wait for shutdown, then join the IPC thread and surface its result — so a headless host keeps the sandbox running instead of aborting at startup.
+pub fn run_headless(
+    shutdown: Arc<Shutdown>,
+    ipc_handle: JoinHandle<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    crate::log::warn!(
+        "no display detected — running headless without the tray; interactive approval prompts can't be shown, so pre-authorize access in lns-policy.yaml"
+    );
+    shutdown.wait_sync();
+    match ipc_handle.join() {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("the ipc thread panicked"),
+    }
+}
+
 struct TrayApp {
     shutdown: Arc<Shutdown>,
     window_state: Arc<WindowState>,
@@ -1029,6 +1056,35 @@ mod tests {
     fn embedded_icon_decodes_successfully() {
         let icon = load_icon().expect("embedded template PNG should decode");
         drop(icon);
+    }
+
+    #[test]
+    fn has_linux_display_true_when_any_display_var_is_present() {
+        assert!(has_linux_display(|k| k == "DISPLAY"));
+        assert!(has_linux_display(|k| k == "WAYLAND_DISPLAY"));
+        assert!(has_linux_display(|k| k == "WAYLAND_SOCKET"));
+    }
+
+    #[test]
+    fn has_linux_display_false_when_no_display_var_is_present() {
+        assert!(!has_linux_display(|_| false));
+    }
+
+    #[test]
+    fn run_headless_joins_the_ipc_thread_and_surfaces_success() {
+        let shutdown = Arc::new(Shutdown::new());
+        shutdown.signal();
+        let ipc = std::thread::spawn(|| Ok(()));
+        assert!(run_headless(shutdown, ipc).is_ok());
+    }
+
+    #[test]
+    fn run_headless_surfaces_an_ipc_thread_error() {
+        let shutdown = Arc::new(Shutdown::new());
+        shutdown.signal();
+        let ipc = std::thread::spawn(|| anyhow::bail!("ipc boom"));
+        let err = run_headless(shutdown, ipc).expect_err("ipc error must surface");
+        assert!(err.to_string().contains("ipc boom"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`make e2e` could not fail CI: the harness used cucumber's `filter_run`, which never sets a non-zero exit code. Every e2e run reported success regardless of outcome — masking **20 of 31 scenarios failing on Linux CI** while the job stayed green.

Making the gate enforce surfaced the failures it had been hiding; this PR fixes them and flips the gate:

### 1. `lns-service` aborted at startup on any headless host (the big one)

`main` unconditionally started the eframe/winit tray, so with no `WAYLAND_DISPLAY`/`DISPLAY` (Linux servers, CI, plain SSH) the service died with a winit `EventLoopError` *before becoming ready* — taking the IPC server (already on its own thread) down with it. This broke the core "background service you don't turn off" promise on headless Linux, not just CI. Fix: `display_present()` gates the tray; with no display the service runs headless (`run_headless` waits for shutdown, joins the IPC thread). Headless hosts pre-authorize access in `lns-policy.yaml`.

### 2. `kill` of an unknown run was inconsistent across platforms

`kill_request` forwarded to the session layer without first checking the run exists, unlike `stop`/`inspect`/`logs`. For an unknown run that surfaced a host-specific message ("no active session" on macOS, the macOS-only capability stub on Linux) instead of the run-not-found error its siblings give. Now it checks existence first and reports `no active run with id <n>` on every host.

### 3. Stale audit fixture

The "intact chain verifies cleanly" scenario wrote only `audit.jsonl` and asserted exit 0, but `5f02c2b` made a missing `audit.anchor` exit non-zero by default. The fixture now builds a real chain **and** anchor via `lns_ipc::AuditChain`.

### 4. The gate now enforces

`filter_run` → `filter_run_and_exit`, so a failed scenario fails the job. The harness also now dumps the failing service's `service.log` (written beside the socket) into the failure output — the diagnostic that root-caused #1, since that log is ephemeral in CI.

## Result

| | macOS | ubuntu CI |
|---|---|---|
| Before | 30/31 (exit 0) | 11/31 (exit 0 — green) |
| After | 31/31 | expected 31/31, **and a real failure now turns CI red** |

Locally verified both directions: green path exits 0; an injected assertion failure exits 2.

## Test instructions

1. `make e2e` → 31/31, exit 0.
2. Break any scenario assertion → `make e2e` exits non-zero (previously it stayed 0).
3. On a headless Linux host, `lns service start` now comes up (no tray) instead of aborting.
4. `lns <kill|stop|inspect> 999999` against a running service → all report `no active run with id 999999`.