### PR TITLE
fix(lns-service): clear the approval card's drop shadow when it closes

### DIFF
--- a/crates/lns-service/examples/approval_preview.rs
+++ b/crates/lns-service/examples/approval_preview.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use eframe::egui;
 use lns_policy::integrations::TokenFallback;
@@ -8,19 +9,46 @@ use lns_service::approval_flow::window::{
     lds_visuals, quiet_debug_overlays,
 };
 use lns_service::tray::{
-    CardAction, MIN_WINDOW_HEIGHT, TokenDraft, WINDOW_WIDTH, content_cap, position_top_right,
-    refresh_window_shadows, render_stack,
+    CardAction, MIN_WINDOW_HEIGHT, TokenDraft, ViewportPlacement, WINDOW_WIDTH, content_cap,
+    install_activation_policy, refresh_window_shadows, render_stack,
 };
 
 const SEED_HEIGHT: f32 = 300.0;
+
+/// Once every card is dismissed the window hides (exactly like production); reseed the stack after this many seconds so the close-then-hide path can be reproduced repeatedly.
+const RESHOW_DELAY: f64 = 1.5;
 
 struct Preview {
     snapshot: Snapshot,
     credential_inputs: HashMap<String, String>,
     token_drafts: HashMap<String, TokenDraft>,
     remember: HashMap<String, bool>,
-    current_height: f32,
-    placed: bool,
+    placement: ViewportPlacement,
+    reshow_at: Option<f64>,
+}
+
+impl Preview {
+    fn maybe_reseed(&mut self, ctx: &egui::Context) {
+        if !self.snapshot.order.is_empty() {
+            self.reshow_at = None;
+            return;
+        }
+        let now = ctx.input(|i| i.time);
+        match self.reshow_at {
+            None => {
+                eprintln!("[approval-preview] stack empty → hiding window");
+                self.reshow_at = Some(now + RESHOW_DELAY);
+                ctx.request_repaint_after(Duration::from_secs_f64(RESHOW_DELAY));
+            }
+            Some(at) if now >= at => {
+                eprintln!("[approval-preview] reseeding → re-showing window");
+                self.snapshot = seed();
+                self.reshow_at = None;
+                ctx.request_repaint();
+            }
+            Some(_) => {}
+        }
+    }
 }
 
 impl eframe::App for Preview {
@@ -29,19 +57,14 @@ impl eframe::App for Preview {
     }
 
     fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        if self.placed {
-            return;
-        }
-        let Some(monitor) = ctx.input(|i| i.viewport().monitor_size) else {
-            ctx.request_repaint();
-            return;
-        };
-        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(position_top_right(
-            monitor,
-        )));
-        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-        ctx.request_repaint();
-        self.placed = true;
+        self.maybe_reseed(ctx);
+        let revealed = self
+            .token_drafts
+            .values()
+            .filter(|d| d.is_revealed())
+            .count();
+        self.placement
+            .sync_visibility(ctx, &self.snapshot.order, revealed);
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -56,14 +79,7 @@ impl eframe::App for Preview {
             cap,
         );
         let target = content_height.clamp(MIN_WINDOW_HEIGHT, cap);
