### PR TITLE
feat(lns-run): host bind mounts with KEEP/DROP secret guard

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -152,10 +152,10 @@ pub struct RunArgs {
     #[arg(
         short = 'v',
         long = "volume",
-        value_parser = lns_ipc::VolumeMount::parse,
-        help = "Attach a named volume as `name:/path[:ro]`; its contents persist across runs (Docker -v style)."
+        value_parser = lns_ipc::MountSpec::parse,
+        help = "Mount into the workload (Docker -v style): a named volume `name:/path[:ro]` (persists across runs) or a host bind `/host/path:/path[:ro]` (live host files)."
     )]
-    pub volumes: Vec<lns_ipc::VolumeMount>,
+    pub mounts: Vec<lns_ipc::MountSpec>,
 
     #[arg(
         last = true,
@@ -175,6 +175,20 @@ impl RunArgs {
     pub fn effective_mem(&self) -> usize {
         self.mem.unwrap_or(DEFAULT_MEM_MIB)
     }
+}
+
+pub fn split_mounts(
+    mounts: &[lns_ipc::MountSpec],
+) -> (Vec<lns_ipc::VolumeMount>, Vec<lns_ipc::BindSpec>) {
+    let mut volumes = Vec::new();
+    let mut binds = Vec::new();
+    for mount in mounts {
+        match mount {
+            lns_ipc::MountSpec::Named(v) => volumes.push(v.clone()),
+            lns_ipc::MountSpec::Bind(b) => binds.push(b.clone()),
+        }
+    }
+    (volumes, binds)
 }
 
 #[derive(clap::Args)]

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -756,13 +756,10 @@ mod tests {
         )
         .unwrap();
         let defaults = load_run_defaults(&path).unwrap();
-        match &defaults.mounts[0] {
-            MountSpec::Named(v) => {
-                assert_eq!(v.target, "/var/cache");
-                assert!(v.read_only);
-            }
-            other => panic!("expected a named volume, got {other:?}"),
-        }
+        assert_eq!(
+            defaults.mounts,
+            vec![MountSpec::parse("cache:/var/cache:ro").unwrap()]
+        );
         assert_eq!(defaults.publish[0].host_port, 8080);
         assert_eq!(defaults.publish[0].container_port, 80);
     }
