### PR TITLE
fix(dashboard): stop text corrupting after long uptime by replaying texture deltas eframe drops on hidden-window passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ dev:
 	$(CARGO) build -p lns-cli -p lns-service
 
 # ── Shipping artifacts (not part of the gate) ─────────────────────────
+# The kernel caches a vnode's code signature, so cp over an already-executed
+# binary gets the next exec SIGKILLed on macOS; unlink before copying.
 
 build: build-lns build-lns-service
 
@@ -64,6 +66,7 @@ build-lns:
 		./crates/lns-cli/scripts/codesign-macos.sh "$(CARGO_TARGET_DIR)/release/lns" >/dev/null; \
 	fi
 	@mkdir -p bin
+	@rm -f bin/lns
 	@cp $(CARGO_TARGET_DIR)/release/lns bin/lns
 
 build-lns-service:
@@ -72,6 +75,7 @@ build-lns-service:
 		./crates/lns-cli/scripts/codesign-macos.sh "$(CARGO_TARGET_DIR)/release/lns-service" >/dev/null; \
 	fi
 	@mkdir -p bin
+	@rm -f bin/lns-service
 	@cp $(CARGO_TARGET_DIR)/release/lns-service bin/lns-service
 
 # ── Gate steps ────────────────────────────────────────────────────────

