### PR TITLE
feat(tools): resolve and inject bundle tools (MCP/API) into a run

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -712,6 +712,9 @@ pub struct RunArgs {
         help = "Override entrypoint+cmd. Everything after `--` is the command."
     )]
     pub cmd: Vec<String>,
+
+    #[arg(skip)]
+    pub mcp_config: Option<lns_ipc::McpConfig>,
 }
 
 pub const DEFAULT_CPUS: u8 = 1;

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -612,6 +612,7 @@ mod tests {
             publish: Vec::new(),
             volumes: Vec::new(),
             cmd: Vec::new(),
+            mcp_config: None,
         }
     }
 

--- a/crates/lns-cli/src/run/resolve.rs
+++ b/crates/lns-cli/src/run/resolve.rs
@@ -2,8 +2,9 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use lns_policy::artifact::{AgentArtifact, BundleArtifact, CredentialRef, Family};
+use lns_policy::artifact::{AgentArtifact, BundleArtifact, CredentialRef, Family, ToolArtifact};
 use lns_policy::credentials::{CredentialEntry, CredentialStateFile};
+use serde_json::{Value, json};
 
 use crate::cli::RunArgs;
 use crate::registry::{Pulled, RegistryClient};
@@ -165,10 +166,18 @@ pub async fn resolve_bundle_ref(
     let bundle = pull_bundle(reference, client).await?;
     let agent_ref = single_agent_ref(reference, &bundle)?;
     let mut resolved = resolve_agent_ref(&agent_ref, client, writer).await?;
-    if let Some(component) = bundle.components.policies.first() {
-        let policy_ref = qualify_component_ref(reference, &component.reference);
-        let (path, file) = materialize_policy(&policy_ref, client).await?;
-        writeln!(writer, "✓ applied bundle policy {policy_ref}")?;
+    let tools = resolve_tools(reference, &bundle, client, writer).await?;
+    let base = match bundle.components.policies.first() {
+        Some(component) => {
+            let policy_ref = qualify_component_ref(reference, &component.reference);
+            let blob = pull_policy_blob(&policy_ref, client).await?;
+            writeln!(writer, "✓ applied bundle policy {policy_ref}")?;
+            Some(blob)
+        }
+        None => None,
+    };
+    if let Some(bytes) = fold_tools_into_policy(base, &tools)? {
+        let (path, file) = write_ephemeral_policy(&bytes)?;
         resolved.policy_path = Some(path);
         resolved._policy_tempfile = Some(file);
     }
@@ -206,11 +215,8 @@ fn single_agent_ref(bundle_ref: &str, bundle: &BundleArtifact) -> Result<String>
     }
 }
 
