### PR TITLE
fix(ci): build Linux release binaries against a glibc 2.35 floor

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -129,14 +129,19 @@ jobs:
             os: darwin
             arch: aarch64
             runner: macos-latest
+          # Pinned to 22.04 (glibc 2.35) to set the Linux release glibc floor:
+          # the host binaries are dynamic-glibc (lns-service links GTK for the
+          # tray, so static-musl is out), making the runner's glibc the floor.
+          # The "Enforce glibc baseline" step fails the build if it creeps above
+          # 2.35 — don't move these to ubuntu-latest.
           - target: aarch64-unknown-linux-gnu
             os: linux
             arch: aarch64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
           - target: x86_64-unknown-linux-gnu
             os: linux
             arch: x86_64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     environment: release
@@ -213,6 +218,30 @@ jobs:
 
       - name: Build lns-service
         run: cargo build --release --locked --target ${{ matrix.target }} -p lns-service
+
+      - name: Enforce glibc baseline (Linux only)
+        if: matrix.os == 'linux'
+        env:
+          GLIBC_FLOOR: "2.35"
+        run: |
+          set -euo pipefail
+          check() {
+            local bin="$1" max
+            max=$(objdump -T "$bin" \
+              | grep -oE 'GLIBC_[0-9]+\.[0-9]+' \
+              | sed 's/GLIBC_//' | sort -V | tail -1)
+            if [ -z "$max" ]; then
+              echo "::error::$bin exposes no GLIBC_ version symbols; cannot verify the floor"
+              exit 1
+            fi
+            if [ "$(printf '%s\n%s\n' "$max" "$GLIBC_FLOOR" | sort -V | tail -1)" != "$GLIBC_FLOOR" ]; then
+              echo "::error::$bin requires glibc $max, above the $GLIBC_FLOOR baseline — would not run on the oldest supported LTS"
+              exit 1
+            fi
+            echo "$bin: max required glibc $max (floor $GLIBC_FLOOR) — OK"
+          }
+          check "target/${{ matrix.target }}/release/lns"
+          check "target/${{ matrix.target }}/release/lns-service"
 
       - name: Codesign with virtualization entitlement (macOS only)
         if: matrix.os == 'darwin'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Lens Sandbox is a local desktop app that runs AI agents, commands, OCI images, a
 curl -fsSL https://get.lns.run | bash
 ```
 
-This installs the `lns` CLI and the `lns-service` background service. Lens Sandbox runs on **macOS on Apple Silicon** (M-series, via the Virtualization framework) and **Linux on x86_64/aarch64** (via KVM + Cloud Hypervisor — needs `/dev/kvm` plus `cloud-hypervisor` and `virtiofsd`). Windows support is on the roadmap.
+This installs the `lns` CLI and the `lns-service` background service. Lens Sandbox runs on **macOS on Apple Silicon** (M-series, via the Virtualization framework) and **Linux on x86_64/aarch64** (glibc 2.35+, e.g. Ubuntu 22.04+; via KVM + Cloud Hypervisor — needs `/dev/kvm` plus `cloud-hypervisor` and `virtiofsd`). Windows support is on the roadmap.
 
 ## Quickstart
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,10 @@ credential-shaped placeholders, the same "policy you run into, not write."
 macOS on Apple Silicon and Linux (x86_64 / aarch64) are supported. Windows support
 is on the roadmap and not yet available.
 
+The Linux binaries require **glibc 2.35 or newer** — Ubuntu 22.04 LTS and newer,
+Debian 12 and newer, Fedora 36 and newer, and current rolling releases (Arch,
+openSUSE Tumbleweed) all qualify. Check yours with `ldd --version`.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Problem

The installer works on Linux, but the **released binaries don't run** on Ubuntu 22.04 LTS (or any still-supported LTS older than 24.04):

```
/home/.../lns: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by .../lns)
```

The host binaries (`lns`, `lns-service`) are dynamic-glibc — `lns-service` links GTK for the tray, so static-musl isn't an option — which makes the **build runner's glibc the release floor**. `ubuntu-latest` silently rolled to 24.04 (glibc 2.39), dragging the floor up so the binaries refuse to start on 22.04 (glibc 2.35) and older. Purely a build-baseline regression; the code is fine (a binary built locally against glibc 2.35 runs).

## Fix

- Pin both Linux release runners to **`ubuntu-22.04` / `ubuntu-22.04-arm`** (glibc 2.35 — the oldest LTS in standard support, EOL April 2027).
- Add an **"Enforce glibc baseline"** step that fails the release build if either binary's required glibc creeps above 2.35, so the baseline can't silently regress again.
- Document the glibc 2.35 floor in `docs/getting-started.md` and `README.md` (positive framing — supported distros + `ldd --version` self-check).

## Shipping the corrected binaries

This fixes the *pipeline*; the already-published 0.14.0 tarballs are still glibc 2.39. To ship rebuilt binaries: either cut a new release (this PR's `fix:` commit will), or re-run `release-please.yml` via `workflow_dispatch` with `force_build_lns` against the existing tag.

## Out of scope

- The same report's tray-lib and microVM-runtime warnings are already handled (installer apt one-liner; the cloud-hypervisor/virtiofsd PATH check is on `main`, pending the lns-install 0.6.0 release in #86).
- Reaching below 2.35 (RHEL 9 / SLES 15 / Amazon Linux at glibc 2.31–2.34) would require `cargo-zigbuild`; deliberately deferred — revisit if real demand appears.