### PR TITLE
ci: fetch the macOS cross-toolchain sha-pinned, not via a Homebrew tap

### DIFF
--- a/.github/actions/install-cross-toolchain/action.yml
+++ b/.github/actions/install-cross-toolchain/action.yml
@@ -10,9 +10,7 @@ description: >-
   (malloc/memcpy/…) are ABI-identical on aarch64; rust-lld does the final link
   against the Rust musl target's own sysroot, so those symbols resolve against
   musl, not glibc. macOS downloads a prebuilt aarch64-musl cross-gcc,
-  sha-pinned. We avoid taiki-e/setup-cross-toolchain-action because it also
-  sets CARGO_BUILD_TARGET, redirecting the host build of lns-cli/lns-service
-  to the cross target.
+  sha-pinned.
 
 runs:
   using: composite

--- a/.github/actions/install-cross-toolchain/action.yml
+++ b/.github/actions/install-cross-toolchain/action.yml
@@ -9,9 +9,12 @@ description: >-
   sound here because it only emits relocatable objects whose libc references
   (malloc/memcpy/…) are ABI-identical on aarch64; rust-lld does the final link
   against the Rust musl target's own sysroot, so those symbols resolve against
-  musl, not glibc. macOS uses a real aarch64-musl cross-gcc. We avoid
-  taiki-e/setup-cross-toolchain-action because it also sets CARGO_BUILD_TARGET,
-  redirecting the host build of lns-cli/lns-service to the cross target.
+  musl, not glibc. macOS fetches the same prebuilt aarch64-musl cross-gcc the
+  messense Homebrew tap wraps, but straight from its GitHub release and
+  sha-pinned, so it doesn't depend on Homebrew's third-party-tap trust gate
+  (lensapp/lens-sandbox#92). We avoid taiki-e/setup-cross-toolchain-action
+  because it also sets CARGO_BUILD_TARGET, redirecting the host build of
+  lns-cli/lns-service to the cross target.
 
 runs:
   using: composite
@@ -26,13 +29,31 @@ runs:
         sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc /usr/local/bin/aarch64-linux-musl-gcc
         sudo ln -sf /usr/bin/aarch64-linux-gnu-ar  /usr/local/bin/aarch64-linux-musl-ar
 
-    - name: Install aarch64-linux-musl cross toolchain (macOS)
+    - name: Install aarch64-linux-musl cross toolchain (macOS, sha-pinned, no Homebrew tap)
       if: runner.os == 'macOS'
       shell: bash
+      env:
+        # The same prebuilt toolchain the messense Homebrew tap wraps, fetched
+        # straight from its GitHub release so we don't trip Homebrew's
+        # third-party-tap trust gate (see lensapp/lens-sandbox#92).
+        TOOLCHAIN_VERSION: "15.2.0"
+        SHA_AARCH64_DARWIN: "f7e081c0e0d0a0f7d4a769872b6471e91457ab982c7a9b201971ef4cb23e4694"
+        SHA_X86_64_DARWIN: "7351afd573d38c9e034d5ab126233deb69aea6d187207624dbd3048ff1b087ea"
       run: |
         set -euo pipefail
-        brew tap messense/macos-cross-toolchains
-        brew install aarch64-unknown-linux-musl
-        prefix="$(brew --prefix)"
-        sudo ln -sf "$prefix/bin/aarch64-unknown-linux-musl-gcc" /usr/local/bin/aarch64-linux-musl-gcc
-        sudo ln -sf "$prefix/bin/aarch64-unknown-linux-musl-ar"  /usr/local/bin/aarch64-linux-musl-ar
+        case "$(uname -m)" in
+          arm64|aarch64) host="aarch64-darwin"; sha="$SHA_AARCH64_DARWIN" ;;
+          x86_64)        host="x86_64-darwin";  sha="$SHA_X86_64_DARWIN" ;;
+          *) echo "::error::unsupported macOS host arch $(uname -m)"; exit 1 ;;
+        esac
+        asset="aarch64-unknown-linux-musl-${host}.tar.gz"
+        url="https://github.com/messense/macos-cross-toolchains/releases/download/v${TOOLCHAIN_VERSION}/${asset}"
+        dest="$RUNNER_TEMP/aarch64-musl-cross"
+        mkdir -p "$dest"
+        curl -fsSL --retry 3 --retry-all-errors -o "$dest/$asset" "$url"
+        echo "${sha}  ${asset}" | (cd "$dest" && shasum -a 256 -c -)
+        tar xzf "$dest/$asset" -C "$dest"
+        bin="$dest/aarch64-unknown-linux-musl/bin"
+        sudo ln -sf "$bin/aarch64-unknown-linux-musl-gcc" /usr/local/bin/aarch64-linux-musl-gcc
+        sudo ln -sf "$bin/aarch64-unknown-linux-musl-ar"  /usr/local/bin/aarch64-linux-musl-ar
+        aarch64-linux-musl-gcc --version | head -1