-async fn materialize_policy(
-    policy_ref: &str,
-    client: &dyn RegistryClient,
-) -> Result<(PathBuf, tempfile::NamedTempFile)> {
-    let blob = match client.pull(policy_ref).await? {
+async fn pull_policy_blob(policy_ref: &str, client: &dyn RegistryClient) -> Result<Vec<u8>> {
+    match client.pull(policy_ref).await? {
         Pulled::Artifact {
             artifact_type,
             config_blob,
@@ -219,27 +225,137 @@ async fn materialize_policy(
             if Family::from_artifact_type(&artifact_type) != Some(Family::Policy) {
                 bail!("{policy_ref} is not a policy artifact (media type {artifact_type})");
             }
-            config_blob
+            Ok(config_blob)
         }
         Pulled::Image { .. } => bail!("{policy_ref} resolved to an image, not a policy artifact"),
-    };
+    }
+}
+
+fn write_ephemeral_policy(bytes: &[u8]) -> Result<(PathBuf, tempfile::NamedTempFile)> {
     let mut file = tempfile::Builder::new()
         .prefix("lns-bundle-policy-")
         .suffix(".yaml")
         .tempfile()
         .context("creating a temp file for the bundle policy")?;
-    file.write_all(&blob)
+    file.write_all(bytes)
         .context("writing the materialized bundle policy")?;
     file.flush().ok();
     let path = file.path().to_path_buf();
     Ok((path, file))
 }
 
+async fn resolve_tools(
+    bundle_ref: &str,
+    bundle: &BundleArtifact,
+    client: &dyn RegistryClient,
+    writer: &mut impl Write,
+) -> Result<Vec<ToolArtifact>> {
+    let mut tools = Vec::new();
+    for component in &bundle.components.tools {
+        let tool_ref = qualify_component_ref(bundle_ref, &component.reference);
+        let tool = pull_tool(&tool_ref, client).await?;
+        writeln!(writer, "✓ resolved tool {} ({tool_ref})", tool.name)?;
+        tools.push(tool);
+    }
+    Ok(tools)
+}
+
+async fn pull_tool(tool_ref: &str, client: &dyn RegistryClient) -> Result<ToolArtifact> {
+    match client.pull(tool_ref).await? {
+        Pulled::Artifact {
+            artifact_type,
+            config_blob,
+            ..
+        } => {
+            if Family::from_artifact_type(&artifact_type) != Some(Family::Tool) {
+                bail!("{tool_ref} is not a tool artifact (media type {artifact_type})");
+            }
+            ToolArtifact::from_config_blob(&config_blob)
+                .with_context(|| format!("parsing tool artifact {tool_ref}"))
+        }
+        Pulled::Image { .. } => bail!("{tool_ref} resolved to an image, not a tool artifact"),
+    }
+}
+
+/// Folds the bundle's remote-tool egress routes and required integrations into the run policy as raw JSON bytes; `Ok(base)` unchanged when nothing needs adding, `Ok(None)` when there is no policy at all.
+fn fold_tools_into_policy(
+    base: Option<Vec<u8>>,
+    tools: &[ToolArtifact],
+) -> Result<Option<Vec<u8>>> {
+    let routes: Vec<Value> = tools
+        .iter()
+        .filter_map(|t| t.remote_url().and_then(url_authority))
+        .map(tool_route)
+        .collect();
+    let integrations: Vec<Value> = tools
+        .iter()
+        .flat_map(|t| t.required_integrations.iter())
+        .map(|id| Value::String(id.clone()))
+        .collect();
+    if routes.is_empty() && integrations.is_empty() {
+        return Ok(base);
+    }
+    let mut policy: Value = match base {
+        Some(blob) => serde_json::from_slice(&blob).context("parsing the bundle policy")?,
+        None => json!({ "network": { "defaultVerdict": "ask", "defaultTransport": "direct" } }),
+    };
+    append_unique(network_routes(&mut policy)?, routes);
+    append_unique(integrations_array(&mut policy)?, integrations);
+    Ok(Some(
+        serde_json::to_vec(&policy).context("serializing the run policy")?,
+    ))
+}
+
+fn network_routes(policy: &mut Value) -> Result<&mut Vec<Value>> {
+    let network = policy
+        .as_object_mut()
+        .context("a policy must be a JSON object")?
+        .entry("network")
+        .or_insert_with(|| json!({}));
+    network
+        .as_object_mut()
+        .context("policy.network must be an object")?
+        .entry("allowedRoutes")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .context("policy.network.allowedRoutes must be an array")
+}
+
+fn integrations_array(policy: &mut Value) -> Result<&mut Vec<Value>> {
+    policy
+        .as_object_mut()
+        .context("a policy must be a JSON object")?
+        .entry("integrations")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .context("policy.integrations must be an array")
+}
+
+fn append_unique(target: &mut Vec<Value>, items: Vec<Value>) {
+    for item in items {
+        if !target.contains(&item) {
+            target.push(item);
+        }
+    }
+}
+
+fn url_authority(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
+    (!authority.is_empty()).then(|| authority.to_string())
+}
+
+fn tool_route(authority: String) -> Value {
+    json!({
+        "match": authority,
+        "verdict": "allow",
+        "transport": "direct",
+        "description": "egress for a bundle tool",
+    })
+}
+
 fn note_skipped_components(bundle: &BundleArtifact, writer: &mut impl Write) -> Result<()> {
     let mut skipped = Vec::new();
-    if !bundle.components.tools.is_empty() {
-        skipped.push("tools");
-    }
     if bundle.components.sandbox.is_some() {
         skipped.push("sandbox");
     }
@@ -305,6 +421,7 @@ mod tests {
     const POLICY_REF: &str = "localhost:5000/org/acme/policies/some-egress:v1";
     const BUNDLE_REF: &str = "localhost:5000/org/acme/bundles/some-system:v1";
     const AGENT_IMAGE: &str = "localhost:5000/org/acme/images/some-agent:v1";
+    const TOOL_REF: &str = "localhost:5000/org/acme/tools/some-tool:v1";
 
     type ArtifactMap = Arc<Mutex<HashMap<String, (String, Vec<u8>)>>>;
     type ImageMap = Arc<Mutex<HashMap<String, String>>>;
@@ -423,6 +540,20 @@ mod tests {
 
     fn policy_blob() -> Vec<u8> {
         lns_policy::artifact::to_config_blob(b"network:\n  defaultVerdict: ask\n").unwrap()
+    }
+
+    fn stdio_tool_blob() -> Vec<u8> {
+        lns_policy::artifact::to_config_blob(
+            b"name: fmt\nkind: mcp\nmcp:\n  transport: stdio\n  command: some-mcp-server\n",
+        )
+        .unwrap()
+    }
+
+    fn remote_tool_blob() -> Vec<u8> {
+        lns_policy::artifact::to_config_blob(
+            b"name: search\nkind: mcp\nmcp:\n  transport: http\n  url: https://api.some-provider.example/mcp\nrequiredIntegrations: [some-oauth]\n",
+        )
+        .unwrap()
     }
 
     async fn agent_client(command: &str, with_cred: bool) -> RefKeyedClient {
@@ -774,7 +905,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_bundle_ref_notes_unapplied_components() {
+    async fn resolve_bundle_ref_notes_only_the_still_unapplied_components() {
         let client = bundle_client(
             "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
              tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n  \
@@ -782,14 +913,123 @@ mod tests {
              knowledge:\n    - { ref: org/acme/knowledge/some-runbook:v1 }\n",
         )
         .await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &stdio_tool_blob()).await;
         let mut out = Vec::new();
         resolve_bundle_ref(BUNDLE_REF, &client, &mut out)
             .await
             .unwrap();
         let msg = String::from_utf8(out).unwrap();
-        assert!(msg.contains("tools"), "got: {msg}");
-        assert!(msg.contains("sandbox"), "got: {msg}");
-        assert!(msg.contains("knowledge"), "got: {msg}");
+        assert!(msg.contains("resolved tool"), "tool is resolved: {msg}");
+        let skipped = msg
+            .lines()
+            .find(|l| l.contains("not yet applied"))
+            .expect("a skipped-components line");
+        assert!(skipped.contains("sandbox"), "got: {skipped}");
+        assert!(skipped.contains("knowledge"), "got: {skipped}");
+        assert!(
+            !skipped.contains("tools"),
+            "tools are applied now: {skipped}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_folds_a_remote_tool_into_a_synthesized_policy() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &remote_tool_blob()).await;
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap();
+        let path = resolved
+            .policy_path
+            .expect("a remote tool synthesizes a run policy");
+        let policy: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let routes = policy["network"]["allowedRoutes"].as_array().unwrap();
+        assert!(
+            routes
+                .iter()
+                .any(|r| r["match"] == "api.some-provider.example"),
+            "got: {policy}"
+        );
+        assert_eq!(policy["integrations"], json!(["some-oauth"]));
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_adds_remote_tool_routes_to_the_bundle_policy() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             policies:\n    - { ref: org/acme/policies/some-egress:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &remote_tool_blob()).await;
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap();
+        let policy: Value =
+            serde_json::from_slice(&std::fs::read(resolved.policy_path.unwrap()).unwrap()).unwrap();
+        assert_eq!(policy["network"]["defaultVerdict"], "ask");
+        let routes = policy["network"]["allowedRoutes"].as_array().unwrap();
+        assert!(
+            routes
+                .iter()
+                .any(|r| r["match"] == "api.some-provider.example"),
+            "got: {policy}"
+        );
+        assert_eq!(policy["integrations"], json!(["some-oauth"]));
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_resolves_a_stdio_tool_without_opening_egress() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &stdio_tool_blob()).await;
+        let mut out = Vec::new();
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut out)
+            .await
+            .unwrap();
+        assert!(
+            resolved.policy_path.is_none(),
+            "a stdio tool adds no egress route"
+        );
+        assert!(String::from_utf8(out).unwrap().contains("resolved tool"));
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_rejects_a_tool_that_is_an_image() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_image(&client, TOOL_REF).await;
+        let err = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("image"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_rejects_a_tool_of_the_wrong_family() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, TOOL_REF, Family::Agent, &agent_blob("x", false)).await;
+        let err = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not a tool artifact"),
+            "got: {err:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/run/resolve.rs
+++ b/crates/lns-cli/src/run/resolve.rs
@@ -21,6 +21,8 @@ pub struct ResolvedRun {
     pub volumes: Vec<lns_ipc::VolumeMount>,
     pub policy_path: Option<PathBuf>,
     pub credentials: Vec<CredentialRef>,
+    pub mcp_injection: Option<lns_policy::artifact::McpInjection>,
+    pub mcp_config: Option<lns_ipc::McpConfig>,
     pub _policy_tempfile: Option<tempfile::NamedTempFile>,
 }
 
@@ -67,6 +69,7 @@ pub async fn resolve_into_run_args(
     {
         args.policy = Some(p.clone());
     }
+    args.mcp_config = resolved.mcp_config;
     let missing = missing_credentials(&resolved.credentials, available_creds);
     if !missing.is_empty() {
         writeln!(writer, "⚠ {}", missing_credentials_warning(&missing))?;
@@ -111,6 +114,8 @@ pub async fn resolve_agent_ref(
         volumes: agent.spec.volumes.iter().map(volume_mount).collect(),
         policy_path: None,
         credentials: agent.spec.credentials,
+        mcp_injection: agent.spec.mcp,
+        mcp_config: None,
         _policy_tempfile: None,
     })
 }
@@ -181,8 +186,42 @@ pub async fn resolve_bundle_ref(
         resolved.policy_path = Some(path);
         resolved._policy_tempfile = Some(file);
     }
+    match resolved.mcp_injection.take() {
+        Some(injection) if !tools.is_empty() => {
+            resolved.mcp_config = Some(lns_ipc::McpConfig {
+                target: injection.config_path,
+                content: render_mcp_servers(&tools),
+            });
+        }
+        None if !tools.is_empty() => writeln!(
+            writer,
+            "⚠ resolved {} tool(s) but the agent declares no spec.mcp injection point; \
+             tools will not be registered with the agent",
+            tools.len()
+        )?,
+        _ => {}
+    }
     note_skipped_components(&bundle, writer)?;
     Ok(resolved)
+}
+
+fn render_mcp_servers(tools: &[ToolArtifact]) -> String {
+    let mut servers = serde_json::Map::new();
+    for tool in tools {
+        servers.insert(tool.name.clone(), mcp_server_entry(tool));
+    }
+    json!({ "mcpServers": Value::Object(servers) }).to_string()
+}
+
+fn mcp_server_entry(tool: &ToolArtifact) -> Value {
+    if let Some(url) = tool.remote_url() {
+        return json!({ "url": url });
+    }
+    let mcp = tool.mcp.as_ref();
+    json!({
+        "command": mcp.and_then(|m| m.command.as_deref()),
+        "args": mcp.map(|m| m.args.as_slice()).unwrap_or_default(),
+    })
 }
 
 async fn pull_bundle(reference: &str, client: &dyn RegistryClient) -> Result<BundleArtifact> {
@@ -556,6 +595,18 @@ mod tests {
         .unwrap()
     }
 
+    fn agent_with_mcp_blob() -> Vec<u8> {
+        lns_policy::artifact::to_config_blob(
+            format!(
+                "apiVersion: lens.dev/v1alpha1\nkind: Agent\n\
+                 metadata:\n  name: some-agent\n\
+                 spec:\n  image: {AGENT_IMAGE}\n  mcp:\n    configPath: /home/agent/.mcp.json\n"
+            )
+            .as_bytes(),
+        )
+        .unwrap()
+    }
+
     async fn agent_client(command: &str, with_cred: bool) -> RefKeyedClient {
         let client = RefKeyedClient::default();
         put_artifact(
@@ -628,6 +679,7 @@ mod tests {
             publish: Vec::new(),
             volumes: Vec::new(),
             cmd: Vec::new(),
+            mcp_config: None,
         }
     }
 
@@ -1029,6 +1081,62 @@ mod tests {
         assert!(
             format!("{err:#}").contains("not a tool artifact"),
             "got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_renders_a_stdio_tool_into_the_mcp_config() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, AGENT_REF, Family::Agent, &agent_with_mcp_blob()).await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &stdio_tool_blob()).await;
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap();
+        let mcp = resolved.mcp_config.expect("an mcp config is rendered");
+        assert_eq!(mcp.target, "/home/agent/.mcp.json");
+        let cfg: Value = serde_json::from_str(&mcp.content).unwrap();
+        assert_eq!(cfg["mcpServers"]["fmt"]["command"], "some-mcp-server");
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_renders_a_remote_tool_url_into_the_mcp_config() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, AGENT_REF, Family::Agent, &agent_with_mcp_blob()).await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &remote_tool_blob()).await;
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut Vec::new())
+            .await
+            .unwrap();
+        let cfg: Value = serde_json::from_str(&resolved.mcp_config.unwrap().content).unwrap();
+        assert_eq!(
+            cfg["mcpServers"]["search"]["url"],
+            "https://api.some-provider.example/mcp"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_bundle_ref_warns_when_tools_resolve_without_an_mcp_injection_point() {
+        let client = bundle_client(
+            "  agents:\n    - { ref: org/acme/agents/some-agent:v1 }\n  \
+             tools:\n    - { ref: org/acme/tools/some-tool:v1 }\n",
+        )
+        .await;
+        put_artifact(&client, TOOL_REF, Family::Tool, &stdio_tool_blob()).await;
+        let mut out = Vec::new();
+        let resolved = resolve_bundle_ref(BUNDLE_REF, &client, &mut out)
+            .await
+            .unwrap();
+        assert!(resolved.mcp_config.is_none());
+        assert!(
+            String::from_utf8(out).unwrap().contains("no spec.mcp"),
+            "warns about the missing injection point"
         );
     }
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -206,6 +206,7 @@ mod tests {
             publish: Vec::new(),
             volumes: Vec::new(),
             cmd: Vec::new(),
+            mcp_config: None,
         }
     }
 

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -88,6 +88,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         detached,
         published_ports: args.publish,
         volumes: args.volumes,
+        mcp_config: args.mcp_config,
     });
     let frame = encode_frame(&request).context("encoding RunImage request")?;
     stream

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -15,9 +15,10 @@ pub use codec::{
 };
 pub use paths::{CachePathError, audit_anchor_for_run, audit_log_for_run, cache_root, data_root};
 pub use protocol::{
-    ExecImageArgs, ImageInfo, LogLevel, PortPublish, Protocol, Request, Response, RunConfig,
-    RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SignalKind, StatusInfo,
-    VolumeInfo, VolumeMount, VolumePruneFailure, validate_volume_name, validate_volume_target,
+    ExecImageArgs, ImageInfo, LogLevel, McpConfig, PortPublish, Protocol, Request, Response,
+    RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SignalKind,
+    StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, validate_volume_name,
+    validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -269,7 +269,6 @@ pub struct RunConfig {
     pub detached: bool,
 }
 
-/// A rendered MCP client config (`mcpServers` shape) and the in-guest path it is written to, so the agent can reach a bundle's tools.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpConfig {
     pub target: String,

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -264,7 +264,16 @@ pub struct RunConfig {
     pub env: Vec<String>,
     pub published_ports: Vec<PortPublish>,
     pub volumes: Vec<VolumeMount>,
+    #[serde(default)]
+    pub mcp_config: Option<McpConfig>,
     pub detached: bool,
+}
+
+/// A rendered MCP client config (`mcpServers` shape) and the in-guest path it is written to, so the agent can reach a bundle's tools.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpConfig {
+    pub target: String,
+    pub content: String,
 }
 
 impl RunConfig {
@@ -278,6 +287,7 @@ impl RunConfig {
             env: args.env.clone(),
             published_ports: args.published_ports.clone(),
             volumes: args.volumes.clone(),
+            mcp_config: args.mcp_config.clone(),
             detached: args.detached,
         }
     }
@@ -333,6 +343,8 @@ pub struct RunImageArgs {
     pub published_ports: Vec<PortPublish>,
     #[serde(default)]
     pub volumes: Vec<VolumeMount>,
+    #[serde(default)]
+    pub mcp_config: Option<McpConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -523,6 +535,7 @@ mod tests {
             detached: false,
             published_ports: vec![mapping],
             volumes: Vec::new(),
+            mcp_config: None,
         });
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
@@ -552,6 +565,7 @@ mod tests {
                 target: "/data".into(),
                 read_only: true,
             }],
+            mcp_config: None,
         };
         let frame = crate::encode_frame(&args).unwrap();
         let decoded: RunImageArgs = crate::decode_frame(&mut &frame[..]).unwrap();
@@ -711,7 +725,19 @@ mod tests {
                 target: "/data".into(),
                 read_only: false,
             }],
+            mcp_config: Some(McpConfig {
+                target: "/home/agent/.mcp.json".into(),
+                content: "{\"mcpServers\":{}}".into(),
+            }),
         }
+    }
+
+    #[test]
+    fn run_image_args_mcp_config_survives_a_frame_round_trip() {
+        let req = Request::RunImage(sample_run_args());
+        let frame = crate::encode_frame(&req).unwrap();
+        let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, req);
     }
 
     #[test]
