### PR TITLE
feat: make the `lns run` detach chord a docker-style detach

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -120,7 +120,7 @@ pub struct RunArgs {
         long,
         default_value = "ctrl-p,ctrl-q",
         value_parser = parse_detach_keys_arg,
-        help = "Comma-separated detach chord (single chars or `ctrl-X`); on match the CLI sends SIGHUP to the workload's foreground pgrp and reports its exit code. To leave a run running, start it with `-d` and re-join with `lns sandbox attach`."
+        help = "Comma-separated detach chord (single chars or `ctrl-X`); on match the CLI returns 0 and leaves the run executing in the background — re-join it with `lns sandbox attach`. No signal is sent to the workload."
     )]
     pub detach_keys: DetachChord,
 

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -779,12 +779,20 @@ async fn send_one_shot(socket: &Path, request: &Request) -> Result<()> {
     let mut stream = UnixStream::connect(socket)
         .await
         .with_context(|| format!("connecting to {} for one-shot", socket.display()))?;
+    write_and_await_ack(&mut stream, request).await
+}
+
+async fn write_and_await_ack<S>(stream: &mut S, request: &Request) -> Result<()>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+{
     let frame = encode_frame(request).context("encoding one-shot request")?;
     stream
         .write_all(&frame)
         .await
         .context("writing one-shot request")?;
-    let _ = read_frame_bytes_async(&mut stream).await;
+    // Awaiting the reply is load-bearing for RunDetach: it blocks until the service has fired detach_tx, so the CLI never closes the run stream first and trips WriteFailed → CancelAndDeregister.
+    let _ = read_frame_bytes_async(stream).await;
     Ok(())
 }
 
@@ -1795,6 +1803,34 @@ mod tests {
         );
         assert!(matches!(control, PumpControl::Detach));
         assert!(pending.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn write_and_await_ack_blocks_until_the_service_responds() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        let mut ack = std::pin::pin!(write_and_await_ack(
+            &mut client,
+            &Request::RunDetach { run_id: 7 },
+        ));
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut ack).await.is_err(),
+            "the detach round-trip must not complete before the service acknowledges — \
+             a fire-and-forget RunDetach would let the CLI close the run stream first and \
+             reintroduce terminate-on-detach",
+        );
+
+        let req = read_frame_bytes_async(&mut server)
+            .await
+            .expect("server reads the request");
+        let decoded: Request = decode_frame(&mut &req[..]).expect("decode request");
+        assert_eq!(decoded, Request::RunDetach { run_id: 7 });
+
+        let frame = encode_frame(&Response::DetachAccepted).expect("encode ack");
+        server.write_all(&frame).await.expect("server writes ack");
+
+        ack.await
+            .expect("the round-trip completes once the service acknowledges");
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -220,6 +220,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         run_id,
         tty,
         detach_chord,
+        DetachBehaviour::DetachRun,
         quiet,
     )
     .await
@@ -269,7 +270,16 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     };
     crate::log::debug!(run_id = run_id, "exec session opened");
 
-    drive_attached_session(stream, Some(socket), run_id, tty, detach_chord, args.quiet).await
+    drive_attached_session(
+        stream,
+        Some(socket),
+        run_id,
+        tty,
+        detach_chord,
+        DetachBehaviour::SignalAndDrain,
+        args.quiet,
+    )
+    .await
 }
 
 pub async fn kill(args: KillArgs) -> Result<()> {
@@ -315,6 +325,7 @@ pub async fn ls() -> Result<()> {
 pub enum DetachBehaviour {
     SignalAndDrain,
     LeaveRunning,
+    DetachRun,
 }
 
 pub(crate) async fn drive_attached_session<S>(
@@ -323,6 +334,7 @@ pub(crate) async fn drive_attached_session<S>(
     run_id: u32,
     tty: bool,
     detach_chord: Vec<u8>,
+    detach: DetachBehaviour,
     quiet: bool,
 ) -> Result<i32>
 where
@@ -337,7 +349,7 @@ where
         tty,
         std::io::stdout().is_terminal(),
         detach_chord,
-        DetachBehaviour::SignalAndDrain,
+        detach,
         &mut stdout,
         &mut stderr,
         quiet,
@@ -519,7 +531,7 @@ where
         DetachBehaviour::SignalAndDrain => {
             drain_after_chord(stream, tty, stdout, stderr, last_stdout_byte, quiet).await
         }
-        DetachBehaviour::LeaveRunning => 0,
+        DetachBehaviour::LeaveRunning | DetachBehaviour::DetachRun => 0,
     }
 }
 
@@ -727,11 +739,13 @@ fn plan_feed(
         }
         FeedAction::Trigger => {
             let mut requests: Vec<Request> = drain_pending(run_id, pending).into_iter().collect();
-            if matches!(detach, DetachBehaviour::SignalAndDrain) {
-                requests.push(Request::RunSignal {
+            match detach {
+                DetachBehaviour::SignalAndDrain => requests.push(Request::RunSignal {
                     run_id,
                     signal: SignalKind::Hup,
-                });
+                }),
+                DetachBehaviour::DetachRun => requests.push(Request::RunDetach { run_id }),
+                DetachBehaviour::LeaveRunning => {}
             }
             (requests, PumpControl::Detach)
         }
@@ -918,9 +932,17 @@ mod tests {
             let frame = encode_frame(&Response::RunExit { code: 7 }).expect("encode RunExit");
             server.write_all(&frame).await.expect("write RunExit");
         });
-        let code = drive_attached_session(client, None, 42, false, Vec::new(), false)
-            .await
-            .expect("drive_attached_session");
+        let code = drive_attached_session(
+            client,
+            None,
+            42,
+            false,
+            Vec::new(),
+            DetachBehaviour::SignalAndDrain,
+            false,
+        )
+        .await
+        .expect("drive_attached_session");
         assert_eq!(code, 7);
     }
 
