### PR TITLE
Persist run history for sandbox ls --all

### DIFF
--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -23,9 +23,9 @@ pub struct SandboxArgs {
 pub enum SandboxCommand {
     #[command(
         visible_alias = "list",
-        about = "List active runs (`docker ps`-style)."
+        about = "List running runs (`docker ps`-style); use --all for finished history."
     )]
-    Ls,
+    Ls(SandboxLsArgs),
     #[command(about = "Open a new session (`docker exec`-style) against a running run.")]
     Exec(ExecArgs),
     #[command(about = "Send a signal to a running run (`docker kill`-style).")]
@@ -48,6 +48,17 @@ pub enum SandboxCommand {
     Rename(SandboxRenameArgs),
     #[command(about = "Remove all finished runs from the list (`docker container prune`-style).")]
     Prune,
+}
+
+#[derive(clap::Args)]
+pub struct SandboxLsArgs {
+    #[arg(
+        short = 'a',
+        long,
+        default_value_t = false,
+        help = "Show finished runs from the durable run history as well as active runs."
+    )]
+    pub all: bool,
 }
 
 #[derive(clap::Args)]
@@ -142,7 +153,7 @@ pub struct SandboxRenameArgs {
 
 pub fn augment(app: clap::Command) -> clap::Command {
     app.subcommand(subcommand::<SandboxArgs>("sandbox").about(
-        "Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.",
+        "Manage sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.",
     ))
 }
 
@@ -183,7 +194,7 @@ where
     E: AsyncWriteExt + Unpin,
 {
     match cmd {
-        SandboxCommand::Ls => ls(svc, out).await,
+        SandboxCommand::Ls(args) => ls(svc, args, out).await,
         SandboxCommand::Kill(args) => kill(svc, args, out).await,
         SandboxCommand::Exec(_) => bail!("sandbox exec is dispatched on its own interactive path"),
         SandboxCommand::Stop(args) => stop(svc, args, out).await,
@@ -205,8 +216,12 @@ pub(crate) fn run_label(run: &str) -> String {
     }
 }
 
-async fn ls<W: std::io::Write>(svc: &impl SandboxService, out: &mut W) -> Result<i32> {
-    let response = svc.one_shot(Request::ListRuns).await?;
+async fn ls<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &SandboxLsArgs,
+    out: &mut W,
+) -> Result<i32> {
+    let response = svc.one_shot(Request::ListRuns { all: args.all }).await?;
     match response {
         Response::RunList { mut runs } => {
             runs.sort_by(|a, b| b.started.cmp(&a.started));
@@ -648,7 +663,9 @@ mod tests {
             message: "registry poisoned".into(),
         });
         let mut out = Vec::new();
-        let err = ls(&svc, &mut out).await.unwrap_err();
+        let err = ls(&svc, &SandboxLsArgs { all: false }, &mut out)
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("registry poisoned"));
     }
 
@@ -656,8 +673,24 @@ mod tests {
     async fn ls_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = ls(&svc, &mut out).await.unwrap_err();
+        let err = ls(&svc, &SandboxLsArgs { all: false }, &mut out)
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[tokio::test]
+    async fn ls_all_sets_the_all_field_on_the_request() {
+        let svc = CannedService::new(Response::RunList { runs: vec![] });
+        let mut out = Vec::new();
+        let code = ls(&svc, &SandboxLsArgs { all: true }, &mut out)
+            .await
+            .unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(
+            *svc.requests.lock().unwrap(),
+            vec![Request::ListRuns { all: true }]
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -60,7 +60,20 @@ pub const KILL_SPEC: CommandSpec = CommandSpec {
 };
 
 pub fn augment_ls(app: clap::Command) -> clap::Command {
-    app.subcommand(clap::Command::new("ls").visible_alias("list").hide(true))
+    app.subcommand(
+        clap::Command::new("ls")
+            .visible_alias("list")
+            .hide(true)
+            .arg(
+                clap::Arg::new("all")
+                    .short('a')
+                    .long("all")
+                    .action(clap::ArgAction::SetTrue)
+                    .help(
+                        "Show finished runs from the durable run history as well as active runs.",
+                    ),
+            ),
+    )
 }
 
 pub const LS_SPEC: CommandSpec = CommandSpec {

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -51,10 +51,10 @@ pub fn kill_command<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunF
     })
 }
 
-pub fn ls_command<'a>(_matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {
+pub fn ls_command<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         require_running().await;
-        ls().await?;
+        ls(matches.get_flag("all")).await?;
         Ok(0)
     })
 }
@@ -304,9 +304,9 @@ pub async fn kill(args: KillArgs) -> Result<()> {
     }
 }
 