@@ -721,6 +747,7 @@ mod tests {
         assert_eq!(config.cpus, 2);
         assert_eq!(config.mem_mib, 1024);
         assert_eq!(config.policy_path.as_deref(), Some("/work/lns-policy.yaml"));
+        assert_eq!(config.mcp_config.unwrap().target, "/home/agent/.mcp.json");
         assert_eq!(config.sandbox_user.as_deref(), Some("sandbox"));
         assert_eq!(config.sandbox_uid, Some(65534));
         assert_eq!(config.env, vec!["FOO=bar".to_string()]);

--- a/crates/lns-policy/src/artifact.rs
+++ b/crates/lns-policy/src/artifact.rs
@@ -163,7 +163,6 @@ pub struct AgentSpec {
     pub mcp: Option<McpInjection>,
 }
 
-/// Where and how an agent ingests its MCP client config; the agent declares the injection point while the format stays the de-facto `mcpServers` shape.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpInjection {
@@ -262,7 +261,6 @@ pub enum ToolKind {
     Api,
 }
 
-/// The transport an MCP tool server speaks; `stdio` is a launched child process, `sse`/`http` are remote endpoints.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum McpTransport {

--- a/crates/lns-policy/src/artifact.rs
+++ b/crates/lns-policy/src/artifact.rs
@@ -159,6 +159,24 @@ pub struct AgentSpec {
     pub volumes: Vec<VolumeMapping>,
     #[serde(default)]
     pub credentials: Vec<CredentialRef>,
+    #[serde(default)]
+    pub mcp: Option<McpInjection>,
+}
+
+/// Where and how an agent ingests its MCP client config; the agent declares the injection point while the format stays the de-facto `mcpServers` shape.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInjection {
+    pub config_path: String,
+    #[serde(default)]
+    pub format: McpConfigFormat,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpConfigFormat {
+    #[default]
+    McpServers,
 }
 
 /// The parsed `agent` artifact (`kind: Agent`) — the runtime-bearing artifact `lns run` resolves.
@@ -234,6 +252,109 @@ impl BundleArtifact {
             ));
         }
         Ok(bundle)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolKind {
+    Mcp,
+    Api,
+}
+
+/// The transport an MCP tool server speaks; `stdio` is a launched child process, `sse`/`http` are remote endpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    Stdio,
+    Sse,
+    Http,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpSpec {
+    pub transport: McpTransport,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+impl McpSpec {
+    fn connection_error(&self) -> Option<&'static str> {
+        let blank = |s: &Option<String>| s.as_deref().unwrap_or_default().trim().is_empty();
+        match self.transport {
+            McpTransport::Stdio if blank(&self.command) => {
+                Some("a stdio mcp tool requires `mcp.command`")
+            }
+            McpTransport::Sse | McpTransport::Http if blank(&self.url) => {
+                Some("an http/sse mcp tool requires `mcp.url`")
+            }
+            _ => None,
+        }
+    }
+}
+
+/// The parsed `tool` artifact — an MCP server or an API the agent may use; mirrors the registry's tool schema.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolArtifact {
+    pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    pub kind: ToolKind,
+    #[serde(default)]
+    pub mcp: Option<McpSpec>,
+    #[serde(default)]
+    pub required_integrations: Vec<String>,
+}
+
+impl ToolArtifact {
+    pub fn from_config_blob(blob: &[u8]) -> io::Result<ToolArtifact> {
+        let tool: ToolArtifact = serde_json::from_slice(blob)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if tool.name.trim().is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tool name must not be empty",
+            ));
+        }
+        match tool.kind {
+            ToolKind::Mcp => {
+                let mcp = tool.mcp.as_ref().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "an mcp tool requires an `mcp` block",
+                    )
+                })?;
+                if let Some(msg) = mcp.connection_error() {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
+                }
+            }
+            ToolKind::Api if tool.remote_url().unwrap_or_default().trim().is_empty() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "an api tool requires a url",
+                ));
+            }
+            ToolKind::Api => {}
+        }
+        Ok(tool)
+    }
+
+    /// The network endpoint a remote tool is reached at (folds into the run policy); `None` for a launched stdio server.
+    pub fn remote_url(&self) -> Option<&str> {
+        let url = self.mcp.as_ref().and_then(|m| m.url.as_deref());
+        match self.kind {
+            ToolKind::Api => url,
+            ToolKind::Mcp => match self.mcp.as_ref().map(|m| m.transport) {
+                Some(McpTransport::Sse | McpTransport::Http) => url,
+                _ => None,
+            },
+        }
     }
 }
 