@@ -1179,9 +1201,17 @@ mod tests {
             let exit = encode_frame(&Response::RunExit { code: 0 }).expect("encode RunExit");
             server.write_all(&exit).await.expect("write RunExit");
         });
-        let code = drive_attached_session(client, None, 42, false, Vec::new(), false)
-            .await
-            .expect("a stray progress frame must not kill an attached session");
+        let code = drive_attached_session(
+            client,
+            None,
+            42,
+            false,
+            Vec::new(),
+            DetachBehaviour::SignalAndDrain,
+            false,
+        )
+        .await
+        .expect("a stray progress frame must not kill an attached session");
         assert_eq!(code, 0);
     }
 
@@ -1195,9 +1225,17 @@ mod tests {
             .expect("encode Error");
             server.write_all(&frame).await.expect("write Error");
         });
-        let err = drive_attached_session(client, None, 42, false, Vec::new(), false)
-            .await
-            .expect_err("daemon Error must surface as anyhow::Error");
+        let err = drive_attached_session(
+            client,
+            None,
+            42,
+            false,
+            Vec::new(),
+            DetachBehaviour::SignalAndDrain,
+            false,
+        )
+        .await
+        .expect_err("daemon Error must surface as anyhow::Error");
         assert!(
             format!("{err:#}").contains("policy file is unreadable"),
             "error context lost"
@@ -1445,6 +1483,33 @@ mod tests {
             decode_wire_frame_from_bytes(&bytes).expect("decode"),
             WireFrame::Json(Response::RunExit { code: 9 })
         ));
+    }
+
+    #[tokio::test]
+    async fn exit_code_after_detach_detach_run_returns_zero_without_draining() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        let exit = encode_frame(&Response::RunExit { code: 9 }).expect("encode exit");
+        server.write_all(&exit).await.expect("write exit");
+
+        let mut captured = Vec::<u8>::new();
+        let mut status = Vec::<u8>::new();
+        let mut last = None;
+        let code = exit_code_after_detach(
+            DetachBehaviour::DetachRun,
+            false,
+            &mut client,
+            &mut captured,
+            &mut status,
+            &mut last,
+            false,
+        )
+        .await;
+
+        assert_eq!(code, 0, "detaching a run returns 0 at once");
+        assert!(
+            captured.is_empty(),
+            "DetachRun must leave the run running, not drain its output"
+        );
     }
 
     #[tokio::test]
@@ -1703,6 +1768,30 @@ mod tests {
                 bytes: vec![b'p']
             }],
             "a docker-style detach flushes pending input but never signals the workload"
