### PR TITLE
feat(ocsf): attribute egress events to the guest client endpoint + process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=5f4ca18#5f4ca18f18d3ed3a10c737235d473dc70e8540a4"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=a473cd3#a473cd3173384335a2f73239078be73fdc58e036"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -7135,7 +7135,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=34d52cfd105c35d339cdecaf6c06495674b8acf8#34d52cfd105c35d339cdecaf6c06495674b8acf8"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=5f4ca18#5f4ca18f18d3ed3a10c737235d473dc70e8540a4"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -7135,7 +7135,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/e2e-tests/features/microvm_egress.feature
+++ b/crates/e2e-tests/features/microvm_egress.feature
@@ -3,10 +3,12 @@ Feature: the network cage blocks denied egress from a real guest
   The supervisor confines the workload's traffic to a local enforcing proxy
   whose verdict comes from the loaded policy. This proves the enforcement end
   to end from inside a booted guest: under a deny-all policy a real outbound
-  connection is refused. It is guest-observable and uses the bundled busybox
-  `wget`. The interactive ask/approve flow needs a developer decision and is
-  pinned at Layer 2; this scenario preloads a deciding policy so no prompt is
-  raised. The allow-path (a permitted host is reachable) is deferred: a
+  connection is refused, and the recorded egress event attributes the attempt
+  to the guest client endpoint and owning process. It is guest-observable and
+  uses the bundled busybox `wget`. The interactive ask/approve flow needs a
+  developer decision and is pinned at Layer 2; this scenario preloads a
+  deciding policy so no prompt is raised. The allow-path (a permitted host is
+  reachable) is deferred: a
   reliable assertion needs a deterministic host-side endpoint rather than a
   real-internet host, whose reachability makes the test flaky.
 
@@ -17,3 +19,4 @@ Feature: the network cage blocks denied egress from a real guest
     Then the exit code is 0
     And the output contains "blocked-2"
     And the output does not contain "reached-9"
+    And the audit log for that run records the denied egress with the client endpoint and process

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -109,24 +109,44 @@ fn start_detached_with_volume(world: &mut E2eWorld, cmd_line: String, name: Stri
     }
 }
 
+fn resolve_run_audit_log(run_id: &str) -> Result<std::path::PathBuf, String> {
+    let direct = lns_ipc::audit_log_for_run(run_id)
+        .map_err(|e| format!("resolving audit log path for run {run_id}: {e}"))?;
+    if direct.exists() {
+        return Ok(direct);
+    }
+    let runs_root = direct
+        .parent()
+        .and_then(std::path::Path::parent)
+        .ok_or("audit log path has no runs root")?;
+    std::fs::read_dir(runs_root)
+        .map_err(|e| format!("reading runs root {}: {e}", runs_root.display()))?
+        .flatten()
+        .find(|entry| entry.file_name().to_string_lossy().starts_with(run_id))
+        .map(|entry| entry.path().join("audit.jsonl"))
+        .filter(|candidate| candidate.exists())
+        .ok_or_else(|| {
+            format!(
+                "no run directory matching {run_id:?} under {}",
+                runs_root.display()
+            )
+        })
+}
+
 #[then(regex = r#"^the audit chain for that run records volume "([^"]+)" at "([^"]+)"$"#)]
 fn audit_records_volume(world: &mut E2eWorld, name: String, path: String) -> Result<(), String> {
-    let run_id = world
-        .last_run_id
-        .clone()
-        .ok_or("no run id was captured from the run output")?;
-    let log_path = lns_ipc::audit_log_for_run(&run_id)
-        .map_err(|e| format!("resolving audit log path for run {run_id}: {e}"))?;
+    let run_id = last_run(world)?;
+    let log_path = resolve_run_audit_log(&run_id)?;
     let contents = std::fs::read_to_string(&log_path)
         .map_err(|e| format!("reading audit chain {}: {e}", log_path.display()))?;
     let recorded = contents.lines().any(|line| {
-        line.contains("volume_attached") && line.contains(&name) && line.contains(&path)
+        line.contains("\"lns_kind\":\"volume\"") && line.contains(&name) && line.contains(&path)
     });
     if recorded {
         Ok(())
     } else {
         Err(format!(
-            "no volume_attached event for {name:?} at {path:?} in {}:\n{contents}",
+            "no volume mount event for {name:?} at {path:?} in {}:\n{contents}",
             log_path.display()
         ))
     }
@@ -142,6 +162,30 @@ fn audit_reports_event(world: &mut E2eWorld, kind: String, name: String) -> Resu
     } else {
         Err(format!(
             "`lns audit {id} --kind {kind}` did not report a {kind:?} event naming {name:?}:\n{out}"
+        ))
+    }
+}
+
+#[then("the audit log for that run records the denied egress with the client endpoint and process")]
+fn audit_egress_records_client(world: &mut E2eWorld) -> Result<(), String> {
+    let run_id = last_run(world)?;
+    let log_path = resolve_run_audit_log(&run_id)?;
+    let contents = std::fs::read_to_string(&log_path)
+        .map_err(|e| format!("reading audit log {}: {e}", log_path.display()))?;
+    let line = contents
+        .lines()
+        .find(|l| l.contains("1.1.1.1") && l.contains("\"src_endpoint\""))
+        .ok_or_else(|| {
+            format!(
+                "no egress event carrying src_endpoint for 1.1.1.1 in {}:\n{contents}",
+                log_path.display()
+            )
+        })?;
+    if line.contains("\"actor\"") && line.contains("\"process\"") && line.contains("\"pid\"") {
+        Ok(())
+    } else {
+        Err(format!(
+            "egress event carried src_endpoint but no actor.process:\n{line}"
         ))
     }
 }