@@ -410,6 +531,138 @@ mod tests {
         assert!(agent.spec.resources.is_none());
         assert!(agent.spec.ports.is_empty());
         assert!(agent.spec.volumes.is_empty());
+        assert!(agent.spec.mcp.is_none());
+    }
+
+    #[test]
+    fn agent_artifact_parses_the_mcp_injection_point_with_a_default_format() {
+        let blob = agent_blob(
+            "apiVersion: lens.dev/v1alpha1\nkind: Agent\n\
+             metadata:\n  name: some-agent\n\
+             spec:\n  image: some-image:1\n  mcp:\n    configPath: /home/agent/.mcp.json\n",
+        );
+        let mcp = AgentArtifact::from_config_blob(&blob)
+            .unwrap()
+            .spec
+            .mcp
+            .unwrap();
+        assert_eq!(mcp.config_path, "/home/agent/.mcp.json");
+        assert_eq!(mcp.format, McpConfigFormat::McpServers);
+    }
+
+    #[test]
+    fn agent_artifact_parses_an_explicit_mcp_format() {
+        let blob = agent_blob(
+            "apiVersion: lens.dev/v1alpha1\nkind: Agent\n\
+             metadata:\n  name: some-agent\n\
+             spec:\n  image: some-image:1\n  mcp:\n    \
+             configPath: /etc/mcp.json\n    format: mcpServers\n",
+        );
+        let mcp = AgentArtifact::from_config_blob(&blob)
+            .unwrap()
+            .spec
+            .mcp
+            .unwrap();
+        assert_eq!(mcp.format, McpConfigFormat::McpServers);
+    }
+
+    fn tool_blob(yaml: &str) -> Vec<u8> {
+        to_config_blob(yaml.as_bytes()).unwrap()
+    }
+
+    #[test]
+    fn tool_artifact_parses_a_stdio_mcp_server() {
+        let blob = tool_blob(
+            "name: fmt\nversion: '1'\nkind: mcp\n\
+             mcp:\n  transport: stdio\n  command: some-mcp-server\n  args: ['--flag']\n\
+             requiredIntegrations: [some-oauth]\n",
+        );
+        let tool = ToolArtifact::from_config_blob(&blob).unwrap();
+        assert_eq!(tool.name, "fmt");
+        assert_eq!(tool.kind, ToolKind::Mcp);
+        let mcp = tool.mcp.as_ref().unwrap();
+        assert_eq!(mcp.transport, McpTransport::Stdio);
+        assert_eq!(mcp.command.as_deref(), Some("some-mcp-server"));
+        assert_eq!(mcp.args, vec!["--flag".to_string()]);
+        assert_eq!(tool.required_integrations, vec!["some-oauth".to_string()]);
+        assert_eq!(tool.remote_url(), None);
+    }
+
+    #[test]
+    fn tool_artifact_parses_an_http_mcp_server_as_remote() {
+        let blob = tool_blob(
+            "name: search\nkind: mcp\n\
+             mcp:\n  transport: http\n  url: https://api.some-provider.example/mcp\n",
+        );
+        let tool = ToolArtifact::from_config_blob(&blob).unwrap();
+        assert_eq!(
+            tool.remote_url(),
+            Some("https://api.some-provider.example/mcp")
+        );
+    }
+
+    #[test]
+    fn tool_artifact_parses_an_sse_mcp_server_as_remote() {
+        let blob = tool_blob(
+            "name: events\nkind: mcp\n\
+             mcp:\n  transport: sse\n  url: https://api.some-provider.example/sse\n",
+        );
+        let tool = ToolArtifact::from_config_blob(&blob).unwrap();
+        assert_eq!(
+            tool.remote_url(),
+            Some("https://api.some-provider.example/sse")
+        );
+    }
+
+    #[test]
+    fn tool_artifact_parses_an_api_tool_as_remote() {
+        let blob = tool_blob(
+            "name: weather\nkind: api\n\
+             mcp:\n  transport: http\n  url: https://api.example.test/v1\n",
+        );
+        let tool = ToolArtifact::from_config_blob(&blob).unwrap();
+        assert_eq!(tool.kind, ToolKind::Api);
+        assert_eq!(tool.remote_url(), Some("https://api.example.test/v1"));
+    }
+
+    #[test]
+    fn tool_artifact_rejects_an_empty_name() {
+        let err =
+            ToolArtifact::from_config_blob(&tool_blob("name: '  '\nkind: api\n")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(format!("{err}").contains("name"), "got: {err}");
+    }
+
+    #[test]
+    fn tool_artifact_rejects_an_mcp_tool_without_an_mcp_block() {
+        let err = ToolArtifact::from_config_blob(&tool_blob("name: x\nkind: mcp\n")).unwrap_err();
+        assert!(format!("{err}").contains("mcp` block"), "got: {err}");
+    }
+
+    #[test]
+    fn tool_artifact_rejects_a_stdio_tool_without_a_command() {
+        let blob = tool_blob("name: x\nkind: mcp\nmcp:\n  transport: stdio\n");
+        let err = ToolArtifact::from_config_blob(&blob).unwrap_err();
+        assert!(format!("{err}").contains("command"), "got: {err}");
+    }
+
+    #[test]
+    fn tool_artifact_rejects_a_remote_mcp_tool_without_a_url() {
+        let blob = tool_blob("name: x\nkind: mcp\nmcp:\n  transport: http\n");
+        let err = ToolArtifact::from_config_blob(&blob).unwrap_err();
+        assert!(format!("{err}").contains("url"), "got: {err}");
+    }
+
+    #[test]
+    fn tool_artifact_rejects_an_api_tool_without_a_url() {
+        let err = ToolArtifact::from_config_blob(&tool_blob("name: x\nkind: api\n")).unwrap_err();
+        assert!(format!("{err}").contains("url"), "got: {err}");
+    }
+
+    #[test]
+    fn tool_artifact_rejects_malformed_json() {
+        let err = ToolArtifact::from_config_blob(b"not json").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -510,6 +510,7 @@ mod tests {
                 detached: false,
                 published_ports: vec![],
                 volumes: vec![],
+                mcp_config: None,
             }),
             Instant::now(),
         )

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -81,13 +81,6 @@ async fn orchestrate(
     let mut run_scratch =
         super::scratch::RunScratchGuard::new(run_scratch_dir, super::scratch::RealRemoveDir);
     let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
-    if let Some(mcp) = args.mcp_config.as_ref() {
-        log::debug!(
-            path = %mcp.target,
-            bytes = mcp.content.len(),
-            "mcp config resolved; guest rootfs write happens during boot"
-        );
-    }
 
     let tools_then_session = async {
         let guest_tools = guest_tools::ensure().await?;

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -81,6 +81,14 @@ async fn orchestrate(
     let mut run_scratch =
         super::scratch::RunScratchGuard::new(run_scratch_dir, super::scratch::RealRemoveDir);
     let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
+    if let Some(mcp) = args.mcp_config.as_ref() {
+        // platform: the rendered mcpServers config is written into the guest rootfs at `mcp.target` during boot — the guest-write hop is tracked in the tool-injection design doc.
+        log::debug!(
+            path = %mcp.target,
+            bytes = mcp.content.len(),
+            "mcp config staged for guest injection"
+        );
+    }
 
     let tools_then_session = async {
         let guest_tools = guest_tools::ensure().await?;

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -82,11 +82,10 @@ async fn orchestrate(
         super::scratch::RunScratchGuard::new(run_scratch_dir, super::scratch::RealRemoveDir);
     let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
     if let Some(mcp) = args.mcp_config.as_ref() {
-        // platform: the rendered mcpServers config is written into the guest rootfs at `mcp.target` during boot — the guest-write hop is tracked in the tool-injection design doc.
         log::debug!(
             path = %mcp.target,
             bytes = mcp.content.len(),
-            "mcp config staged for guest injection"
+            "mcp config resolved; guest rootfs write happens during boot"
         );
     }
 


### PR DESCRIPTION
Stacked on #61 (`feat/registry-login-policy-artifacts`). Teaches `lns run <bundle>` to actually **use** the bundle's `tool` components instead of skipping them — meeting the tool schema the lns-registry already defines.

## What it does
- **`lns-policy`** — typed `ToolArtifact` mirroring the registry tool schema (`kind: mcp|api`, transport `stdio|sse|http`, `requiredIntegrations`) with a `from_config_blob` validator, plus the agent's **`spec.mcp`** injection point (`configPath` + `format`, default `mcpServers`).
- **`lns-cli` resolve** — pulls each tool component; folds **remote** (`http`/`sse`/`api`) tools' hosts into the run policy as allow-routes and their `requiredIntegrations` into the policy integrations; renders the de-facto **`mcpServers`** config targeted at `spec.mcp.configPath`. Partial policies still round-trip byte-for-byte when nothing is added.
- **`lns-ipc`** — `McpConfig { target, content }` carried on `RunImageArgs` / `RunConfig`.
- **`lns-service`** — receives the `McpConfig` on the run request; the guest-rootfs write is the deferred hop (below).

## Design
Lens-sandbox is a **tool-config materializer, not an MCP host**: tools run in-guest under the existing policy/credential machinery; the agent's own MCP client spawns/dials them from a config we write. Full rationale, the kind/transport split, and the open decisions are in the design doc (shared separately).

## Scope / what's deliberately deferred
- **The guest-write hop is not yet wired.** The `McpConfig` reaches the daemon but is not yet written into the running microVM at `configPath` — that step is Linux-microVM/Vz-only and can't be built or tested from a macOS host. The host-side spine (resolve → fold policy → render → carry to the daemon) is fully tested; the guest write is the remaining hop.
- **Tools shipping their own image** (so a stdio binary need not pre-exist in the agent image) needs an `image`/`layers` field on the registry tool schema + guest rootfs overlay — a companion change in `lns-registry`, out of scope here.
- Registry-side: the agent schema should gain `spec.mcp` (and the pending `resources`/`ports`/`volumes` drift fix) — follow-up in `lns-registry`.

## Tests / gate
`make lint` + `make complexity` green. New Layer-3 coverage: tool artifact parse/validate (every kind/transport + error paths), remote-tool policy folding (synthesized + augmented), `mcpServers` rendering (stdio command/args and remote url), the missing-`spec.mcp` warning, and the IPC `McpConfig` round-trip. Full `make coverage` not run locally.