+        );
+        assert!(matches!(control, PumpControl::Detach));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn plan_feed_trigger_sends_run_detach_without_signalling_for_run() {
+        let mut pending = vec![b'p'];
+        let (requests, control) = plan_feed(
+            FeedAction::Trigger,
+            9,
+            &mut pending,
+            DetachBehaviour::DetachRun,
+        );
+        assert_eq!(
+            requests,
+            vec![
+                Request::RunStdin {
+                    run_id: 9,
+                    bytes: vec![b'p']
+                },
+                Request::RunDetach { run_id: 9 },
+            ],
+            "detaching a run flushes pending input then asks the service to keep it running — no SIGHUP",
         );
         assert!(matches!(control, PumpControl::Detach));
         assert!(pending.is_empty());

--- a/crates/lns-cli/tests/smoke/interactive-shell.exp
+++ b/crates/lns-cli/tests/smoke/interactive-shell.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 # Smoke test for `lns run -it` interactive shell behaviors.
 #
-# Locks in three user-facing contracts that any change touching the
+# Locks in four user-facing contracts that any change touching the
 # interactive-shell transport (stdio pumps, chord detector, lns-init
 # PTY plumbing, future session broker) must preserve:
 #
@@ -9,13 +9,12 @@
 #      `hi` on its own line.
 #   2. Ctrl+C inside the shell does NOT detach. The guest kernel's
 #      TTY line discipline echoes `^C` and the shell reprompts.
-#   3. The Docker-style chord (`Ctrl+P` `Ctrl+Q`) exits cleanly.
-#      `lns` reports the workload's real exit code — which for
-#      `sh` killed by SIGHUP is 129 (128 + SIGHUP). Earlier
-#      revisions hardcoded 0 from `emit_completion`'s Ok path
-#      regardless of the workload's real exit; that masked the
-#      bug fixed in `fix(lns-service): forward workload exit code
-#      to CLI instead of always reporting 0`.
+#   3. The Docker-style chord (`Ctrl+P` `Ctrl+Q`) detaches: `lns`
+#      returns 0 and the run keeps executing in the background. No
+#      SIGHUP is sent to the workload (an earlier revision sent
+#      SIGHUP and reported 129 — terminate-and-exit, not detach).
+#   4. The detached run is still listed by `lns sandbox ls` and
+#      `lns sandbox attach` re-joins its shell.
 #
 # Run with `expect -f crates/lns-cli/tests/smoke/interactive-shell.exp`
 # from the workspace root. Requires `/usr/bin/expect` (pre-installed
@@ -35,7 +34,7 @@ if {![file executable $wrapper]} {
     exit 1
 }
 
-spawn $wrapper run alpine:latest -- sh
+spawn $wrapper run --name detach-smoke alpine:latest -- sh
 
 # --- (1) shell comes up and echoes a command ------------------------------
 
@@ -82,13 +81,13 @@ expect {
     "~ # "
 }
 
-# --- (3) Ctrl+P Ctrl+Q must exit cleanly ---------------------------------
+# --- (3) Ctrl+P Ctrl+Q detaches, leaving the run running -----------------
 
 send "\x10\x11"
 set timeout 30
 expect {
     timeout {
-        puts "\nFAIL: chord did not exit within 30s — guest shell froze (most likely SIGHUP wasn't delivered)"
+        puts "\nFAIL: chord did not detach within 30s — the CLI kept relaying or the guest froze"
         exit 1
     }
     eof
@@ -100,15 +99,51 @@ if {$os_error_flag != 0} {
     puts "\nFAIL: OS error after chord, errno $value"
     exit 1
 }
-# Chord → broker delivers SIGHUP to the workload's foreground
-# process group → `sh` exits with `128 + 1 = 129`. Any other code
-# would mean either the chord didn't fire (workload ended for some
-# other reason) or the exit-code propagation regressed back to
-# always-0.
-if {$value != 129} {
-    puts "\nFAIL: expected exit 129 (128 + SIGHUP) after chord, got $value"
+# Docker-style detach: the chord makes the CLI return 0 and leaves the
+# run executing in the background. No SIGHUP is sent to the workload —
+# a regression to terminate-and-exit would surface here as 129.
+if {$value != 0} {
+    puts "\nFAIL: expected exit 0 after docker-style detach, got $value"
     exit 1
 }
 
-puts "\nPASS: interactive shell behaviors all green (chord-exit 129 confirmed)"
+# --- (4) the detached run is still listed and re-attachable --------------
+
+set timeout 15
+spawn $wrapper sandbox ls
+expect {
+    timeout {
+        puts "\nFAIL: `lns sandbox ls` did not list the detached run as running"
+        exit 1
+    }
+    -re "detach-smoke.*(?i)running"
+}
+catch wait
+
+spawn $wrapper sandbox attach detach-smoke
+expect {
+    timeout {
+        puts "\nFAIL: `lns sandbox attach` did not re-join the detached run's shell"
+        exit 1
+    }
+    "~ # "
+}
+send "echo rejoined\r"
+expect {
+    timeout {
+        puts "\nFAIL: re-attached shell produced no output"
+        exit 1
+    }
+    -re "\nrejoined\r"
+}
+# Detach again (still no signal), then tear the run down explicitly.
+send "\x10\x11"
+expect eof
+catch wait
+
+spawn $wrapper sandbox kill detach-smoke
+expect eof
+catch wait
+
+puts "\nPASS: interactive shell behaviors all green (docker-style detach + re-attach confirmed)"
 exit 0

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -28,6 +28,9 @@ pub enum Request {
         run_id: u32,
         signal: SignalKind,
     },
+    RunDetach {
+        run_id: u32,
+    },
     ExecImage(ExecImageArgs),
     Kill {
         run: String,
@@ -120,6 +123,7 @@ pub enum Response {
         code: i32,
     },
     CancelAccepted,
+    DetachAccepted,
     Acknowledged,
     RunList {
         runs: Vec<RunSummary>,
@@ -968,6 +972,22 @@ mod tests {
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
         assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn run_detach_request_survives_a_round_trip() {
+        let req = Request::RunDetach { run_id: 7 };
+        let frame = crate::encode_frame(&req).unwrap();
+        let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn detach_accepted_response_survives_a_round_trip() {
+        let resp = Response::DetachAccepted;
+        let frame = crate::encode_frame(&resp).unwrap();
+        let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, resp);
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -424,6 +424,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
 
     let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(FRAME_CHAN_BUF);
     let (cancel_tx, cancel_rx) = oneshot::channel::<i32>();
+    let (detach_tx, detach_rx) = oneshot::channel::<()>();
 
     let run_id = crate::run_registry::allocate_run_id();
     let detached = args.detached;
@@ -457,6 +458,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
         requested_name,
         crate::run_registry::RunHandle {
             cancel_tx,
+            detach_tx: std::sync::Mutex::new(Some(detach_tx)),
             task: run_task,
             input_tx: Some(input_tx),
             connector: None,
@@ -493,7 +495,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
         return Err(e);
     }
 
-    let outcome = pump_responses(&mut stream, &mut frame_rx, cancel_rx).await?;
+    let outcome = pump_responses(&mut stream, &mut frame_rx, cancel_rx, detach_rx).await?;
     match post_pump_action(&outcome, detached) {
         PostPumpAction::Retain => {
             crate::run_registry::mark_exited_from_log(run_id);
@@ -598,8 +600,10 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
     drop(frame_tx);
 
     let (_dead_cancel_tx, dead_cancel_rx) = oneshot::channel::<i32>();
+    let (_dead_detach_tx, dead_detach_rx) = oneshot::channel::<()>();
 
-    let outcome = pump_responses(&mut stream, &mut frame_rx, dead_cancel_rx).await?;
+    let outcome =
+        pump_responses(&mut stream, &mut frame_rx, dead_cancel_rx, dead_detach_rx).await?;
     if let PumpOutcome::WriteFailed(e) = &outcome {
         log::debug!(error = %e, "exec stream write failed; tearing session down");
     }

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -123,15 +123,15 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
                 }
             }
         }
-        Request::RunDetach { run_id } => {
-            if crate::run_registry::request_detach(*run_id) {
-                Response::DetachAccepted
-            } else {
-                Response::Error {
-                    message: format!("no active run with id {run_id}"),
-                }
-            }
-        }
+        Request::RunDetach { run_id } => match crate::run_registry::request_detach(*run_id) {
+            crate::run_registry::DetachOutcome::Detached => Response::DetachAccepted,
+            crate::run_registry::DetachOutcome::NotAttached => Response::Error {
+                message: format!("run {run_id} is not attached"),
+            },
+            crate::run_registry::DetachOutcome::NotFound => Response::Error {
+                message: format!("no active run with id {run_id}"),
+            },
+        },
         Request::RunStdin { run_id, bytes } => {
             forward_session_input(*run_id, session_input_from_stdin(bytes.clone()), "RunStdin")
                 .await
@@ -1257,10 +1257,13 @@ mod tests {
         );
 
         let resp = handle_request(&Request::RunDetach { run_id }, Instant::now()).await;
-        assert!(
-            matches!(resp, Response::Error { .. }),
-            "a second detach is a no-op once the signal is consumed",
-        );
+        match resp {
+            Response::Error { message } => assert!(
+                message.contains("is not attached"),
+                "a second detach of a still-registered run is not-attached, not absent: {message}",
+            ),
+            other => unreachable!("expected Error on a second detach, got {other:?}"),
+        }
         let _ = crate::run_registry::cancel(run_id);
     }
 

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -11,6 +11,7 @@ pub use adapter::run_server;
 pub(super) enum PumpOutcome {
     ExitFrame,
     ChannelClosed,
+    Detached,
     WriteFailed(String),
 }
 
@@ -24,6 +25,7 @@ pub(super) enum PostPumpAction {
 pub(super) fn post_pump_action(outcome: &PumpOutcome, detached: bool) -> PostPumpAction {
     match outcome {
         PumpOutcome::ExitFrame | PumpOutcome::ChannelClosed => PostPumpAction::Retain,
+        PumpOutcome::Detached => PostPumpAction::BackgroundDrain,
         PumpOutcome::WriteFailed(_) if detached => PostPumpAction::BackgroundDrain,
         PumpOutcome::WriteFailed(_) => PostPumpAction::CancelAndDeregister,
     }
@@ -37,11 +39,13 @@ async fn pump_responses<W>(
     stream: &mut W,
     frame_rx: &mut mpsc::Receiver<WireFrame>,
     cancel_rx: oneshot::Receiver<i32>,
+    detach_rx: oneshot::Receiver<()>,
 ) -> anyhow::Result<PumpOutcome>
 where
     W: AsyncWriteExt + Unpin,
 {
     let mut cancel_rx = Some(cancel_rx);
+    let mut detach_rx = Some(detach_rx);
     loop {
         tokio::select! {
             biased;
@@ -59,6 +63,17 @@ where
                     return Ok(PumpOutcome::WriteFailed(e.to_string()));
                 }
                 return Ok(PumpOutcome::ExitFrame);
+            }
+            detach = async {
+                match detach_rx.as_mut() {
+                    Some(rx) => rx.await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                detach_rx = None;
+                if detach.is_ok() {
+                    return Ok(PumpOutcome::Detached);
+                }
             }
             maybe = frame_rx.recv() => {
                 let Some(wire) = maybe else {
@@ -102,6 +117,15 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
         Request::CancelRun { run_id } => {
             if crate::run_registry::cancel(*run_id) {
                 Response::CancelAccepted
+            } else {
+                Response::Error {
+                    message: format!("no active run with id {run_id}"),
+                }
+            }
+        }
+        Request::RunDetach { run_id } => {
+            if crate::run_registry::request_detach(*run_id) {
+                Response::DetachAccepted
             } else {
                 Response::Error {
                     message: format!("no active run with id {run_id}"),
@@ -555,11 +579,16 @@ mod tests {
         oneshot::channel()
     }
 
+    fn never_detach() -> (oneshot::Sender<()>, oneshot::Receiver<()>) {
+        oneshot::channel()
+    }
+
     #[tokio::test]
     async fn pump_preserves_frame_order_and_exits_on_run_exit() {
         let mut sink: Vec<u8> = Vec::new();
         let (tx, mut rx) = mpsc::channel::<WireFrame>(8);
         let (_cancel_tx, cancel_rx) = never_cancel();
+        let (_detach_tx, detach_rx) = never_detach();
 
         tx.send(WireFrame::Stdout(b"hello".to_vec())).await.unwrap();
         tx.send(WireFrame::Json(Response::RunLog {
@@ -575,7 +604,9 @@ mod tests {
         tx.send(WireFrame::Stdout(b"never".to_vec())).await.unwrap();
         drop(tx);
 
-        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx).await.unwrap();
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
         assert_eq!(outcome, PumpOutcome::ExitFrame);
 
         let decoded = decode_wire_frames_from(&sink);
@@ -596,10 +627,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
         let (tx, mut rx) = mpsc::channel::<WireFrame>(8);
         let (_cancel_tx, cancel_rx) = never_cancel();
+        let (_detach_tx, detach_rx) = never_detach();
         tx.send(WireFrame::Stdout(b"x".to_vec())).await.unwrap();
         drop(tx);
 
-        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx).await.unwrap();
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
         assert_eq!(outcome, PumpOutcome::ChannelClosed);
     }
 
@@ -610,11 +644,14 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<WireFrame>(8);
         let (_cancel_tx, cancel_rx) = never_cancel();
+        let (_detach_tx, detach_rx) = never_detach();
         tx.send(WireFrame::Stdout(vec![0; 1024])).await.unwrap();
         drop(tx);
 
         let mut w = write_side;
-        let outcome = pump_responses(&mut w, &mut rx, cancel_rx).await.unwrap();
+        let outcome = pump_responses(&mut w, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
         assert!(
             matches!(outcome, PumpOutcome::WriteFailed(_)),
             "expected WriteFailed, got {outcome:?}",
@@ -626,13 +663,16 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
         let (tx, mut rx) = mpsc::channel::<WireFrame>(1);
         let (cancel_tx, cancel_rx) = oneshot::channel::<i32>();
+        let (_detach_tx, detach_rx) = never_detach();
 
         tx.send(WireFrame::Stdout(b"buffered".to_vec()))
             .await
             .unwrap();
         cancel_tx.send(130).unwrap();
 
-        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx).await.unwrap();
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
         assert_eq!(outcome, PumpOutcome::ExitFrame);
 
         let decoded = decode_wire_frames_from(&sink);
@@ -648,6 +688,7 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
         let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
         let (cancel_tx, cancel_rx) = oneshot::channel::<i32>();
+        let (_detach_tx, detach_rx) = never_detach();
 
         drop(cancel_tx);
 
@@ -657,7 +698,9 @@ mod tests {
             .unwrap();
         drop(tx);
 
-        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx).await.unwrap();
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
         assert_eq!(outcome, PumpOutcome::ExitFrame);
 
         let decoded = decode_wire_frames_from(&sink);
@@ -666,6 +709,62 @@ mod tests {
             decoded[1],
             WireFrame::Json(Response::RunExit { code: 0 })
         ));
+    }
+
+    #[tokio::test]
+    async fn pump_returns_detached_when_the_detach_signal_fires() {
+        let mut sink: Vec<u8> = Vec::new();
+        let (_tx, mut rx) = mpsc::channel::<WireFrame>(8);
+        let (_cancel_tx, cancel_rx) = never_cancel();
+        let (detach_tx, detach_rx) = never_detach();
+
+        detach_tx.send(()).unwrap();
+
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            PumpOutcome::Detached,
+            "a deliberate detach must hand the run off, not cancel it",
+        );
+    }
+
+    #[tokio::test]
+    async fn pump_continues_after_detach_sender_drop_without_firing() {
+        let mut sink: Vec<u8> = Vec::new();
+        let (tx, mut rx) = mpsc::channel::<WireFrame>(4);
+        let (_cancel_tx, cancel_rx) = never_cancel();
+        let (detach_tx, detach_rx) = never_detach();
+
+        drop(detach_tx);
+
+        tx.send(WireFrame::Json(Response::RunExit { code: 0 }))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            PumpOutcome::ExitFrame,
+            "a dropped detach sender must not be mistaken for a detach",
+        );
+    }
+
+    #[test]
+    fn post_pump_action_detach_signal_drains_in_background_regardless_of_detached() {
+        assert_eq!(
+            post_pump_action(&PumpOutcome::Detached, false),
+            PostPumpAction::BackgroundDrain,
+            "a deliberate detach of an attached run must leave it running, not cancel it",
+        );
+        assert_eq!(
+            post_pump_action(&PumpOutcome::Detached, true),
+            PostPumpAction::BackgroundDrain,
+        );
     }
 
     #[test]
@@ -723,6 +822,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_request_detach_unknown_run_returns_error() {
+        let resp = handle_request(&Request::RunDetach { run_id: u32::MAX }, Instant::now()).await;
+        match resp {
+            Response::Error { message } => assert!(message.contains("no active run")),
+            other => unreachable!("expected Error for a missing run, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn forward_session_input_awaits_back_pressure_instead_of_dropping() {
         use crate::vm::session_client::SessionInput;
         use tokio::sync::mpsc;
@@ -740,6 +848,7 @@ mod tests {
             id,
             crate::run_registry::RunHandle {
                 cancel_tx,
+                detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: Some(input_tx),
                 connector: None,
@@ -1098,6 +1207,7 @@ mod tests {
         let task = tokio::spawn(async {});
         let handle = crate::run_registry::RunHandle {
             cancel_tx,
+            detach_tx: std::sync::Mutex::new(None),
             task,
             input_tx: None,
             connector: None,
@@ -1116,6 +1226,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_request_detach_registered_run_accepts_and_fires_the_signal() {
+        use std::sync::Mutex;
+        use tokio::sync::oneshot;
+        let run_id = u32::MAX - 23;
+        let (cancel_tx, _cancel_rx) = oneshot::channel();
+        let (detach_tx, detach_rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(async {});
+        let handle = crate::run_registry::RunHandle {
+            cancel_tx,
+            detach_tx: Mutex::new(Some(detach_tx)),
+            task,
+            input_tx: None,
+            connector: None,
+            name: String::new(),
+            image: "detach-test".into(),
+            command: "".into(),
+            started: "1970-01-01T00:00:00Z".into(),
+            status: Mutex::new(lns_ipc::RunStatus::Running),
+            logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
+            config: lns_ipc::RunConfig::default(),
+        };
+        crate::run_registry::register(run_id, handle);
+
+        let resp = handle_request(&Request::RunDetach { run_id }, Instant::now()).await;
+        assert!(matches!(resp, Response::DetachAccepted));
+        assert!(
+            detach_rx.await.is_ok(),
+            "the run's pump must be told to hand off, not cancel",
+        );
+
+        let resp = handle_request(&Request::RunDetach { run_id }, Instant::now()).await;
+        assert!(
+            matches!(resp, Response::Error { .. }),
+            "a second detach is a no-op once the signal is consumed",
+        );
+        let _ = crate::run_registry::cancel(run_id);
+    }
+
+    #[tokio::test]
     async fn forward_session_input_errors_when_input_channel_is_closed() {
         use std::sync::Mutex;
         use tokio::sync::{mpsc, oneshot};
@@ -1126,6 +1275,7 @@ mod tests {
         let task = tokio::spawn(async {});
         let handle = crate::run_registry::RunHandle {
             cancel_tx,
+            detach_tx: std::sync::Mutex::new(None),
             task,
             input_tx: Some(input_tx),
             connector: None,
@@ -1195,8 +1345,9 @@ mod tests {
         let mut sink = FailingWriter;
         let (_tx, mut rx) = mpsc::channel::<WireFrame>(1);
         let (cancel_tx, cancel_rx) = oneshot::channel();
+        let (_detach_tx, detach_rx) = never_detach();
         cancel_tx.send(130).expect("cancel send");
-        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx)
+        let outcome = pump_responses(&mut sink, &mut rx, cancel_rx, detach_rx)
             .await
             .expect("pump returned Result");
         assert!(
@@ -1212,6 +1363,7 @@ mod tests {
             run_id,
             crate::run_registry::RunHandle {
                 cancel_tx,
+                detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: None,
                 connector: None,
@@ -1510,6 +1662,7 @@ mod tests {
             id,
             crate::run_registry::RunHandle {
                 cancel_tx,
+                detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: Some(input_tx),
                 connector: None,

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -271,15 +271,26 @@ pub fn cancel(run_id: u32) -> bool {
     true
 }
 
-pub fn request_detach(run_id: u32) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetachOutcome {
+    Detached,
+    NotAttached,
+    NotFound,
+}
+
+pub fn request_detach(run_id: u32) -> DetachOutcome {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     let Some(handle) = g.as_ref().and_then(|m| m.get(&run_id)) else {
-        return false;
+        return DetachOutcome::NotFound;
     };
     let Some(tx) = handle.detach_tx.lock().expect("detach_tx poisoned").take() else {
-        return false;
+        return DetachOutcome::NotAttached;
     };
-    tx.send(()).is_ok()
+    if tx.send(()).is_ok() {
+        DetachOutcome::Detached
+    } else {
+        DetachOutcome::NotAttached
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -585,9 +596,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_detach_unknown_run_returns_false() {
+    async fn request_detach_unknown_run_reports_not_found() {
         let id = allocate_run_id() + 2_000_000;
-        assert!(!request_detach(id));
+        assert_eq!(request_detach(id), DetachOutcome::NotFound);
     }
 
     #[tokio::test]
@@ -598,11 +609,29 @@ mod tests {
         handle.detach_tx = Mutex::new(Some(detach_tx));
         register(id, handle);
 
-        assert!(request_detach(id));
+        assert_eq!(request_detach(id), DetachOutcome::Detached);
         assert!(detach_rx.await.is_ok(), "detach signal must be delivered");
-        assert!(
-            !request_detach(id),
-            "second detach of the same id must be a no-op"
+        assert_eq!(
+            request_detach(id),
+            DetachOutcome::NotAttached,
+            "a registered run whose detach signal was already consumed is not attached, not absent",
+        );
+        deregister(id);
+    }
+
+    #[tokio::test]
+    async fn request_detach_reports_not_attached_when_the_pump_has_gone() {
+        let id = allocate_run_id();
+        let (mut handle, _cancel_rx) = make_handle();
+        let (detach_tx, detach_rx) = oneshot::channel::<()>();
+        drop(detach_rx);
+        handle.detach_tx = Mutex::new(Some(detach_tx));
+        register(id, handle);
+
+        assert_eq!(
+            request_detach(id),
+            DetachOutcome::NotAttached,
+            "a run whose pump already returned can no longer be detached",
         );
         deregister(id);
     }

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -21,6 +21,7 @@ static ACTIVE: Mutex<Option<HashMap<u32, RunHandle>>> = Mutex::new(None);
 
 pub struct RunHandle {
     pub cancel_tx: oneshot::Sender<i32>,
+    pub detach_tx: Mutex<Option<oneshot::Sender<()>>>,
     pub task: JoinHandle<()>,
     pub input_tx: Option<mpsc::Sender<SessionInput>>,
     pub connector: Option<std::sync::Arc<dyn GuestTransport>>,
@@ -270,6 +271,17 @@ pub fn cancel(run_id: u32) -> bool {
     true
 }
 
+pub fn request_detach(run_id: u32) -> bool {
+    let g = ACTIVE.lock().expect("ACTIVE poisoned");
+    let Some(handle) = g.as_ref().and_then(|m| m.get(&run_id)) else {
+        return false;
+    };
+    let Some(tx) = handle.detach_tx.lock().expect("detach_tx poisoned").take() else {
+        return false;
+    };
+    tx.send(()).is_ok()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoveOutcome {
     Removed,
@@ -330,6 +342,7 @@ mod tests {
         (
             RunHandle {
                 cancel_tx,
+                detach_tx: Mutex::new(None),
                 task,
                 input_tx: None,
                 connector: None,
@@ -569,6 +582,29 @@ mod tests {
 
         assert!(cancel(id));
         assert!(!cancel(id), "second cancel of the same id must be a no-op");
+    }
+
+    #[tokio::test]
+    async fn request_detach_unknown_run_returns_false() {
+        let id = allocate_run_id() + 2_000_000;
+        assert!(!request_detach(id));
+    }
+
+    #[tokio::test]
+    async fn request_detach_fires_the_detach_signal_once() {
+        let id = allocate_run_id();
+        let (mut handle, _cancel_rx) = make_handle();
+        let (detach_tx, detach_rx) = oneshot::channel::<()>();
+        handle.detach_tx = Mutex::new(Some(detach_tx));
+        register(id, handle);
+
+        assert!(request_detach(id));
+        assert!(detach_rx.await.is_ok(), "detach signal must be delivered");
+        assert!(
+            !request_detach(id),
+            "second detach of the same id must be a no-op"
+        );
+        deregister(id);
     }
 
     #[tokio::test]

--- a/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
@@ -15,6 +15,7 @@ pub fn fresh_handle(
     let task = tokio::spawn(async {});
     lns_service::run_registry::RunHandle {
         cancel_tx,
+        detach_tx: std::sync::Mutex::new(None),
         task,
         input_tx: None,
         connector: None,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -39,7 +39,7 @@ run, which requires a `COMMAND` after `--`.
 | `-i`, `--interactive`        | `true`           | Keep stdin open and forward host stdin to the workload. Disable with `--interactive=false` (or `-i=false`). |
 | `-t`, `--tty`                | `true`           | Allocate a PTY; pipe mode is auto-selected when stdin isn't a TTY. Disable with `--tty=false` (or `-t=false`). |
 | `-d`, `--detach`             | `false`          | Return immediately; the run continues in the service. Conflicts with `-i`/`-t`. |
-| `--detach-keys <CHORD>`      | `ctrl-p,ctrl-q`  | Comma-separated detach chord (single chars or `ctrl-X`).                |
+| `--detach-keys <CHORD>`      | `ctrl-p,ctrl-q`  | Detach chord (single chars or `ctrl-X`, comma-separated). On match `lns` returns `0` and leaves the run executing in the background — re-join with `lns sandbox attach`; no signal is sent. Killing `lns` without the chord cancels the run. |
 | `--sandbox-user <NAME>`      | `sandbox`        | Username the workload runs as inside the guest.                         |
 | `--sandbox-uid <UID>`        | `65534`          | UID the workload runs as inside the guest.                              |
 | `-- <COMMAND...>`            |                  | Override the entrypoint and command. Everything after `--`.             |

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -276,16 +276,21 @@ A detached run is reachable later via the
 
 ### Detaching from an attached run
 
-While attached, the detach chord (default `ctrl-p,ctrl-q`) sends `SIGHUP` to the
-workload and returns its exit code; the run does not keep running once you leave.
-To start something you can step away from and re-join, use `-d` and
-[`lns sandbox attach`](#attaching). Change the chord with `--detach-keys`:
+While attached, the detach chord (default `ctrl-p,ctrl-q`) is a docker-style
+detach: `lns` returns `0` and the run keeps executing in the background — no
+signal is sent to the workload. Re-join it any time with
+[`lns sandbox attach`](#attaching), and detach again with the same chord. Change
+the chord with `--detach-keys`:
 
 ```bash
 lns run --detach-keys ctrl-x,ctrl-x ghcr.io/acme/agent
 ```
 
 The value is a comma-separated chord of single characters or `ctrl-X` tokens.
+
+A deliberate detach is distinct from the `lns` process dying unexpectedly: if the
+CLI is killed (or its connection drops) without the chord, the attached run is
+cancelled. Use the chord — or start the run with `-d` — to step away safely.
 
 ## `lns sandbox` — managing runs you've started
 


### PR DESCRIPTION
## What

`lns run -it`'s detach chord (`ctrl-p,ctrl-q`) was **terminate-and-exit**: it sent `SIGHUP` to the workload's foreground process group and the CLI returned the workload's exit code (129 for an `sh` killed by SIGHUP). The run did not survive.

It is now a **docker-style detach**, matching `lns sandbox attach`: the CLI returns `0` and the run keeps executing in the background. Re-join it with `lns sandbox attach`.

Closes #58.

## How

The service ties an attached (non-`-d`) run to its CLI — `post_pump_action` mapped a CLI stream-close on a non-detached run to `CancelAndDeregister`. The fix threads a deliberate **detach intent** through the IPC so the service can tell a deliberate detach apart from an accidental CLI crash:

- **`lns-ipc`** — new `Request::RunDetach { run_id }` / `Response::DetachAccepted`.
- **`lns-service`** — `RunDetach` fires a per-run oneshot (`detach_tx` on `RunHandle`); the response pump (`pump_responses`) returns a new `PumpOutcome::Detached`, which `post_pump_action` maps to `BackgroundDrain` (keep running) instead of `CancelAndDeregister`. The run's output keeps flowing into the log buffer, so a later `attach` re-joins it.
- **`lns-cli`** — `lns run`/`exec` no longer hardcode `SignalAndDrain`. `lns run` drives the new `DetachBehaviour::DetachRun`: on the chord it flushes pending input, sends `RunDetach`, sends **no signal**, and returns `0` without draining. `lns exec` keeps its prior `SignalAndDrain` behaviour (exec sessions aren't independently registered, so "leave running + re-attach" doesn't map onto the current model).

## Disconnect policy (acceptance criterion)

A **deliberate** detach (chord) leaves the run running. An **accidental** disconnect — the `lns` process dying without the chord — still cancels the attached run (`WriteFailed` + not-detached → `CancelAndDeregister`, unchanged). Documented in `docs/running-workloads.md` and `docs/cli-reference.md`.

## Tests

- Layer 3: `request_detach` (registry), `PumpOutcome::Detached` → `BackgroundDrain`, `pump_responses` returns `Detached` on signal / ignores a dropped sender, `handle_request(RunDetach)` accept + unknown-run error, `plan_feed` Trigger sends `RunDetach` (no SIGHUP) for `DetachRun`, `exit_code_after_detach(DetachRun)` returns 0 without draining, IPC round-trips.
- Smoke: `crates/lns-cli/tests/smoke/interactive-shell.exp` contract #3 rewritten — chord → exit `0`, run still listed by `lns sandbox ls`, `lns sandbox attach` re-joins (manual, needs a live microVM).
- Gate: `make lint`, `make complexity`, and the affected-crates coverage gate (lns-ipc / lns-service / lns-cli all 100% on changed files) pass locally.