-pub async fn ls() -> Result<()> {
+pub async fn ls(all: bool) -> Result<()> {
     let socket = super::socket_path()?;
-    let response = real::send_request(&socket, &Request::ListRuns)
+    let response = real::send_request(&socket, &Request::ListRuns { all })
         .await
         .ok_or_else(|| anyhow::anyhow!("no response from lns-service (is it running?)"))?;
     let mut rows = match response {

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -42,6 +42,12 @@ Feature: managing running sandboxes from the CLI
     And the output contains "running"
     And the service received a ListRuns request
 
+  Scenario: sandbox ls --all asks the service for historical runs too
+    Given the service reports a run listing with run 3 of image "some-image" running
+    When the user runs sandbox command "ls --all"
+    Then the exit code is 0
+    And the service received a ListRuns --all request
+
   Scenario: sandbox list is an alias for sandbox ls
     Given the service reports a run listing with run 3 of image "some-image" running
     When the user runs sandbox command "list"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -156,10 +156,20 @@ fn canned_run_listing(w: &mut BehaviourWorld, run_id: u32, image: String) {
 #[then("the service received a ListRuns request")]
 fn then_list_runs_request(w: &mut BehaviourWorld) -> Result<(), String> {
     let requests = w.sandbox.requests.lock().unwrap();
-    if requests.contains(&Request::ListRuns) {
+    if requests.contains(&Request::ListRuns { all: false }) {
         Ok(())
     } else {
         Err(format!("expected ListRuns among {requests:?}"))
+    }
+}
+
+#[then("the service received a ListRuns --all request")]
+fn then_list_runs_all_request(w: &mut BehaviourWorld) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    if requests.contains(&Request::ListRuns { all: true }) {
+        Ok(())
+    } else {
+        Err(format!("expected ListRuns --all among {requests:?}"))
     }
 }
 

--- a/crates/lns-ipc/src/codec.rs
+++ b/crates/lns-ipc/src/codec.rs
@@ -275,6 +275,20 @@ mod tests {
     }
 
     #[test]
+    fn list_runs_defaults_to_live_only_when_the_all_field_is_absent() {
+        let decoded: Request = serde_json::from_slice(br#"{"type":"ListRuns"}"#).unwrap();
+        assert_eq!(decoded, Request::ListRuns { all: false });
+    }
+
+    #[test]
+    fn list_runs_round_trips_with_all_enabled() {
+        let request = Request::ListRuns { all: true };
+        let frame = encode_frame(&request).unwrap();
+        let decoded: Request = decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
     fn rejects_frame_too_large() {
         let mut buf = Vec::new();
         buf.extend_from_slice(&FRAME_MAGIC);

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -13,7 +13,10 @@ pub use codec::{
     decode_wire_frame_from_payload, decode_wire_frame_sync, encode_frame, encode_raw_frame,
     encode_wire_frame, read_frame_bytes_async,
 };
-pub use paths::{CachePathError, audit_anchor_for_run, audit_log_for_run, cache_root, data_root};
+pub use paths::{
+    CachePathError, audit_anchor_for_run, audit_log_for_run, cache_root, data_root,
+    run_metadata_for_run,
+};
 pub use protocol::{
     BindMount, BindSpec, ExecImageArgs, ImageInfo, LogLevel, MountSpec, PortPublish, Protocol,
     Request, Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary,

--- a/crates/lns-ipc/src/paths.rs
+++ b/crates/lns-ipc/src/paths.rs
@@ -29,6 +29,10 @@ pub fn audit_anchor_for_run(run_id: &str) -> Result<PathBuf, CachePathError> {
     Ok(cache_root()?.join("runs").join(run_id).join("audit.anchor"))
 }
 
+pub fn run_metadata_for_run(run_id: &str) -> Result<PathBuf, CachePathError> {
+    Ok(data_root()?.join("runs").join(run_id).join("run.json"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,6 +50,13 @@ mod tests {
         let anchor = audit_anchor_for_run("42").expect("audit_anchor_for_run");
         assert_eq!(anchor.parent(), log.parent());
         assert!(anchor.ends_with("runs/42/audit.anchor"));
+    }
+
+    #[test]
+    fn run_metadata_path_appends_runs_runid_filename_under_data_root() {
+        let root = data_root().expect("data dir resolves in test env");
+        let p = run_metadata_for_run("42").expect("run_metadata_for_run");
+        assert_eq!(p, root.join("runs").join("42").join("run.json"));
     }
 
     #[test]

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -36,7 +36,10 @@ pub enum Request {
         run: String,
         signal: SignalKind,
     },
-    ListRuns,
+    ListRuns {
+        #[serde(default)]
+        all: bool,
+    },
     StopRun {
         run: String,
         timeout_secs: u64,

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -463,19 +463,30 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             input_tx: Some(input_tx),
             connector: None,
             name: String::new(),
-            image: image_label,
-            command: command_label,
-            started: started_label,
+            image: image_label.clone(),
+            command: command_label.clone(),
+            started: started_label.clone(),
             status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
             logs,
             config,
         },
     );
-    if let Err(message) = registered {
-        abort.abort();
-        let _ = write_error(&mut stream, message).await;
-        return Ok(());
-    }
+    let run_name = match registered {
+        Ok(run_name) => run_name,
+        Err(message) => {
+            abort.abort();
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
+    persist_run_summary(lns_ipc::RunSummary {
+        id: run_id,
+        name: run_name,
+        image: image_label,
+        command: command_label,
+        status: lns_ipc::RunStatus::Running,
+        started: started_label,
+    });
 
     drop(frame_tx);
 
@@ -499,6 +510,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
     match post_pump_action(&outcome, detached) {
         PostPumpAction::Retain => {
             crate::run_registry::mark_exited_from_log(run_id);
+            persist_run_summary_from_registry(run_id);
         }
         PostPumpAction::BackgroundDrain => {
             if let PumpOutcome::WriteFailed(e) = &outcome {
@@ -507,6 +519,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             tokio::spawn(async move {
                 while frame_rx.recv().await.is_some() {}
                 crate::run_registry::mark_exited_from_log(run_id);
+                persist_run_summary_from_registry(run_id);
             });
         }
         PostPumpAction::CancelAndDeregister => {
@@ -518,6 +531,18 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
         }
     }
     Ok(())
+}
+
+fn persist_run_summary(summary: lns_ipc::RunSummary) {
+    if let Err(e) = crate::run_metadata::persist(&summary) {
+        log::warn!(run_id = summary.id, error = %format_args!("{e:#}"), "failed to persist run metadata");
+    }
+}
+
+fn persist_run_summary_from_registry(run_id: u32) {
+    if let Some(summary) = crate::run_registry::summary(run_id) {
+        persist_run_summary(summary);
+    }
 }
 
 async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> anyhow::Result<()> {

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -148,9 +148,7 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             forward_session_input(*run_id, session_input_from_signal(*signal), "RunSignal").await
         }
         Request::Kill { run, signal } => kill_request(run, *signal).await,
-        Request::ListRuns => Response::RunList {
-            runs: crate::run_registry::snapshot(),
-        },
+        Request::ListRuns { all } => list_runs_response(*all),
         Request::ListVolumes => volume_response(
             crate::volume_store::list()
                 .await
@@ -220,9 +218,7 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             Ok(()) => Response::Acknowledged,
             Err(message) => Response::Error { message },
         },
-        Request::PruneRuns => Response::RunsPruned {
-            removed: crate::run_registry::prune_exited(),
-        },
+        Request::PruneRuns => prune_runs_request(),
         Request::RunLogs { .. } => {
             unreachable!("Request::RunLogs must be dispatched via handle_logs, not handle_request")
         }
@@ -289,19 +285,93 @@ fn inspect_run_request(run: &str) -> Response {
 fn remove_run_request(run: &str) -> Response {
     let id = match crate::run_registry::resolve(run) {
         Ok(id) => id,
-        Err(message) => return Response::Error { message },
+        Err(live_message) => match crate::run_metadata::resolve_disk_handle(run) {
+            Ok(Some(id)) => {
+                return match crate::run_metadata::remove_run_dirs(id) {
+                    Ok(()) => Response::Acknowledged,
+                    Err(e) => Response::Error {
+                        message: format!("{e:#}"),
+                    },
+                };
+            }
+            Ok(None) => {
+                return Response::Error {
+                    message: live_message,
+                };
+            }
+            Err(e) => {
+                return Response::Error {
+                    message: format!("{e:#}"),
+                };
+            }
+        },
     };
     match crate::run_registry::remove_if_exited(id) {
-        crate::run_registry::RemoveOutcome::Removed => Response::Acknowledged,
+        crate::run_registry::RemoveOutcome::Removed => {
+            remove_run_dirs_response(id).unwrap_or(Response::Acknowledged)
+        }
         crate::run_registry::RemoveOutcome::Running => Response::Error {
             message: format!(
                 "run {id} is still running; stop it first with `lns sandbox stop {id}`"
             ),
         },
-        crate::run_registry::RemoveOutcome::NotFound => Response::Error {
-            message: format!("no run with id {id}"),
+        crate::run_registry::RemoveOutcome::NotFound => {
+            match crate::run_metadata::resolve_disk_handle(run) {
+                Ok(Some(id)) => remove_run_dirs_response(id).unwrap_or(Response::Acknowledged),
+                Ok(None) => Response::Error {
+                    message: format!("no run with id {id}"),
+                },
+                Err(e) => Response::Error {
+                    message: format!("{e:#}"),
+                },
+            }
+        }
+    }
+}
+
+fn list_runs_response(all: bool) -> Response {
+    let live = crate::run_registry::snapshot();
+    if !all {
+        return Response::RunList { runs: live };
+    }
+    match crate::run_metadata::list() {
+        Ok(disk) => Response::RunList {
+            runs: crate::run_metadata::merge_live_and_disk(live, disk),
+        },
+        Err(e) => Response::Error {
+            message: format!("{e:#}"),
         },
     }
+}
+
+fn remove_run_dirs_response(id: u32) -> Option<Response> {
+    crate::run_metadata::remove_run_dirs(id)
+        .err()
+        .map(|e| Response::Error {
+            message: format!("{e:#}"),
+        })
+}
+
+fn prune_runs_request() -> Response {
+    let live_before = crate::run_registry::snapshot();
+    let disk = match crate::run_metadata::list() {
+        Ok(disk) => disk,
+        Err(e) => {
+            return Response::Error {
+                message: format!("{e:#}"),
+            };
+        }
+    };
+    let mut removed = crate::run_registry::prune_exited();
+    removed.extend(crate::run_metadata::disk_only_ids(&live_before, &disk));
+    removed.sort_unstable();
+    removed.dedup();
+    for id in &removed {
+        if let Some(response) = remove_run_dirs_response(*id) {
+            return response;
+        }
+    }
+    Response::RunsPruned { removed }
 }
 
 fn volume_response(result: anyhow::Result<Response>) -> Response {
@@ -1008,7 +1078,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_list_runs_returns_snapshot() {
-        let response = handle_request(&Request::ListRuns, Instant::now()).await;
+        let response = handle_request(&Request::ListRuns { all: false }, Instant::now()).await;
         assert!(matches!(response, Response::RunList { .. }));
     }
 

--- a/crates/lns-service/src/lib.rs
+++ b/crates/lns-service/src/lib.rs
@@ -25,6 +25,7 @@ pub mod paths;
 pub mod relay;
 pub mod run;
 pub mod run_log;
+pub mod run_metadata;
 pub mod run_name;
 pub mod run_registry;
 pub mod runtime_layer;

--- a/crates/lns-service/src/run_metadata.rs
+++ b/crates/lns-service/src/run_metadata.rs
@@ -1,0 +1,467 @@
+use std::collections::HashSet;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use lns_ipc::{RunStatus, RunSummary};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunMetadataRoots {
+    pub metadata_runs: PathBuf,
+    pub scratch_runs: PathBuf,
+}
+
+pub trait RunMetadataFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()>;
+    fn write_secure_file(&self, path: &Path, bytes: &[u8]) -> io::Result<()>;
+    fn read_to_string(&self, path: &Path) -> io::Result<String>;
+    fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<PathBuf>>;
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
+}
+
+#[derive(Clone, Copy)]
+pub struct RealRunMetadataFs;
+
+impl RunMetadataFs for RealRunMetadataFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn write_secure_file(&self, path: &Path, bytes: &[u8]) -> io::Result<()> {
+        write_secure_file(path, bytes)
+    }
+
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+
+    fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+        std::fs::read_dir(path)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect()
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        std::fs::remove_dir_all(path)
+    }
+}
+
+#[cfg(unix)]
+fn write_secure_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let tmp = path.with_extension("json.tmp");
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(&tmp)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    std::fs::rename(tmp, path)
+}
+
+#[cfg(not(unix))]
+fn write_secure_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(tmp, path)
+}
+
+pub fn production_roots() -> Result<RunMetadataRoots> {
+    Ok(RunMetadataRoots {
+        metadata_runs: lns_ipc::data_root()?.join("runs"),
+        scratch_runs: lns_ipc::cache_root()?.join("runs"),
+    })
+}
+
+pub fn persist(summary: &RunSummary) -> Result<()> {
+    persist_with(
+        &RealRunMetadataFs,
+        &production_roots()?.metadata_runs,
+        summary,
+    )
+}
+
+pub fn list() -> Result<Vec<RunSummary>> {
+    list_with(&RealRunMetadataFs, &production_roots()?.metadata_runs)
+}
+
+pub fn remove_run_dirs(run_id: u32) -> Result<()> {
+    remove_run_dirs_with(&RealRunMetadataFs, &production_roots()?, run_id)
+}
+
+pub fn resolve_disk_handle(handle: &str) -> Result<Option<u32>> {
+    resolve_disk_handle_from(&list()?, handle)
+}
+
+pub fn merge_live_and_disk(live: Vec<RunSummary>, disk: Vec<RunSummary>) -> Vec<RunSummary> {
+    let live_ids: HashSet<u32> = live.iter().map(|run| run.id).collect();
+    disk.into_iter()
+        .filter(|run| !live_ids.contains(&run.id))
+        .chain(live)
+        .collect()
+}
+
+pub fn disk_only_ids(live: &[RunSummary], disk: &[RunSummary]) -> Vec<u32> {
+    let live_ids: HashSet<u32> = live.iter().map(|run| run.id).collect();
+    disk.iter()
+        .filter(|run| !live_ids.contains(&run.id))
+        .map(|run| run.id)
+        .collect()
+}
+
+pub fn persist_with(
+    fs: &impl RunMetadataFs,
+    metadata_runs: &Path,
+    summary: &RunSummary,
+) -> Result<()> {
+    let path = metadata_runs.join(summary.id.to_string()).join("run.json");
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("run metadata path has no parent: {}", path.display()))?;
+    fs.create_dir_all(parent)
+        .with_context(|| format!("creating {}", parent.display()))?;
+    let bytes = serde_json::to_vec_pretty(summary)?;
+    fs.write_secure_file(&path, &bytes)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+pub fn list_with(fs: &impl RunMetadataFs, metadata_runs: &Path) -> Result<Vec<RunSummary>> {
+    let entries = match fs.read_dir_paths(metadata_runs) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", metadata_runs.display())),
+    };
+    let mut summaries = Vec::new();
+    for entry in entries {
+        let path = entry.join("run.json");
+        match fs.read_to_string(&path) {
+            Ok(contents) => {
+                let mut summary: RunSummary = serde_json::from_str(&contents)
+                    .with_context(|| format!("parsing {}", path.display()))?;
+                normalize_disk_only_status(&mut summary);
+                summaries.push(summary);
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+        }
+    }
+    Ok(summaries)
+}
+
+fn normalize_disk_only_status(summary: &mut RunSummary) {
+    if matches!(summary.status, RunStatus::Running) {
+        summary.status = RunStatus::Exited { code: 130 };
+    }
+}
+
+pub fn remove_run_dirs_with(
+    fs: &impl RunMetadataFs,
+    roots: &RunMetadataRoots,
+    run_id: u32,
+) -> Result<()> {
+    let metadata_file = roots
+        .metadata_runs
+        .join(run_id.to_string())
+        .join("run.json");
+    match fs.read_to_string(&metadata_file) {
+        Ok(_) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", metadata_file.display())),
+    }
+    for root in [&roots.metadata_runs, &roots.scratch_runs] {
+        let path = root.join(run_id.to_string());
+        match fs.remove_dir_all(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("removing {}", path.display())),
+        }
+    }
+    Ok(())
+}
+
+pub fn resolve_disk_handle_from(summaries: &[RunSummary], handle: &str) -> Result<Option<u32>> {
+    if let Ok(id) = handle.parse::<u32>() {
+        return Ok(summaries.iter().any(|run| run.id == id).then_some(id));
+    }
+    let matches: Vec<u32> = summaries
+        .iter()
+        .filter(|run| run.name == handle)
+        .map(|run| run.id)
+        .collect();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        _ => anyhow::bail!("run name {handle:?} is ambiguous in history; use the run id"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct FakeFs {
+        files: RefCell<HashMap<PathBuf, String>>,
+        dirs: RefCell<HashSet<PathBuf>>,
+        removed: RefCell<Vec<PathBuf>>,
+        remove_fail: RefCell<Option<PathBuf>>,
+    }
+
+    impl FakeFs {
+        fn put_summary(&self, root: &Path, summary: &RunSummary) {
+            let dir = root.join(summary.id.to_string());
+            self.dirs.borrow_mut().insert(dir.clone());
+            self.files.borrow_mut().insert(
+                dir.join("run.json"),
+                serde_json::to_string(summary).expect("serialize summary"),
+            );
+        }
+    }
+
+    impl RunMetadataFs for FakeFs {
+        fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+            self.dirs.borrow_mut().insert(path.to_path_buf());
+            Ok(())
+        }
+
+        fn write_secure_file(&self, path: &Path, bytes: &[u8]) -> io::Result<()> {
+            self.files.borrow_mut().insert(
+                path.to_path_buf(),
+                String::from_utf8(bytes.to_vec()).expect("metadata is utf8"),
+            );
+            Ok(())
+        }
+
+        fn read_to_string(&self, path: &Path) -> io::Result<String> {
+            self.files
+                .borrow()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))
+        }
+
+        fn read_dir_paths(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+            let children = self
+                .dirs
+                .borrow()
+                .iter()
+                .filter(|dir| dir.parent() == Some(path))
+                .cloned()
+                .collect();
+            Ok(children)
+        }
+
+        fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+            if self.remove_fail.borrow().as_ref() == Some(&path.to_path_buf()) {
+                return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+            }
+            self.removed.borrow_mut().push(path.to_path_buf());
+            Ok(())
+        }
+    }
+
+    fn summary(id: u32, name: &str, status: RunStatus) -> RunSummary {
+        RunSummary {
+            id,
+            name: name.into(),
+            image: "some-image".into(),
+            command: "some-command".into(),
+            status,
+            started: format!("2026-01-01T00:00:0{id}Z"),
+        }
+    }
+
+    #[test]
+    fn persist_writes_run_json_under_the_data_runs_root() {
+        let fs = FakeFs::default();
+        let root = Path::new("/data/runs");
+        let run = summary(7, "reviewer", RunStatus::Running);
+
+        persist_with(&fs, root, &run).unwrap();
+
+        let path = root.join("7/run.json");
+        let written = fs.files.borrow().get(&path).cloned().unwrap();
+        assert!(written.contains("\"id\": 7"), "got: {written}");
+        assert!(fs.dirs.borrow().contains(&root.join("7")));
+    }
+
+    #[test]
+    fn list_reads_metadata_and_normalizes_stale_running_runs_to_exited() {
+        let fs = FakeFs::default();
+        let root = Path::new("/data/runs");
+        fs.put_summary(root, &summary(7, "reviewer", RunStatus::Running));
+        fs.put_summary(root, &summary(8, "auditor", RunStatus::Exited { code: 0 }));
+
+        let mut listed = list_with(&fs, root).unwrap();
+        listed.sort_by_key(|run| run.id);
+
+        assert_eq!(listed[0].status, RunStatus::Exited { code: 130 });
+        assert_eq!(listed[1].status, RunStatus::Exited { code: 0 });
+    }
+
+    #[test]
+    fn list_missing_root_returns_empty() {
+        struct MissingRootFs;
+        impl RunMetadataFs for MissingRootFs {
+            fn create_dir_all(&self, _path: &Path) -> io::Result<()> {
+                Ok(())
+            }
+            fn write_secure_file(&self, _path: &Path, _bytes: &[u8]) -> io::Result<()> {
+                Ok(())
+            }
+            fn read_to_string(&self, _path: &Path) -> io::Result<String> {
+                unreachable!("no entries are read when the root is missing")
+            }
+            fn read_dir_paths(&self, _path: &Path) -> io::Result<Vec<PathBuf>> {
+                Err(io::Error::from(io::ErrorKind::NotFound))
+            }
+            fn remove_dir_all(&self, _path: &Path) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        assert!(
+            list_with(&MissingRootFs, Path::new("/missing"))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn merge_live_and_disk_keeps_live_entries_authoritative() {
+        let live = vec![summary(7, "live", RunStatus::Running)];
+        let disk = vec![
+            summary(7, "stale", RunStatus::Exited { code: 130 }),
+            summary(8, "old", RunStatus::Exited { code: 0 }),
+        ];
+
+        let mut merged = merge_live_and_disk(live, disk);
+        merged.sort_by_key(|run| run.id);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].name, "live");
+        assert_eq!(merged[0].status, RunStatus::Running);
+        assert_eq!(merged[1].id, 8);
+    }
+
+    #[test]
+    fn disk_only_ids_excludes_live_runs() {
+        let live = vec![summary(7, "live", RunStatus::Running)];
+        let disk = vec![
+            summary(7, "stale", RunStatus::Exited { code: 130 }),
+            summary(8, "old", RunStatus::Exited { code: 0 }),
+        ];
+
+        assert_eq!(disk_only_ids(&live, &disk), vec![8]);
+    }
+
+    #[test]
+    fn remove_run_dirs_deletes_metadata_and_scratch_dirs() {
+        let fs = FakeFs::default();
+        let roots = RunMetadataRoots {
+            metadata_runs: "/data/runs".into(),
+            scratch_runs: "/cache/runs".into(),
+        };
+        fs.put_summary(
+            &roots.metadata_runs,
+            &summary(9, "reviewer", RunStatus::Exited { code: 0 }),
+        );
+
+        remove_run_dirs_with(&fs, &roots, 9).unwrap();
+
+        assert_eq!(
+            *fs.removed.borrow(),
+            vec![
+                PathBuf::from("/data/runs/9"),
+                PathBuf::from("/cache/runs/9")
+            ]
+        );
+    }
+
+    #[test]
+    fn remove_run_dirs_surfaces_non_not_found_failures() {
+        let fs = FakeFs::default();
+        let roots = RunMetadataRoots {
+            metadata_runs: "/data/runs".into(),
+            scratch_runs: "/cache/runs".into(),
+        };
+        fs.put_summary(
+            &roots.metadata_runs,
+            &summary(9, "reviewer", RunStatus::Exited { code: 0 }),
+        );
+        *fs.remove_fail.borrow_mut() = Some(PathBuf::from("/cache/runs/9"));
+
+        let err = remove_run_dirs_with(&fs, &roots, 9).unwrap_err();
+        assert!(format!("{err:#}").contains("/cache/runs/9"));
+    }
+
+    #[test]
+    fn remove_run_dirs_skips_paths_without_a_metadata_record() {
+        let fs = FakeFs::default();
+        let roots = RunMetadataRoots {
+            metadata_runs: "/data/runs".into(),
+            scratch_runs: "/cache/runs".into(),
+        };
+
+        remove_run_dirs_with(&fs, &roots, 9).unwrap();
+
+        assert!(fs.removed.borrow().is_empty());
+    }
+
+    #[test]
+    fn resolve_disk_handle_accepts_id_or_unique_name() {
+        let summaries = vec![
+            summary(7, "reviewer", RunStatus::Exited { code: 0 }),
+            summary(8, "auditor", RunStatus::Exited { code: 1 }),
+        ];
+
+        assert_eq!(resolve_disk_handle_from(&summaries, "7").unwrap(), Some(7));
+        assert_eq!(
+            resolve_disk_handle_from(&summaries, "auditor").unwrap(),
+            Some(8)
+        );
+        assert_eq!(resolve_disk_handle_from(&summaries, "ghost").unwrap(), None);
+        assert_eq!(resolve_disk_handle_from(&summaries, "99").unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_disk_handle_rejects_ambiguous_names() {
+        let summaries = vec![
+            summary(7, "reviewer", RunStatus::Exited { code: 0 }),
+            summary(8, "reviewer", RunStatus::Exited { code: 1 }),
+        ];
+
+        let err = resolve_disk_handle_from(&summaries, "reviewer").unwrap_err();
+        assert!(format!("{err:#}").contains("ambiguous"));
+    }
+
+    #[test]
+    fn real_fs_writes_and_removes_metadata_in_a_temp_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let metadata_runs = dir.path().join("data/runs");
+        let scratch_runs = dir.path().join("cache/runs");
+        let run = summary(7, "reviewer", RunStatus::Exited { code: 0 });
+
+        persist_with(&RealRunMetadataFs, &metadata_runs, &run).unwrap();
+        std::fs::create_dir_all(scratch_runs.join("7")).unwrap();
+
+        let listed = list_with(&RealRunMetadataFs, &metadata_runs).unwrap();
+        assert_eq!(listed, vec![run]);
+
+        remove_run_dirs_with(
+            &RealRunMetadataFs,
+            &RunMetadataRoots {
+                metadata_runs,
+                scratch_runs,
+            },
+            7,
+        )
+        .unwrap();
+        assert!(!dir.path().join("data/runs/7").exists());
+        assert!(!dir.path().join("cache/runs/7").exists());
+    }
+}

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -248,6 +248,13 @@ fn summary_of(id: u32, h: &RunHandle) -> lns_ipc::RunSummary {
     }
 }
 
+pub fn summary(run_id: u32) -> Option<lns_ipc::RunSummary> {
+    let g = ACTIVE.lock().expect("ACTIVE poisoned");
+    g.as_ref()
+        .and_then(|m| m.get(&run_id))
+        .map(|h| summary_of(run_id, h))
+}
+
 pub fn inspect(run_id: u32) -> Option<lns_ipc::RunDetails> {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     g.as_ref()
@@ -935,6 +942,21 @@ mod tests {
         assert_eq!(row.command, "sleep 1");
         assert_eq!(row.started, "2026-05-21 10:00:00");
         assert_eq!(row.status, RunStatus::Running);
+
+        deregister(id);
+    }
+
+    #[tokio::test]
+    async fn summary_returns_one_registered_run() {
+        let id = allocate_run_id();
+        let (mut handle, _rx) = make_handle();
+        handle.image = "alpine:latest".to_string();
+        register(id, handle);
+
+        let row = summary(id).expect("registered run has a summary");
+        assert_eq!(row.id, id);
+        assert_eq!(row.image, "alpine:latest");
+        assert_eq!(summary(id + 6_000_000), None);
 
         deregister(id);
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -112,10 +112,10 @@ a per-user file (`~/.lns-registry-auth.json`, `0600`; override with
 
 ## `lns sandbox`
 
-Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.
+Manage sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.
 
 ```bash
-lns sandbox ls
+lns sandbox ls [-a|--all]
 lns sandbox exec [OPTIONS] <RUN> -- <COMMAND...>
 lns sandbox kill <RUN> [--signal <SIG>]
 lns sandbox stop <RUN> [-t <SECONDS>]
@@ -133,17 +133,17 @@ interchangeable everywhere a run is addressed.
 
 | Subcommand | Meaning |
 | ---------- | ------- |
-| `ls`       | List active runs (`docker ps`-style). |
+| `ls`       | List running runs by default (`docker ps`-style); `-a` / `--all` also shows finished runs from the durable run history. |
 | `exec`     | Open a new session against a running run (`docker exec`-style). `-i`/`-t` and `--detach-keys` work as for `lns run`; detaching closes only the exec session. |
 | `kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
-| `logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, and only while the run is listed by `lns sandbox ls`. |
+| `logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run while it still has that run in memory. |
 | `attach`   | Re-join a run's live output, most useful after `lns run -d`. The detach chord (`ctrl-p,ctrl-q` by default) leaves the run running and returns you to your shell (docker-attach style; no signal is sent). Stdin reaches the workload only if the run was started with stdin open. |
 | `inspect`  | Print the run's state and launch configuration as JSON, with the policy file's parsed contents embedded when it is readable. |
 | `stats`    | Sample the sandbox's CPU share and memory over one second, via the guest's `/proc`. |
-| `rm`       | Remove a single finished run from the list (`docker rm`-style). Refuses a run that is still running — stop it first. |
+| `rm`       | Remove a single finished run record and its on-disk run directory (`docker rm`-style). Refuses a run that is still running — stop it first. |
 | `rename`   | Give a run a name or change it (`docker rename`-style); the new name resolves immediately and must be unique among listed runs. |
-| `prune`    | Remove every finished run from the list at once (`docker container prune`-style); running runs are left untouched. |
+| `prune`    | Remove every finished run record at once (`docker container prune`-style); running runs are left untouched. |
 
 The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working
 as hidden aliases; the `lns sandbox` forms are the documented ones.

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -297,7 +297,8 @@ cancelled. Use the chord — or start the run with `-d` — to step away safely.
 Everything you do to a run after starting it lives under `lns sandbox`:
 
 ```bash
-lns sandbox ls                 # list active runs
+lns sandbox ls                 # list running runs
+lns sandbox ls -a              # include finished run history
 lns sandbox exec 7 -- bash     # open another session inside a run
 lns sandbox kill 7             # send one signal (default SIGTERM)
 lns sandbox stop 7             # SIGTERM, wait up to 10s, then SIGKILL
@@ -337,7 +338,7 @@ exit, `killed run #7` when it had to escalate.
 ### Logs
 
 The service keeps a rolling capture of every run's stdout and stderr — the most
-recent 2 MiB — for as long as the run is listed by `lns sandbox ls`. `lns sandbox logs`
+recent 2 MiB — while the service still has that run in memory. `lns sandbox logs`
 prints what's buffered; `-f` streams new output until the run exits. Output of
 exec sessions is not captured, only the run's primary session.
 
@@ -365,11 +366,12 @@ so the numbers cover everything the run is doing.
 
 ### Cleaning up the list
 
-A finished run lingers in `lns sandbox ls` (as `exited`) until its teardown
-completes, so you can still read its captured logs. To drop it sooner, `lns
-sandbox rm 7` removes one finished run; `lns sandbox prune` removes every
-finished run at once. Both refuse to touch a run that is still running — stop it
-first with `lns sandbox stop`. Removing a run also discards its buffered logs.
+By default, `lns sandbox ls` shows running runs. Add `-a` / `--all` to include
+finished runs from the durable run history, including runs discovered after a
+service restart. `lns sandbox rm 7` removes one finished run record and its
+on-disk run directory; `lns sandbox prune` removes every finished run at once.
+Both refuse to touch a run that is still running — stop it first with `lns
+sandbox stop`.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- persist run summaries to `data_root()/runs/<id>/run.json` while retaining scratch/cache run data separately
- add `lns sandbox ls --all` and the hidden top-level `lns ls --all` alias to include historical finished runs
- merge live registry state with durable run metadata for list/remove/prune, with tests and docs covering the new behavior

Closes #114.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lns-ipc -p lns-cli -p lns-service --all-targets -- -D warnings`
- `cargo test -p lns-ipc`
- `cargo test -p lns-cli --test behaviours`
- `cargo test -p lns-service --test behaviours`
- `cargo test -p lns-service --lib run_metadata::tests`
- `cargo test -p lns-service --lib run_registry::tests::summary_returns_one_registered_run`
- `cargo test -p lns-cli --lib sandbox::tests::ls`
- `cargo test -p lns-ipc list_runs`

## Notes

Full `cargo test -p lns-cli --lib` and `cargo test -p lns-service --lib` sweeps were attempted, but the managed sandbox blocks local HTTP/Unix socket binds used by unrelated tests (`Operation not permitted`). An escalated rerun was also attempted and rejected by the environment as out of credits.
