### PR TITLE
fix(policy): make add_rule idempotent so re-approvals do not duplicate routes

### DIFF
--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -424,7 +424,6 @@ network:
 
     #[test]
     fn add_rule_skips_an_exact_duplicate() {
-        // Concurrent re-approvals of one host must not stack identical rules.
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("huggingface.co"));
         p.add_rule(RouteRule::allow_host("huggingface.co"));

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -120,7 +120,9 @@ impl Policy {
     }
 
     pub fn add_rule(&mut self, rule: RouteRule) {
-        self.network.allowed_routes.push(rule);
+        if !self.network.allowed_routes.contains(&rule) {
+            self.network.allowed_routes.push(rule);
+        }
     }
 
     pub fn connect(&mut self, id: impl Into<String>) {
@@ -418,6 +420,23 @@ network:
         assert_eq!(p.network.allowed_routes[0].verdict, Verdict::Allow);
         assert_eq!(p.network.allowed_routes[1].match_pattern, "b");
         assert_eq!(p.network.allowed_routes[1].verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn add_rule_skips_an_exact_duplicate() {
+        // Concurrent re-approvals of one host must not stack identical rules.
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("huggingface.co"));
+        p.add_rule(RouteRule::allow_host("huggingface.co"));
+        assert_eq!(p.network.allowed_routes.len(), 1);
+    }
+
+    #[test]
+    fn add_rule_keeps_a_same_host_rule_that_differs() {
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("example.com"));
+        p.add_rule(RouteRule::deny_host("example.com"));
+        assert_eq!(p.network.allowed_routes.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Re-approving the same host stacked **duplicate entries** in `lns-policy.yaml`. A real run produced:

```yaml
- match: huggingface.co        # allow   (×5)
- match: '*.huggingface.co'    # allow   (×5)
- match: api.openai.com        # allow   (×3)
```

`Policy::add_rule` did an unconditional `allowed_routes.push(rule)`, so every "Allow always" / "Deny always" for a host that was already persisted appended another identical `RouteRule`. This happens in practice when several guest requests to one host race the follow-up `policy` frame back into the JIT gate, surfacing multiple approval cards for the same host within a single run.

Functionally harmless (first-match still wins) but it bloats the policy file and makes it hard to read or hand-edit.

## Fix

`add_rule` now skips a rule that's already present (`RouteRule` derives `PartialEq`/`Eq`):

```rust
pub fn add_rule(&mut self, rule: RouteRule) {
    if !self.network.allowed_routes.contains(&rule) {
        self.network.allowed_routes.push(rule);
    }
}
```

- **Exact equality** is the dedup key, so genuinely distinct rules with the same host (e.g. a different verdict, scheme, or transport) still append — only true duplicates are dropped.
- `apply_persistent_rule` still pushes the policy frame and saves the snapshot, so the no-op case is idempotent end to end (the host still gets the route; nothing is written twice).
- Order is preserved for distinct rules (first-match semantics unchanged).

## Tests

- `add_rule_skips_an_exact_duplicate` — re-adding an identical rule leaves one entry (the fix).
- `add_rule_keeps_a_same_host_rule_that_differs` — same host, different verdict still appends (dedup is by full equality, not host).
- `add_rule_appends_to_allowed_routes_in_order` (existing) — distinct rules still append in order.

Gate: `make lint`, `make complexity`, and `cargo test -p lns-policy -p lns-service` all pass (153 + 1428 tests). Both branches of the new guard are covered.

## Note

This prevents *new* duplicates; existing bloated `lns-policy.yaml` files aren't rewritten by this change (a stale file keeps its dups until manually cleaned).