@@ -773,14 +770,10 @@ mod tests {
         let path = dir.path().join("config.yaml");
         std::fs::write(&path, "run:\n  volume:\n    - /srv/data:/data:ro\n").unwrap();
         let defaults = load_run_defaults(&path).unwrap();
-        match &defaults.mounts[0] {
-            MountSpec::Bind(b) => {
-                assert_eq!(b.host_source, "/srv/data");
-                assert_eq!(b.target, "/data");
-                assert!(b.read_only);
-            }
-            other => panic!("expected a host bind, got {other:?}"),
-        }
+        assert_eq!(
+            defaults.mounts,
+            vec![MountSpec::parse("/srv/data:/data:ro").unwrap()]
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::FromArgMatches;
-use lns_ipc::{PortPublish, VolumeMount};
+use lns_ipc::{MountSpec, PortPublish};
 use serde::{Deserialize, Serialize};
 
 use crate::cli::RunArgs;
@@ -270,8 +270,7 @@ fn store(cfg: &mut ConfigFile, key: ConfigKey, values: &[String]) -> Result<()> 
             cfg.run.env = validated(key, values, |s| crate::cli::parse_env_kv(s).map(|_| ()))?;
         }
         ConfigKey::RunVolume => {
-            cfg.run.volume =
-                validated(key, values, |s| lns_ipc::VolumeMount::parse(s).map(|_| ()))?;
+            cfg.run.volume = validated(key, values, |s| lns_ipc::MountSpec::parse(s).map(|_| ()))?;
         }
         ConfigKey::RunPublish => {
             cfg.run.publish = validated(key, values, |s| {
@@ -349,7 +348,7 @@ pub struct RunDefaults {
     pub mem: Option<usize>,
     pub registry: Option<String>,
     pub env: Vec<String>,
-    pub volumes: Vec<VolumeMount>,
+    pub mounts: Vec<MountSpec>,
     pub publish: Vec<PortPublish>,
 }
 
@@ -365,11 +364,11 @@ pub fn load_run_defaults(path: &Path) -> Result<RunDefaults> {
             path,
             crate::cli::parse_env_kv,
         )?,
-        volumes: parsed_defaults(
+        mounts: parsed_defaults(
             ConfigKey::RunVolume,
             &cfg.run.volume,
             path,
-            VolumeMount::parse,
+            MountSpec::parse,
         )?,
         publish: parsed_defaults(
             ConfigKey::RunPublish,
@@ -421,7 +420,7 @@ pub fn apply_run_defaults(mut args: RunArgs, defaults: RunDefaults) -> RunArgs {
         args.image = Some(resolve_default_registry(&image, args.registry.as_deref()));
     }
     args.env = merged_env(defaults.env, args.env);
-    args.volumes = merged_volumes(defaults.volumes, args.volumes);
+    args.mounts = merged_mounts(defaults.mounts, args.mounts);
     args.publish = merged_publish(defaults.publish, args.publish);
     args
 }
@@ -459,10 +458,10 @@ fn env_key(entry: &str) -> &str {
     entry.split_once('=').map_or(entry, |(key, _)| key)
 }
 
-fn merged_volumes(defaults: Vec<VolumeMount>, flags: Vec<VolumeMount>) -> Vec<VolumeMount> {
-    let mut merged: Vec<VolumeMount> = defaults
+fn merged_mounts(defaults: Vec<MountSpec>, flags: Vec<MountSpec>) -> Vec<MountSpec> {
+    let mut merged: Vec<MountSpec> = defaults
         .into_iter()
-        .filter(|d| !flags.iter().any(|f| f.target == d.target))
+        .filter(|d| !flags.iter().any(|f| f.target() == d.target()))
         .collect();
     merged.extend(flags);
     merged
@@ -742,7 +741,7 @@ mod tests {
             env: Vec::new(),
             env_file: Vec::new(),
             publish: Vec::new(),
-            volumes: Vec::new(),
+            mounts: Vec::new(),
             cmd: Vec::new(),
         }
     }
@@ -757,10 +756,31 @@ mod tests {
         )
         .unwrap();
         let defaults = load_run_defaults(&path).unwrap();
-        assert_eq!(defaults.volumes[0].target, "/var/cache");
-        assert!(defaults.volumes[0].read_only);
+        match &defaults.mounts[0] {
+            MountSpec::Named(v) => {
+                assert_eq!(v.target, "/var/cache");
+                assert!(v.read_only);
+            }
+            other => panic!("expected a named volume, got {other:?}"),
+        }
         assert_eq!(defaults.publish[0].host_port, 8080);
         assert_eq!(defaults.publish[0].container_port, 80);
+    }
+
+    #[test]
+    fn load_run_defaults_parses_a_host_bind_entry() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "run:\n  volume:\n    - /srv/data:/data:ro\n").unwrap();
+        let defaults = load_run_defaults(&path).unwrap();
+        match &defaults.mounts[0] {
+            MountSpec::Bind(b) => {
+                assert_eq!(b.host_source, "/srv/data");
+                assert_eq!(b.target, "/data");
+                assert!(b.read_only);
+            }
+            other => panic!("expected a host bind, got {other:?}"),
+        }
     }
 
     #[test]
@@ -971,14 +991,21 @@ mod tests {
     }
 
     #[test]
-    fn merged_volumes_keeps_the_same_volume_mounted_at_two_different_targets() {
-        let mount = |spec: &str| VolumeMount::parse(spec).unwrap();
-        let merged = merged_volumes(vec![mount("cache:/a")], vec![mount("cache:/b")]);
+    fn merged_mounts_keeps_the_same_volume_mounted_at_two_different_targets() {
+        let mount = |spec: &str| MountSpec::parse(spec).unwrap();
+        let merged = merged_mounts(vec![mount("cache:/a")], vec![mount("cache:/b")]);
         assert_eq!(
             merged.len(),
             2,
             "same name at distinct targets is not a conflict"
         );
+    }
+
+    #[test]
+    fn merged_mounts_lets_a_flag_override_the_configured_mount_at_the_same_target() {
+        let mount = |spec: &str| MountSpec::parse(spec).unwrap();
+        let merged = merged_mounts(vec![mount("cache:/data")], vec![mount("/srv/data:/data")]);
+        assert_eq!(merged, vec![mount("/srv/data:/data")]);
     }
 
     #[test]

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -53,15 +53,42 @@ pub fn looks_like_secret(name: &str) -> bool {
         || EXACT_SECRET_NAMES.contains(&name)
 }
 
-/// Top-level names that need a KEEP/DROP decision: secret-shaped files, plus anything the bind's `.lensignore` names so an explicit "never expose this" works for any file, not only secret-shaped ones.
-fn names_needing_a_decision(scan: &dyn DirScan, root: &Path, ignore: &[String]) -> Vec<String> {
+fn secret_shaped_top_level(scan: &dyn DirScan, root: &Path) -> Vec<String> {
     let mut found: Vec<String> = scan
         .entries(root)
         .into_iter()
-        .filter(|name| looks_like_secret(name) || is_ignored(name, ignore))
+        .filter(|name| looks_like_secret(name))
         .collect();
     found.sort();
     found
+}
+
+/// `.lensignore`-listed paths that exist in the bind, dropped with no prompt; a nested entry is honored so an explicit "never expose this" reaches a secret the top-level scan can't see.
+fn ignored_paths_present(
+    scan: &dyn DirScan,
+    root: &Path,
+    ignore: &[String],
+) -> Result<Vec<String>> {
+    let mut found = Vec::new();
+    for entry in ignore {
+        validate_lensignore_entry(entry)?;
+        if scan.exists(&root.join(entry)) {
+            found.push(entry.clone());
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+/// A `.lensignore` entry is masked at `target/<entry>` in the guest, so an absolute or `..`-bearing entry would escape the bind — refuse it loudly rather than silently expose the file the operator listed.
+fn validate_lensignore_entry(entry: &str) -> Result<()> {
+    if entry.starts_with('/') {
+        bail!(".lensignore entry {entry:?} must be relative to the bind, not an absolute path");
+    }
+    if entry.split('/').any(|seg| seg == "." || seg == "..") {
+        bail!(".lensignore entry {entry:?} must not contain `.` or `..` path segments");
+    }
+    Ok(())
 }
 
 pub fn lensignore_patterns(scan: &dyn DirScan, root: &Path) -> Vec<String> {
@@ -97,6 +124,7 @@ impl ResolvedBind {
             target: self.target.clone(),
             read_only: self.read_only,
             dropped_paths: self.dropped.clone(),
+            kept_paths: self.kept.clone(),
         }
     }
 }
@@ -121,9 +149,11 @@ pub fn resolve_binds(
         let ignore = lensignore_patterns(scan, root);
         let mut kept = Vec::new();
         let mut dropped = Vec::new();
-        for name in names_needing_a_decision(scan, root, &ignore) {
+        for path in ignored_paths_present(scan, root, &ignore)? {
+            push_drop(&mut dropped, path)?;
+        }
+        for name in secret_shaped_top_level(scan, root) {
             if is_ignored(&name, &ignore) {
-                push_drop(&mut dropped, name)?;
                 continue;
             }
             let key = root.join(&name).to_string_lossy().into_owned();
@@ -285,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn names_needing_a_decision_returns_sorted_secret_shaped_entries() {
+    fn secret_shaped_top_level_returns_sorted_secret_shaped_entries() {
         let dir = FakeDir {
             entries: vec![
                 "src".into(),
@@ -295,27 +325,61 @@ mod tests {
             ],
             ..Default::default()
         };
-        let found = names_needing_a_decision(&dir, Path::new("/proj"), &[]);
+        let found = secret_shaped_top_level(&dir, Path::new("/proj"));
         assert_eq!(found, vec![".env".to_string(), ".npmrc".to_string()]);
     }
 
     #[test]
-    fn names_needing_a_decision_also_includes_lensignore_listed_non_secrets() {
-        let dir = FakeDir {
-            entries: vec!["src".into(), "notes.txt".into(), ".env".into()],
-            ..Default::default()
-        };
-        let found = names_needing_a_decision(&dir, Path::new("/proj"), &["notes.txt".to_string()]);
-        assert_eq!(found, vec![".env".to_string(), "notes.txt".to_string()]);
-    }
-
-    #[test]
-    fn names_needing_a_decision_is_empty_for_a_clean_directory() {
+    fn secret_shaped_top_level_is_empty_for_a_clean_directory() {
         let dir = FakeDir {
             entries: vec!["src".into(), "Cargo.toml".into()],
             ..Default::default()
         };
-        assert!(names_needing_a_decision(&dir, Path::new("/proj"), &[]).is_empty());
+        assert!(secret_shaped_top_level(&dir, Path::new("/proj")).is_empty());
+    }
+
+    #[test]
+    fn ignored_paths_present_honors_top_level_and_nested_entries_that_exist() {
+        let dir = FakeDir::default();
+        let found = ignored_paths_present(
+            &dir,
+            Path::new("/proj"),
+            &["notes.txt".to_string(), "packages/api/.env".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            found,
+            vec!["notes.txt".to_string(), "packages/api/.env".to_string()],
+            "a nested .lensignore path is honored, not silently ignored"
+        );
+    }
+
+    #[test]
+    fn ignored_paths_present_skips_a_listed_path_that_is_absent() {
+        let dir = FakeDir {
+            missing: vec!["/proj/ghost.env".into()],
+            ..Default::default()
+        };
+        let found =
+            ignored_paths_present(&dir, Path::new("/proj"), &["ghost.env".to_string()]).unwrap();
+        assert!(
+            found.is_empty(),
+            "a .lensignore rule for an absent file is a no-op, not a phantom drop"
+        );
+    }
+
+    #[test]
+    fn ignored_paths_present_refuses_an_entry_that_would_escape_the_bind() {
+        let dir = FakeDir::default();
+        for bad in ["../secrets", "/etc/shadow", "a/../../etc"] {
+            let err = ignored_paths_present(&dir, Path::new("/proj"), &[bad.to_string()])
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains(".lensignore entry"),
+                "{bad} must be refused loudly: {err}"
+            );
+        }
     }
 
     #[test]
@@ -506,6 +570,46 @@ mod tests {
     }
 
     #[test]
+    fn resolve_binds_lensignore_drops_a_nested_path_without_prompting() {
+        let mut files = HashMap::new();
+        files.insert(
+            "/proj/.lensignore".to_string(),
+            "packages/api/.env\n".to_string(),
+        );
+        let dir = FakeDir {
+            entries: vec!["packages".into(), "src".into()],
+            files,
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        assert_eq!(
+            out.unwrap()[0].dropped,
+            vec!["packages/api/.env".to_string()],
+            "a nested .lensignore entry must drop the file, not silently expose it"
+        );
+        assert!(prompt.is_empty(), "a .lensignore drop never prompts");
+    }
+
+    #[test]
+    fn resolve_binds_refuses_a_lensignore_entry_that_escapes_the_bind() {
+        let mut files = HashMap::new();
+        files.insert(
+            "/proj/.lensignore".to_string(),
+            "../../etc/shadow\n".to_string(),
+        );
+        let dir = FakeDir {
+            entries: vec!["src".into()],
+            files,
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        let err = out.unwrap_err().to_string();
+        assert!(err.contains(".lensignore entry"), "got: {err}");
+    }
+
+    #[test]
     fn resolve_binds_non_interactive_defaults_to_drop_and_reports() {
         let dir = FakeDir {
             entries: vec![".env".into()],
@@ -562,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn to_wire_carries_source_target_mode_and_only_the_dropped_paths() {
+    fn to_wire_carries_source_target_mode_and_both_kept_and_dropped_paths() {
         let resolved = ResolvedBind {
             host_source: "/proj".into(),
             target: "/work".into(),
@@ -578,6 +682,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: true,
                 dropped_paths: vec![".npmrc".into()],
+                kept_paths: vec![".env".into()],
             }
         );
     }

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -122,7 +122,7 @@ pub fn resolve_binds(
         let mut dropped = Vec::new();
         for name in scan_secrets(scan, root) {
             if is_ignored(&name, &ignore) {
-                dropped.push(name);
+                push_drop(&mut dropped, name)?;
                 continue;
             }
             let key = root.join(&name).to_string_lossy().into_owned();
@@ -144,7 +144,7 @@ pub fn resolve_binds(
             };
             match disposition {
                 SecretDisposition::Keep => kept.push(name),
-                SecretDisposition::Drop => dropped.push(name),
+                SecretDisposition::Drop => push_drop(&mut dropped, name)?,
             }
         }
         resolved.push(ResolvedBind {
@@ -161,6 +161,17 @@ pub fn resolve_binds(
             .context("saving host-bind decisions")?;
     }
     Ok(resolved)
+}
+
+/// A dropped path travels to the guest on the kernel cmdline, which is whitespace-tokenized; a name with whitespace would be silently split and mis-masked, so we refuse it loudly rather than risk exposing the very secret the operator chose to drop.
+fn push_drop(dropped: &mut Vec<String>, name: String) -> Result<()> {
+    if name.contains(char::is_whitespace) {
+        bail!(
+            "cannot drop secret-shaped file {name:?}: its name contains whitespace, which can't be carried to the guest safely — rename it or move it out of the bind"
+        );
+    }
+    dropped.push(name);
+    Ok(())
 }
 
 fn prompt_disposition(
@@ -482,6 +493,18 @@ mod tests {
             0,
             "a fallback drop is not recorded"
         );
+    }
+
+    #[test]
+    fn resolve_binds_refuses_to_drop_a_secret_whose_name_has_whitespace() {
+        let dir = FakeDir {
+            entries: vec![".env backup".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "drop\n");
+        let err = out.unwrap_err().to_string();
+        assert!(err.contains("whitespace"), "got: {err}");
     }
 
     #[test]

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -53,11 +53,12 @@ pub fn looks_like_secret(name: &str) -> bool {
         || EXACT_SECRET_NAMES.contains(&name)
 }
 
-pub fn scan_secrets(scan: &dyn DirScan, root: &Path) -> Vec<String> {
+/// Top-level names that need a KEEP/DROP decision: secret-shaped files, plus anything the bind's `.lensignore` names so an explicit "never expose this" works for any file, not only secret-shaped ones.
+fn names_needing_a_decision(scan: &dyn DirScan, root: &Path, ignore: &[String]) -> Vec<String> {
     let mut found: Vec<String> = scan
         .entries(root)
         .into_iter()
-        .filter(|name| looks_like_secret(name))
+        .filter(|name| looks_like_secret(name) || is_ignored(name, ignore))
         .collect();
     found.sort();
     found
@@ -100,7 +101,7 @@ impl ResolvedBind {
     }
 }
 
-/// Scans each bind for secret-shaped files and resolves a KEEP/DROP for every one — honoring `.lensignore`, reusing recorded decisions, prompting for the rest (or defaulting to DROP when there is no terminal).
+/// Resolves a KEEP/DROP for every secret-shaped file in each bind (and every `.lensignore`-listed path, whatever its shape) — `.lensignore` and recorded decisions drop silently, the rest prompt or default to DROP when there is no terminal.
 pub fn resolve_binds(
     specs: &[lns_ipc::BindSpec],
     scan: &dyn DirScan,
@@ -120,7 +121,7 @@ pub fn resolve_binds(
         let ignore = lensignore_patterns(scan, root);
         let mut kept = Vec::new();
         let mut dropped = Vec::new();
-        for name in scan_secrets(scan, root) {
+        for name in names_needing_a_decision(scan, root, &ignore) {
             if is_ignored(&name, &ignore) {
                 push_drop(&mut dropped, name)?;
                 continue;
@@ -163,11 +164,11 @@ pub fn resolve_binds(
     Ok(resolved)
 }
 
-/// A dropped path travels to the guest on the kernel cmdline, which is whitespace-tokenized; a name with whitespace would be silently split and mis-masked, so we refuse it loudly rather than risk exposing the very secret the operator chose to drop.
+/// A dropped path travels to the guest on the kernel cmdline, which is whitespace-tokenized; a name with whitespace would be silently split and mis-masked, so we refuse it loudly rather than risk exposing the very file the operator chose to drop.
 fn push_drop(dropped: &mut Vec<String>, name: String) -> Result<()> {
     if name.contains(char::is_whitespace) {
         bail!(
-            "cannot drop secret-shaped file {name:?}: its name contains whitespace, which can't be carried to the guest safely — rename it or move it out of the bind"
+            "cannot drop {name:?}: its name contains whitespace, which can't be carried to the guest safely — rename it or move it out of the bind"
         );
     }
     dropped.push(name);
@@ -284,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_secrets_returns_sorted_matching_top_level_entries() {
+    fn names_needing_a_decision_returns_sorted_secret_shaped_entries() {
         let dir = FakeDir {
             entries: vec![
                 "src".into(),
@@ -294,17 +295,27 @@ mod tests {
             ],
             ..Default::default()
         };
-        let found = scan_secrets(&dir, Path::new("/proj"));
+        let found = names_needing_a_decision(&dir, Path::new("/proj"), &[]);
         assert_eq!(found, vec![".env".to_string(), ".npmrc".to_string()]);
     }
 
     #[test]
-    fn scan_secrets_is_empty_for_a_clean_directory() {
+    fn names_needing_a_decision_also_includes_lensignore_listed_non_secrets() {
+        let dir = FakeDir {
+            entries: vec!["src".into(), "notes.txt".into(), ".env".into()],
+            ..Default::default()
+        };
+        let found = names_needing_a_decision(&dir, Path::new("/proj"), &["notes.txt".to_string()]);
+        assert_eq!(found, vec![".env".to_string(), "notes.txt".to_string()]);
+    }
+
+    #[test]
+    fn names_needing_a_decision_is_empty_for_a_clean_directory() {
         let dir = FakeDir {
             entries: vec!["src".into(), "Cargo.toml".into()],
             ..Default::default()
         };
-        assert!(scan_secrets(&dir, Path::new("/proj")).is_empty());
+        assert!(names_needing_a_decision(&dir, Path::new("/proj"), &[]).is_empty());
     }
 
     #[test]
@@ -473,6 +484,25 @@ mod tests {
             0,
             ".lensignore is not a decision"
         );
+    }
+
+    #[test]
+    fn resolve_binds_lensignore_drops_a_non_secret_shaped_file_too() {
+        let mut files = HashMap::new();
+        files.insert("/proj/.lensignore".to_string(), "notes.txt\n".to_string());
+        let dir = FakeDir {
+            entries: vec!["notes.txt".into(), "src".into()],
+            files,
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        assert_eq!(
+            out.unwrap()[0].dropped,
+            vec!["notes.txt".to_string()],
+            ".lensignore must drop any listed file, not only secret-shaped ones"
+        );
+        assert!(prompt.is_empty(), "a .lensignore drop never prompts");
     }
 
     #[test]

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -36,6 +36,9 @@ const EXACT_SECRET_NAMES: &[&str] = &[
     ".netrc",
     ".git-credentials",
     ".pgpass",
+    ".pypirc",
+    ".yarnrc.yml",
+    "auth.json",
     "id_rsa",
     "id_dsa",
     "id_ecdsa",
@@ -44,12 +47,19 @@ const EXACT_SECRET_NAMES: &[&str] = &[
     ".ssh",
     ".aws",
     ".gnupg",
+    ".kube",
+    ".azure",
+    ".oci",
+    ".docker",
 ];
 
 pub fn looks_like_secret(name: &str) -> bool {
     name.starts_with(".env")
+        || name.starts_with("credentials.")
         || name.ends_with(".pem")
         || name.ends_with(".key")
+        || name.ends_with(".ppk")
+        || name.ends_with(".keystore")
         || EXACT_SECRET_NAMES.contains(&name)
 }
 
@@ -296,12 +306,22 @@ mod tests {
             ".env.local",
             "server.pem",
             "tls.key",
+            "server.ppk",
+            "release.keystore",
+            "credentials.json",
             ".npmrc",
             ".netrc",
+            ".pypirc",
+            ".yarnrc.yml",
+            "auth.json",
             "id_rsa",
             "id_ed25519",
             ".ssh",
             ".aws",
+            ".kube",
+            ".azure",
+            ".oci",
+            ".docker",
         ] {
             assert!(looks_like_secret(s), "{s} should look like a secret");
         }

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -1,6 +1,11 @@
+use std::io::{BufRead, Write};
 use std::path::Path;
 
+use anyhow::{Context, Result, bail};
+use lns_policy::host_bind_decisions::{HostBindDecisionStore, SecretDisposition};
+
 pub trait DirScan {
+    fn exists(&self, path: &Path) -> bool;
     fn entries(&self, dir: &Path) -> Vec<String>;
     fn read_to_string(&self, path: &Path) -> Option<String>;
 }
@@ -8,6 +13,10 @@ pub trait DirScan {
 pub struct RealDirScan;
 
 impl DirScan for RealDirScan {
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
     fn entries(&self, dir: &Path) -> Vec<String> {
         let Ok(read) = std::fs::read_dir(dir) else {
             return Vec::new();
@@ -70,17 +79,103 @@ pub fn is_ignored(name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|p| p == name)
 }
 
+/// Scans each bind for secret-shaped files and resolves a KEEP/DROP for every one — honoring `.lensignore`, reusing recorded decisions, prompting for the rest (or defaulting to DROP when there is no terminal) — and returns wire binds whose `dropped_paths` the guest will mask.
+pub fn resolve_binds(
+    specs: &[lns_ipc::BindSpec],
+    scan: &dyn DirScan,
+    store: &dyn HostBindDecisionStore,
+    interactive: bool,
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<Vec<lns_ipc::BindMount>> {
+    let mut decisions = store.load().context("loading host-bind decisions")?;
+    let mut recorded = false;
+    let mut resolved = Vec::with_capacity(specs.len());
+    for spec in specs {
+        let root = Path::new(&spec.host_source);
+        if !scan.exists(root) {
+            bail!("host path does not exist: {}", spec.host_source);
+        }
+        let ignore = lensignore_patterns(scan, root);
+        let mut dropped = Vec::new();
+        for name in scan_secrets(scan, root) {
+            if is_ignored(&name, &ignore) {
+                dropped.push(name);
+                continue;
+            }
+            let key = root.join(&name).to_string_lossy().into_owned();
+            let disposition = match decisions.get(&key).copied() {
+                Some(d) => d,
+                None if interactive => {
+                    let chosen = prompt_disposition(&key, input, output)?;
+                    decisions.insert(key.clone(), chosen);
+                    recorded = true;
+                    chosen
+                }
+                None => {
+                    writeln!(
+                        output,
+                        "lns: no terminal to ask — dropping secret-shaped file {key} from the bind (run interactively to keep it)"
+                    )?;
+                    SecretDisposition::Drop
+                }
+            };
+            if disposition == SecretDisposition::Drop {
+                dropped.push(name);
+            }
+        }
+        resolved.push(lns_ipc::BindMount {
+            host_source: spec.host_source.clone(),
+            target: spec.target.clone(),
+            read_only: spec.read_only,
+            dropped_paths: dropped,
+        });
+    }
+    if recorded {
+        store
+            .save(&decisions)
+            .context("saving host-bind decisions")?;
+    }
+    Ok(resolved)
+}
+
+fn prompt_disposition(
+    secret_path: &str,
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<SecretDisposition> {
+    write!(
+        output,
+        "Host bind: {secret_path} looks like a secret. Expose it to the workload? [k]eep / [D]rop (default): "
+    )?;
+    output.flush()?;
+    let mut line = String::new();
+    input.read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(if answer == "k" || answer == "keep" {
+        SecretDisposition::Keep
+    } else {
+        SecretDisposition::Drop
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lns_policy::host_bind_decisions::HostBindDecisionFile;
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
     #[derive(Default)]
     struct FakeDir {
         entries: Vec<String>,
         files: HashMap<String, String>,
+        missing: Vec<String>,
     }
     impl DirScan for FakeDir {
+        fn exists(&self, path: &Path) -> bool {
+            !self.missing.contains(&path.to_string_lossy().into_owned())
+        }
         fn entries(&self, _dir: &Path) -> Vec<String> {
             self.entries.clone()
         }
@@ -89,6 +184,43 @@ mod tests {
                 .get(&path.to_string_lossy().into_owned())
                 .cloned()
         }
+    }
+
+    #[derive(Default)]
+    struct FakeStore {
+        state: Mutex<HostBindDecisionFile>,
+        saves: Mutex<usize>,
+    }
+    impl HostBindDecisionStore for FakeStore {
+        fn load(&self) -> std::io::Result<HostBindDecisionFile> {
+            Ok(self.state.lock().unwrap().clone())
+        }
+        fn save(&self, state: &HostBindDecisionFile) -> std::io::Result<()> {
+            *self.state.lock().unwrap() = state.clone();
+            *self.saves.lock().unwrap() += 1;
+            Ok(())
+        }
+    }
+
+    fn bind(src: &str, target: &str) -> lns_ipc::BindSpec {
+        lns_ipc::BindSpec {
+            host_source: src.into(),
+            target: target.into(),
+            read_only: false,
+        }
+    }
+
+    fn resolve(
+        specs: &[lns_ipc::BindSpec],
+        dir: &FakeDir,
+        store: &FakeStore,
+        interactive: bool,
+        answer: &str,
+    ) -> (Result<Vec<lns_ipc::BindMount>>, String) {
+        let mut input = std::io::Cursor::new(answer.to_string());
+        let mut out = Vec::new();
+        let r = resolve_binds(specs, dir, store, interactive, &mut input, &mut out);
+        (r, String::from_utf8(out).unwrap())
     }
 
     #[test]
@@ -174,6 +306,8 @@ mod tests {
         std::fs::write(dir.path().join(".env"), "SECRET=1").unwrap();
         std::fs::write(dir.path().join(".lensignore"), ".env\n").unwrap();
         let scan = RealDirScan;
+        assert!(scan.exists(&dir.path().join(".env")));
+        assert!(!scan.exists(&dir.path().join("absent")));
         assert!(scan.entries(dir.path()).contains(&".env".to_string()));
         assert_eq!(
             scan.read_to_string(&dir.path().join(".lensignore")),
@@ -181,5 +315,155 @@ mod tests {
         );
         assert_eq!(scan.read_to_string(&dir.path().join("absent")), None);
         assert!(scan.entries(Path::new("/no/such/dir")).is_empty());
+    }
+
+    #[test]
+    fn resolve_binds_leaves_a_clean_bind_untouched_and_never_prompts() {
+        let dir = FakeDir {
+            entries: vec!["src".into(), "Cargo.toml".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        let binds = out.unwrap();
+        assert_eq!(binds.len(), 1);
+        assert!(binds[0].dropped_paths.is_empty());
+        assert!(prompt.is_empty(), "clean bind must not prompt: {prompt:?}");
+        assert_eq!(*store.saves.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn resolve_binds_keep_exposes_the_file_and_records_the_decision() {
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "keep\n");
+        let binds = out.unwrap();
+        assert!(binds[0].dropped_paths.is_empty(), "KEEP must not drop");
+        assert!(prompt.contains("/proj/.env"), "prompt names the secret");
+        assert_eq!(
+            store.state.lock().unwrap().get("/proj/.env").copied(),
+            Some(SecretDisposition::Keep)
+        );
+        assert_eq!(*store.saves.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn resolve_binds_drop_hides_the_file_and_records_the_decision() {
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "drop\n");
+        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert_eq!(
+            store.state.lock().unwrap().get("/proj/.env").copied(),
+            Some(SecretDisposition::Drop)
+        );
+    }
+
+    #[test]
+    fn resolve_binds_empty_answer_defaults_to_drop() {
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "\n");
+        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+    }
+
+    #[test]
+    fn resolve_binds_reuses_a_recorded_decision_without_prompting() {
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        store
+            .state
+            .lock()
+            .unwrap()
+            .insert("/proj/.env".into(), SecretDisposition::Keep);
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        assert!(out.unwrap()[0].dropped_paths.is_empty());
+        assert!(prompt.is_empty(), "a recorded decision must not re-prompt");
+        assert_eq!(*store.saves.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn resolve_binds_prompts_only_for_the_newly_appeared_secret() {
+        let dir = FakeDir {
+            entries: vec![".env".into(), ".npmrc".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        store
+            .state
+            .lock()
+            .unwrap()
+            .insert("/proj/.env".into(), SecretDisposition::Keep);
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "keep\n");
+        out.unwrap();
+        assert!(prompt.contains("/proj/.npmrc"), "must prompt for .npmrc");
+        assert!(
+            !prompt.contains("/proj/.env"),
+            "must not re-prompt the decided .env: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_binds_lensignore_drops_without_prompting() {
+        let mut files = HashMap::new();
+        files.insert("/proj/.lensignore".to_string(), ".env\n".to_string());
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            files,
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert!(prompt.is_empty(), ".lensignore must pre-empt the prompt");
+        assert_eq!(
+            *store.saves.lock().unwrap(),
+            0,
+            ".lensignore is not a decision"
+        );
+    }
+
+    #[test]
+    fn resolve_binds_non_interactive_defaults_to_drop_and_reports() {
+        let dir = FakeDir {
+            entries: vec![".env".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, report) = resolve(&[bind("/proj", "/work")], &dir, &store, false, "");
+        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert!(
+            report.contains("/proj/.env"),
+            "drop is reported: {report:?}"
+        );
+        assert_eq!(
+            *store.saves.lock().unwrap(),
+            0,
+            "a fallback drop is not recorded"
+        );
+    }
+
+    #[test]
+    fn resolve_binds_refuses_a_missing_host_path_before_any_run() {
+        let dir = FakeDir {
+            missing: vec!["/proj".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
+        let err = out.unwrap_err().to_string();
+        assert!(err.contains("host path does not exist"), "got: {err}");
     }
 }

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -164,11 +164,11 @@ pub fn resolve_binds(
     Ok(resolved)
 }
 
-/// A dropped path travels to the guest on the kernel cmdline, which is whitespace-tokenized; a name with whitespace would be silently split and mis-masked, so we refuse it loudly rather than risk exposing the very file the operator chose to drop.
+/// A dropped path travels to the guest on the kernel cmdline the guest tokenizes; a name with whitespace or a quote would be mis-split or mis-masked, so we refuse it loudly rather than risk exposing the very file the operator chose to drop.
 fn push_drop(dropped: &mut Vec<String>, name: String) -> Result<()> {
-    if name.contains(char::is_whitespace) {
+    if name.contains(lns_ipc::cmdline_unsafe_char) {
         bail!(
-            "cannot drop {name:?}: its name contains whitespace, which can't be carried to the guest safely — rename it or move it out of the bind"
+            "cannot drop {name:?}: its name contains whitespace, quotes, or control characters, which can't be carried to the guest safely — rename it or move it out of the bind"
         );
     }
     dropped.push(name);
@@ -535,6 +535,18 @@ mod tests {
         let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "drop\n");
         let err = out.unwrap_err().to_string();
         assert!(err.contains("whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_binds_refuses_to_drop_a_secret_whose_name_has_a_quote() {
+        let dir = FakeDir {
+            entries: vec![".env\"x".into()],
+            ..Default::default()
+        };
+        let store = FakeStore::default();
+        let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "drop\n");
+        let err = out.unwrap_err().to_string();
+        assert!(err.contains("quote"), "got: {err}");
     }
 
     #[test]

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -1,0 +1,185 @@
+use std::path::Path;
+
+pub trait DirScan {
+    fn entries(&self, dir: &Path) -> Vec<String>;
+    fn read_to_string(&self, path: &Path) -> Option<String>;
+}
+
+pub struct RealDirScan;
+
+impl DirScan for RealDirScan {
+    fn entries(&self, dir: &Path) -> Vec<String> {
+        let Ok(read) = std::fs::read_dir(dir) else {
+            return Vec::new();
+        };
+        read.flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .collect()
+    }
+
+    fn read_to_string(&self, path: &Path) -> Option<String> {
+        std::fs::read_to_string(path).ok()
+    }
+}
+
+const EXACT_SECRET_NAMES: &[&str] = &[
+    ".npmrc",
+    ".netrc",
+    ".git-credentials",
+    ".pgpass",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "credentials",
+    ".ssh",
+    ".aws",
+    ".gnupg",
+];
+
+pub fn looks_like_secret(name: &str) -> bool {
+    name.starts_with(".env")
+        || name.ends_with(".pem")
+        || name.ends_with(".key")
+        || EXACT_SECRET_NAMES.contains(&name)
+}
+
+pub fn scan_secrets(scan: &dyn DirScan, root: &Path) -> Vec<String> {
+    let mut found: Vec<String> = scan
+        .entries(root)
+        .into_iter()
+        .filter(|name| looks_like_secret(name))
+        .collect();
+    found.sort();
+    found
+}
+
+pub fn lensignore_patterns(scan: &dyn DirScan, root: &Path) -> Vec<String> {
+    let Some(content) = scan.read_to_string(&root.join(".lensignore")) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn is_ignored(name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|p| p == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct FakeDir {
+        entries: Vec<String>,
+        files: HashMap<String, String>,
+    }
+    impl DirScan for FakeDir {
+        fn entries(&self, _dir: &Path) -> Vec<String> {
+            self.entries.clone()
+        }
+        fn read_to_string(&self, path: &Path) -> Option<String> {
+            self.files
+                .get(&path.to_string_lossy().into_owned())
+                .cloned()
+        }
+    }
+
+    #[test]
+    fn looks_like_secret_matches_env_keys_and_known_credential_files() {
+        for s in [
+            ".env",
+            ".env.local",
+            "server.pem",
+            "tls.key",
+            ".npmrc",
+            ".netrc",
+            "id_rsa",
+            "id_ed25519",
+            ".ssh",
+            ".aws",
+        ] {
+            assert!(looks_like_secret(s), "{s} should look like a secret");
+        }
+    }
+
+    #[test]
+    fn looks_like_secret_passes_ordinary_files() {
+        for s in ["main.rs", "README.md", "Cargo.toml", "src", "package.json"] {
+            assert!(!looks_like_secret(s), "{s} should not look like a secret");
+        }
+    }
+
+    #[test]
+    fn scan_secrets_returns_sorted_matching_top_level_entries() {
+        let dir = FakeDir {
+            entries: vec![
+                "src".into(),
+                ".npmrc".into(),
+                "Cargo.toml".into(),
+                ".env".into(),
+            ],
+            ..Default::default()
+        };
+        let found = scan_secrets(&dir, Path::new("/proj"));
+        assert_eq!(found, vec![".env".to_string(), ".npmrc".to_string()]);
+    }
+
+    #[test]
+    fn scan_secrets_is_empty_for_a_clean_directory() {
+        let dir = FakeDir {
+            entries: vec!["src".into(), "Cargo.toml".into()],
+            ..Default::default()
+        };
+        assert!(scan_secrets(&dir, Path::new("/proj")).is_empty());
+    }
+
+    #[test]
+    fn lensignore_patterns_skips_blanks_and_comments() {
+        let mut files = HashMap::new();
+        files.insert(
+            "/proj/.lensignore".to_string(),
+            "# secrets\n.env\n\n  .npmrc  \n".to_string(),
+        );
+        let dir = FakeDir {
+            files,
+            ..Default::default()
+        };
+        let patterns = lensignore_patterns(&dir, Path::new("/proj"));
+        assert_eq!(patterns, vec![".env".to_string(), ".npmrc".to_string()]);
+    }
+
+    #[test]
+    fn lensignore_patterns_empty_when_file_absent() {
+        let dir = FakeDir::default();
+        assert!(lensignore_patterns(&dir, Path::new("/proj")).is_empty());
+    }
+
+    #[test]
+    fn is_ignored_matches_exact_names_only() {
+        let patterns = vec![".env".to_string()];
+        assert!(is_ignored(".env", &patterns));
+        assert!(!is_ignored(".env.local", &patterns));
+    }
+
+    #[test]
+    fn real_dir_scan_reads_entries_and_files_from_disk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join(".env"), "SECRET=1").unwrap();
+        std::fs::write(dir.path().join(".lensignore"), ".env\n").unwrap();
+        let scan = RealDirScan;
+        assert!(scan.entries(dir.path()).contains(&".env".to_string()));
+        assert_eq!(
+            scan.read_to_string(&dir.path().join(".lensignore")),
+            Some(".env\n".to_string())
+        );
+        assert_eq!(scan.read_to_string(&dir.path().join("absent")), None);
+        assert!(scan.entries(Path::new("/no/such/dir")).is_empty());
+    }
+}

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -79,7 +79,28 @@ pub fn is_ignored(name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|p| p == name)
 }
 
-/// Scans each bind for secret-shaped files and resolves a KEEP/DROP for every one — honoring `.lensignore`, reusing recorded decisions, prompting for the rest (or defaulting to DROP when there is no terminal) — and returns wire binds whose `dropped_paths` the guest will mask.
+/// One host bind after secret resolution: the secrets to expose (`kept`) and to mask (`dropped`), ready to render in the summary or lower to the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBind {
+    pub host_source: String,
+    pub target: String,
+    pub read_only: bool,
+    pub kept: Vec<String>,
+    pub dropped: Vec<String>,
+}
+
+impl ResolvedBind {
+    pub fn to_wire(&self) -> lns_ipc::BindMount {
+        lns_ipc::BindMount {
+            host_source: self.host_source.clone(),
+            target: self.target.clone(),
+            read_only: self.read_only,
+            dropped_paths: self.dropped.clone(),
+        }
+    }
+}
+
+/// Scans each bind for secret-shaped files and resolves a KEEP/DROP for every one — honoring `.lensignore`, reusing recorded decisions, prompting for the rest (or defaulting to DROP when there is no terminal).
 pub fn resolve_binds(
     specs: &[lns_ipc::BindSpec],
     scan: &dyn DirScan,
@@ -87,7 +108,7 @@ pub fn resolve_binds(
     interactive: bool,
     input: &mut dyn BufRead,
     output: &mut dyn Write,
-) -> Result<Vec<lns_ipc::BindMount>> {
+) -> Result<Vec<ResolvedBind>> {
     let mut decisions = store.load().context("loading host-bind decisions")?;
     let mut recorded = false;
     let mut resolved = Vec::with_capacity(specs.len());
@@ -97,6 +118,7 @@ pub fn resolve_binds(
             bail!("host path does not exist: {}", spec.host_source);
         }
         let ignore = lensignore_patterns(scan, root);
+        let mut kept = Vec::new();
         let mut dropped = Vec::new();
         for name in scan_secrets(scan, root) {
             if is_ignored(&name, &ignore) {
@@ -120,15 +142,17 @@ pub fn resolve_binds(
                     SecretDisposition::Drop
                 }
             };
-            if disposition == SecretDisposition::Drop {
-                dropped.push(name);
+            match disposition {
+                SecretDisposition::Keep => kept.push(name),
+                SecretDisposition::Drop => dropped.push(name),
             }
         }
-        resolved.push(lns_ipc::BindMount {
+        resolved.push(ResolvedBind {
             host_source: spec.host_source.clone(),
             target: spec.target.clone(),
             read_only: spec.read_only,
-            dropped_paths: dropped,
+            kept,
+            dropped,
         });
     }
     if recorded {
@@ -216,7 +240,7 @@ mod tests {
         store: &FakeStore,
         interactive: bool,
         answer: &str,
-    ) -> (Result<Vec<lns_ipc::BindMount>>, String) {
+    ) -> (Result<Vec<ResolvedBind>>, String) {
         let mut input = std::io::Cursor::new(answer.to_string());
         let mut out = Vec::new();
         let r = resolve_binds(specs, dir, store, interactive, &mut input, &mut out);
@@ -327,7 +351,7 @@ mod tests {
         let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
         let binds = out.unwrap();
         assert_eq!(binds.len(), 1);
-        assert!(binds[0].dropped_paths.is_empty());
+        assert!(binds[0].dropped.is_empty());
         assert!(prompt.is_empty(), "clean bind must not prompt: {prompt:?}");
         assert_eq!(*store.saves.lock().unwrap(), 0);
     }
@@ -341,7 +365,12 @@ mod tests {
         let store = FakeStore::default();
         let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "keep\n");
         let binds = out.unwrap();
-        assert!(binds[0].dropped_paths.is_empty(), "KEEP must not drop");
+        assert!(binds[0].dropped.is_empty(), "KEEP must not drop");
+        assert_eq!(
+            binds[0].kept,
+            vec![".env".to_string()],
+            "KEEP records exposed"
+        );
         assert!(prompt.contains("/proj/.env"), "prompt names the secret");
         assert_eq!(
             store.state.lock().unwrap().get("/proj/.env").copied(),
@@ -358,7 +387,7 @@ mod tests {
         };
         let store = FakeStore::default();
         let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "drop\n");
-        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert_eq!(out.unwrap()[0].dropped, vec![".env".to_string()]);
         assert_eq!(
             store.state.lock().unwrap().get("/proj/.env").copied(),
             Some(SecretDisposition::Drop)
@@ -373,7 +402,7 @@ mod tests {
         };
         let store = FakeStore::default();
         let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "\n");
-        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert_eq!(out.unwrap()[0].dropped, vec![".env".to_string()]);
     }
 
     #[test]
@@ -389,7 +418,7 @@ mod tests {
             .unwrap()
             .insert("/proj/.env".into(), SecretDisposition::Keep);
         let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
-        assert!(out.unwrap()[0].dropped_paths.is_empty());
+        assert!(out.unwrap()[0].dropped.is_empty());
         assert!(prompt.is_empty(), "a recorded decision must not re-prompt");
         assert_eq!(*store.saves.lock().unwrap(), 0);
     }
@@ -426,7 +455,7 @@ mod tests {
         };
         let store = FakeStore::default();
         let (out, prompt) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
-        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert_eq!(out.unwrap()[0].dropped, vec![".env".to_string()]);
         assert!(prompt.is_empty(), ".lensignore must pre-empt the prompt");
         assert_eq!(
             *store.saves.lock().unwrap(),
@@ -443,7 +472,7 @@ mod tests {
         };
         let store = FakeStore::default();
         let (out, report) = resolve(&[bind("/proj", "/work")], &dir, &store, false, "");
-        assert_eq!(out.unwrap()[0].dropped_paths, vec![".env".to_string()]);
+        assert_eq!(out.unwrap()[0].dropped, vec![".env".to_string()]);
         assert!(
             report.contains("/proj/.env"),
             "drop is reported: {report:?}"
@@ -465,5 +494,26 @@ mod tests {
         let (out, _) = resolve(&[bind("/proj", "/work")], &dir, &store, true, "");
         let err = out.unwrap_err().to_string();
         assert!(err.contains("host path does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn to_wire_carries_source_target_mode_and_only_the_dropped_paths() {
+        let resolved = ResolvedBind {
+            host_source: "/proj".into(),
+            target: "/work".into(),
+            read_only: true,
+            kept: vec![".env".into()],
+            dropped: vec![".npmrc".into()],
+        };
+        let wire = resolved.to_wire();
+        assert_eq!(
+            wire,
+            lns_ipc::BindMount {
+                host_source: "/proj".into(),
+                target: "/work".into(),
+                read_only: true,
+                dropped_paths: vec![".npmrc".into()],
+            }
+        );
     }
 }

--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -1,4 +1,5 @@
 pub mod env_file;
+pub mod host_bind;
 pub mod progress;
 pub mod summary;
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -128,6 +128,20 @@ fn bind_line(bind: &lns_ipc::BindSpec) -> String {
     format!("{} → {} ({mode})", bind.host_source, bind.target)
 }
 
+/// Renders the post-scan secret disposition of each host bind (printed after KEEP/DROP resolution); empty when no bind exposed or dropped a secret.
+pub fn format_bind_dispositions(binds: &[crate::run::host_bind::ResolvedBind]) -> String {
+    let mut s = String::new();
+    for bind in binds {
+        for name in &bind.kept {
+            writeln!(s, "  {name}: kept (exposed)").unwrap();
+        }
+        for name in &bind.dropped {
+            writeln!(s, "  {name}: dropped").unwrap();
+        }
+    }
+    s
+}
+
 fn flags_line(args: &RunArgs) -> String {
     let mut flags: Vec<&str> = Vec::new();
     if args.interactive {
@@ -371,6 +385,52 @@ mod tests {
             s.contains("Bind:      /Users/me/proj → /work (read-write)"),
             "missing bind line: {s}"
         );
+    }
+
+    #[test]
+    fn summary_marks_a_read_only_host_bind() {
+        let mut args = run_args(Some("ubuntu"));
+        args.mounts = vec![lns_ipc::MountSpec::Bind(lns_ipc::BindSpec {
+            host_source: "/Users/me/cfg".into(),
+            target: "/cfg".into(),
+            read_only: true,
+        })];
+        let s = format_summary(
+            &args,
+            &Policy::default(),
+            Path::new("/x/lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("Bind:      /Users/me/cfg → /cfg (read-only)"),
+            "missing read-only bind line: {s}"
+        );
+    }
+
+    #[test]
+    fn bind_dispositions_render_kept_and_dropped_secrets() {
+        let binds = vec![crate::run::host_bind::ResolvedBind {
+            host_source: "/Users/me/proj".into(),
+            target: "/work".into(),
+            read_only: false,
+            kept: vec![".env".into()],
+            dropped: vec![".npmrc".into()],
+        }];
+        let s = format_bind_dispositions(&binds);
+        assert!(s.contains(".env: kept (exposed)"), "missing kept line: {s}");
+        assert!(s.contains(".npmrc: dropped"), "missing dropped line: {s}");
+    }
+
+    #[test]
+    fn bind_dispositions_are_empty_without_detected_secrets() {
+        let binds = vec![crate::run::host_bind::ResolvedBind {
+            host_source: "/Users/me/proj".into(),
+            target: "/work".into(),
+            read_only: false,
+            kept: vec![],
+            dropped: vec![],
+        }];
+        assert!(format_bind_dispositions(&binds).is_empty());
     }
 
     #[test]

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -74,8 +74,12 @@ pub fn format_summary(
     let mut s = String::with_capacity(512);
     s.push_str("lns run\n");
     writeln!(s, "  Image:     {}", image_line(args)).unwrap();
-    for vol in &args.volumes {
+    let (volumes, binds) = crate::cli::split_mounts(&args.mounts);
+    for vol in &volumes {
         writeln!(s, "  Volume:    {}", volume_line(vol)).unwrap();
+    }
+    for bind in &binds {
+        writeln!(s, "  Bind:      {}", bind_line(bind)).unwrap();
     }
     if let Some(dir) = &args.workdir {
         writeln!(s, "  Workdir:   {dir}").unwrap();
@@ -113,6 +117,15 @@ fn image_line(args: &RunArgs) -> String {
 fn volume_line(vol: &lns_ipc::VolumeMount) -> String {
     let mode = if vol.read_only { " (ro)" } else { "" };
     format!("{} → {}{mode}", vol.name, vol.target)
+}
+
+fn bind_line(bind: &lns_ipc::BindSpec) -> String {
+    let mode = if bind.read_only {
+        "read-only"
+    } else {
+        "read-write"
+    };
+    format!("{} → {} ({mode})", bind.host_source, bind.target)
 }
 
 fn flags_line(args: &RunArgs) -> String {
@@ -206,7 +219,7 @@ mod tests {
             env: Vec::new(),
             env_file: Vec::new(),
             publish: Vec::new(),
-            volumes: Vec::new(),
+            mounts: Vec::new(),
             cmd: Vec::new(),
         }
     }
@@ -312,17 +325,17 @@ mod tests {
     #[test]
     fn summary_lists_attached_volumes_with_target_and_ro_marker() {
         let mut args = run_args(Some("ubuntu"));
-        args.volumes = vec![
-            lns_ipc::VolumeMount {
+        args.mounts = vec![
+            lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
                 name: "prism-data".into(),
                 target: "/data".into(),
                 read_only: false,
-            },
-            lns_ipc::VolumeMount {
+            }),
+            lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
                 name: "ro-cfg".into(),
                 target: "/cfg".into(),
                 read_only: true,
-            },
+            }),
         ];
         let s = format_summary(
             &args,
@@ -337,6 +350,26 @@ mod tests {
         assert!(
             s.contains("Volume:    ro-cfg → /cfg (ro)"),
             "missing ro volume line: {s}"
+        );
+    }
+
+    #[test]
+    fn summary_lists_a_host_bind_with_its_mode() {
+        let mut args = run_args(Some("ubuntu"));
+        args.mounts = vec![lns_ipc::MountSpec::Bind(lns_ipc::BindSpec {
+            host_source: "/Users/me/proj".into(),
+            target: "/work".into(),
+            read_only: false,
+        })];
+        let s = format_summary(
+            &args,
+            &Policy::default(),
+            Path::new("/x/lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("Bind:      /Users/me/proj → /work (read-write)"),
+            "missing bind line: {s}"
         );
     }
 

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -381,6 +381,7 @@ fn render_inspect<W: std::io::Write>(
         "volumes".into(),
         serde_json::to_value(&details.config.volumes)?,
     );
+    config.insert("binds".into(), serde_json::to_value(&details.config.binds)?);
     config.insert(
         "sandboxUser".into(),
         serde_json::to_value(&details.config.sandbox_user)?,

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -99,7 +99,15 @@ fn real_client() -> Result<real::RealServiceClient> {
     ))
 }
 
-fn resolve_host_binds(specs: &[lns_ipc::BindSpec]) -> Result<Vec<lns_ipc::BindMount>> {
+/// A detached run must never block on the KEEP/DROP prompt, so it drops undecided secrets like a no-terminal run even when launched from a TTY.
+fn host_binds_interactive(detached: bool, stdin_is_tty: bool) -> bool {
+    !detached && stdin_is_tty
+}
+
+fn resolve_host_binds(
+    specs: &[lns_ipc::BindSpec],
+    interactive: bool,
+) -> Result<Vec<crate::run::host_bind::ResolvedBind>> {
     if specs.is_empty() {
         return Ok(Vec::new());
     }
@@ -113,7 +121,7 @@ fn resolve_host_binds(specs: &[lns_ipc::BindSpec]) -> Result<Vec<lns_ipc::BindMo
         specs,
         &scan,
         &store,
-        crate::raw_mode::stdin_is_tty(),
+        interactive,
         &mut input,
         &mut std::io::stderr(),
     )
@@ -124,7 +132,13 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
     let resolved_policy = print_run_summary(&args, &cwd, &mut std::io::stderr())?;
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
-    let binds = resolve_host_binds(&bind_specs)?;
+    let interactive = host_binds_interactive(args.detach, crate::raw_mode::stdin_is_tty());
+    let resolved_binds = resolve_host_binds(&bind_specs, interactive)?;
+    let dispositions = crate::run::summary::format_bind_dispositions(&resolved_binds);
+    if !dispositions.is_empty() {
+        eprint!("{dispositions}");
+    }
+    let binds: Vec<lns_ipc::BindMount> = resolved_binds.iter().map(|b| b.to_wire()).collect();
 
     let client = real_client()?;
     let socket = client.socket();
@@ -1272,6 +1286,22 @@ mod tests {
     fn lf_to_crlf_expands_every_newline_and_leaves_other_bytes() {
         assert_eq!(lf_to_crlf(b"a\nb\n"), b"a\r\nb\r\n");
         assert_eq!(lf_to_crlf(b"no newline"), b"no newline");
+    }
+
+    #[test]
+    fn host_binds_interactive_is_suppressed_for_a_detached_run_even_with_a_tty() {
+        assert!(
+            host_binds_interactive(false, true),
+            "attached + tty prompts"
+        );
+        assert!(
+            !host_binds_interactive(true, true),
+            "a detached run must never block on the secret prompt, even from a terminal"
+        );
+        assert!(
+            !host_binds_interactive(false, false),
+            "no terminal cannot prompt"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -119,6 +119,17 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
     };
     let detach_chord = args.detach_keys.0.clone();
 
+    let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
+    let binds = bind_specs
+        .into_iter()
+        .map(|b| lns_ipc::BindMount {
+            host_source: b.host_source,
+            target: b.target,
+            read_only: b.read_only,
+            dropped_paths: Vec::new(),
+        })
+        .collect();
+
     let request = Request::RunImage(RunImageArgs {
         cpus: args.effective_cpus(),
         mem: args.effective_mem(),
@@ -136,7 +147,8 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         initial_winsize,
         detached,
         published_ports: args.publish,
-        volumes: args.volumes,
+        volumes,
+        binds,
     });
     let frame = encode_frame(&request).context("encoding RunImage request")?;
     stream

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -99,9 +99,32 @@ fn real_client() -> Result<real::RealServiceClient> {
     ))
 }
 
+fn resolve_host_binds(specs: &[lns_ipc::BindSpec]) -> Result<Vec<lns_ipc::BindMount>> {
+    if specs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let scan = crate::run::host_bind::RealDirScan;
+    let store = lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
+        lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
+    );
+    let stdin = std::io::stdin();
+    let mut input = stdin.lock();
+    crate::run::host_bind::resolve_binds(
+        specs,
+        &scan,
+        &store,
+        crate::raw_mode::stdin_is_tty(),
+        &mut input,
+        &mut std::io::stderr(),
+    )
+}
+
 pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
     let cwd = std::env::current_dir().context("reading current directory")?;
     let resolved_policy = print_run_summary(&args, &cwd, &mut std::io::stderr())?;
+
+    let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
+    let binds = resolve_host_binds(&bind_specs)?;
 
     let client = real_client()?;
     let socket = client.socket();
@@ -118,17 +141,6 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         None
     };
     let detach_chord = args.detach_keys.0.clone();
-
-    let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
-    let binds = bind_specs
-        .into_iter()
-        .map(|b| lns_ipc::BindMount {
-            host_source: b.host_source,
-            target: b.target,
-            read_only: b.read_only,
-            dropped_paths: Vec::new(),
-        })
-        .collect();
 
     let request = Request::RunImage(RunImageArgs {
         cpus: args.effective_cpus(),

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -32,28 +32,23 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     Then the exit code is 2
     And the output contains "must be an absolute path"
 
-  @todo
   Scenario: A non-existent host source path is refused before the run starts
     Given the host path "/Users/me/typo" does not exist
-    When the user runs `lns run -v /Users/me/typo:/work alpine`
+    When the user runs `lns run -v /Users/me/typo:/work alpine` interactively
     Then the command fails with "host path does not exist"
-    And no run is started
 
-  @todo
   Scenario: A clean bind with no secret-shaped files runs without prompting
     Given the host directory "/Users/me/proj" contains no secret-shaped files
     When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
     Then no KEEP or DROP prompt is shown
     And the run starts
 
-  @todo
   Scenario: First run prompts KEEP or DROP for a detected secret-shaped file
     Given the host directory "/Users/me/proj" contains ".env"
     And no prior decision is recorded for "/Users/me/proj/.env"
     When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
     Then the operator is prompted to KEEP or DROP "/Users/me/proj/.env"
 
-  @todo
   Scenario: KEEP exposes the real file and records a per-machine decision
     Given the host directory "/Users/me/proj" contains ".env"
     And the operator will answer the secret prompt with "keep"
@@ -62,7 +57,6 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     And a per-machine KEEP decision is recorded for "/Users/me/proj/.env"
     And a later run with the same bind shows no prompt
 
-  @todo
   Scenario: DROP hides the file from the guest and records the decision
     Given the host directory "/Users/me/proj" contains ".env"
     And the operator will answer the secret prompt with "drop"
@@ -71,7 +65,6 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     And a per-machine DROP decision is recorded for "/Users/me/proj/.env"
     And a later run with the same bind shows no prompt
 
-  @todo
   Scenario: A committed .lensignore drops matching paths with no prompt
     Given the host directory "/Users/me/proj" contains ".env"
     And the host directory "/Users/me/proj" has a ".lensignore" listing ".env"
@@ -79,7 +72,6 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     Then ".env" is dropped from the bind
     And no KEEP or DROP prompt is shown
 
-  @todo
   Scenario: A newly-appeared, undecided secret prompts only for itself
     Given the host directory "/Users/me/proj" contains ".env" and ".npmrc"
     And a per-machine KEEP decision is recorded for "/Users/me/proj/.env"
@@ -87,7 +79,6 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
     Then the operator is prompted only for "/Users/me/proj/.npmrc"
 
-  @todo
   Scenario: A non-interactive run defaults undecided secrets to DROP
     Given the host directory "/Users/me/proj" contains an undecided ".env"
     When the user runs `lns run -d -v /Users/me/proj:/work alpine` with no terminal

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -1,0 +1,104 @@
+Feature: lns run mounts host directories into the sandbox (docker `-v host:guest`)
+  The day-one need is "run an agent against *this* repo". `lns run -v` gains a
+  second flavor alongside named volumes: when the source segment is an absolute
+  host path it is a host bind, mounting live host files into the guest; when it
+  is a bare name it stays a named volume (the existing behavior, unchanged). The
+  hard part is secrets — a bind drags `.env`, keys, and credential files onto the
+  guest, silently defeating "real secrets stay outside the workload". So before
+  the run starts, `lns` detects secret-shaped files in each bind and, the same
+  trust-on-first-use way the network policy works, asks the operator to KEEP or
+  DROP each one and remembers the decision. These scenarios pin the CLI grammar,
+  the disambiguation rule, the secret decision flow, and the run-summary surface
+  against the in-process `Cli`; the live host↔guest byte-path (the guest actually
+  seeing the files, writes propagating back, read-only enforcement) is a microVM
+  concern covered by the @microvm e2e contract, out of scope here.
+
+  Scenario: An absolute -v source resolves to a host bind
+    When the mounts are resolved for `lns run -v /Users/me/proj:/work alpine`
+    Then the resolved host binds are exactly "/Users/me/proj -> /work"
+    And the resolved volumes are exactly ""
+
+  Scenario: A read-only host bind keeps its :ro marker
+    When the mounts are resolved for `lns run -v /Users/me/proj:/work:ro alpine`
+    Then the resolved host binds are exactly "/Users/me/proj -> /work:ro"
+
+  Scenario: A bare -v name still resolves to a named volume
+    When the mounts are resolved for `lns run -v build-cache:/cache alpine`
+    Then the resolved volumes are exactly "build-cache:/cache"
+    And the resolved host binds are exactly ""
+
+  Scenario: A host bind target must be absolute with no '..' segments
+    When I run "lns run -v /Users/me/proj:work alpine"
+    Then the exit code is 2
+    And the output contains "must be an absolute path"
+
+  @todo
+  Scenario: A non-existent host source path is refused before the run starts
+    Given the host path "/Users/me/typo" does not exist
+    When the user runs `lns run -v /Users/me/typo:/work alpine`
+    Then the command fails with "host path does not exist"
+    And no run is started
+
+  @todo
+  Scenario: A clean bind with no secret-shaped files runs without prompting
+    Given the host directory "/Users/me/proj" contains no secret-shaped files
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then no KEEP or DROP prompt is shown
+    And the run starts
+
+  @todo
+  Scenario: First run prompts KEEP or DROP for a detected secret-shaped file
+    Given the host directory "/Users/me/proj" contains ".env"
+    And no prior decision is recorded for "/Users/me/proj/.env"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then the operator is prompted to KEEP or DROP "/Users/me/proj/.env"
+
+  @todo
+  Scenario: KEEP exposes the real file and records a per-machine decision
+    Given the host directory "/Users/me/proj" contains ".env"
+    And the operator will answer the secret prompt with "keep"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then ".env" is exposed to the guest under "/work"
+    And a per-machine KEEP decision is recorded for "/Users/me/proj/.env"
+    And a later run with the same bind shows no prompt
+
+  @todo
+  Scenario: DROP hides the file from the guest and records the decision
+    Given the host directory "/Users/me/proj" contains ".env"
+    And the operator will answer the secret prompt with "drop"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then ".env" is dropped from the bind
+    And a per-machine DROP decision is recorded for "/Users/me/proj/.env"
+    And a later run with the same bind shows no prompt
+
+  @todo
+  Scenario: A committed .lensignore drops matching paths with no prompt
+    Given the host directory "/Users/me/proj" contains ".env"
+    And the host directory "/Users/me/proj" has a ".lensignore" listing ".env"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then ".env" is dropped from the bind
+    And no KEEP or DROP prompt is shown
+
+  @todo
+  Scenario: A newly-appeared, undecided secret prompts only for itself
+    Given the host directory "/Users/me/proj" contains ".env" and ".npmrc"
+    And a per-machine KEEP decision is recorded for "/Users/me/proj/.env"
+    And no prior decision is recorded for "/Users/me/proj/.npmrc"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then the operator is prompted only for "/Users/me/proj/.npmrc"
+
+  @todo
+  Scenario: A non-interactive run defaults undecided secrets to DROP
+    Given the host directory "/Users/me/proj" contains an undecided ".env"
+    When the user runs `lns run -d -v /Users/me/proj:/work alpine` with no terminal
+    Then ".env" is dropped from the bind
+    And the dropped path "/Users/me/proj/.env" is reported on stderr
+    And no KEEP or DROP prompt is shown
+
+  @todo
+  Scenario: The run summary lists each bind, its mode, and secret disposition
+    Given the host directory "/Users/me/proj" contains ".env"
+    And the operator will answer the secret prompt with "keep"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then the summary shows a bind line "/Users/me/proj → /work (read-write)"
+    And the summary shows ".env: kept (exposed)"

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -86,7 +86,6 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     And the dropped path "/Users/me/proj/.env" is reported on stderr
     And no KEEP or DROP prompt is shown
 
-  @todo
   Scenario: The run summary lists each bind, its mode, and secret disposition
     Given the host directory "/Users/me/proj" contains ".env"
     And the operator will answer the secret prompt with "keep"

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -72,6 +72,13 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     Then ".env" is dropped from the bind
     And no KEEP or DROP prompt is shown
 
+  Scenario: A .lensignore drops any listed file, even one that isn't secret-shaped
+    Given the host directory "/Users/me/proj" contains "notes.txt"
+    And the host directory "/Users/me/proj" has a ".lensignore" listing "notes.txt"
+    When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
+    Then "notes.txt" is dropped from the bind
+    And no KEEP or DROP prompt is shown
+
   Scenario: A newly-appeared, undecided secret prompts only for itself
     Given the host directory "/Users/me/proj" contains ".env" and ".npmrc"
     And a per-machine KEEP decision is recorded for "/Users/me/proj/.env"

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -2,7 +2,9 @@ use crate::world::{BehaviourWorld, HostBindOutcome, ResolvedRunView};
 use cucumber::{given, then, when};
 use lns_cli::cli::{RunArgs, split_mounts};
 use lns_cli::command::parse_args;
-use lns_cli::run::host_bind::{DirScan, resolve_binds};
+use lns_cli::run::host_bind::{DirScan, ResolvedBind, resolve_binds};
+use lns_cli::run::summary::{PolicySource, format_bind_dispositions, format_summary};
+use lns_policy::Policy;
 use lns_policy::host_bind_decisions::{
     HostBindDecisionFile, HostBindDecisionStore, SecretDisposition,
 };
@@ -109,10 +111,27 @@ fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
     let mut out = Vec::new();
     let result = resolve_binds(&specs, &dir, &store, interactive, &mut input, &mut out)
         .map_err(|e| e.to_string());
+    let summary = match &result {
+        Ok(resolved) => {
+            let mut argv = vec!["lns".to_string(), "run".to_string()];
+            argv.extend(flags.split_whitespace().map(str::to_string));
+            let args: RunArgs = parse_args(&argv).expect("argv must parse");
+            let mut text = format_summary(
+                &args,
+                &Policy::default(),
+                Path::new("./lns-policy.yaml"),
+                &PolicySource::FoundInCwd,
+            );
+            text.push_str(&format_bind_dispositions(resolved));
+            text
+        }
+        Err(_) => String::new(),
+    };
     world.host_bind.outcome = Some(HostBindOutcome {
         result,
         prompt: String::from_utf8(out).unwrap(),
         persisted: store.state.into_inner().unwrap(),
+        summary,
     });
 }
 
@@ -124,7 +143,7 @@ fn outcome(world: &BehaviourWorld) -> Result<&HostBindOutcome, String> {
         .ok_or_else(|| "no host-bind outcome captured".to_string())
 }
 
-fn resolved_binds(world: &BehaviourWorld) -> Result<&[lns_ipc::BindMount], String> {
+fn resolved_binds(world: &BehaviourWorld) -> Result<&[ResolvedBind], String> {
     outcome(world)?
         .result
         .as_deref()
@@ -229,7 +248,7 @@ fn run_starts(world: &mut BehaviourWorld) -> Result<(), String> {
 #[then(regex = r#"^"([^"]+)" is exposed to the guest under "([^"]+)"$"#)]
 fn exposed(world: &mut BehaviourWorld, name: String, _target: String) -> Result<(), String> {
     let b = resolved_binds(world)?;
-    if b.iter().any(|m| m.dropped_paths.contains(&name)) {
+    if b.iter().any(|m| m.dropped.contains(&name)) {
         Err(format!("{name:?} was dropped, expected it kept"))
     } else {
         Ok(())
@@ -239,7 +258,7 @@ fn exposed(world: &mut BehaviourWorld, name: String, _target: String) -> Result<
 #[then(regex = r#"^"([^"]+)" is dropped from the bind$"#)]
 fn dropped(world: &mut BehaviourWorld, name: String) -> Result<(), String> {
     let b = resolved_binds(world)?;
-    if b.iter().any(|m| m.dropped_paths.contains(&name)) {
+    if b.iter().any(|m| m.dropped.contains(&name)) {
         Ok(())
     } else {
         Err(format!("expected {name:?} dropped, binds: {b:?}"))
@@ -303,4 +322,25 @@ fn dropped_reported(world: &mut BehaviourWorld, path: String) -> Result<(), Stri
     } else {
         Err(format!("expected {path:?} reported, got {prompt:?}"))
     }
+}
+
+fn summary_contains(world: &BehaviourWorld, needle: &str) -> Result<(), String> {
+    let summary = &outcome(world)?.summary;
+    if summary.contains(needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected summary to contain {needle:?}, got:\n{summary}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the summary shows a bind line "([^"]+)"$"#)]
+fn summary_shows_bind_line(world: &mut BehaviourWorld, line: String) -> Result<(), String> {
+    summary_contains(world, &line)
+}
+
+#[then(regex = r#"^the summary shows "([^"]+)"$"#)]
+fn summary_shows(world: &mut BehaviourWorld, line: String) -> Result<(), String> {
+    summary_contains(world, &line)
 }

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -1,7 +1,13 @@
-use crate::world::{BehaviourWorld, ResolvedRunView};
-use cucumber::{then, when};
+use crate::world::{BehaviourWorld, HostBindOutcome, ResolvedRunView};
+use cucumber::{given, then, when};
 use lns_cli::cli::{RunArgs, split_mounts};
 use lns_cli::command::parse_args;
+use lns_cli::run::host_bind::{DirScan, resolve_binds};
+use lns_policy::host_bind_decisions::{
+    HostBindDecisionFile, HostBindDecisionStore, SecretDisposition,
+};
+use std::path::Path;
+use std::sync::Mutex;
 
 #[when(regex = r"^the mounts are resolved for `lns run ([^`]+)`$")]
 fn resolve_mounts(world: &mut BehaviourWorld, flags: String) {
@@ -41,5 +47,260 @@ fn resolved_binds_are(world: &mut BehaviourWorld, expected: String) -> Result<()
         Err(format!(
             "expected host binds {expected:?}, got {rendered:?}"
         ))
+    }
+}
+
+struct FakeDir {
+    entries: Vec<String>,
+    lensignore: Option<String>,
+    missing: bool,
+}
+impl DirScan for FakeDir {
+    fn exists(&self, _path: &Path) -> bool {
+        !self.missing
+    }
+    fn entries(&self, _dir: &Path) -> Vec<String> {
+        self.entries.clone()
+    }
+    fn read_to_string(&self, path: &Path) -> Option<String> {
+        if path.ends_with(".lensignore") {
+            self.lensignore.clone()
+        } else {
+            None
+        }
+    }
+}
+
+struct FakeStore {
+    state: Mutex<HostBindDecisionFile>,
+}
+impl HostBindDecisionStore for FakeStore {
+    fn load(&self) -> std::io::Result<HostBindDecisionFile> {
+        Ok(self.state.lock().unwrap().clone())
+    }
+    fn save(&self, state: &HostBindDecisionFile) -> std::io::Result<()> {
+        *self.state.lock().unwrap() = state.clone();
+        Ok(())
+    }
+}
+
+fn parsed_bind_specs(flags: &str) -> Vec<lns_ipc::BindSpec> {
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    let args: RunArgs = parse_args(&argv).expect("argv must parse");
+    split_mounts(&args.mounts).1
+}
+
+fn dir_from(world: &BehaviourWorld) -> FakeDir {
+    FakeDir {
+        entries: world.host_bind.entries.clone(),
+        lensignore: world.host_bind.lensignore.clone(),
+        missing: world.host_bind.missing,
+    }
+}
+
+fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
+    let specs = parsed_bind_specs(flags);
+    let dir = dir_from(world);
+    let store = FakeStore {
+        state: Mutex::new(world.host_bind.decisions.clone()),
+    };
+    let mut input = std::io::Cursor::new(world.host_bind.answer.clone().unwrap_or_default());
+    let mut out = Vec::new();
+    let result = resolve_binds(&specs, &dir, &store, interactive, &mut input, &mut out)
+        .map_err(|e| e.to_string());
+    world.host_bind.outcome = Some(HostBindOutcome {
+        result,
+        prompt: String::from_utf8(out).unwrap(),
+        persisted: store.state.into_inner().unwrap(),
+    });
+}
+
+fn outcome(world: &BehaviourWorld) -> Result<&HostBindOutcome, String> {
+    world
+        .host_bind
+        .outcome
+        .as_ref()
+        .ok_or_else(|| "no host-bind outcome captured".to_string())
+}
+
+fn resolved_binds(world: &BehaviourWorld) -> Result<&[lns_ipc::BindMount], String> {
+    outcome(world)?
+        .result
+        .as_deref()
+        .map_err(|e| format!("resolution failed: {e}"))
+}
+
+#[given(regex = r#"^the host path "([^"]+)" does not exist$"#)]
+fn host_path_missing(world: &mut BehaviourWorld, _path: String) {
+    world.host_bind.missing = true;
+}
+
+#[given(regex = r#"^the host directory "([^"]+)" contains no secret-shaped files$"#)]
+fn dir_is_clean(world: &mut BehaviourWorld, _dir: String) {
+    world.host_bind.entries = vec!["src".into(), "Cargo.toml".into()];
+}
+
+#[given(regex = r#"^the host directory "([^"]+)" contains "([^"]+)"$"#)]
+fn dir_contains(world: &mut BehaviourWorld, _dir: String, name: String) {
+    world.host_bind.entries.push(name);
+}
+
+#[given(regex = r#"^the host directory "([^"]+)" contains "([^"]+)" and "([^"]+)"$"#)]
+fn dir_contains_two(world: &mut BehaviourWorld, _dir: String, a: String, b: String) {
+    world.host_bind.entries.push(a);
+    world.host_bind.entries.push(b);
+}
+
+#[given(regex = r#"^the host directory "([^"]+)" contains an undecided "([^"]+)"$"#)]
+fn dir_contains_undecided(world: &mut BehaviourWorld, _dir: String, name: String) {
+    world.host_bind.entries.push(name);
+}
+
+#[given(regex = r#"^no prior decision is recorded for "([^"]+)"$"#)]
+fn no_prior_decision(_world: &mut BehaviourWorld, _path: String) {}
+
+#[given(regex = r#"^a per-machine KEEP decision is recorded for "([^"]+)"$"#)]
+fn keep_decision_recorded(world: &mut BehaviourWorld, path: String) {
+    world
+        .host_bind
+        .decisions
+        .insert(path, SecretDisposition::Keep);
+}
+
+#[given(regex = r#"^the host directory "([^"]+)" has a "\.lensignore" listing "([^"]+)"$"#)]
+fn lensignore_lists(world: &mut BehaviourWorld, _dir: String, name: String) {
+    world.host_bind.lensignore = Some(format!("{name}\n"));
+}
+
+#[given(regex = r#"^the operator will answer the secret prompt with "([^"]+)"$"#)]
+fn operator_answers(world: &mut BehaviourWorld, answer: String) {
+    world.host_bind.answer = Some(format!("{answer}\n"));
+}
+
+#[when(regex = r"^the user runs `lns run ([^`]+)` interactively$")]
+fn run_interactively(world: &mut BehaviourWorld, flags: String) {
+    run_resolve(world, &flags, true);
+}
+
+#[when(regex = r"^the user runs `lns run ([^`]+)` with no terminal$")]
+fn run_non_interactively(world: &mut BehaviourWorld, flags: String) {
+    run_resolve(world, &flags, false);
+}
+
+#[then(regex = r#"^the operator is prompted to KEEP or DROP "([^"]+)"$"#)]
+fn prompted_for(world: &mut BehaviourWorld, path: String) -> Result<(), String> {
+    let prompt = &outcome(world)?.prompt;
+    if prompt.contains(&path) {
+        Ok(())
+    } else {
+        Err(format!("expected a prompt for {path:?}, got {prompt:?}"))
+    }
+}
+
+#[then(regex = r#"^the operator is prompted only for "([^"]+)"$"#)]
+fn prompted_only_for(world: &mut BehaviourWorld, path: String) -> Result<(), String> {
+    let prompt = &outcome(world)?.prompt;
+    let count = prompt.matches("looks like a secret").count();
+    if prompt.contains(&path) && count == 1 {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected exactly one prompt for {path:?}, got {prompt:?}"
+        ))
+    }
+}
+
+#[then(regex = r"^no KEEP or DROP prompt is shown$")]
+fn no_prompt(world: &mut BehaviourWorld) -> Result<(), String> {
+    let prompt = &outcome(world)?.prompt;
+    if prompt.contains("looks like a secret") {
+        Err(format!("expected no prompt, got {prompt:?}"))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r"^the run starts$")]
+fn run_starts(world: &mut BehaviourWorld) -> Result<(), String> {
+    resolved_binds(world).map(|_| ())
+}
+
+#[then(regex = r#"^"([^"]+)" is exposed to the guest under "([^"]+)"$"#)]
+fn exposed(world: &mut BehaviourWorld, name: String, _target: String) -> Result<(), String> {
+    let b = resolved_binds(world)?;
+    if b.iter().any(|m| m.dropped_paths.contains(&name)) {
+        Err(format!("{name:?} was dropped, expected it kept"))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" is dropped from the bind$"#)]
+fn dropped(world: &mut BehaviourWorld, name: String) -> Result<(), String> {
+    let b = resolved_binds(world)?;
+    if b.iter().any(|m| m.dropped_paths.contains(&name)) {
+        Ok(())
+    } else {
+        Err(format!("expected {name:?} dropped, binds: {b:?}"))
+    }
+}
+
+#[then(regex = r#"^a per-machine (KEEP|DROP) decision is recorded for "([^"]+)"$"#)]
+fn decision_recorded(world: &mut BehaviourWorld, kind: String, path: String) -> Result<(), String> {
+    let want = if kind == "KEEP" {
+        SecretDisposition::Keep
+    } else {
+        SecretDisposition::Drop
+    };
+    match outcome(world)?.persisted.get(&path).copied() {
+        Some(d) if d == want => Ok(()),
+        other => Err(format!("expected {want:?} for {path:?}, got {other:?}")),
+    }
+}
+
+#[then(regex = r"^a later run with the same bind shows no prompt$")]
+fn later_run_no_prompt(world: &mut BehaviourWorld) -> Result<(), String> {
+    let persisted = outcome(world)?.persisted.clone();
+    let specs: Vec<lns_ipc::BindSpec> = resolved_binds(world)?
+        .iter()
+        .map(|m| lns_ipc::BindSpec {
+            host_source: m.host_source.clone(),
+            target: m.target.clone(),
+            read_only: m.read_only,
+        })
+        .collect();
+    let dir = dir_from(world);
+    let store = FakeStore {
+        state: Mutex::new(persisted),
+    };
+    let mut input = std::io::Cursor::new(String::new());
+    let mut out = Vec::new();
+    resolve_binds(&specs, &dir, &store, true, &mut input, &mut out).map_err(|e| e.to_string())?;
+    let prompt = String::from_utf8(out).unwrap();
+    if prompt.contains("looks like a secret") {
+        Err(format!("a later run re-prompted: {prompt:?}"))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^the command fails with "([^"]+)"$"#)]
+fn command_fails_with(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    match &outcome(world)?.result {
+        Err(e) if e.contains(&needle) => Ok(()),
+        other => Err(format!(
+            "expected failure containing {needle:?}, got {other:?}"
+        )),
+    }
+}
+
+#[then(regex = r#"^the dropped path "([^"]+)" is reported on stderr$"#)]
+fn dropped_reported(world: &mut BehaviourWorld, path: String) -> Result<(), String> {
+    let prompt = &outcome(world)?.prompt;
+    if prompt.contains(&path) {
+        Ok(())
+    } else {
+        Err(format!("expected {path:?} reported, got {prompt:?}"))
     }
 }

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -1,0 +1,45 @@
+use crate::world::{BehaviourWorld, ResolvedRunView};
+use cucumber::{then, when};
+use lns_cli::cli::{RunArgs, split_mounts};
+use lns_cli::command::parse_args;
+
+#[when(regex = r"^the mounts are resolved for `lns run ([^`]+)`$")]
+fn resolve_mounts(world: &mut BehaviourWorld, flags: String) {
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    let args: RunArgs = parse_args(&argv).expect("argv must parse against the CLI grammar");
+    let (volumes, binds) = split_mounts(&args.mounts);
+    world.resolved_run = Some(ResolvedRunView {
+        volumes: volumes
+            .iter()
+            .map(|v| {
+                let ro = if v.read_only { ":ro" } else { "" };
+                format!("{}:{}{ro}", v.name, v.target)
+            })
+            .collect(),
+        binds: binds
+            .iter()
+            .map(|b| {
+                let ro = if b.read_only { ":ro" } else { "" };
+                format!("{} -> {}{ro}", b.host_source, b.target)
+            })
+            .collect(),
+        ..Default::default()
+    });
+}
+
+#[then(regex = r#"^the resolved host binds are exactly "([^"]*)"$"#)]
+fn resolved_binds_are(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    let view = world
+        .resolved_run
+        .as_ref()
+        .ok_or_else(|| "no resolved run captured".to_string())?;
+    let rendered = view.binds.join(", ");
+    if rendered == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected host binds {expected:?}, got {rendered:?}"
+        ))
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod config_cli;
 pub mod env_file;
+pub mod host_bind;
 pub mod image_cli;
 pub mod integration_cli;
 pub mod policy_cli;

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -38,6 +38,7 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
         }
     };
     let resolved = config::apply_run_defaults(args, defaults);
+    let (volumes, binds) = lns_cli::cli::split_mounts(&resolved.mounts);
     world.resolved_run = Some(ResolvedRunView {
         summary: format_summary(
             &resolved,
@@ -46,12 +47,18 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
             &PolicySource::FoundInCwd,
         ),
         env: resolved.env.clone(),
-        volumes: resolved
-            .volumes
+        volumes: volumes
             .iter()
             .map(|v| {
                 let ro = if v.read_only { ":ro" } else { "" };
                 format!("{}:{}{ro}", v.name, v.target)
+            })
+            .collect(),
+        binds: binds
+            .iter()
+            .map(|b| {
+                let ro = if b.read_only { ":ro" } else { "" };
+                format!("{} -> {}{ro}", b.host_source, b.target)
             })
             .collect(),
         publish: resolved
@@ -87,7 +94,7 @@ fn resolved_env_is(world: &mut BehaviourWorld, expected: String) -> Result<(), S
     expect_exactly("env", &resolved(world)?.env, &expected)
 }
 
-#[then(regex = r#"^the resolved volumes are exactly "([^"]+)"$"#)]
+#[then(regex = r#"^the resolved volumes are exactly "([^"]*)"$"#)]
 fn resolved_volumes_are(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
     expect_exactly("volumes", &resolved(world)?.volumes, &expected)
 }

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -29,6 +29,27 @@ pub struct BehaviourWorld {
     pub image: ImageCliRig,
     pub merged_env: Option<Result<Vec<String>, String>>,
     pub sandbox: SandboxCliRig,
+    pub host_bind: HostBindRig,
+}
+
+use lns_policy::host_bind_decisions::SecretDisposition;
+
+/// Scripted host directory + recorded decisions for driving `resolve_binds`.
+#[derive(Debug, Default)]
+pub struct HostBindRig {
+    pub entries: Vec<String>,
+    pub lensignore: Option<String>,
+    pub missing: bool,
+    pub decisions: std::collections::HashMap<String, SecretDisposition>,
+    pub answer: Option<String>,
+    pub outcome: Option<HostBindOutcome>,
+}
+
+#[derive(Debug)]
+pub struct HostBindOutcome {
+    pub result: Result<Vec<lns_ipc::BindMount>, String>,
+    pub prompt: String,
+    pub persisted: std::collections::HashMap<String, SecretDisposition>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -47,9 +47,10 @@ pub struct HostBindRig {
 
 #[derive(Debug)]
 pub struct HostBindOutcome {
-    pub result: Result<Vec<lns_ipc::BindMount>, String>,
+    pub result: Result<Vec<lns_cli::run::host_bind::ResolvedBind>, String>,
     pub prompt: String,
     pub persisted: std::collections::HashMap<String, SecretDisposition>,
+    pub summary: String,
 }
 
 #[derive(Debug, Default)]

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -36,6 +36,7 @@ pub struct ResolvedRunView {
     pub summary: String,
     pub env: Vec<String>,
     pub volumes: Vec<String>,
+    pub binds: Vec<String>,
     pub publish: Vec<String>,
 }
 

--- a/crates/lns-init/src/cmdline.rs
+++ b/crates/lns-init/src/cmdline.rs
@@ -8,6 +8,8 @@ pub struct CmdlineParams {
     pub composefs_descriptor_sha256: Option<String>,
     pub volumes: Vec<VolumeParam>,
     pub incomplete_volumes: Vec<usize>,
+    pub binds: Vec<BindParam>,
+    pub incomplete_binds: Vec<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +17,51 @@ pub struct VolumeParam {
     pub dev: String,
     pub target: String,
     pub read_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindParam {
+    pub tag: String,
+    pub target: String,
+    pub read_only: bool,
+    pub dropped_paths: Vec<String>,
+}
+
+#[derive(Default)]
+struct PartialBind {
+    tag: Option<String>,
+    target: Option<String>,
+    read_only: bool,
+    drops_count: Option<usize>,
+    drops: BTreeMap<usize, String>,
+}
+
+enum BindOutcome {
+    Ready(BindParam),
+    Incomplete,
+    Skip,
+}
+
+impl PartialBind {
+    fn resolve(self) -> BindOutcome {
+        let read_only = self.read_only;
+        match (self.tag, self.target) {
+            (None, None) => BindOutcome::Skip,
+            (Some(_), None) | (None, Some(_)) => BindOutcome::Incomplete,
+            (Some(_), Some(_)) if self.drops.len() != self.drops_count.unwrap_or(0) => {
+                BindOutcome::Incomplete
+            }
+            (Some(tag), Some(target)) if target_within_root(&target) => {
+                BindOutcome::Ready(BindParam {
+                    tag,
+                    target,
+                    read_only,
+                    dropped_paths: self.drops.into_values().collect(),
+                })
+            }
+            (Some(_), Some(_)) => BindOutcome::Skip,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -56,6 +103,7 @@ impl CmdlineParams {
     pub fn parse(cmdline: &str) -> Self {
         let mut out = Self::default();
         let mut vols: BTreeMap<usize, PartialVolume> = BTreeMap::new();
+        let mut binds: BTreeMap<usize, PartialBind> = BTreeMap::new();
         for tok in tokenize(cmdline) {
             let (key, value) = match tok.split_once('=') {
                 Some(kv) => kv,
@@ -71,6 +119,7 @@ impl CmdlineParams {
                 "composefs.descriptor.sha256" => {
                     out.composefs_descriptor_sha256 = Some(value.to_string())
                 }
+                _ if key.starts_with("bind.") => parse_bind_key(key, value, &mut binds),
                 _ => parse_volume_key(key, value, &mut vols),
             }
         }
@@ -79,6 +128,13 @@ impl CmdlineParams {
                 VolumeOutcome::Ready(v) => out.volumes.push(v),
                 VolumeOutcome::Incomplete => out.incomplete_volumes.push(idx),
                 VolumeOutcome::Skip => {}
+            }
+        }
+        for (idx, partial) in binds {
+            match partial.resolve() {
+                BindOutcome::Ready(b) => out.binds.push(b),
+                BindOutcome::Incomplete => out.incomplete_binds.push(idx),
+                BindOutcome::Skip => {}
             }
         }
         out
@@ -99,6 +155,31 @@ fn parse_volume_key(key: &str, value: &str, vols: &mut BTreeMap<usize, PartialVo
         "target" => entry.target = Some(value.to_string()),
         "ro" => entry.read_only = value == "1",
         _ => {}
+    }
+}
+
+fn parse_bind_key(key: &str, value: &str, binds: &mut BTreeMap<usize, PartialBind>) {
+    let Some((idx, field)) = key
+        .strip_prefix("bind.")
+        .and_then(|rest| rest.split_once('.'))
+        .and_then(|(idx, field)| idx.parse::<usize>().ok().map(|i| (i, field)))
+    else {
+        return;
+    };
+    let entry = binds.entry(idx).or_default();
+    match field {
+        "tag" => entry.tag = Some(value.to_string()),
+        "target" => entry.target = Some(value.to_string()),
+        "ro" => entry.read_only = value == "1",
+        "drops" => entry.drops_count = value.parse::<usize>().ok(),
+        _ => {
+            if let Some(j) = field
+                .strip_prefix("drop.")
+                .and_then(|j| j.parse::<usize>().ok())
+            {
+                entry.drops.insert(j, value.to_string());
+            }
+        }
     }
 }
 
@@ -364,5 +445,68 @@ mod tests {
     fn sanitize_drops_a_bare_internal_key_with_no_value() {
         let clean = sanitize_cmdline("console=hvc0 LENS_SANDBOX_DEBUG quiet");
         assert!(!clean.contains("LENS_SANDBOX_DEBUG"), "{clean}");
+    }
+
+    #[test]
+    fn parses_bind_keys_with_ordered_dropped_paths() {
+        let p = CmdlineParams::parse(
+            "bind.0.tag=lns-bind-0 bind.0.target=/work bind.0.ro=0 \
+             bind.0.drops=2 bind.0.drop.1=.npmrc bind.0.drop.0=.env",
+        );
+        assert_eq!(
+            p.binds,
+            vec![BindParam {
+                tag: "lns-bind-0".into(),
+                target: "/work".into(),
+                read_only: false,
+                dropped_paths: vec![".env".into(), ".npmrc".into()],
+            }]
+        );
+        assert!(p.incomplete_binds.is_empty());
+    }
+
+    #[test]
+    fn bind_ro_and_no_drops_parse_cleanly() {
+        let p = CmdlineParams::parse(
+            "bind.0.tag=lns-bind-0 bind.0.target=/cfg bind.0.ro=1 bind.0.drops=0",
+        );
+        assert_eq!(p.binds.len(), 1);
+        assert!(p.binds[0].read_only);
+        assert!(p.binds[0].dropped_paths.is_empty());
+    }
+
+    #[test]
+    fn bind_missing_its_target_is_flagged_incomplete() {
+        let p = CmdlineParams::parse("bind.0.tag=lns-bind-0");
+        assert!(p.binds.is_empty());
+        assert_eq!(p.incomplete_binds, vec![0]);
+    }
+
+    #[test]
+    fn bind_with_fewer_drops_than_declared_is_incomplete_so_a_secret_is_never_silently_exposed() {
+        let p = CmdlineParams::parse(
+            "bind.0.tag=lns-bind-0 bind.0.target=/work bind.0.drops=2 bind.0.drop.0=.env",
+        );
+        assert!(p.binds.is_empty(), "a truncated drop list must not mount");
+        assert_eq!(p.incomplete_binds, vec![0]);
+    }
+
+    #[test]
+    fn bind_with_a_dot_dot_target_is_dropped_so_the_mount_cannot_escape_newroot() {
+        let p = CmdlineParams::parse("bind.0.tag=lns-bind-0 bind.0.target=/../etc bind.0.drops=0");
+        assert!(p.binds.is_empty());
+    }
+
+    #[test]
+    fn malformed_bind_index_is_ignored() {
+        let p = CmdlineParams::parse("bind.x.tag=lns-bind-0 bind.x.target=/work");
+        assert!(p.binds.is_empty());
+        assert!(p.incomplete_binds.is_empty());
+    }
+
+    #[test]
+    fn no_bind_keys_yields_empty_binds() {
+        let p = CmdlineParams::parse("upper.dev=/dev/vda");
+        assert!(p.binds.is_empty());
     }
 }

--- a/crates/lns-init/src/cmdline.rs
+++ b/crates/lns-init/src/cmdline.rs
@@ -509,4 +509,14 @@ mod tests {
         let p = CmdlineParams::parse("upper.dev=/dev/vda");
         assert!(p.binds.is_empty());
     }
+
+    #[test]
+    fn a_stray_bind_field_with_neither_tag_nor_target_is_skipped() {
+        let p = CmdlineParams::parse("bind.0.ro=1");
+        assert!(p.binds.is_empty());
+        assert!(
+            p.incomplete_binds.is_empty(),
+            "a bare ro flag is not a truncated bind"
+        );
+    }
 }

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -2091,14 +2091,14 @@ mod tests {
             "/newroot",
         )
         .unwrap();
+        let calls = sys.calls();
         assert!(
-            sys.calls().iter().any(
+            calls.iter().any(
                 |c| matches!(c, Call::Mount { source, target, fstype, flags, .. }
                 if source == "lns-bind-0" && target == "/newroot/work" && fstype == "virtiofs"
                 && *flags == MountFlags::none().nosuid().nodev())
             ),
-            "expected a writable virtiofs mount at /newroot/work: {:?}",
-            sys.calls()
+            "expected a writable virtiofs mount at /newroot/work: {calls:?}"
         );
     }
 
@@ -2128,13 +2128,13 @@ mod tests {
             "/newroot",
         )
         .unwrap();
+        let calls = sys.calls();
         assert!(
-            sys.calls()
+            calls
                 .iter()
                 .any(|c| matches!(c, Call::Mount { source, target, flags, .. }
                 if source == DEV_NULL && target == "/newroot/work/.env" && flags.bind)),
-            "a dropped file must be masked by a /dev/null bind: {:?}",
-            sys.calls()
+            "a dropped file must be masked by a /dev/null bind: {calls:?}"
         );
     }
 
@@ -2147,14 +2147,14 @@ mod tests {
             "/newroot",
         )
         .unwrap();
+        let calls = sys.calls();
         assert!(
-            sys.calls()
+            calls
                 .iter()
                 .any(|c| matches!(c, Call::Mount { target, fstype, data, .. }
                 if target == "/newroot/work/.ssh" && fstype == "tmpfs"
                 && data.as_deref() == Some("mode=0000,size=4k"))),
-            "a dropped directory must be masked by an empty tmpfs: {:?}",
-            sys.calls()
+            "a dropped directory must be masked by an empty tmpfs: {calls:?}"
         );
     }
 

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -16,6 +16,7 @@ pub use real::mount_and_exec;
 const PROC: &str = "/proc";
 const SYS: &str = "/sys";
 const DEV: &str = "/dev";
+const DEV_NULL: &str = "/dev/null";
 const DEV_PTS: &str = "/dev/pts";
 const DEV_PTMX: &str = "/dev/ptmx";
 const CONTENT: &str = "/content";
@@ -99,6 +100,7 @@ pub(crate) trait Syscalls {
     fn chroot(&self, path: &CStr) -> std::io::Result<()>;
     fn chdir(&self, path: &CStr) -> std::io::Result<()>;
     fn path_exists(&self, path: &CStr) -> bool;
+    fn is_dir(&self, path: &CStr) -> bool;
     fn open_ro(&self, path: &CStr) -> std::io::Result<RawFd>;
     fn fexecve(&self, fd: RawFd, argv0: &CStr) -> std::io::Error;
     fn lchown(&self, path: &CStr, uid: u32, gid: u32) -> std::io::Result<()>;
@@ -124,6 +126,7 @@ pub(crate) trait Syscalls {
 pub enum MountError {
     MissingCmdlineKey(&'static str),
     IncompleteVolume(usize),
+    IncompleteBind(usize),
     InteriorNul(&'static str),
     Syscall { op: String, err: std::io::Error },
     DescriptorDigestMismatch { expected: String, actual: String },
@@ -143,6 +146,12 @@ impl fmt::Display for MountError {
                 "volume.{idx} on the kernel cmdline is missing its dev or target \
                  (likely a truncated cmdline); refusing to boot rather than start \
                  the workload without its volume"
+            ),
+            Self::IncompleteBind(idx) => write!(
+                f,
+                "bind.{idx} on the kernel cmdline is missing its tag/target or a declared \
+                 dropped path (likely a truncated cmdline); refusing to boot rather than \
+                 risk exposing a secret the operator chose to drop"
             ),
             Self::InteriorNul(field) => {
                 write!(f, "cmdline field {field} contained an interior NUL")
@@ -359,6 +368,9 @@ pub fn validate_cmdline(p: &CmdlineParams) -> Result<(), MountError> {
     if let Some(&idx) = p.incomplete_volumes.first() {
         return Err(MountError::IncompleteVolume(idx));
     }
+    if let Some(&idx) = p.incomplete_binds.first() {
+        return Err(MountError::IncompleteBind(idx));
+    }
     Ok(())
 }
 
@@ -478,6 +490,43 @@ fn mount_volumes(
         do_mount(sys, &vol.dev, &target, "ext4", flags, None)?;
     }
     Ok(())
+}
+
+fn mount_binds(
+    sys: &dyn Syscalls,
+    binds: &[crate::cmdline::BindParam],
+    newroot: &str,
+) -> Result<(), MountError> {
+    for bind in binds {
+        let target = format!("{newroot}{}", bind.target);
+        do_mkdir_p(sys, &target, 0o755)?;
+        let flags = match bind.read_only {
+            true => MountFlags::read_only().nosuid().nodev(),
+            false => MountFlags::none().nosuid().nodev(),
+        };
+        do_mount(sys, &bind.tag, &target, "virtiofs", flags, None)?;
+        for dropped in &bind.dropped_paths {
+            mask_dropped_path(sys, &format!("{target}/{dropped}"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Hides a dropped secret from the workload without deleting it from the live share: an empty tmpfs over a directory, a `/dev/null` bind over a file.
+fn mask_dropped_path(sys: &dyn Syscalls, path: &str) -> Result<(), MountError> {
+    let path_c = cstring(path, "mask-path")?;
+    if sys.is_dir(&path_c) {
+        do_mount(
+            sys,
+            "tmpfs",
+            path,
+            "tmpfs",
+            MountFlags::none().nosuid().nodev().noexec(),
+            Some("mode=0000,size=4k"),
+        )
+    } else {
+        do_mount(sys, DEV_NULL, path, "none", MountFlags::bind(), None)
+    }
 }
 
 fn mount_run_tmpfs(
@@ -706,6 +755,8 @@ fn mount_composefs_and_exec_broker_inner(
 
     mount_volumes(sys, &params.volumes, newroot, run_ids)?;
 
+    mount_binds(sys, &params.binds, newroot)?;
+
     mount_run_tmpfs(sys, newroot, run_ids)?;
 
     allow_unprivileged_low_ports(sys)?;
@@ -830,6 +881,8 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![],
         };
         assert!(validate_cmdline(&p).is_ok());
     }
@@ -843,6 +896,8 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![],
         };
         let err = validate_cmdline(&p).unwrap_err();
         assert!(format!("{err}").contains("upper.dev"));
@@ -857,6 +912,8 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![],
         };
         let err = validate_cmdline(&p).unwrap_err();
         assert!(format!("{err}").contains("content.tag"));
@@ -871,6 +928,8 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![],
         };
         let err = validate_cmdline(&p).unwrap_err();
         assert!(format!("{err}").contains("composefs.descriptor.dev"));
@@ -885,9 +944,27 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![3],
+            binds: vec![],
+            incomplete_binds: vec![],
         };
         let err = validate_cmdline(&p).unwrap_err();
         assert!(format!("{err}").contains("volume.3"), "{err}");
+    }
+
+    #[test]
+    fn validate_cmdline_refuses_to_boot_when_a_bind_drop_list_was_truncated() {
+        let p = CmdlineParams {
+            upper_dev: Some("/dev/vda".into()),
+            composefs_descriptor_dev: Some("/dev/vdb".into()),
+            content_tag: Some("lns-content".into()),
+            composefs_descriptor_sha256: None,
+            volumes: vec![],
+            incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![1],
+        };
+        let err = validate_cmdline(&p).unwrap_err();
+        assert!(format!("{err}").contains("bind.1"), "{err}");
     }
 
     #[test]
@@ -903,6 +980,8 @@ mod tests {
         assert!(format!("{missing}").contains("upper.dev"));
         let incomplete = MountError::IncompleteVolume(3);
         assert!(format!("{incomplete}").contains("volume.3"));
+        let incomplete_bind = MountError::IncompleteBind(2);
+        assert!(format!("{incomplete_bind}").contains("bind.2"));
         let read = MountError::DescriptorRead(std::io::Error::other("boom"));
         assert!(format!("{read}").contains("composefs descriptor"));
         let syscall = MountError::Syscall {
@@ -1212,6 +1291,7 @@ mod tests {
     struct FakeSyscalls {
         calls: RefCell<Vec<Call>>,
         ptmx_exists: bool,
+        dir_paths: Vec<String>,
         fail_when: FailWhen,
         digest_result: RefCell<Option<Result<(), MountError>>>,
     }
@@ -1221,9 +1301,15 @@ mod tests {
             Self {
                 calls: RefCell::new(Vec::new()),
                 ptmx_exists: true,
+                dir_paths: Vec::new(),
                 fail_when: Box::new(|_| None),
                 digest_result: RefCell::new(None),
             }
+        }
+
+        fn with_dir(mut self, path: &str) -> Self {
+            self.dir_paths.push(path.to_string());
+            self
         }
 
         fn fail_when(mut self, f: impl Fn(&Call) -> Option<std::io::ErrorKind> + 'static) -> Self {
@@ -1316,6 +1402,9 @@ mod tests {
                 .push(Call::PathExists(path.to_str().unwrap().to_string()));
             self.ptmx_exists
         }
+        fn is_dir(&self, path: &CStr) -> bool {
+            self.dir_paths.iter().any(|p| p == path.to_str().unwrap())
+        }
         fn open_ro(&self, path: &CStr) -> std::io::Result<RawFd> {
             self.record(Call::OpenRo(path.to_str().unwrap().to_string()))?;
             Ok(7)
@@ -1389,6 +1478,8 @@ mod tests {
             composefs_descriptor_sha256: None,
             volumes: vec![],
             incomplete_volumes: vec![],
+            binds: vec![],
+            incomplete_binds: vec![],
         }
     }
 
@@ -1974,6 +2065,96 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, Call::Mount { target, flags, .. }
             if target == "/newroot/cache" && *flags == MountFlags::read_only().nosuid().nodev()))
+        );
+    }
+
+    fn bind_param(
+        tag: &str,
+        target: &str,
+        read_only: bool,
+        drops: &[&str],
+    ) -> crate::cmdline::BindParam {
+        crate::cmdline::BindParam {
+            tag: tag.into(),
+            target: target.into(),
+            read_only,
+            dropped_paths: drops.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn mount_binds_mounts_each_tag_as_virtiofs_under_newroot() {
+        let sys = FakeSyscalls::new();
+        mount_binds(
+            &sys,
+            &[bind_param("lns-bind-0", "/work", false, &[])],
+            "/newroot",
+        )
+        .unwrap();
+        assert!(
+            sys.calls().iter().any(
+                |c| matches!(c, Call::Mount { source, target, fstype, flags, .. }
+                if source == "lns-bind-0" && target == "/newroot/work" && fstype == "virtiofs"
+                && *flags == MountFlags::none().nosuid().nodev())
+            ),
+            "expected a writable virtiofs mount at /newroot/work: {:?}",
+            sys.calls()
+        );
+    }
+
+    #[test]
+    fn mount_binds_marks_a_read_only_bind_read_only() {
+        let sys = FakeSyscalls::new();
+        mount_binds(
+            &sys,
+            &[bind_param("lns-bind-0", "/cfg", true, &[])],
+            "/newroot",
+        )
+        .unwrap();
+        assert!(
+            sys.calls()
+                .iter()
+                .any(|c| matches!(c, Call::Mount { target, flags, .. }
+                if target == "/newroot/cfg" && *flags == MountFlags::read_only().nosuid().nodev()))
+        );
+    }
+
+    #[test]
+    fn mount_binds_masks_a_dropped_file_with_a_dev_null_bind() {
+        let sys = FakeSyscalls::new();
+        mount_binds(
+            &sys,
+            &[bind_param("lns-bind-0", "/work", false, &[".env"])],
+            "/newroot",
+        )
+        .unwrap();
+        assert!(
+            sys.calls()
+                .iter()
+                .any(|c| matches!(c, Call::Mount { source, target, flags, .. }
+                if source == DEV_NULL && target == "/newroot/work/.env" && flags.bind)),
+            "a dropped file must be masked by a /dev/null bind: {:?}",
+            sys.calls()
+        );
+    }
+
+    #[test]
+    fn mount_binds_masks_a_dropped_directory_with_an_empty_tmpfs() {
+        let sys = FakeSyscalls::new().with_dir("/newroot/work/.ssh");
+        mount_binds(
+            &sys,
+            &[bind_param("lns-bind-0", "/work", false, &[".ssh"])],
+            "/newroot",
+        )
+        .unwrap();
+        assert!(
+            sys.calls()
+                .iter()
+                .any(|c| matches!(c, Call::Mount { target, fstype, data, .. }
+                if target == "/newroot/work/.ssh" && fstype == "tmpfs"
+                && data.as_deref() == Some("mode=0000,size=4k"))),
+            "a dropped directory must be masked by an empty tmpfs: {:?}",
+            sys.calls()
         );
     }
 

--- a/crates/lns-init/src/mount/real.rs
+++ b/crates/lns-init/src/mount/real.rs
@@ -112,6 +112,15 @@ impl Syscalls for RealSyscalls {
         }
     }
 
+    fn is_dir(&self, path: &CStr) -> bool {
+        // SAFETY: all-zero is a valid libc::stat; stat(2) overwrites it and only reads *path.
+        unsafe {
+            let mut buf = std::mem::zeroed::<libc::stat>();
+            libc::stat(path.as_ptr(), &mut buf) == 0
+                && (buf.st_mode & libc::S_IFMT) == libc::S_IFDIR
+        }
+    }
+
     fn open_ro(&self, path: &CStr) -> io::Result<RawFd> {
         // SAFETY: path is a valid NUL-terminated C string.
         let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -15,10 +15,10 @@ pub use codec::{
 };
 pub use paths::{CachePathError, audit_anchor_for_run, audit_log_for_run, cache_root, data_root};
 pub use protocol::{
-    ExecImageArgs, ImageInfo, LogLevel, PortPublish, Protocol, Request, Response, RunConfig,
-    RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SignalKind, StatusInfo,
-    VolumeInfo, VolumeMount, VolumePruneFailure, validate_run_name, validate_volume_name,
-    validate_volume_target,
+    BindMount, BindSpec, ExecImageArgs, ImageInfo, LogLevel, MountSpec, PortPublish, Protocol,
+    Request, Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary,
+    SignalKind, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, validate_bind_source,
+    validate_run_name, validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -17,8 +17,8 @@ pub use paths::{CachePathError, audit_anchor_for_run, audit_log_for_run, cache_r
 pub use protocol::{
     BindMount, BindSpec, ExecImageArgs, ImageInfo, LogLevel, MountSpec, PortPublish, Protocol,
     Request, Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary,
-    SignalKind, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, validate_bind_source,
-    validate_run_name, validate_volume_name, validate_volume_target,
+    SignalKind, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, cmdline_unsafe_char,
+    validate_bind_source, validate_run_name, validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -254,6 +254,8 @@ pub struct RunConfig {
     pub env: Vec<String>,
     pub published_ports: Vec<PortPublish>,
     pub volumes: Vec<VolumeMount>,
+    #[serde(default)]
+    pub binds: Vec<BindMount>,
     pub detached: bool,
 }
 
@@ -268,6 +270,7 @@ impl RunConfig {
             env: args.env.clone(),
             published_ports: args.published_ports.clone(),
             volumes: args.volumes.clone(),
+            binds: args.binds.clone(),
             detached: args.detached,
         }
     }
@@ -325,6 +328,8 @@ pub struct RunImageArgs {
     pub published_ports: Vec<PortPublish>,
     #[serde(default)]
     pub volumes: Vec<VolumeMount>,
+    #[serde(default)]
+    pub binds: Vec<BindMount>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -411,6 +416,88 @@ pub fn validate_run_name(name: &str) -> Result<(), String> {
         )),
         None => Ok(()),
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindMount {
+    pub host_source: String,
+    pub target: String,
+    pub read_only: bool,
+    #[serde(default)]
+    pub dropped_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindSpec {
+    pub host_source: String,
+    pub target: String,
+    pub read_only: bool,
+}
+
+impl BindSpec {
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let read_only = spec.ends_with(":ro");
+        let body = spec
+            .strip_suffix(":ro")
+            .or_else(|| spec.strip_suffix(":rw"))
+            .unwrap_or(spec);
+        let (source, target) = body
+            .split_once(':')
+            .ok_or_else(|| format!("invalid host bind {spec:?}: expected /host-path:/path[:ro]"))?;
+        validate_volume_target(target)?;
+        validate_bind_source(source)?;
+        Ok(Self {
+            host_source: source.to_string(),
+            target: target.to_string(),
+            read_only,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountSpec {
+    Named(VolumeMount),
+    Bind(BindSpec),
+}
+
+impl MountSpec {
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        if Self::source_is_path(spec) {
+            BindSpec::parse(spec).map(MountSpec::Bind)
+        } else {
+            VolumeMount::parse(spec).map(MountSpec::Named)
+        }
+    }
+
+    fn source_is_path(spec: &str) -> bool {
+        let body = spec
+            .strip_suffix(":ro")
+            .or_else(|| spec.strip_suffix(":rw"))
+            .unwrap_or(spec);
+        let source = body.split_once(':').map_or(body, |(s, _)| s);
+        source.starts_with('/')
+    }
+
+    pub fn target(&self) -> &str {
+        match self {
+            MountSpec::Named(v) => &v.target,
+            MountSpec::Bind(b) => &b.target,
+        }
+    }
+}
+
+pub fn validate_bind_source(source: &str) -> Result<(), String> {
+    if !source.starts_with('/') {
+        return Err(format!(
+            "invalid host bind source {source:?}: must be an absolute path"
+        ));
+    }
+    if source.chars().any(target_char_forbidden) {
+        return Err(format!(
+            "invalid host bind source {source:?}: must not contain whitespace, quotes, or control characters"
+        ));
+    }
+    Ok(())
 }
 
 fn default_tty() -> bool {
@@ -533,6 +620,7 @@ mod tests {
             detached: false,
             published_ports: vec![mapping],
             volumes: Vec::new(),
+            binds: Vec::new(),
         });
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
@@ -540,7 +628,7 @@ mod tests {
     }
 
     #[test]
-    fn run_image_args_volumes_survive_postcard_round_trip() {
+    fn run_image_args_volumes_and_binds_survive_postcard_round_trip() {
         let args = RunImageArgs {
             image: Some("ubuntu".into()),
             name: None,
@@ -562,6 +650,12 @@ mod tests {
                 name: "prism-data".into(),
                 target: "/data".into(),
                 read_only: true,
+            }],
+            binds: vec![BindMount {
+                host_source: "/Users/me/proj".into(),
+                target: "/work".into(),
+                read_only: false,
+                dropped_paths: vec![".env".into()],
             }],
         };
         let frame = crate::encode_frame(&args).unwrap();
@@ -681,6 +775,12 @@ mod tests {
                 target: "/data".into(),
                 read_only: false,
             }],
+            binds: vec![BindMount {
+                host_source: "/Users/me/proj".into(),
+                target: "/work".into(),
+                read_only: false,
+                dropped_paths: vec![],
+            }],
         }
     }
 
@@ -696,6 +796,7 @@ mod tests {
         assert_eq!(config.env, vec!["FOO=bar".to_string()]);
         assert_eq!(config.published_ports, args.published_ports);
         assert_eq!(config.volumes, args.volumes);
+        assert_eq!(config.binds, args.binds);
         assert!(config.detached);
     }
 
@@ -1073,5 +1174,76 @@ mod tests {
         validate_volume_target("/srv/..").unwrap_err();
         validate_volume_target("/../etc").unwrap_err();
         validate_volume_target("/a/./b").unwrap_err();
+    }
+
+    #[test]
+    fn mount_spec_parse_routes_an_absolute_source_to_a_host_bind() {
+        let m = MountSpec::parse("/Users/me/proj:/work").unwrap();
+        assert_eq!(
+            m,
+            MountSpec::Bind(BindSpec {
+                host_source: "/Users/me/proj".into(),
+                target: "/work".into(),
+                read_only: false,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_spec_parse_routes_a_bare_name_to_a_named_volume() {
+        let m = MountSpec::parse("build-cache:/cache").unwrap();
+        assert_eq!(
+            m,
+            MountSpec::Named(VolumeMount {
+                name: "build-cache".into(),
+                target: "/cache".into(),
+                read_only: false,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_spec_target_reads_through_either_variant() {
+        assert_eq!(MountSpec::parse("/h:/work").unwrap().target(), "/work");
+        assert_eq!(MountSpec::parse("vol:/data").unwrap().target(), "/data");
+    }
+
+    #[test]
+    fn bind_spec_parse_honors_ro_and_rw_suffixes() {
+        assert!(BindSpec::parse("/h:/work:ro").unwrap().read_only);
+        assert!(!BindSpec::parse("/h:/work:rw").unwrap().read_only);
+        assert!(!BindSpec::parse("/h:/work").unwrap().read_only);
+    }
+
+    #[test]
+    fn bind_spec_parse_rejects_a_relative_target() {
+        let err = BindSpec::parse("/Users/me/proj:work").unwrap_err();
+        assert!(err.contains("must be an absolute path"), "got: {err}");
+    }
+
+    #[test]
+    fn bind_spec_parse_rejects_a_missing_target_separator() {
+        BindSpec::parse("/Users/me/proj").unwrap_err();
+    }
+
+    #[test]
+    fn a_relative_dot_dot_source_stays_a_named_volume_and_keeps_its_error() {
+        let err = MountSpec::parse("../etc:/data").unwrap_err();
+        assert!(err.contains("invalid volume name"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_bind_source_requires_absolute_and_clean_chars() {
+        validate_bind_source("/Users/me/proj").unwrap();
+        assert!(
+            validate_bind_source("relative/path")
+                .unwrap_err()
+                .contains("must be an absolute path")
+        );
+        assert!(
+            validate_bind_source("/has a space")
+                .unwrap_err()
+                .contains("must not contain whitespace")
+        );
     }
 }

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -426,6 +426,9 @@ pub struct BindMount {
     pub read_only: bool,
     #[serde(default)]
     pub dropped_paths: Vec<String>,
+    /// Secret-shaped files the operator chose to expose; carried for the audit record, not consumed by the guest.
+    #[serde(default)]
+    pub kept_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -657,6 +660,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: false,
                 dropped_paths: vec![".env".into()],
+                kept_paths: vec![".npmrc".into()],
             }],
         };
         let frame = crate::encode_frame(&args).unwrap();
@@ -781,6 +785,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: false,
                 dropped_paths: vec![],
+                kept_paths: vec![],
             }],
         }
     }

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -365,7 +365,7 @@ pub fn validate_volume_target(target: &str) -> Result<(), String> {
             "invalid volume target {target:?}: must be an absolute path"
         ));
     }
-    if target.chars().any(target_char_forbidden) {
+    if target.chars().any(cmdline_unsafe_char) {
         return Err(format!(
             "invalid volume target {target:?}: must not contain whitespace, quotes, or control characters"
         ));
@@ -378,7 +378,8 @@ pub fn validate_volume_target(target: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn target_char_forbidden(c: char) -> bool {
+/// A char that can't safely ride the kernel cmdline value position the guest tokenizes (whitespace splits, `"` toggles quoting); rejected in volume targets, bind sources, and dropped-path names alike.
+pub fn cmdline_unsafe_char(c: char) -> bool {
     c.is_whitespace() || c.is_control() || c == '"'
 }
 
@@ -492,7 +493,7 @@ pub fn validate_bind_source(source: &str) -> Result<(), String> {
             "invalid host bind source {source:?}: must be an absolute path"
         ));
     }
-    if source.chars().any(target_char_forbidden) {
+    if source.chars().any(cmdline_unsafe_char) {
         return Err(format!(
             "invalid host bind source {source:?}: must not contain whitespace, quotes, or control characters"
         ));

--- a/crates/lns-policy/src/host_bind_decisions.rs
+++ b/crates/lns-policy/src/host_bind_decisions.rs
@@ -1,0 +1,178 @@
+//! Host-bind KEEP/DROP decisions live in `~/.lns-host-bind-decisions.json`, per-machine and never committed — a KEEP exposes a real secret to the workload, which is a per-machine risk acceptance, not a shareable rule.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SecretDisposition {
+    Keep,
+    Drop,
+}
+
+pub type HostBindDecisionFile = HashMap<String, SecretDisposition>;
+
+pub trait HostBindDecisionStore: Send + Sync {
+    fn load(&self) -> io::Result<HostBindDecisionFile>;
+    fn save(&self, state: &HostBindDecisionFile) -> io::Result<()>;
+}
+
+/// Falls back to `./.lns-host-bind-decisions.json` when `HOME` is unset rather than panicking.
+pub fn default_host_bind_decisions_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("LNS_HOST_BIND_DECISIONS_PATH") {
+        return PathBuf::from(p);
+    }
+    std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".lns-host-bind-decisions.json"))
+        .unwrap_or_else(|| PathBuf::from(".lns-host-bind-decisions.json"))
+}
+
+pub struct JsonFileHostBindDecisionStore {
+    pub path: PathBuf,
+}
+
+impl JsonFileHostBindDecisionStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl HostBindDecisionStore for JsonFileHostBindDecisionStore {
+    fn load(&self) -> io::Result<HostBindDecisionFile> {
+        match fs::read_to_string(&self.path) {
+            Ok(text) => serde_json::from_str(&text)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(HashMap::new()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn save(&self, state: &HostBindDecisionFile) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(state)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        crate::secure_file::write_json_secret_atomic(&self.path, json.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_state() -> HostBindDecisionFile {
+        let mut m = HostBindDecisionFile::new();
+        m.insert("/Users/me/proj/.env".into(), SecretDisposition::Keep);
+        m.insert("/Users/me/proj/.npmrc".into(), SecretDisposition::Drop);
+        m
+    }
+
+    #[test]
+    fn dispositions_serialize_to_kebab_case() {
+        assert_eq!(
+            serde_json::to_value(SecretDisposition::Keep).unwrap(),
+            json!("keep")
+        );
+        assert_eq!(
+            serde_json::to_value(SecretDisposition::Drop).unwrap(),
+            json!("drop")
+        );
+    }
+
+    #[test]
+    fn dispositions_round_trip_through_json() {
+        for d in [SecretDisposition::Keep, SecretDisposition::Drop] {
+            let s = serde_json::to_string(&d).unwrap();
+            let parsed: SecretDisposition = serde_json::from_str(&s).unwrap();
+            assert_eq!(d, parsed);
+        }
+    }
+
+    #[test]
+    fn unknown_disposition_deserializes_as_error() {
+        let r: serde_json::Result<SecretDisposition> = serde_json::from_str(r#""mask""#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn load_returns_empty_state_when_file_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = JsonFileHostBindDecisionStore::new(dir.path().join("never-created.json"));
+        assert!(store.load().unwrap().is_empty());
+    }
+
+    #[test]
+    fn load_returns_invalid_data_for_malformed_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("decisions.json");
+        fs::write(&path, "{ not json").unwrap();
+        let store = JsonFileHostBindDecisionStore::new(path);
+        assert_eq!(store.load().unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn load_propagates_non_not_found_io_errors() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = JsonFileHostBindDecisionStore::new(dir.path().to_path_buf());
+        assert_ne!(store.load().unwrap_err().kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn save_then_load_round_trips_full_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = JsonFileHostBindDecisionStore::new(dir.path().join("decisions.json"));
+        let original = sample_state();
+        store.save(&original).unwrap();
+        assert_eq!(store.load().unwrap(), original);
+    }
+
+    #[test]
+    fn save_overwrites_existing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = JsonFileHostBindDecisionStore::new(dir.path().join("decisions.json"));
+        store.save(&sample_state()).unwrap();
+        let mut second = HostBindDecisionFile::new();
+        second.insert("/Users/me/proj/.env".into(), SecretDisposition::Drop);
+        store.save(&second).unwrap();
+        assert_eq!(store.load().unwrap(), second);
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_path_uses_override_when_set() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::set("LNS_HOST_BIND_DECISIONS_PATH", "/tmp/custom-decisions.json");
+        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
+        assert_eq!(
+            default_host_bind_decisions_path(),
+            PathBuf::from("/tmp/custom-decisions.json")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_path_falls_back_to_home_dotfile() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::unset("LNS_HOST_BIND_DECISIONS_PATH");
+        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
+        assert_eq!(
+            default_host_bind_decisions_path(),
+            PathBuf::from("/home/dev/.lns-host-bind-decisions.json")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn default_path_falls_back_to_cwd_when_home_unset() {
+        use crate::test_env::EnvVarGuard;
+        let _g1 = EnvVarGuard::unset("LNS_HOST_BIND_DECISIONS_PATH");
+        let _g2 = EnvVarGuard::unset("HOME");
+        assert_eq!(
+            default_host_bind_decisions_path(),
+            PathBuf::from(".lns-host-bind-decisions.json")
+        );
+    }
+}

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod credentials;
 mod env_subst;
+pub mod host_bind_decisions;
 pub mod integrations;
 pub mod providers;
 pub mod registry_auth;

--- a/crates/lns-service/src/audit.rs
+++ b/crates/lns-service/src/audit.rs
@@ -210,7 +210,16 @@ pub fn record_volume_attached(run_id: u32, name: &str, target: &str) -> Result<(
     record_volume_attached_at(&audit_path(run_id)?, name, target)
 }
 
-fn bind_attached_obj(source: &str, target: &str) -> Map<String, Value> {
+fn string_array(items: &[String]) -> Value {
+    Value::Array(items.iter().map(|s| Value::String(s.clone())).collect())
+}
+
+fn bind_attached_obj(
+    source: &str,
+    target: &str,
+    exposed_secrets: &[String],
+    dropped_secrets: &[String],
+) -> Map<String, Value> {
     let mut obj = Map::new();
     obj.insert(
         "type".to_string(),
@@ -219,15 +228,38 @@ fn bind_attached_obj(source: &str, target: &str) -> Map<String, Value> {
     obj.insert("origin".to_string(), Value::String("host".to_string()));
     obj.insert("source".to_string(), Value::String(source.to_string()));
     obj.insert("target".to_string(), Value::String(target.to_string()));
+    obj.insert("exposed_secrets".to_string(), string_array(exposed_secrets));
+    obj.insert("dropped_secrets".to_string(), string_array(dropped_secrets));
     obj
 }
 
-pub fn record_bind_attached_at(path: &Path, source: &str, target: &str) -> Result<()> {
-    append_event_at(path, bind_attached_obj(source, target))
+pub fn record_bind_attached_at(
+    path: &Path,
+    source: &str,
+    target: &str,
+    exposed_secrets: &[String],
+    dropped_secrets: &[String],
+) -> Result<()> {
+    append_event_at(
+        path,
+        bind_attached_obj(source, target, exposed_secrets, dropped_secrets),
+    )
 }
 
-pub fn record_bind_attached(run_id: u32, source: &str, target: &str) -> Result<()> {
-    record_bind_attached_at(&audit_path(run_id)?, source, target)
+pub fn record_bind_attached(
+    run_id: u32,
+    source: &str,
+    target: &str,
+    exposed_secrets: &[String],
+    dropped_secrets: &[String],
+) -> Result<()> {
+    record_bind_attached_at(
+        &audit_path(run_id)?,
+        source,
+        target,
+        exposed_secrets,
+        dropped_secrets,
+    )
 }
 
 #[cfg(test)]
@@ -267,7 +299,7 @@ mod tests {
     fn record_bind_attached_writes_host_source_and_target() {
         let d = tempfile::tempdir().unwrap();
         let path = d.path().join("audit.jsonl");
-        record_bind_attached_at(&path, "/Users/me/proj", "/work").unwrap();
+        record_bind_attached_at(&path, "/Users/me/proj", "/work", &[], &[]).unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("\"type\":\"bind_attached\""), "{content}");
@@ -280,12 +312,39 @@ mod tests {
     }
 
     #[test]
+    fn record_bind_attached_records_which_secrets_were_exposed_versus_masked() {
+        let d = tempfile::tempdir().unwrap();
+        let path = d.path().join("audit.jsonl");
+        record_bind_attached_at(
+            &path,
+            "/Users/me/proj",
+            "/work",
+            &[".env".to_string()],
+            &[".npmrc".to_string(), ".ssh".to_string()],
+        )
+        .unwrap();
+
+        let line: serde_json::Value =
+            serde_json::from_str(std::fs::read_to_string(&path).unwrap().trim()).unwrap();
+        assert_eq!(
+            line["exposed_secrets"],
+            serde_json::json!([".env"]),
+            "the tamper-evident log must name the real secret the run exposed"
+        );
+        assert_eq!(
+            line["dropped_secrets"],
+            serde_json::json!([".npmrc", ".ssh"]),
+            "and the secrets it masked"
+        );
+    }
+
+    #[test]
     #[serial_test::serial(env)]
     fn record_bind_attached_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
         let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
-        record_bind_attached(123, "/Users/me/proj", "/work").unwrap();
+        record_bind_attached(123, "/Users/me/proj", "/work", &[], &[]).unwrap();
         let content = std::fs::read_to_string(audit_path(123).unwrap()).unwrap();
         assert!(
             content.contains("\"source\":\"/Users/me/proj\""),

--- a/crates/lns-service/src/audit.rs
+++ b/crates/lns-service/src/audit.rs
@@ -280,6 +280,21 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
+    fn record_bind_attached_writes_under_the_runs_audit_log() {
+        let d = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
+        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
+        record_bind_attached(123, "/Users/me/proj", "/work").unwrap();
+        let content = std::fs::read_to_string(audit_path(123).unwrap()).unwrap();
+        assert!(
+            content.contains("\"source\":\"/Users/me/proj\""),
+            "{content}"
+        );
+        assert!(content.contains("\"target\":\"/work\""), "{content}");
+    }
+
+    #[test]
     fn successive_events_form_a_valid_hash_chain() {
         let d = tempfile::tempdir().unwrap();
         let path = d.path().join("audit.jsonl");

--- a/crates/lns-service/src/audit.rs
+++ b/crates/lns-service/src/audit.rs
@@ -210,6 +210,26 @@ pub fn record_volume_attached(run_id: u32, name: &str, target: &str) -> Result<(
     record_volume_attached_at(&audit_path(run_id)?, name, target)
 }
 
+fn bind_attached_obj(source: &str, target: &str) -> Map<String, Value> {
+    let mut obj = Map::new();
+    obj.insert(
+        "type".to_string(),
+        Value::String("bind_attached".to_string()),
+    );
+    obj.insert("origin".to_string(), Value::String("host".to_string()));
+    obj.insert("source".to_string(), Value::String(source.to_string()));
+    obj.insert("target".to_string(), Value::String(target.to_string()));
+    obj
+}
+
+pub fn record_bind_attached_at(path: &Path, source: &str, target: &str) -> Result<()> {
+    append_event_at(path, bind_attached_obj(source, target))
+}
+
+pub fn record_bind_attached(run_id: u32, source: &str, target: &str) -> Result<()> {
+    record_bind_attached_at(&audit_path(run_id)?, source, target)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,6 +261,22 @@ mod tests {
             content.contains(&format!("\"prev_hash\":\"{}\"", lns_ipc::GENESIS_PREV_HASH)),
             "first line must be genesis: {content}"
         );
+    }
+
+    #[test]
+    fn record_bind_attached_writes_host_source_and_target() {
+        let d = tempfile::tempdir().unwrap();
+        let path = d.path().join("audit.jsonl");
+        record_bind_attached_at(&path, "/Users/me/proj", "/work").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("\"type\":\"bind_attached\""), "{content}");
+        assert!(content.contains("\"origin\":\"host\""), "{content}");
+        assert!(
+            content.contains("\"source\":\"/Users/me/proj\""),
+            "{content}"
+        );
+        assert!(content.contains("\"target\":\"/work\""), "{content}");
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -529,6 +529,7 @@ mod tests {
                 detached: false,
                 published_ports: vec![],
                 volumes: vec![],
+                binds: vec![],
             }),
             Instant::now(),
         )

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -157,7 +157,13 @@ async fn orchestrate(
         })
         .collect();
     for bind in &args.binds {
-        crate::audit::record_bind_attached(run_id, &bind.host_source, &bind.target)?;
+        crate::audit::record_bind_attached(
+            run_id,
+            &bind.host_source,
+            &bind.target,
+            &bind.kept_paths,
+            &bind.dropped_paths,
+        )?;
     }
 
     let imageless = args.image.is_none();

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -146,6 +146,20 @@ async fn orchestrate(
         crate::audit::record_volume_attached(run_id, &vol.name, &vol.target)?;
     }
 
+    let bind_attachments: Vec<vm::BindAttachment> = args
+        .binds
+        .iter()
+        .map(|b| vm::BindAttachment {
+            host_source: std::path::PathBuf::from(&b.host_source),
+            target: b.target.clone(),
+            read_only: b.read_only,
+            dropped_paths: b.dropped_paths.clone(),
+        })
+        .collect();
+    for bind in &args.binds {
+        crate::audit::record_bind_attached(run_id, &bind.host_source, &bind.target)?;
+    }
+
     let imageless = args.image.is_none();
     let runtime_layer = runtime_layer::for_run(
         imageless,
@@ -228,6 +242,7 @@ async fn orchestrate(
         descriptor_sha256: Some(descriptor.descriptor_sha256.clone()),
         upper_disk: upper_disk_path,
         volumes: volume_attachments,
+        binds: bind_attachments,
         #[cfg(target_os = "macos")]
         vsock: session.as_ref().map(|s| vm::VsockChannel {
             port: crate::relay::VSOCK_PORT,

--- a/crates/lns-service/src/vm/cloud_hypervisor.rs
+++ b/crates/lns-service/src/vm/cloud_hypervisor.rs
@@ -44,6 +44,7 @@ mod tests {
             descriptor_sha256: None,
             upper_disk: PathBuf::from("/upper"),
             volumes: vec![],
+            binds: vec![],
             debug: false,
             exec: ExecSpec {
                 kernel_env: Vec::new(),

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -26,6 +26,7 @@ pub struct VmSpec {
     pub descriptor_sha256: Option<String>,
     pub upper_disk: PathBuf,
     pub volumes: Vec<VolumeAttachment>,
+    pub binds: Vec<BindAttachment>,
     #[cfg(target_os = "macos")]
     pub vsock: Option<VsockChannel>,
     #[cfg(target_os = "macos")]
@@ -41,6 +42,19 @@ pub struct VolumeAttachment {
     pub host_image: PathBuf,
     pub target: String,
     pub read_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindAttachment {
+    pub host_source: PathBuf,
+    pub target: String,
+    pub read_only: bool,
+    pub dropped_paths: Vec<String>,
+}
+
+/// The virtio-fs tag the host shares a bind under and the guest mounts it by; one per bind, distinct from the content share.
+pub fn bind_share_tag(index: usize) -> String {
+    format!("lns-bind-{index}")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,6 +233,7 @@ pub fn resolve_run_as(
 }
 
 #[cfg_attr(not(any(target_os = "linux", target_os = "macos")), allow(dead_code))]
+#[allow(clippy::too_many_arguments)] // a flat list of independent cmdline inputs reads clearer than a one-shot params struct
 pub fn build_kernel_cmdline(
     exec: &ExecSpec,
     console: &str,
@@ -227,6 +242,7 @@ pub fn build_kernel_cmdline(
     descriptor_sha256: Option<&str>,
     debug: bool,
     volumes: &[VolumeAttachment],
+    binds: &[BindAttachment],
 ) -> String {
     let mut parts = vec![format!("console={console}"), "rw".to_string()];
     if !debug {
@@ -249,6 +265,14 @@ pub fn build_kernel_cmdline(
         parts.push(format!("volume.{i}.dev={dev}"));
         parts.push(format!("volume.{i}.target={}", v.target));
         parts.push(format!("volume.{i}.ro={}", u8::from(v.read_only)));
+    }
+    for (i, b) in binds.iter().enumerate() {
+        parts.push(format!("bind.{i}.tag={}", bind_share_tag(i)));
+        parts.push(format!("bind.{i}.target={}", b.target));
+        parts.push(format!("bind.{i}.ro={}", u8::from(b.read_only)));
+        for (j, dropped) in b.dropped_paths.iter().enumerate() {
+            parts.push(format!("bind.{i}.drop.{j}={dropped}"));
+        }
     }
     for (k, v) in &exec.kernel_env {
         debug_assert!(
@@ -349,6 +373,7 @@ mod tests {
             None,
             /*debug*/ false,
             &[],
+            &[],
         );
         let toks: Vec<&str> = quiet.split_whitespace().collect();
         assert!(toks.contains(&"quiet"), "expected `quiet` at debug=false");
@@ -364,6 +389,7 @@ mod tests {
             "lns-content",
             None,
             /*debug*/ true,
+            &[],
             &[],
         );
         let toks: Vec<&str> = loud.split_whitespace().collect();
@@ -388,6 +414,7 @@ mod tests {
             None,
             false,
             &[],
+            &[],
         );
         let toks: Vec<&str> = with_pci.split_whitespace().collect();
         assert!(
@@ -402,6 +429,7 @@ mod tests {
             "lns-content",
             None,
             false,
+            &[],
             &[],
         );
         let toks: Vec<&str> = no_pci.split_whitespace().collect();
@@ -421,6 +449,7 @@ mod tests {
             "lns-content",
             Some("deadbeef"),
             false,
+            &[],
             &[],
         );
         let toks: Vec<&str> = cmdline.split_whitespace().collect();
@@ -461,10 +490,60 @@ mod tests {
     #[test]
     fn build_kernel_cmdline_no_volumes_emits_no_volume_keys() {
         let exec = ExecSpec::from_image_config(None, &["true".into()]);
-        let cmdline = build_kernel_cmdline(&exec, "hvc0", true, "lns-content", None, false, &[]);
+        let cmdline =
+            build_kernel_cmdline(&exec, "hvc0", true, "lns-content", None, false, &[], &[]);
         assert!(
             !cmdline.contains("volume."),
             "no volume keys when none attached: {cmdline}"
+        );
+        assert!(
+            !cmdline.contains("bind."),
+            "no bind keys when none attached: {cmdline}"
+        );
+    }
+
+    #[test]
+    fn bind_share_tag_is_distinct_per_index() {
+        assert_eq!(bind_share_tag(0), "lns-bind-0");
+        assert_eq!(bind_share_tag(1), "lns-bind-1");
+        assert_ne!(bind_share_tag(0), bind_share_tag(1));
+    }
+
+    #[test]
+    fn build_kernel_cmdline_emits_tag_target_ro_and_drops_per_bind() {
+        let exec = ExecSpec::from_image_config(None, &["true".into()]);
+        let binds = [
+            BindAttachment {
+                host_source: "/Users/me/proj".into(),
+                target: "/work".into(),
+                read_only: false,
+                dropped_paths: vec![".env".into(), ".npmrc".into()],
+            },
+            BindAttachment {
+                host_source: "/Users/me/cfg".into(),
+                target: "/cfg".into(),
+                read_only: true,
+                dropped_paths: vec![],
+            },
+        ];
+        let cmdline =
+            build_kernel_cmdline(&exec, "hvc0", true, "lns-content", None, false, &[], &binds);
+        let toks: Vec<&str> = cmdline.split_whitespace().collect();
+        for expected in [
+            "bind.0.tag=lns-bind-0",
+            "bind.0.target=/work",
+            "bind.0.ro=0",
+            "bind.0.drop.0=.env",
+            "bind.0.drop.1=.npmrc",
+            "bind.1.tag=lns-bind-1",
+            "bind.1.target=/cfg",
+            "bind.1.ro=1",
+        ] {
+            assert!(toks.contains(&expected), "missing {expected}: {toks:?}");
+        }
+        assert!(
+            toks.contains(&"content.tag=lns-content"),
+            "content share tag must be left untouched: {toks:?}"
         );
     }
 
@@ -483,8 +562,16 @@ mod tests {
                 read_only: true,
             },
         ];
-        let cmdline =
-            build_kernel_cmdline(&exec, "hvc0", true, "lns-content", None, false, &volumes);
+        let cmdline = build_kernel_cmdline(
+            &exec,
+            "hvc0",
+            true,
+            "lns-content",
+            None,
+            false,
+            &volumes,
+            &[],
+        );
         let toks: Vec<&str> = cmdline.split_whitespace().collect();
         for expected in [
             "volume.0.dev=/dev/vdc",
@@ -546,8 +633,16 @@ mod tests {
                 read_only: true,
             },
         ];
-        let cmdline =
-            build_kernel_cmdline(&exec, "hvc0", true, "lns-content", None, false, &volumes);
+        let cmdline = build_kernel_cmdline(
+            &exec,
+            "hvc0",
+            true,
+            "lns-content",
+            None,
+            false,
+            &volumes,
+            &[],
+        );
         let toks: Vec<&str> = cmdline.split_whitespace().collect();
         for expected in [
             "volume.0.dev=/dev/vdc",
@@ -803,6 +898,7 @@ mod tests {
             descriptor_sha256: None,
             upper_disk: PathBuf::from("/dev/null"),
             volumes: vec![],
+            binds: vec![],
             #[cfg(target_os = "macos")]
             vsock: None,
             #[cfg(target_os = "macos")]

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -270,6 +270,7 @@ pub fn build_kernel_cmdline(
         parts.push(format!("bind.{i}.tag={}", bind_share_tag(i)));
         parts.push(format!("bind.{i}.target={}", b.target));
         parts.push(format!("bind.{i}.ro={}", u8::from(b.read_only)));
+        parts.push(format!("bind.{i}.drops={}", b.dropped_paths.len()));
         for (j, dropped) in b.dropped_paths.iter().enumerate() {
             parts.push(format!("bind.{i}.drop.{j}={dropped}"));
         }
@@ -533,11 +534,13 @@ mod tests {
             "bind.0.tag=lns-bind-0",
             "bind.0.target=/work",
             "bind.0.ro=0",
+            "bind.0.drops=2",
             "bind.0.drop.0=.env",
             "bind.0.drop.1=.npmrc",
             "bind.1.tag=lns-bind-1",
             "bind.1.target=/cfg",
             "bind.1.ro=1",
+            "bind.1.drops=0",
         ] {
             assert!(toks.contains(&expected), "missing {expected}: {toks:?}");
         }

--- a/crates/lns-service/src/vm/vz/ffi.rs
+++ b/crates/lns-service/src/vm/vz/ffi.rs
@@ -205,6 +205,7 @@ fn run_vz(spec: VmSpec) -> Result<()> {
         spec.descriptor_sha256.as_deref(),
         spec.debug,
         &spec.volumes,
+        &spec.binds,
     );
 
     let queue = DispatchQueue::new("lns.vz", DispatchQueueAttr::SERIAL);

--- a/crates/lns-service/src/vm/vz/ffi.rs
+++ b/crates/lns-service/src/vm/vz/ffi.rs
@@ -220,6 +220,7 @@ fn run_vz(spec: VmSpec) -> Result<()> {
     let composefs_descriptor = spec.composefs_descriptor.clone();
     let upper_disk = spec.upper_disk.clone();
     let volumes = spec.volumes.clone();
+    let binds = spec.binds.clone();
     let vsock = spec.vsock;
     let connector_tx = spec.connector_tx;
     let console_fd = spec.console_fd;
@@ -237,6 +238,7 @@ fn run_vz(spec: VmSpec) -> Result<()> {
             composefs_descriptor: &composefs_descriptor,
             upper_disk: &upper_disk,
             volumes: &volumes,
+            binds: &binds,
             vsock: vsock.as_ref(),
             console_fd,
             cmdline: &cmdline,
@@ -275,6 +277,7 @@ struct BuildInputs<'a> {
     composefs_descriptor: &'a Path,
     upper_disk: &'a Path,
     volumes: &'a [crate::vm::VolumeAttachment],
+    binds: &'a [crate::vm::BindAttachment],
     vsock: Option<&'a crate::vm::VsockChannel>,
     console_fd: std::os::fd::RawFd,
     cmdline: &'a str,
@@ -445,8 +448,38 @@ unsafe fn build_config(
             &NSString::from_str(inputs.content_tag),
         );
         fs_dev.setShare(Some(&*single_share));
+        let mut share_devs: Vec<Retained<VZDirectorySharingDeviceConfiguration>> =
+            vec![Retained::cast_unchecked(fs_dev)];
+        for (i, bind) in inputs.binds.iter().enumerate() {
+            if !bind.host_source.exists() {
+                bail!(
+                    "host bind source does not exist: {}",
+                    bind.host_source.display()
+                );
+            }
+            let bind_url = NSURL::fileURLWithPath_isDirectory(
+                &NSString::from_str(&bind.host_source.to_string_lossy()),
+                true,
+            );
+            let bind_shared = VZSharedDirectory::initWithURL_readOnly(
+                VZSharedDirectory::alloc(),
+                &bind_url,
+                bind.read_only,
+            );
+            let bind_single: Retained<VZDirectoryShare> =
+                Retained::cast_unchecked(VZSingleDirectoryShare::initWithDirectory(
+                    VZSingleDirectoryShare::alloc(),
+                    &bind_shared,
+                ));
+            let bind_dev = VZVirtioFileSystemDeviceConfiguration::initWithTag(
+                VZVirtioFileSystemDeviceConfiguration::alloc(),
+                &NSString::from_str(&crate::vm::bind_share_tag(i)),
+            );
+            bind_dev.setShare(Some(&*bind_single));
+            share_devs.push(Retained::cast_unchecked(bind_dev));
+        }
         let dirs: Retained<NSArray<VZDirectorySharingDeviceConfiguration>> =
-            NSArray::from_retained_slice(&[Retained::cast_unchecked(fs_dev)]);
+            NSArray::from_retained_slice(&share_devs);
         config.setDirectorySharingDevices(&dirs);
 
         // Vz preserves array order in setStorageDevices; upper_disk must be first (→ /dev/vda) and composefs_descriptor second (→ /dev/vdb) to match the cmdline keys.

--- a/crates/lns-service/tests/behaviours.rs
+++ b/crates/lns-service/tests/behaviours.rs
@@ -1,5 +1,7 @@
 #[path = "behaviours/approval_rig.rs"]
 mod approval_rig;
+#[path = "behaviours/bind_rig.rs"]
+mod bind_rig;
 #[path = "behaviours/credential_rig.rs"]
 mod credential_rig;
 #[path = "behaviours/forward_rig.rs"]

--- a/crates/lns-service/tests/behaviours/bind_rig.rs
+++ b/crates/lns-service/tests/behaviours/bind_rig.rs
@@ -47,9 +47,17 @@ impl BindRig {
         )
     }
 
-    pub fn record_audit(&self, source: &str, target: &str) {
-        lns_service::audit::record_bind_attached_at(&self.audit_file, source, target)
-            .expect("record bind audit event");
+    pub fn record_audit(&self, source: &str, target: &str, exposed: &[&str], dropped: &[&str]) {
+        let exposed: Vec<String> = exposed.iter().map(|s| s.to_string()).collect();
+        let dropped: Vec<String> = dropped.iter().map(|s| s.to_string()).collect();
+        lns_service::audit::record_bind_attached_at(
+            &self.audit_file,
+            source,
+            target,
+            &exposed,
+            &dropped,
+        )
+        .expect("record bind audit event");
     }
 
     pub fn audit_contents(&self) -> String {

--- a/crates/lns-service/tests/behaviours/bind_rig.rs
+++ b/crates/lns-service/tests/behaviours/bind_rig.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use lns_service::vm::{BindAttachment, ExecSpec, build_kernel_cmdline};
+
+/// Drives the host-bind slice the service owns without booting a VM: it builds
+/// the kernel cmdline from `BindAttachment`s and records the audit line.
+#[derive(Debug)]
+pub struct BindRig {
+    binds: Vec<BindAttachment>,
+    audit_file: PathBuf,
+    _tmp: tempfile::TempDir,
+}
+
+impl BindRig {
+    pub fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let audit_file = tmp.path().join("audit.jsonl");
+        Self {
+            binds: Vec::new(),
+            audit_file,
+            _tmp: tmp,
+        }
+    }
+
+    pub fn request(&mut self, source: &str, target: &str, read_only: bool, drops: &[&str]) {
+        self.binds.push(BindAttachment {
+            host_source: source.into(),
+            target: target.into(),
+            read_only,
+            dropped_paths: drops.iter().map(|s| s.to_string()).collect(),
+        });
+    }
+
+    pub fn cmdline(&self) -> String {
+        let exec = ExecSpec {
+            kernel_env: Vec::new(),
+        };
+        build_kernel_cmdline(
+            &exec,
+            "hvc0",
+            true,
+            "lns-content",
+            None,
+            false,
+            &[],
+            &self.binds,
+        )
+    }
+
+    pub fn record_audit(&self, source: &str, target: &str) {
+        lns_service::audit::record_bind_attached_at(&self.audit_file, source, target)
+            .expect("record bind audit event");
+    }
+
+    pub fn audit_contents(&self) -> String {
+        std::fs::read_to_string(&self.audit_file).unwrap_or_default()
+    }
+}

--- a/crates/lns-service/tests/behaviours/host_binds.feature
+++ b/crates/lns-service/tests/behaviours/host_binds.feature
@@ -29,3 +29,7 @@ Feature: host bind mounts — virtio-fs shares, read-only mode, dropped secrets,
   Scenario: Attaching a host bind emits an audit record
     When a host bind "/Users/me/proj" at "/work" is recorded in the audit chain
     Then the audit chain records the host source "/Users/me/proj" and target "/work"
+
+  Scenario: The audit record distinguishes exposed secrets from masked ones
+    When a host bind "/Users/me/proj" at "/work" exposing ".env" and dropping ".npmrc" is recorded in the audit chain
+    Then the audit chain records ".env" as exposed and ".npmrc" as dropped

--- a/crates/lns-service/tests/behaviours/host_binds.feature
+++ b/crates/lns-service/tests/behaviours/host_binds.feature
@@ -1,0 +1,31 @@
+Feature: host bind mounts — virtio-fs shares, read-only mode, dropped secrets, audit
+  Guest-observable outcomes (the workload reading host files, writes landing back
+  on the host, read-only enforcement, a dropped file being absent) need a microVM
+  and live in the @microvm e2e contract. These scenarios pin the behaviour the
+  service owns without booting a VM: a host bind becomes a tagged virtio-fs share
+  in the VM spec (not a block-device disk like a named volume), each bind gets its
+  own share tag, read-only is carried on the share, the secret paths the operator
+  chose to DROP are threaded onto the spec so the guest can mask them, and the
+  bind is recorded in the audit chain.
+
+  Scenario: A host bind is attached as a virtio-fs share at its target, writable
+    When a run requests host bind "/Users/me/proj" at "/work"
+    Then the spec carries a virtio-fs share for "/Users/me/proj" at "/work"
+    And that share is writable
+
+  Scenario: A read-only host bind is marked read-only on its share
+    When a run requests host bind "/Users/me/proj" at "/work" read-only
+    Then the spec marks the share for "/Users/me/proj" read-only
+
+  Scenario: Two host binds in one run get distinct share tags
+    When a run requests host bind "/Users/me/proj" at "/work" and "/Users/me/data" at "/data"
+    Then the spec carries two virtio-fs shares with distinct tags
+    And the content share tag is left untouched
+
+  Scenario: Dropped secret paths are threaded onto the bind spec for the guest to mask
+    When a run requests host bind "/Users/me/proj" at "/work" dropping ".env"
+    Then the bind spec for "/work" lists ".env" in its dropped paths
+
+  Scenario: Attaching a host bind emits an audit record
+    When a host bind "/Users/me/proj" at "/work" is recorded in the audit chain
+    Then the audit chain records the host source "/Users/me/proj" and target "/work"

--- a/crates/lns-service/tests/behaviours/steps/host_binds.rs
+++ b/crates/lns-service/tests/behaviours/steps/host_binds.rs
@@ -1,0 +1,101 @@
+use cucumber::{then, when};
+
+use crate::world::BehaviourWorld;
+
+fn cmdline_has(w: &mut BehaviourWorld, token: &str) -> Result<(), String> {
+    let cmdline = w.bind().cmdline();
+    if cmdline.split_whitespace().any(|t| t == token) {
+        Ok(())
+    } else {
+        Err(format!("expected token {token:?} in cmdline: {cmdline}"))
+    }
+}
+
+#[when(expr = "a run requests host bind {string} at {string}")]
+async fn request(w: &mut BehaviourWorld, source: String, target: String) {
+    w.bind().request(&source, &target, false, &[]);
+}
+
+#[when(expr = "a run requests host bind {string} at {string} read-only")]
+async fn request_ro(w: &mut BehaviourWorld, source: String, target: String) {
+    w.bind().request(&source, &target, true, &[]);
+}
+
+#[when(expr = "a run requests host bind {string} at {string} and {string} at {string}")]
+async fn request_two(
+    w: &mut BehaviourWorld,
+    a_src: String,
+    a_tgt: String,
+    b_src: String,
+    b_tgt: String,
+) {
+    w.bind().request(&a_src, &a_tgt, false, &[]);
+    w.bind().request(&b_src, &b_tgt, false, &[]);
+}
+
+#[when(expr = "a run requests host bind {string} at {string} dropping {string}")]
+async fn request_dropping(w: &mut BehaviourWorld, source: String, target: String, drop: String) {
+    w.bind().request(&source, &target, false, &[&drop]);
+}
+
+#[when(expr = "a host bind {string} at {string} is recorded in the audit chain")]
+async fn record_bind_audit(w: &mut BehaviourWorld, source: String, target: String) {
+    w.bind().record_audit(&source, &target);
+}
+
+#[then(expr = "the spec carries a virtio-fs share for {string} at {string}")]
+async fn share_at_target(
+    w: &mut BehaviourWorld,
+    _source: String,
+    target: String,
+) -> Result<(), String> {
+    cmdline_has(w, "bind.0.tag=lns-bind-0")?;
+    cmdline_has(w, &format!("bind.0.target={target}"))
+}
+
+#[then(expr = "that share is writable")]
+async fn share_writable(w: &mut BehaviourWorld) -> Result<(), String> {
+    cmdline_has(w, "bind.0.ro=0")
+}
+
+#[then(expr = "the spec marks the share for {string} read-only")]
+async fn share_read_only(w: &mut BehaviourWorld, _source: String) -> Result<(), String> {
+    cmdline_has(w, "bind.0.ro=1")
+}
+
+#[then(expr = "the spec carries two virtio-fs shares with distinct tags")]
+async fn two_distinct_tags(w: &mut BehaviourWorld) -> Result<(), String> {
+    cmdline_has(w, "bind.0.tag=lns-bind-0")?;
+    cmdline_has(w, "bind.1.tag=lns-bind-1")
+}
+
+#[then(expr = "the content share tag is left untouched")]
+async fn content_tag_untouched(w: &mut BehaviourWorld) -> Result<(), String> {
+    cmdline_has(w, "content.tag=lns-content")
+}
+
+#[then(expr = "the bind spec for {string} lists {string} in its dropped paths")]
+async fn bind_lists_drop(
+    w: &mut BehaviourWorld,
+    target: String,
+    name: String,
+) -> Result<(), String> {
+    cmdline_has(w, &format!("bind.0.target={target}"))?;
+    cmdline_has(w, &format!("bind.0.drop.0={name}"))
+}
+
+#[then(expr = "the audit chain records the host source {string} and target {string}")]
+async fn audit_records(
+    w: &mut BehaviourWorld,
+    source: String,
+    target: String,
+) -> Result<(), String> {
+    let content = w.bind().audit_contents();
+    if content.contains(&format!("\"source\":\"{source}\""))
+        && content.contains(&format!("\"target\":\"{target}\""))
+    {
+        Ok(())
+    } else {
+        Err(format!("audit chain missing source/target: {content}"))
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/host_binds.rs
+++ b/crates/lns-service/tests/behaviours/steps/host_binds.rs
@@ -40,7 +40,21 @@ async fn request_dropping(w: &mut BehaviourWorld, source: String, target: String
 
 #[when(expr = "a host bind {string} at {string} is recorded in the audit chain")]
 async fn record_bind_audit(w: &mut BehaviourWorld, source: String, target: String) {
-    w.bind().record_audit(&source, &target);
+    w.bind().record_audit(&source, &target, &[], &[]);
+}
+
+#[when(
+    expr = "a host bind {string} at {string} exposing {string} and dropping {string} is recorded in the audit chain"
+)]
+async fn record_bind_audit_with_secrets(
+    w: &mut BehaviourWorld,
+    source: String,
+    target: String,
+    exposed: String,
+    dropped: String,
+) {
+    w.bind()
+        .record_audit(&source, &target, &[&exposed], &[&dropped]);
 }
 
 #[then(expr = "the spec carries a virtio-fs share for {string} at {string}")]
@@ -97,5 +111,21 @@ async fn audit_records(
         Ok(())
     } else {
         Err(format!("audit chain missing source/target: {content}"))
+    }
+}
+
+#[then(expr = "the audit chain records {string} as exposed and {string} as dropped")]
+async fn audit_records_disposition(
+    w: &mut BehaviourWorld,
+    exposed: String,
+    dropped: String,
+) -> Result<(), String> {
+    let content = w.bind().audit_contents();
+    if content.contains(&format!("\"exposed_secrets\":[\"{exposed}\"]"))
+        && content.contains(&format!("\"dropped_secrets\":[\"{dropped}\"]"))
+    {
+        Ok(())
+    } else {
+        Err(format!("audit chain missing secret disposition: {content}"))
     }
 }

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -2,6 +2,7 @@ pub mod approval_flow;
 pub mod credential_flow;
 pub mod env_injection;
 pub mod forward;
+pub mod host_binds;
 pub mod image_management;
 pub mod ipc;
 pub mod oauth_integration;

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::approval_rig::ApprovalRig;
+use crate::bind_rig::BindRig;
 use crate::credential_rig::CredentialRig;
 use crate::forward_rig::ForwardFake;
 use crate::image_rig::ImageRig;
@@ -43,6 +44,8 @@ pub struct BehaviourWorld {
     pub forward_error: Option<String>,
 
     pub volume: Option<VolumeRig>,
+
+    pub bind: Option<BindRig>,
 
     pub image: Option<ImageRig>,
 
@@ -89,6 +92,13 @@ impl BehaviourWorld {
             self.volume = Some(VolumeRig::new());
         }
         self.volume.as_mut().expect("volume rig must exist")
+    }
+
+    pub fn bind(&mut self) -> &mut BindRig {
+        if self.bind.is_none() {
+            self.bind = Some(BindRig::new());
+        }
+        self.bind.as_mut().expect("bind rig must exist")
     }
 
     pub fn image(&mut self) -> &mut ImageRig {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ run, which requires a `COMMAND` after `--`.
 | `-w`, `--workdir <DIR>`      | image `WORKDIR`  | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
 | `--env-file <FILE>`          |                  | Read `KEY=VALUE` lines from a file into the workload env (repeatable; later files and `-e` win). |
-| `-v`, `--volume <SPEC>`      |                  | Attach a named volume as `name:/path[:ro]` (repeatable); persists across runs. |
+| `-v`, `--volume <SPEC>`      |                  | Mount into the workload (repeatable): a named volume `name:/path[:ro]` (persists across runs) or a host bind `/host/path:/path[:ro]` (live host files; prompts to keep/drop secret-shaped files). |
 | `-p`, `--publish <SPEC>`     |                  | Publish a guest port as `[host_ip:]hostport:containerport[/proto]` (repeatable). Host bind defaults to `127.0.0.1`. |
 | `-i`, `--interactive`        | `true`           | Keep stdin open and forward host stdin to the workload.                 |
 | `-t`, `--tty`                | `true`           | Allocate a PTY; pipe mode is auto-selected when stdin isn't a TTY.      |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,9 +83,10 @@ lns run
 
 You run Lens Sandbox from a project directory — that's where it looks for
 `lns-policy.yaml`, creating one with a default verdict of `ask` the first time. To
-make host files available to the workload, attach a volume (see
-[Running workloads](running-workloads.md)). The workload's own working directory
-comes from the image.
+give the workload your actual project files, bind-mount the directory with
+`-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for scratch
+space that persists across runs instead, attach a named volume. The workload's own
+working directory comes from the image.
 
 ## What happens on an unknown request
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -221,18 +221,20 @@ Host bind: /Users/you/proj/.env looks like a secret. Expose it to the workload? 
   it on stderr, rather than exposing it unasked.
 - Decisions to **keep** a real secret are per-machine and never written to a shared
   file. To share a "never expose these" rule with your team, commit a `.lensignore`
-  in the bind directory — one path per line — and those files are dropped with no
-  prompt.
+  in the bind root — one path per line — and those paths are dropped with no prompt.
+  An entry may be a top-level name or a nested path relative to the bind root
+  (`packages/api/.env`); it must stay inside the bind (no leading `/`, no `..`), and a
+  rule for a file that isn't present is simply a no-op.
 
 The run summary lists each bind, its mode, and the disposition of every detected
 secret (`kept (exposed)` / `dropped`).
 
-> **The scan is top-level only.** Only the immediate contents of the bind root are
-> checked, so secrets nested in subdirectories (`packages/api/.env`, a key under
-> `server/certs/`, credentials embedded in `.git/config`) are exposed to the
-> workload **without a prompt**. Until the scan descends, treat a bind of a deep
-> tree as exposing everything under it, and use `:ro` or bind a narrower path when a
-> subtree holds secrets you don't want the workload to read.
+> **The automatic scan is top-level only.** Only the immediate contents of the bind
+> root are scanned for secret shapes, so a secret nested in a subdirectory
+> (`packages/api/.env`, a key under `server/certs/`, credentials embedded in
+> `.git/config`) is exposed to the workload **without a prompt**. To hide a nested
+> secret you know about, name it in `.lensignore` (a nested path is honored); for an
+> untrusted subtree, bind a narrower path or use `:ro`.
 
 ### Publishing ports
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -13,8 +13,10 @@ lns run [OPTIONS] [IMAGE] [-- COMMAND...]
 ```
 
 You run `lns run` from a project directory; that's where Lens Sandbox looks for the
-`lns-policy.yaml` that governs the run. To expose host files to the workload, attach
-a volume with `-v`.
+`lns-policy.yaml` that governs the run. To expose your actual host files to the
+workload, bind-mount a directory with `-v /host/path:/guest/path` (see
+[Host bind mounts](#host-bind-mounts)); for scratch space that persists across runs,
+attach a named volume instead.
 
 ### Running an image
 
@@ -181,6 +183,56 @@ lns volume prune               # delete every volume no running sandbox holds
 asks for confirmation unless you pass `-f`/`--force`. Everything else in a
 sandbox is ephemeral by design — volumes are the one place data persists, so
 removing one is permanent.
+
+### Host bind mounts
+
+When the source of a `-v` is an **absolute host path** rather than a name, it's a
+host bind: the workload sees your live host files at the target, Docker-style.
+
+```bash
+lns run -v "$(pwd)":/work ghcr.io/acme/agent        # the agent edits your repo
+lns run -v /etc/myapp:/config:ro ghcr.io/acme/app   # read-only
+```
+
+The format is `/host/path:/absolute/target[:ro]`. The source must be an absolute
+path that already exists (a missing path is refused, not silently created — the one
+deliberate divergence from `docker run`). Binds default to read-write; append `:ro`
+for read-only. Disambiguation is by shape: a leading `/` is a host bind, anything
+else is a named volume, so `-v build-cache:/cache` is still a volume.
+
+#### Secrets in a bind
+
+A bind exposes everything in the directory — including `.env` files, SSH keys, and
+other credentials that the [credential flow](credentials.md) is designed to keep
+*outside* the workload. Before the run starts, `lns` scans the **top level** of each
+bind for secret-shaped files (`.env*`, `*.pem`, `*.key`, `id_rsa`, `.npmrc`,
+`.netrc`, `.ssh/`, `.aws/`, …) and asks you, once per file, whether to **keep** it
+(expose the real file) or **drop** it (hide it from the workload). Your choice is
+remembered per-machine, so later runs don't ask again:
+
+```text
+Host bind: /Users/you/proj/.env looks like a secret. Expose it to the workload? [k]eep / [D]rop (default):
+```
+
+- **Keep** mounts the real file through; **Drop** masks it so the workload can't
+  read it (the file is never modified or deleted on the host).
+- The default on a bare Enter is **drop** — the safe choice.
+- A non-interactive run (`-d`, or no terminal) drops any undecided secret and notes
+  it on stderr, rather than exposing it unasked.
+- Decisions to **keep** a real secret are per-machine and never written to a shared
+  file. To share a "never expose these" rule with your team, commit a `.lensignore`
+  in the bind directory — one path per line — and those files are dropped with no
+  prompt.
+
+The run summary lists each bind, its mode, and the disposition of every detected
+secret (`kept (exposed)` / `dropped`).
+
+> **The scan is top-level only.** Only the immediate contents of the bind root are
+> checked, so secrets nested in subdirectories (`packages/api/.env`, a key under
+> `server/certs/`, credentials embedded in `.git/config`) are exposed to the
+> workload **without a prompt**. Until the scan descends, treat a bind of a deep
+> tree as exposing everything under it, and use `:ro` or bind a narrower path when a
+> subtree holds secrets you don't want the workload to read.
 
 ### Publishing ports
 


### PR DESCRIPTION
## Summary

The day-one motivating use case — "run an agent against *this* repo" — requires live host files in the sandbox. Named volumes only give you scratch space. This PR adds **host bind mounts** to `lns run -v`, while enforcing the core principle that real secrets stay outside the workload.

### 1. `-v` disambiguation: absolute path → host bind, bare name → named volume

`MountSpec` replaces `VolumeMount` as the `-v` value type. Parsing is shape-based: a leading `/` in the source segment routes to `BindSpec`; anything else stays a `VolumeMount`. No flags, no ambiguity.

```
lns run -v "$(pwd)":/work alpine          # host bind (new)
lns run -v build-cache:/cache alpine      # named volume (unchanged)
lns run -v /etc/myapp:/config:ro alpine   # read-only host bind
```

The `MountSpec` type flows through `RunArgs`, `RunDefaults`, and `apply_run_defaults`. A missing host path is refused before the run starts — not silently created (deliberate Docker divergence, documented).

### 2. Secret guard: KEEP/DROP prompt with per-machine decisions

Before the run starts, `lns` scans the **top level** of each bind root for secret-shaped files (`.env*`, `*.pem`, `*.key`, `id_rsa`, `.npmrc`, `.netrc`, `.ssh/`, `.aws/`, `.gnupg`, …) and prompts once per undecided file:

```
Host bind: /Users/you/proj/.env looks like a secret. Expose it to the workload? [k]eep / [D]rop (default):
```

- Decisions are stored in `~/.lns-host-bind-decisions.json` — per-machine, never committed.
- **Default on bare Enter is DROP** — the safe choice.
- A **detached run** (`-d`) drops all undecided secrets regardless of TTY, so `lns run -d` never blocks.
- A **non-interactive run** (no terminal) drops and reports on stderr without prompting.

For team-wide "never expose these" rules, commit a `.lensignore` in the bind root — one path per line. Entries may be nested (`packages/api/.env`), must stay inside the bind (no leading `/`, no `..`), and rules for absent files are silent no-ops.

### 3. Guest-side masking (lns-init)

Dropped paths ride the kernel cmdline (`bind.N.drop.M=<name>`) to PID-1 in the guest. `lns-init` mounts each bind as a tagged virtio-fs share, then masks each dropped path **before** the workload sees the filesystem:

- A regular file → `/dev/null` bind-mount over it.
- A directory → empty `tmpfs` (mode `0000`, 4 KiB) over it.

A truncated drop-list (cmdline cut short) makes the guest **refuse to boot** with `IncompleteBind` rather than silently expose a file the operator chose to drop.

### 4. Service: virtio-fs share per bind (Vz)

Each bind becomes its own `VZVirtioFileSystemDeviceConfiguration` on the macOS Vz backend, tagged `lns-bind-{N}`. The content share tag is unaffected. The Cloud Hypervisor (Linux) backend continues to `bail!` entirely — no half-wired Linux path.

### 5. Audit chain records exposed vs masked

`record_bind_attached` appends a `bind_attached` event with `origin: host`, `source`, `target`, `exposed_secrets`, and `dropped_secrets` to the run's audit log. A KEEP is a deliberate risk acceptance, and the audit record names it explicitly.

## Docs

`docs/running-workloads.md` gains a "Host bind mounts" section covering the grammar, the secret flow, `.lensignore`, the top-level-only scan limitation, and mitigations. `docs/getting-started.md` and `docs/cli-reference.md` updated to surface the feature at first-touch.

## Screenshots
<!-- Add screenshot or recording demonstrating the new feature -->

## Test instructions

1. **No binds — unchanged behavior**: `lns run build-cache:/cache alpine -- sh -c "ls /cache"` — named volume attach works as before, no prompt, no new output.

2. **Clean bind**: `lns run -v "$(pwd)":/work alpine -- ls /work` — if the bind root has no secret-shaped files, no prompt appears and the run proceeds.

3. **First-time secret prompt — DROP**: Create `/tmp/test-bind/.env` with `SECRET=1`. Run `lns run -v /tmp/test-bind:/work alpine -- ls /work`. The prompt appears for `.env`. Press Enter (default DROP). Verify `/work/.env` is absent in the workload (or a zero-byte file). Run again — no prompt.

4. **First-time secret prompt — KEEP**: Same setup. Answer `k` at the prompt. Verify `/work/.env` is present and readable in the workload. Run again — no prompt.

5. **Read-only bind**: `lns run -v /tmp/test-bind:/work:ro alpine -- touch /work/x` — the mount is read-only, the write fails.

6. **`.lensignore`**: Add `notes.txt` to `/tmp/test-bind` and a `.lensignore` listing `notes.txt`. Run — no prompt, `notes.txt` is absent in `/work`.

7. **Detached run drops without prompting**: `lns run -d -v /tmp/test-bind:/work alpine -- sleep 30` — no prompt; a message on stderr reports the dropped `.env`.

8. **Missing host path**: `lns run -v /tmp/does-not-exist:/work alpine` — fails immediately with "host path does not exist" before connecting to the daemon.

9. **Run summary**: Any bind run — the `lns run` summary header lists `Bind: /tmp/test-bind → /work (read-write)` and, after resolution, `.env: kept (exposed)` or `.env: dropped`.