-        if (self.current_height - target).abs() > 0.5 {
-            ui.ctx()
-                .send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
-                    WINDOW_WIDTH,
-                    target,
-                )));
-            self.current_height = target;
-        }
+        self.placement.fit_height(ui.ctx(), target);
         if let Some(action) = action {
             eprintln!("[approval-preview] {action:?}");
             dismiss_card(&mut self.snapshot, &action);
@@ -107,6 +123,31 @@ fn dismiss_card(snapshot: &mut Snapshot, action: &CardAction) {
 }
 
 fn seed() -> Snapshot {
+    if std::env::var_os("APPROVAL_PREVIEW_ONE").is_some() {
+        seed_one()
+    } else {
+        seed_all()
+    }
+}
+
+fn seed_one() -> Snapshot {
+    Snapshot {
+        pending: vec![PendingPrompt {
+            id: "net-allow".into(),
+            host: "pypi.org".into(),
+            action: "CONNECT pypi.org:443".into(),
+            offer: None,
+            token_fallback: None,
+        }],
+        pending_credentials: vec![],
+        sign_ins: vec![],
+        informs: vec![],
+        connecting: vec![],
+        order: vec![StackItem::Network(0)],
+    }
+}
+
+fn seed_all() -> Snapshot {
     Snapshot {
         pending: vec![
             PendingPrompt {
@@ -192,14 +233,17 @@ fn main() -> eframe::Result {
     let viewport = egui::ViewportBuilder::default()
         .with_title("approval preview")
         .with_decorations(false)
+        .with_resizable(true)
         .with_transparent(true)
         .with_always_on_top()
+        .with_mouse_passthrough(true)
         .with_visible(false)
         .with_inner_size([WINDOW_WIDTH, SEED_HEIGHT]);
-    let options = eframe::NativeOptions {
+    let mut options = eframe::NativeOptions {
         viewport,
         ..Default::default()
     };
+    install_activation_policy(&mut options);
     eframe::run_native(
         "approval preview",
         options,
@@ -213,8 +257,8 @@ fn main() -> eframe::Result {
                 credential_inputs: HashMap::new(),
                 token_drafts: HashMap::new(),
                 remember: HashMap::new(),
-                current_height: SEED_HEIGHT,
-                placed: false,
+                placement: ViewportPlacement::new(),
+                reshow_at: None,
             }))
         }),
     )

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -1811,7 +1811,7 @@ pub fn refresh_window_shadows() {
     }
 }
 
-/// Belt to the deferred hide: dropping the shadow before `orderOut` backstops the rare frame where the emptied content hasn't composited in time, so the card-shaped shadow can't outlive the window; re-enabled on the next show.
+/// Dropped before the hide so the card-shaped shadow can't outlive the window; re-enabled on the next show.
 #[cfg(target_os = "macos")]
 fn set_window_shadows(enabled: bool) {
     use objc2::MainThreadMarker;

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -187,15 +187,13 @@ struct TrayApp {
     window_state: Arc<WindowState>,
     #[cfg(target_os = "macos")]
     _tray: tray_icon::TrayIcon,
-    last_visible: bool,
+    placement: ViewportPlacement,
     /// Kept on `TrayApp` (not [`WindowState`]) so the snapshot passed to [`render_stack`] stays immutable.
     credential_inputs: HashMap<String, String>,
     /// Per-card progressive-disclosure state for the "use a token instead" fallback, keyed by the shown card's id.
     token_drafts: HashMap<String, TokenDraft>,
     /// Per-network-card "remember this decision" toggle, keyed by request id; true persists the choice as an always-rule.
     remember: HashMap<String, bool>,
-    /// The viewport inner height last applied; grows to fit a revealed token field and shrinks back when none is open.
-    current_height: f32,
 }
 
 /// The transient UI state of one card's token fallback: whether the field is revealed and what's been typed.
@@ -203,6 +201,12 @@ struct TrayApp {
 pub struct TokenDraft {
     revealed: bool,
     value: String,
+}
+
+impl TokenDraft {
+    pub fn is_revealed(&self) -> bool {
+        self.revealed
+    }
 }
 
 impl TrayApp {
@@ -230,17 +234,41 @@ impl TrayApp {
             window_state,
             #[cfg(target_os = "macos")]
             _tray,
-            last_visible: false,
+            placement: ViewportPlacement::new(),
             credential_inputs: HashMap::new(),
             token_drafts: HashMap::new(),
             remember: HashMap::new(),
-            current_height: WINDOW_HEIGHT,
         })
     }
+}
 
-    fn sync_viewport_visibility(&mut self, ctx: &egui::Context) {
-        let order = self.window_state.snapshot().order;
+/// Drives the approval viewport's show/hide and programmatic resize from the current stack, so the production tray and the `approval_preview` harness exercise the identical window lifecycle.
+pub struct ViewportPlacement {
+    last_visible: bool,
+    current_height: f32,
+    pending_hide: bool,
+}
+
+impl Default for ViewportPlacement {
+    fn default() -> Self {
+        Self {
+            last_visible: false,
+            current_height: WINDOW_HEIGHT,
+            pending_hide: false,
+        }
+    }
+}
+
+impl ViewportPlacement {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn sync_visibility(&mut self, ctx: &egui::Context, order: &[StackItem], revealed: usize) {
         let should_show = !order.is_empty();
+        if should_show {
+            self.pending_hide = false;
+        }
 
         match visibility_transition(should_show, self.last_visible) {
             VisibilityTransition::Show => {
@@ -250,10 +278,10 @@ impl TrayApp {
                     return;
                 };
                 // A seed height keeps the reveal frame (which skips ui()) close to size; ui() then snaps the window to its measured content so no estimate slop shows as bottom padding.
-                let revealed = self.token_drafts.values().filter(|d| d.revealed).count();
                 let monitor_height = ctx.input(|i| i.viewport().monitor_size).map(|m| m.y);
-                let seed = target_height(&order, revealed, monitor_height);
+                let seed = target_height(order, revealed, monitor_height);
                 join_all_spaces();
+                set_window_shadows(true);
                 ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(pos));
                 ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
                     WINDOW_WIDTH,
@@ -267,10 +295,17 @@ impl TrayApp {
                 self.current_height = seed;
                 self.last_visible = true;
             }
+            VisibilityTransition::Hide if !self.pending_hide => {
+                // The window must stay up one more frame to composite its now-empty content, or macOS strands the last card-shaped shadow as a ghost after the orderOut.
+                self.pending_hide = true;
+                ctx.request_repaint();
+            }
             VisibilityTransition::Hide => {
+                set_window_shadows(false);
                 ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
                 ctx.send_viewport_cmd(egui::ViewportCommand::MousePassthrough(true));
                 self.last_visible = false;
+                self.pending_hide = false;
             }
             // Resizing while visible is driven by ui()'s content measurement, not an estimate.
             VisibilityTransition::Unchanged => {}
@@ -278,7 +313,7 @@ impl TrayApp {
     }
 
     /// Snaps the viewport to `target` using measured content size, not the window-bounded `min_rect`, so a card taller than the current window grows it instead of being clipped.
-    fn fit_height_to_content(&mut self, ctx: &egui::Context, target: f32) {
+    pub fn fit_height(&mut self, ctx: &egui::Context, target: f32) {
         if (self.current_height - target).abs() > 0.5 {
             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
                 WINDOW_WIDTH,
@@ -299,7 +334,13 @@ impl eframe::App for TrayApp {
             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             return;
         }
-        self.sync_viewport_visibility(ctx);
+        let order = self.window_state.snapshot().order;
+        let revealed = self
+            .token_drafts
+            .values()
+            .filter(|d| d.is_revealed())
+            .count();
+        self.placement.sync_visibility(ctx, &order, revealed);
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -319,7 +360,7 @@ impl eframe::App for TrayApp {
             cap,
         );
         let target = content_height.clamp(MIN_WINDOW_HEIGHT, cap);
-        self.fit_height_to_content(ui.ctx(), target);
+        self.placement.fit_height(ui.ctx(), target);
 
         match action {
             Some(CardAction::CloseAll) => {
@@ -1726,7 +1767,7 @@ fn visibility_transition(should_show: bool, last_visible: bool) -> VisibilityTra
 }
 
 #[cfg(target_os = "macos")]
-fn install_activation_policy(opts: &mut eframe::NativeOptions) {
+pub fn install_activation_policy(opts: &mut eframe::NativeOptions) {
     use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
     opts.event_loop_builder = Some(Box::new(|builder| {
         builder.with_activation_policy(ActivationPolicy::Accessory);
@@ -1734,7 +1775,7 @@ fn install_activation_policy(opts: &mut eframe::NativeOptions) {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn install_activation_policy(_opts: &mut eframe::NativeOptions) {}
+pub fn install_activation_policy(_opts: &mut eframe::NativeOptions) {}
 
 /// Lets the always-on-top approval window appear on whichever macOS Space is active — including a full-screen app's Space — instead of staying pinned to the desktop it was created on.
 #[cfg(target_os = "macos")]
@@ -1756,7 +1797,7 @@ fn join_all_spaces() {
 #[cfg(not(target_os = "macos"))]
 fn join_all_spaces() {}
 
-/// macOS recomputes a transparent window's shadow only on resize, so without per-frame invalidation a scrolled card's shadow freezes at its old position.
+/// A transparent window's shadow recomputes only on resize, never on a same-size repaint, so a scrolled card needs explicit per-frame invalidation or its shadow freezes at the old position.
 #[cfg(target_os = "macos")]
 pub fn refresh_window_shadows() {
     use objc2::MainThreadMarker;
@@ -1769,6 +1810,23 @@ pub fn refresh_window_shadows() {
         window.invalidateShadow();
     }
 }
+
+/// Belt to the deferred hide: dropping the shadow before `orderOut` backstops the rare frame where the emptied content hasn't composited in time, so the card-shaped shadow can't outlive the window; re-enabled on the next show.
+#[cfg(target_os = "macos")]
+fn set_window_shadows(enabled: bool) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    for window in NSApplication::sharedApplication(mtm).windows().iter() {
+        window.setHasShadow(enabled);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_window_shadows(_enabled: bool) {}
 
 #[cfg(not(target_os = "macos"))]
 pub fn refresh_window_shadows() {}


### PR DESCRIPTION
## Problem

Closing the approval prompt left the card's **drop shadow** lingering on screen for ~0.3–0.5 s after the card itself was gone.

On macOS the approval window is transparent + borderless with the default `NSWindow` shadow, so the visible card shadow is a WindowServer surface derived from the window's opaque pixels (there is no egui-painted shadow anywhere). When the **last** card is dismissed, the stack empties and the window was hidden via `orderOut` (`ViewportCommand::Visible(false)`) **in the same frame**. The last shadow the WindowServer computed was the card-shaped one, and `orderOut` on a transparent/floating window doesn't tear that cached surface down synchronously — so it ghosts.

This only happened on the **visible → hidden** transition (closing the last/only card). Closing a card while others remain just resizes the still-visible window, which recomputes the shadow cleanly.

## Fix

- **Defer the `orderOut` by one frame** (`pending_hide`): when the stack empties, keep the window up one extra frame so it composites its now-empty content while still visible — recomputing the shadow to nothing — *then* hide. This is the exact path an intermediate-card close already takes (and which never ghosted).
- **Drop `hasShadow` before the hide** as a cheap backstop for the rare frame where the emptied content hasn't composited in time; re-enabled on show.

## Refactor enabling the fix + verification

- Extracted the show/hide + programmatic-resize state machine out of `TrayApp` into a shared `ViewportPlacement`. The production tray and the `approval_preview` example now drive the **identical** window lifecycle, so the fix lands in both by construction (not a parallel reimplementation).
- Made the `approval_preview` harness faithfully reproduce the production window: macOS **Accessory** activation policy, transparent + always-on-top + all-spaces, and the real `orderOut` hide path. A single closeable card (`APPROVAL_PREVIEW_ONE=1`) reaches the empty→hide transition; the default remains the full multi-card showcase.

## Verification

- **Preview harness** (`APPROVAL_PREVIEW_ONE=1 cargo run -p lns-service --example approval_preview`): ghost reproduced before the fix, gone after; shadow returns correctly on each reseed.
- **Real app**: `make build` → `./bin/lns service start` → live microVM egress (`busybox wget`) under `defaultVerdict: ask` → dismissed the network card → no lingering shadow in the actual tray.

## Notes for CI

`crates/lns-service/src/tray.rs` is in the coverage IGNORES (eframe main-loop adapter), so the new code there isn't coverage-gated; the example isn't coverage-measured. `lint` / `complexity` / `coverage` run in CI.