### PR TITLE
fix(registry): apply loopback/plain-HTTP protocol in verify_login

### DIFF
--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -61,8 +61,13 @@ pub async fn verify_login(registry: &str, username: &str, secret: &str) -> Resul
     let reference: Reference = format!("{registry}/{LOGIN_PROBE_REPOSITORY}")
         .parse()
         .with_context(|| format!("invalid registry {registry:?}"))?;
+    let protocol = super::registry_protocol(
+        std::env::var("LNS_REGISTRY_PLAIN_HTTP").ok().as_deref(),
+        Some(registry),
+    );
     let client = oci_client::Client::new(ClientConfig {
         platform_resolver: Some(Box::new(linux_platform_resolver)),
+        protocol,
         ..Default::default()
     });
     let auth = RegistryAuth::Basic(username.to_string(), secret.to_string());


### PR DESCRIPTION
**Stacked on #61** (base = `feat/registry-login-policy-artifacts`; retarget to `main` once #61 merges). Depends on #61's `registry_protocol` helper, which isn't in `main` yet.

## The bug

`lns login localhost:<port>` against a plain-HTTP loopback registry always failed:

```
Error: login to localhost:8080 was rejected: error sending request for url (https://localhost:8080/v2/)
```

`verify_login` built its oci-client with `ClientConfig { platform_resolver, ..Default::default() }`, leaving `protocol: Https`. So the login probe always used `https://`, even for loopback — despite the pull/push path already selecting HTTP for loopback via `registry_protocol` (added in #61's `6442702`). Login and pull/push disagreed on scheme.

## The fix

Route `verify_login` through the same selection the pull builder (`RealRegistry::for_reference`) uses:

```rust
let protocol = super::registry_protocol(
    std::env::var("LNS_REGISTRY_PLAIN_HTTP").ok().as_deref(),
    Some(registry),
);
```

Now `lns login` picks HTTP for loopback registries (and honors `LNS_REGISTRY_PLAIN_HTTP`) exactly like pull/push.

## Verification

Reproduced and fixed against a local Harbor (`oidc_auth` mode) at `localhost:8080`: before the fix `lns login` errored on `https://localhost:8080/v2/`; after, `lns login -u <user> --password-stdin localhost:8080` succeeds, and a full push → `lns run` → `lns sandbox commit` round-trip works over plain HTTP.

`cargo check -p lns-service` clean. `crates/lns-service/src/image/real.rs` is already in the coverage IGNORES table (oci-client production wiring leaf), so no new test is required.