### PR TITLE
ci: parse the grouped release PR title so github-release cuts the tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "release-label": "autorelease: tagged,release",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
+  "group-pull-request-title-pattern": "chore${scope}: release ${component} libraries",
   "plugins": [
     {
       "type": "cargo-workspace",


### PR DESCRIPTION
## Problem

Merging the bundle release PR (#100) **did not cut `lns-v0.13.0`**. release-please's github-release phase found the merged PR but couldn't parse its title:

```
❯ Found pull request #100: 'chore(main): release lns libraries'
✖ Bad pull request title: 'chore(main): release lns libraries'
⚠ There are untagged, merged release PRs outstanding - aborting
```

No tag/release was created, `build-lns`/`publish` were skipped, and release-please is now **stuck** (it won't open new release PRs while #100 sits merged-but-untagged).

## Root cause

The `linked-versions` plugin generates the grouped PR title as `chore${scope}: release <groupName> libraries`. At github-release time, release-please parses the merged title with two patterns (`strategies/base.js`): the per-component default (`chore${scope}: release${component} ${version}` — requires a numeric version) and `group-pull-request-title-pattern ?? 'chore: release ${branch}'`. We never set `group-pull-request-title-pattern`, so **neither pattern matches** `chore(main): release lns libraries` → "Bad pull request title".

This is independent of the recent group rename — it would have failed identically with `lns-bundle`; #100 is simply the first grouped release PR ever *merged*, so the gap only surfaced now.

## Fix

Set `group-pull-request-title-pattern` to match what `linked-versions` generates:

```json
"group-pull-request-title-pattern": "chore${scope}: release ${component} libraries"
```

(`libraries` is a literal hardcoded by `linked-versions`; the parse pattern must match the generated title, so it stays.)

## Verification

Ran the **actual release-please library parsers** (`PullRequestTitle.parse` + `PullRequestBody.parse`) against #100's real merged title and body:
- per-component default → fails (reproduces the bug);
- with this fix → parses, `component=lns`;
- body → `lns` section at `0.13.0`;
- → `buildRelease` would create `lns-v0.13.0`.

A live CLI dry-run of the merged path isn't possible (github-release finds #100 only with `targetBranch=main` and reads config from `main`'s HEAD), so the library-level reproduction is the strongest pre-merge check.

## After merge

release-please reprocesses the outstanding #100 → parses the title → cuts `lns-v0.13.0` (tag + release with the unified changelog) → fires `build-lns` + `publish`, finally shipping the accumulated work.