--- a/.github/actions/install-cross-toolchain/action.yml
+++ b/.github/actions/install-cross-toolchain/action.yml
@@ -9,12 +9,10 @@ description: >-
   sound here because it only emits relocatable objects whose libc references
   (malloc/memcpy/…) are ABI-identical on aarch64; rust-lld does the final link
   against the Rust musl target's own sysroot, so those symbols resolve against
-  musl, not glibc. macOS fetches the same prebuilt aarch64-musl cross-gcc the
-  messense Homebrew tap wraps, but straight from its GitHub release and
-  sha-pinned, so it doesn't depend on Homebrew's third-party-tap trust gate
-  (lensapp/lens-sandbox#92). We avoid taiki-e/setup-cross-toolchain-action
-  because it also sets CARGO_BUILD_TARGET, redirecting the host build of
-  lns-cli/lns-service to the cross target.
+  musl, not glibc. macOS downloads a prebuilt aarch64-musl cross-gcc,
+  sha-pinned. We avoid taiki-e/setup-cross-toolchain-action because it also
+  sets CARGO_BUILD_TARGET, redirecting the host build of lns-cli/lns-service
+  to the cross target.
 
 runs:
   using: composite
@@ -29,13 +27,10 @@ runs:
         sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc /usr/local/bin/aarch64-linux-musl-gcc
         sudo ln -sf /usr/bin/aarch64-linux-gnu-ar  /usr/local/bin/aarch64-linux-musl-ar
 
-    - name: Install aarch64-linux-musl cross toolchain (macOS, sha-pinned, no Homebrew tap)
+    - name: Install aarch64-linux-musl cross toolchain (macOS)
       if: runner.os == 'macOS'
       shell: bash
       env:
-        # The same prebuilt toolchain the messense Homebrew tap wraps, fetched
-        # straight from its GitHub release so we don't trip Homebrew's
-        # third-party-tap trust gate (see lensapp/lens-sandbox#92).
         TOOLCHAIN_VERSION: "15.2.0"
         SHA_AARCH64_DARWIN: "f7e081c0e0d0a0f7d4a769872b6471e91457ab982c7a9b201971ef4cb23e4694"
         SHA_X86_64_DARWIN: "7351afd573d38c9e034d5ab126233deb69aea6d187207624dbd3048ff1b087ea"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
               - 'crates/lns-cli/scripts/**'
               - '.github/workflows/release-please.yml'
               - '.github/workflows/ci.yml'
+              - '.github/actions/install-cross-toolchain/**'
               - 'scripts/lns-install/**'
               - 'scripts/lns-cli.sh'
             static-nft:


### PR DESCRIPTION
Closes #92.

## Problem

The macOS leg of `.github/actions/install-cross-toolchain` installed the `aarch64-linux-musl` cross-`gcc` from the `messense/macos-cross-toolchains` **Homebrew tap**. Homebrew 5.1/6.x added a third-party-tap *trust gate*, so `brew install` now fails with `Refusing to load formula … from untrusted tap`. It's **flaky today** (the `macos-latest` runner fleet is mid-rollout to the gated Homebrew, so the same commit passes or fails depending on the runner) and becomes a **hard failure** once the fleet finishes updating. This blocks `check-release-build` (and the real release build, which uses the same action).

The cross-`gcc` itself is required — the embedded Linux-musl guest payloads pull `aws-lc-sys`/`ring`, which compile C/.S that needs an aarch64 `cc` — so the fix isn't to drop the toolchain, just to stop getting it through the flaky tap.

## Fix

Fetch the **same prebuilt toolchain the tap wraps**, straight from the messense GitHub release (`v15.2.0`), **sha-pinned per host arch and verified before use**. No Homebrew tap, no trust gate. The binaries are symlinked to the same `/usr/local/bin/aarch64-linux-musl-{gcc,ar}` names `build.rs` expects, so nothing downstream changes. The Linux leg (apt glibc cross-gcc + `rust-lld` musl link) is untouched.

This matches the repo's existing "no system dependencies / sha-pinned fetch" pattern, and is strictly better than the old step (which was an *unpinned* network install anyway).

## Verification (local, arm64 macOS)

- Downloaded `aarch64-unknown-linux-musl-aarch64-darwin.tar.gz` → **bytes match the published `.sha256`** (`f7e081c0…4694`).
- Extracted → `aarch64-unknown-linux-musl-gcc (GCC) 15.2.0`.
- Compiled a C source with it → `ELF 64-bit LSB relocatable, ARM aarch64` — i.e. it produces the aarch64 objects `aws-lc-sys`/`ring` need (`rust-lld` does the musl link).
- `action.yml` parses as valid YAML.

Both macOS host arches are pinned (`aarch64-darwin` + `x86_64-darwin`) and selected by `uname -m`, so it's robust if the runner image's arch ever changes. CI on this PR exercises the real macOS path.