--- a/crates/lns-service/examples/approval_preview.rs
+++ b/crates/lns-service/examples/approval_preview.rs
@@ -250,6 +250,7 @@ fn main() -> eframe::Result {
         Box::new(|cc| {
             cc.egui_ctx.set_visuals(lds_visuals());
             quiet_debug_overlays(&cc.egui_ctx);
+            lns_service::ui::texture_delta_guard::install(&cc.egui_ctx);
             install_system_fonts(&cc.egui_ctx);
             install_icon_font(&cc.egui_ctx);
             Ok(Box::new(Preview {

--- a/crates/lns-service/examples/audit_dashboard.rs
+++ b/crates/lns-service/examples/audit_dashboard.rs
@@ -187,6 +187,7 @@ fn main() -> eframe::Result {
         options,
         Box::new(|cc| {
             quiet_debug_overlays(&cc.egui_ctx);
+            lns_service::ui::texture_delta_guard::install(&cc.egui_ctx);
             install_system_fonts(&cc.egui_ctx);
             install_icon_font(&cc.egui_ctx);
             dashboard::style(&cc.egui_ctx);

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -148,6 +148,7 @@ pub fn run_tray(
         Box::new(move |cc| {
             cc.egui_ctx.set_visuals(window::lds_visuals());
             window::quiet_debug_overlays(&cc.egui_ctx);
+            crate::ui::texture_delta_guard::install(&cc.egui_ctx);
             window::install_system_fonts(&cc.egui_ctx);
             window::install_icon_font(&cc.egui_ctx);
             window::install_ctx(cc.egui_ctx.clone());

--- a/crates/lns-service/src/ui/mod.rs
+++ b/crates/lns-service/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod badge;
 pub mod button;
 pub mod card;
+pub mod texture_delta_guard;
 pub mod theme;
 
 pub use badge::badges;

--- a/crates/lns-service/src/ui/texture_delta_guard.rs
+++ b/crates/lns-service/src/ui/texture_delta_guard.rs
@@ -1,0 +1,159 @@
+use eframe::egui;
+use egui::epaint::textures::TexturesDelta;
+
+/// Recovers the texture updates eframe discards for passes of unpainted windows (emilk/egui: `run_ui_and_paint` skips `paint_and_update_textures` when the window is hidden, losing the pass's drained `TexturesDelta` and desyncing the GPU font atlas until restart) by stashing them and replaying them ahead of the next painted pass.
+#[derive(Default)]
+pub struct TextureDeltaGuard {
+    pass_painted: Vec<bool>,
+    stashed: TexturesDelta,
+}
+
+pub fn install(ctx: &egui::Context) {
+    ctx.add_plugin(TextureDeltaGuard::default());
+}
+
+impl egui::Plugin for TextureDeltaGuard {
+    fn debug_name(&self) -> &'static str {
+        "lns_texture_delta_guard"
+    }
+
+    fn on_begin_pass(&mut self, ui: &mut egui::Ui) {
+        let painted = ui.ctx().input(|i| i.viewport().visible().unwrap_or(true));
+        self.pass_painted.push(painted);
+    }
+
+    fn output_hook(&mut self, output: &mut egui::FullOutput) {
+        let painted = self.pass_painted.pop().unwrap_or(true);
+        if !painted {
+            self.stashed
+                .append(std::mem::take(&mut output.textures_delta));
+        } else if !self.stashed.is_empty() {
+            let mut deltas = std::mem::take(&mut self.stashed);
+            deltas.append(std::mem::take(&mut output.textures_delta));
+            output.textures_delta = deltas;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_pass(
+        ctx: &egui::Context,
+        minimized_and_occluded: Option<bool>,
+        mut in_pass: impl FnMut(&egui::Context),
+    ) -> egui::FullOutput {
+        let mut info = egui::ViewportInfo::default();
+        if let Some(hidden) = minimized_and_occluded {
+            info.minimized = Some(hidden);
+            info.occluded = Some(hidden);
+        }
+        let mut input = egui::RawInput::default();
+        input.viewports.insert(egui::ViewportId::ROOT, info);
+        ctx.run_ui(input, |ui| in_pass(ui.ctx()))
+    }
+
+    fn alloc_texture(ctx: &egui::Context, name: &str) -> egui::TextureId {
+        ctx.tex_manager().write().alloc(
+            name.to_owned(),
+            egui::ColorImage::example().into(),
+            egui::TextureOptions::LINEAR,
+        )
+    }
+
+    fn set_position(output: &egui::FullOutput, id: egui::TextureId) -> usize {
+        output
+            .textures_delta
+            .set
+            .iter()
+            .position(|(set_id, _)| *set_id == id)
+            .expect("texture id missing from output deltas")
+    }
+
+    #[test]
+    fn an_unpainted_pass_hands_the_backend_no_texture_deltas() {
+        let ctx = egui::Context::default();
+        install(&ctx);
+        let output = run_pass(&ctx, Some(true), |ctx| {
+            alloc_texture(ctx, "hidden-pass");
+        });
+        assert!(output.textures_delta.is_empty());
+    }
+
+    #[test]
+    fn the_next_painted_pass_replays_stashed_deltas_before_its_own() {
+        let ctx = egui::Context::default();
+        install(&ctx);
+        let mut hidden_id = None;
+        run_pass(&ctx, Some(true), |ctx| {
+            hidden_id = Some(alloc_texture(ctx, "stashed"));
+        });
+        let mut painted_id = None;
+        let output = run_pass(&ctx, Some(false), |ctx| {
+            painted_id = Some(alloc_texture(ctx, "current"));
+        });
+        let stashed_pos = set_position(&output, hidden_id.unwrap());
+        let current_pos = set_position(&output, painted_id.unwrap());
+        assert!(stashed_pos < current_pos);
+        assert!(
+            ctx.with_plugin(|guard: &mut TextureDeltaGuard| guard.stashed.is_empty())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn frees_from_an_unpainted_pass_reach_the_next_painted_pass() {
+        let ctx = egui::Context::default();
+        install(&ctx);
+        let mut id = None;
+        run_pass(&ctx, Some(false), |ctx| {
+            id = Some(alloc_texture(ctx, "victim"));
+        });
+        run_pass(&ctx, Some(true), |ctx| {
+            ctx.tex_manager().write().free(id.unwrap());
+        });
+        let output = run_pass(&ctx, Some(false), |_| {});
+        assert!(output.textures_delta.free.contains(&id.unwrap()));
+    }
+
+    #[test]
+    fn a_painted_pass_with_nothing_stashed_keeps_its_deltas() {
+        let ctx = egui::Context::default();
+        install(&ctx);
+        let mut id = None;
+        let output = run_pass(&ctx, Some(false), |ctx| {
+            id = Some(alloc_texture(ctx, "plain"));
+        });
+        set_position(&output, id.unwrap());
+    }
+
+    #[test]
+    fn unknown_visibility_counts_as_painted() {
+        let ctx = egui::Context::default();
+        install(&ctx);
+        let mut id = None;
+        let output = run_pass(&ctx, None, |ctx| {
+            id = Some(alloc_texture(ctx, "unknown"));
+        });
+        set_position(&output, id.unwrap());
+    }
+
+    #[test]
+    fn an_output_without_a_matching_pass_counts_as_painted() {
+        let mut guard = TextureDeltaGuard::default();
+        let mut output = egui::FullOutput::default();
+        output.textures_delta.free.push(egui::TextureId::Managed(7));
+        egui::Plugin::output_hook(&mut guard, &mut output);
+        assert!(!output.textures_delta.is_empty());
+        assert!(guard.stashed.is_empty());
+    }
+
+    #[test]
+    fn the_debug_name_identifies_the_guard() {
+        assert_eq!(
+            egui::Plugin::debug_name(&TextureDeltaGuard::default()),
+            "lns_texture_delta_guard"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

After the service runs for a while, all text and icons in the egui audit dashboard (and any other window) render garbled — glyphs shifted and smeared — and only `lns service stop/start` recovers. The dashboard is fine right after startup.

## Root cause

eframe runs a full egui pass for every viewport it wakes, **including the permanently-hidden ROOT viewport** (our approval window drives `App::logic()` while hidden). Each pass's `Context::end_pass` drains the context-global `TexturesDelta` into that pass's `FullOutput` — but eframe's `run_ui_and_paint` skips `paint_and_update_textures` entirely for non-visible windows, so the drained delta is **dropped on the floor** (unfixed on egui `main` as of today).

epaint's font atlas accumulates glyphs while the dashboard/approval cards render (changing relative timestamps, new sandbox names, icons). When the atlas crosses 80% fill, the *next* pass's `Fonts::begin_pass` throws the whole atlas away and rebuilds it. If that next pass is a hidden-ROOT pass (tray menu event, dashboard-open request, decision handler — all request ROOT repaints), the full-texture delta describing the rebuilt atlas is lost. From then on the GPU copy of the font texture no longer matches the CPU atlas that glyph UVs are computed against, so every glyph in every viewport samples the wrong texels — permanently, because the CPU side believes the delta was delivered.

## Fix

`ui::texture_delta_guard` — an `egui::Plugin` registered on the tray context (and both preview examples) that mirrors what eframe should do:

- `on_begin_pass` records whether eframe will paint this pass, using the exact same signal eframe's skip decision reads (`ViewportInfo::visible()` from the pass's raw input).
- `output_hook` moves the `TexturesDelta` of unpainted passes into a stash (eframe then has nothing to drop), and replays the stash ahead of the next painted pass's own deltas.

Ordering is safe by construction: sets apply oldest-first, frees are only ever delayed past the paint they must not precede, and `TextureManager` never reuses freed ids.

## Testing

- 7 Layer 3 tests pin the stash/replay behavior on a raw `egui::Context` (hidden pass hands the backend nothing; next painted pass replays stashed sets before its own and drains the stash; frees survive; unknown visibility fails open as painted).
- `make lint`, `make complexity`, `make coverage-affected` green — new file at 100% (81/81).
- `audit_dashboard` example launches and runs cleanly with the guard installed.

## Also in this PR

`make build` copied the re-signed binaries over the existing `bin/lns` / `bin/lns-service` inodes; macOS caches a vnode's code signature after first exec, so the overwritten binary gets SIGKILLed on the next launch (`zsh: killed`). The copy step now unlinks the destination first.