--- a/crates/lns-service/src/relay/mod.rs
+++ b/crates/lns-service/src/relay/mod.rs
@@ -206,15 +206,16 @@ fn guest_egress_to_ocsf(
         .get("metadata")
         .and_then(|m| m.get("reason"))
         .and_then(Value::as_str);
-    Some(crate::ocsf_audit::egress_event(
-        cx,
-        method,
-        url,
-        status_code,
-        result,
-        reason,
-        true,
-    ))
+    let mut event =
+        crate::ocsf_audit::egress_event(cx, method, url, status_code, result, reason, true);
+    // The guest resolves the client endpoint + owning process; copy the
+    // OCSF-ready fragments through when present.
+    for key in ["src_endpoint", "actor"] {
+        if let Some(value) = obj.get(key) {
+            event.insert(key.to_string(), value.clone());
+        }
+    }
+    Some(event)
 }
 
 const HOST_RESERVED_EVENTS: &[&str] = &["run_env"];
@@ -935,6 +936,39 @@ mod tests {
         assert_eq!(obj["unmapped"]["lns_result"], "success");
         assert_eq!(obj["unmapped"]["lns_origin"], "guest-proxy");
         assert_eq!(anchor.anchors.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_guest_egress_frame_carries_the_client_endpoint_and_process_through_to_ocsf() {
+        let session = session_with_dummy_sink();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut log = MemLog::default();
+        let mut anchor = MemAnchor::default();
+        handle_inbound(
+            Message::Text(
+                r#"{"type":"audit_event","action":"GET http://api.example.test:443/","result":"success","src_endpoint":{"ip":"10.42.0.31","port":37494},"actor":{"process":{"name":"curl","pid":57}}}"#
+                    .into(),
+            ),
+            &session,
+            &credential_session_with_dummy_sink(),
+            &mut AuditWriter {
+                chain: &mut chain,
+                log: &mut log,
+                anchor: &mut anchor,
+                run: "test-run",
+                microvm: "calm-finch",
+            },
+            &AuditBudget::with_defaults(),
+            &CLOCK,
+        )
+        .await
+        .expect("handle_inbound");
+        let obj: Value =
+            serde_json::from_str(String::from_utf8(log.bytes).unwrap().trim_end()).unwrap();
+        assert_eq!(obj["src_endpoint"]["ip"], "10.42.0.31");
+        assert_eq!(obj["src_endpoint"]["port"], 37494);
+        assert_eq!(obj["actor"]["process"]["name"], "curl");
+        assert_eq!(obj["actor"]["process"]["pid"], 57);
     }
 
     #[tokio::test]

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "34d52cfd105c35d339cdecaf6c06495674b8acf8" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "5f4ca18" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "5f4ca18" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "a473cd3" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
Stacked on #118 (OCSF migration). Attributes every egress OCSF event to the **guest client endpoint** and its **owning process**, so a Network/HTTP Activity event answers "who inside the sandbox reached out" — the OpenShell-style `src_endpoint` + `actor.process` that the host can't synthesize on its own.

### What changes
- **Host relay** (`guest_egress_to_ocsf`): copies the `src_endpoint` and `actor` fragments the guest proxy now resolves straight into the OCSF egress event.
- **Re-pin** `lns-supervisor` at `lens-sandbox-core` `a473cd3` (lensapp/lens-sandbox-core#33), which stamps the transparent plaintext-HTTP path — the busybox `wget` path — with the resolved client context.
- **microVM assertion**: the deny-all `@microvm` egress scenario now asserts the run's `audit.jsonl` egress event carries `src_endpoint` + `actor.process`.

### Validated on a real boot
`make e2e-microvm` (macOS Vz), all 32 `@microvm` scenarios green. The deny-all egress event recorded by a real guest:

```json
{"class_uid":4002,"class_name":"HTTP Activity","activity_name":"Get",
 "actor":{"process":{"name":"busybox","pid":100}},
 "src_endpoint":{"ip":"127.0.0.1","port":41176},
 "dst_endpoint":{"domain":"1.1.1.1","port":80},
 "message":"GET 1.1.1.1:80 — policy-deny → 403 failure",
 "status":"Failure","status_detail":"policy-deny",
 "unmapped":{"lns_kind":"egress","lns_result":"failure",...}}
```

### Also fixed (OCSF-migration debt the manual microVM suite never caught)
- The audit-log e2e steps resolved the **short display run id** against the literal `runs/<id>` path; storage keys by the full id (as `lns audit` resolves a prefix). Added a prefix-resolving helper.
- The volume-audit step still asserted the pre-OCSF `volume_attached` string instead of the File System Activity mount event (`"lns_kind":"volume"`).

### Follow-up
Re-pin to core #33's **merge commit** once it lands (currently pinned at the PR-branch head).
