### PR TITLE
chore(deps): Bump lens-sandbox-core to ab9f09f

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,7 +3040,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=c48ab6750021a650c446f400c732e4745ad569a2#c48ab6750021a650c446f400c732e4745ad569a2"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=ab9f09ffa744cdc8d79d28d96f5434163b423659#ab9f09ffa744cdc8d79d28d96f5434163b423659"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "c48ab6750021a650c446f400c732e4745ad569a2" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "ab9f09ffa744cdc8d79d28d96f5434163b423659" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

Bumps the `lens-sandbox-core` git pin from `c48ab67` → `ab9f09f` (16 upstream commits).

All changes are internal to core — no API surface touched, supervisor compiles and links clean against the new rev.

### Security / routing hardening
- Default-drop egress chains (fail-closed instead of accept-plus-terminal-reject)
- Bounded forward-proxy upstream connect/TLS timeout
- DNS: suppress HTTPS/SVCB and ANY records so address hints can't bypass the IPv4 proxy path
- CA cert cache: bounded per-host cache size, O(1) lookups, normalized host key
- Policy temp-file delivery: atomic, symlink-safe (`O_NOFOLLOW` walk, `O_EXCL` create, `fchown` by fd)

### Routing fixes
- Percent-encoded path separators (`%2F`, `%5C`) are now decoded before matching network path rules, so an encoded separator can no longer slip past a path-based allow/deny rule
- Bare `%` no longer swallows the following character in the percent-decode pass
- Catch-all `*` domain pattern support in route matching

### Policy
- `defaultVerdict` field now parsed through the schema enum (proper validation rather than a bespoke parser)

## Test instructions

1. Cross-clippy passes: `cargo clippy -p lns-supervisor --target aarch64-unknown-linux-musl --all-targets -- -D warnings` — verified green locally.
2. Full gate: let CI run `make lint && make complexity && make coverage` — only workspace members are exercised; the supervisor is embedded by `lns-service/build.rs` and its tests run on Linux in the `@microvm` suite.