### PR TITLE
chore(deps): bump lens-sandbox-core to 34d52cf for DNS allow-once fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=ab9f09ffa744cdc8d79d28d96f5434163b423659#ab9f09ffa744cdc8d79d28d96f5434163b423659"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=34d52cfd105c35d339cdecaf6c06495674b8acf8#34d52cfd105c35d339cdecaf6c06495674b8acf8"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "ab9f09ffa744cdc8d79d28d96f5434163b423659" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "34d52cfd105c35d339cdecaf6c06495674b8acf8" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
Bumps the `lens-sandbox-core` pin in `lns-supervisor` from `ab9f09f` → `34d52cf` to pick up [lens-sandbox-core#30](https://github.com/lensapp/lens-sandbox-core/pull/30).

## Why

`#30` fixes the DNS-stub ask→502 bug ([lens-sandbox-core#29](https://github.com/lensapp/lens-sandbox-core/issues/29)). Under the default auto-created policy (`defaultVerdict: ask`, empty `allowedRoutes`), the DNS stub gated resolution on the route table only:

- **"Allow once" could never connect** — it persists no route, so the stub kept `NXDOMAIN`-ing the host and the request died with **502** even after the developer clicked Allow.
- **"Allow always" raced** the follow-up `policy` frame, so the first request could still 502.

The core fix records each gate-approved host in a session-scoped set the DNS stub consults *after* the policy routes, so an interactive allow resolves immediately with no policy round-trip.

## Scope of the bump

`main` of the core is exactly the `#30` merge commit — the only delta between our old pin and the new one is that one PR (6 commits, all confined to `dns.rs` / `gate.rs` / `proxy.rs` / `routing.rs`).

**No breaking changes for the supervisor:**
- The new `ProxyState` field (`gate_resolved_hosts`) is `pub(crate)` and initialized inside `ProxyServer::new` — the constructor signature is unchanged.
- The routing rename is internal: `hostname_allowed` (the `pub fn`) is preserved and delegates to the new `pub(crate)` `hostname_match`/`HostnameMatch`.
- The supervisor does not import `dns` / `routing` / `gate` — the fix reaches us purely through core's internal proxy machinery.
- No touch to the frame/protocol/credential surface, so the host's `credential_pending` approval flow is unaffected.

## Verification

- `cargo build -p lns-supervisor` passes against `34d52cf`.

The fix itself is behavioral (in-guest DNS resolution) and is exercised by the `@microvm` e2e suite against a real guest, not the routine PR gate. It ships out with the next `lns` / `lns-service` bundle release.