### PR TITLE
ci: rename release group from "lns-bundle" to "lns"

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "linked-versions",
-      "groupName": "lns-bundle",
+      "groupName": "lns",
       "components": ["lns", "lns-cli", "lns-service", "e2e-tests"]
     }
   ],


### PR DESCRIPTION
## Problem

The grouped release PR opened by release-please reads **`chore(main): release lns-bundle libraries`** (e.g. #97). The `lns-bundle` part is internal release-flow jargon leaking into an operator-facing surface — the PR title, the PR branch name, and (via squash) the merge commit on `main`.

## Root cause

The `linked-versions` plugin hardcodes the grouped-PR title as `chore${scope}: release <groupName> libraries` (it ignores `group-pull-request-title-pattern`). The only configurable token is `groupName`, which we set to `lns-bundle`.

## Fix

Rename the `linked-versions` `groupName` from `lns-bundle` → `lns`. Future release PRs read **`chore(main): release lns libraries`**.

- `libraries` is a literal hardcoded by `linked-versions` and can't be removed via config — this drops the part we control (`bundle`).
- Verified the group branch namespace (`…--groups--lns`) does not collide with the root component's branch (`…--components--lns`).
- Cosmetic-only: `groupName` affects the grouped PR's title and branch name; it is **not** a tag, release name, version, or changelog entry. Versions/tags/releases are unaffected.

## After merge

release-please opens a fresh release PR on the new group branch (`…--groups--lns`) with the corrected title. The current #97 (`…--groups--lns-bundle`) goes stale and should be closed.