### PR TITLE
fix: persist named-volume writes and the workload's final output

### DIFF
--- a/crates/lns-session-broker/src/main.rs
+++ b/crates/lns-session-broker/src/main.rs
@@ -62,13 +62,13 @@ fn run() -> Result<i32, String> {
     let forker = forker::LibcForker;
     let primary_outcome = session::handle_session(primary_conn, None, &forker);
 
-    // close(2) alone doesn't wake the accept thread; shutdown(SHUT_RDWR) is required first.
     // SAFETY: listen_fd is owned and unused after this block.
     unsafe {
         libc::shutdown(listen_fd, libc::SHUT_RDWR);
         libc::close(listen_fd);
     }
-    let _ = accept_thread.join();
+    // Abandon rather than join the exec-accept thread: a blocking AF_VSOCK accept() is not woken by shutdown()/close(), so joining would hang run() short of main()'s sync()+poweroff and the guest would never flush its disks; the imminent poweroff reaps it.
+    drop(accept_thread);
 
     reap_exec_sessions(&exec_sessions);
 

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -10,6 +10,9 @@ use lns_session::{ClientFrame, ServerFrame, Winsize, encode_frame};
 
 const PTY_DRAIN_GRACE: Duration = Duration::from_millis(500);
 
+// Bounded wait for the host to read the final frames and close the connection before we let PID 1 power off, so output and the exit frame aren't cut off mid-flight; returns as soon as the host closes (the common case is sub-millisecond).
+const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
 use super::{
     LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close, dispatch_frame,
     read_client_frame, signal_target, validate_argv, validate_open_session,
@@ -198,9 +201,11 @@ fn drive_session_tty(
         let _ = drained_tx.send(());
     });
 
+    let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_for_ctrl = conn.clone();
     let ctrl_thread = std::thread::spawn(move || {
         client_loop_tty(conn_for_ctrl, stdin_dup, ctrl_dup, child_pid);
+        let _ = host_closed_tx.send(());
     });
 
     let exit_code = forker.wait(child_pid)?;
@@ -209,6 +214,9 @@ fn drive_session_tty(
     let _ = drained_rx.recv_timeout(PTY_DRAIN_GRACE);
 
     send_exit(&conn, exit_code);
+
+    // Wait (bounded) for the host to read the exit frame and close the connection before returning lets PID 1 power off, so the final frames aren't cut off mid-flight.
+    let _ = host_closed_rx.recv_timeout(HOST_DRAIN_GRACE);
 
     shutdown_read(conn.raw());
     let _ = ctrl_thread.join();
@@ -234,19 +242,25 @@ fn drive_session_pipes(
         pump_fd_to_vsock_stderr(stderr_r, conn_err);
     });
 
+    let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_in = conn.clone();
     let in_thread = std::thread::spawn(move || {
         client_loop_pipes(conn_in, stdin_w, child_pid);
+        let _ = host_closed_tx.send(());
     });
 
     let exit_code = forker.wait(child_pid)?;
 
-    shutdown_read(conn.raw());
-    let _ = in_thread.join();
     let _ = out_thread.join();
     let _ = err_thread.join();
 
     send_exit(&conn, exit_code);
+
+    // Wait (bounded) for the host to read the exit frame and close the connection before returning lets PID 1 power off, so the final frames aren't cut off mid-flight.
+    let _ = host_closed_rx.recv_timeout(HOST_DRAIN_GRACE);
+
+    shutdown_read(conn.raw());
+    let _ = in_thread.join();
     Ok(SessionOutcome { exit_code })
 }
 

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -215,7 +215,6 @@ fn drive_session_tty(
 
     send_exit(&conn, exit_code);
 
-    // Wait (bounded) for the host to read the exit frame and close the connection before returning lets PID 1 power off, so the final frames aren't cut off mid-flight.
     let _ = host_closed_rx.recv_timeout(HOST_DRAIN_GRACE);
 
     shutdown_read(conn.raw());
@@ -256,7 +255,6 @@ fn drive_session_pipes(
 
     send_exit(&conn, exit_code);
 
-    // Wait (bounded) for the host to read the exit frame and close the connection before returning lets PID 1 power off, so the final frames aren't cut off mid-flight.
     let _ = host_closed_rx.recv_timeout(HOST_DRAIN_GRACE);
 
     shutdown_read(conn.raw());

--- a/crates/lns-supervisor/src/dispatcher/runtime.rs
+++ b/crates/lns-supervisor/src/dispatcher/runtime.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 use std::io::IsTerminal;
+#[cfg(target_os = "linux")]
+use std::os::fd::FromRawFd;
+use std::os::fd::{OwnedFd, RawFd};
 use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -12,6 +15,32 @@ use lens_sandbox_core::privilege::SandboxCredentials;
 use super::agent::{AgentRunner, agent_child_spec, build_agent_command, stream_output};
 use super::{CYAN, DIM, GREEN, RED, RESET};
 use crate::config::AgentConfig;
+
+/// Hold an extra slave fd open for the agent's PTY: while any slave is open the master never returns EIO, so the agent's final output stays buffered through its exit instead of being lost to the slave-close race; we drop this fd after the agent exits for a clean drain-then-EOF.
+#[cfg(target_os = "linux")]
+fn hold_pty_slave(master_fd: RawFd) -> Option<OwnedFd> {
+    let mut path = [0 as libc::c_char; 256];
+    // SAFETY: ptsname_r writes a NUL-terminated slave path into `path` (capacity 256); master_fd is the caller-owned PTY master.
+    if unsafe { libc::ptsname_r(master_fd, path.as_mut_ptr(), path.len()) } != 0 {
+        return None;
+    }
+    // SAFETY: `path` holds the NUL-terminated slave path ptsname_r just wrote.
+    let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR | libc::O_NOCTTY) };
+    if fd < 0 {
+        return None;
+    }
+    // SAFETY: fd is a freshly-opened descriptor owned by no one else.
+    Some(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+// The supervisor only runs inside the Linux guest; the host build (lint/tests) just needs this to compile, and ptsname_r is Linux-only.
+#[cfg(not(target_os = "linux"))]
+fn hold_pty_slave(_master_fd: RawFd) -> Option<OwnedFd> {
+    None
+}
+
+/// How long to let the async reader consume the agent's final buffered PTY output before we close our held slave and let the master EOF.
+const PTY_TAIL_SETTLE: std::time::Duration = std::time::Duration::from_millis(25);
 
 /// Flush stdout and let the activity forwarder drain before `process::exit` tears down pid 1.
 async fn drain_console() {
@@ -123,6 +152,7 @@ async fn run_agent_pty(
     let mut writer = proc.writer;
     let mut child = proc.child;
     let master_fd = proc.master_fd;
+    let held_slave = hold_pty_slave(master_fd.raw());
 
     // Register the PID before any await so a SIGCHLD can't make the reaper reap the agent before it's in the protected set.
     if let Some(pid) = child.id() {
@@ -178,6 +208,9 @@ async fn run_agent_pty(
             Ok(status) => status.code().unwrap_or(1),
             Err(_) => 1,
         };
+        // Let the reader consume the agent's final buffered output — the held slave keeps it from being discarded — before closing our slave makes the master EOF.
+        tokio::time::sleep(PTY_TAIL_SETTLE).await;
+        drop(held_slave);
         let _ = output_task.await;
         input_task.abort();
 
@@ -204,6 +237,9 @@ async fn run_agent_pty(
 
         match wait_with_signal_forwarding(&mut child, DEFAULT_GRACE).await {
             Ok(status) => {
+                // Let the reader consume the agent's final buffered output — the held slave keeps it from being discarded — before closing our slave makes the master EOF.
+                tokio::time::sleep(PTY_TAIL_SETTLE).await;
+                drop(held_slave);
                 let _ = drain_task.await;
                 let code = status.code().unwrap_or(1);
                 let color = if code == 0 { GREEN } else { RED };

--- a/crates/lns-supervisor/src/dispatcher/runtime.rs
+++ b/crates/lns-supervisor/src/dispatcher/runtime.rs
@@ -25,7 +25,12 @@ fn hold_pty_slave(master_fd: RawFd) -> Option<OwnedFd> {
         return None;
     }
     // SAFETY: `path` holds the NUL-terminated slave path ptsname_r just wrote.
-    let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR | libc::O_NOCTTY) };
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDWR | libc::O_NOCTTY | libc::O_CLOEXEC,
+        )
+    };
     if fd < 0 {
         return None;
     }
@@ -208,7 +213,6 @@ async fn run_agent_pty(
             Ok(status) => status.code().unwrap_or(1),
             Err(_) => 1,
         };
-        // Let the reader consume the agent's final buffered output — the held slave keeps it from being discarded — before closing our slave makes the master EOF.
         tokio::time::sleep(PTY_TAIL_SETTLE).await;
         drop(held_slave);
         let _ = output_task.await;
@@ -237,7 +241,6 @@ async fn run_agent_pty(
 
         match wait_with_signal_forwarding(&mut child, DEFAULT_GRACE).await {
             Ok(status) => {
-                // Let the reader consume the agent's final buffered output — the held slave keeps it from being discarded — before closing our slave makes the master EOF.
                 tokio::time::sleep(PTY_TAIL_SETTLE).await;
                 drop(held_slave);
                 let _ = drain_task.await;


### PR DESCRIPTION
Two guest-teardown bugs the microVM e2e work surfaced, both root-caused and fixed. They're behaviorally coupled (the first fix exposes the second), so they ship together. The regression tests live in the stacked e2e PR.

## Bug 1 — named-volume writes never persisted
Write to a `-v` volume, restart, and the data is gone — the volume comes back pristine (`lost+found` only). The broker (guest PID 1) flushes the guest's disks via `sync()` + `reboot(RB_POWER_OFF)` only after `run()` returns, but `run()` blocked forever on `accept_thread.join()` — a blocking AF_VSOCK `accept()` that neither `shutdown()` nor `close()` wakes. So the guest never synced; the host abandoned the VM after its 2s grace and every guest write was discarded (tell-tale: every run took ~2.3–2.6s = boot + the full grace).

**Fix:** abandon (don't join) the un-joinable accept thread so `run()` returns promptly — the imminent poweroff reaps it. Plus a bounded wait for the host to drain the final frames before poweroff.

## Bug 2 — the workload's final stdout line was dropped (~1 in 4 fast runs)
Exposed once Bug 1's fix made runs fast (the slow teardown had been masking it). The agent runs in a PTY; on a fast exit a master read returns `EIO` at the slave-close, racing the buffered tail, which the async reader treats as end-of-stream.

**Fix:** hold a second slave fd open so the master never `EIO`s while the agent's output is still buffered; after the agent exits, let the reader drain it, then close the held slave for a clean EOF. (`ptsname_r` is Linux-only, so the helper is cfg-gated — the host build is lint/test-only.)

## Validation
- Volume persistence: data round-trips across runs (manually reproduced and confirmed fixed).
- Output loss: ~25% → **0/55** in a tight repro and **9/9** in the microVM e2e suite.
