### PR TITLE
feat(cli): `lns ps` alias for `ls` + (ports, filter, quiet, json)

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -275,6 +275,91 @@ pub struct KillArgs {
     pub signal: String,
 }
 
+#[derive(clap::Args)]
+pub struct LsArgs {
+    #[arg(
+        short = 'a',
+        long = "all",
+        default_value_t = false,
+        help = "docker-ps compatibility flag. lns already lists finished runs until `rm`/`prune`, so this is a no-op; narrow the list instead with `--filter status=running`."
+    )]
+    pub all: bool,
+
+    #[arg(
+        short = 'q',
+        long = "quiet",
+        default_value_t = false,
+        help = "Print run ids only, one per line — e.g. `lns kill $(lns ps -q)`."
+    )]
+    pub quiet: bool,
+
+    #[arg(
+        long = "filter",
+        value_name = "KEY=VALUE",
+        value_parser = parse_ls_filter,
+        help = "Restrict the list: `status=running`, `status=exited`, or `name=<substring>`. Repeatable; a run must match every filter."
+    )]
+    pub filters: Vec<LsFilter>,
+
+    #[arg(
+        long = "format",
+        value_enum,
+        help = "Output format: `table` (default) or `json`."
+    )]
+    pub format: Option<LsFormat>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum LsFormat {
+    Table,
+    Json,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum StatusFilter {
+    Running,
+    Exited,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LsFilter {
+    Status(StatusFilter),
+    Name(String),
+}
+
+pub(crate) fn parse_ls_filter(s: &str) -> Result<LsFilter, String> {
+    let (key, value) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected KEY=VALUE filter, got `{s}`"))?;
+    match key {
+        "status" => match value {
+            "running" => Ok(LsFilter::Status(StatusFilter::Running)),
+            "exited" => Ok(LsFilter::Status(StatusFilter::Exited)),
+            other => Err(format!(
+                "unsupported status filter `{other}` (use `running` or `exited`)"
+            )),
+        },
+        "name" if value.is_empty() => Err("filter `name=` needs a value".to_string()),
+        "name" => Ok(LsFilter::Name(value.to_string())),
+        other => Err(format!(
+            "unsupported filter key `{other}` (supported: status, name)"
+        )),
+    }
+}
+
+pub fn ls_filter_matches(filters: &[LsFilter], run: &lns_ipc::RunSummary) -> bool {
+    filters.iter().all(|filter| match filter {
+        LsFilter::Status(StatusFilter::Running) => {
+            matches!(run.status, lns_ipc::RunStatus::Running)
+        }
+        LsFilter::Status(StatusFilter::Exited) => {
+            matches!(run.status, lns_ipc::RunStatus::Exited { .. })
+        }
+        LsFilter::Name(substring) => run.name.contains(substring.as_str()),
+    })
+}
+
 // Newtype: clap would otherwise treat Vec<u8> as a multi-value arg and downcast at runtime.
 #[derive(Clone, Debug)]
 pub struct DetachChord(pub Vec<u8>);
@@ -395,6 +480,30 @@ mod tests {
         args: ExecArgs,
     }
 
+    #[derive(Parser)]
+    struct LsHarness {
+        #[command(flatten)]
+        args: LsArgs,
+    }
+
+    fn parse_ls(argv: &[&str]) -> Result<LsArgs, clap::Error> {
+        let mut full = vec!["ls"];
+        full.extend_from_slice(argv);
+        LsHarness::try_parse_from(full).map(|h| h.args)
+    }
+
+    fn summary_named(name: &str, status: lns_ipc::RunStatus) -> lns_ipc::RunSummary {
+        lns_ipc::RunSummary {
+            id: "1a2b3c4d0000000000000000000000aa".into(),
+            name: name.into(),
+            image: "some-image".into(),
+            command: String::new(),
+            status,
+            started: String::new(),
+            published_ports: Vec::new(),
+        }
+    }
+
     fn parse_run(argv: &[&str]) -> Result<RunArgs, clap::Error> {
         let mut full = vec!["run"];
         full.extend_from_slice(argv);
@@ -483,6 +592,137 @@ mod tests {
         .expect("explicit false should parse");
         assert!(!args.interactive, "interactive should be false");
         assert!(!args.tty, "tty should be false");
+    }
+
+    #[test]
+    fn ls_defaults_are_show_all_table_no_filters() {
+        let args = parse_ls(&[]).expect("bare ls parses");
+        assert!(!args.all);
+        assert!(!args.quiet);
+        assert!(args.filters.is_empty());
+        assert_eq!(args.format, None);
+    }
+
+    #[test]
+    fn ls_accepts_the_docker_style_flags() {
+        let args = parse_ls(&["-a", "-q", "--filter", "status=running", "--format", "json"])
+            .expect("flags parse");
+        assert!(args.all);
+        assert!(args.quiet);
+        assert_eq!(args.filters, vec![LsFilter::Status(StatusFilter::Running)]);
+        assert_eq!(args.format, Some(LsFormat::Json));
+    }
+
+    #[test]
+    fn ls_filter_is_repeatable() {
+        let args = parse_ls(&["--filter", "status=exited", "--filter", "name=rev"])
+            .expect("repeated filters parse");
+        assert_eq!(
+            args.filters,
+            vec![
+                LsFilter::Status(StatusFilter::Exited),
+                LsFilter::Name("rev".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn ls_rejects_an_unknown_format() {
+        assert!(parse_ls(&["--format", "yaml"]).is_err());
+    }
+
+    #[test]
+    fn parse_ls_filter_reads_status_running_and_exited() {
+        assert_eq!(
+            parse_ls_filter("status=running").unwrap(),
+            LsFilter::Status(StatusFilter::Running)
+        );
+        assert_eq!(
+            parse_ls_filter("status=exited").unwrap(),
+            LsFilter::Status(StatusFilter::Exited)
+        );
+    }
+
+    #[test]
+    fn parse_ls_filter_reads_a_name_substring() {
+        assert_eq!(
+            parse_ls_filter("name=review").unwrap(),
+            LsFilter::Name("review".into())
+        );
+    }
+
+    #[test]
+    fn parse_ls_filter_rejects_an_empty_name_value() {
+        let err = parse_ls_filter("name=").unwrap_err();
+        assert!(err.contains("needs a value"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_ls_filter_rejects_an_unknown_status_value() {
+        let err = parse_ls_filter("status=paused").unwrap_err();
+        assert!(err.contains("running"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_ls_filter_rejects_an_unknown_key() {
+        let err = parse_ls_filter("label=team").unwrap_err();
+        assert!(err.contains("supported: status, name"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_ls_filter_rejects_a_missing_equals() {
+        let err = parse_ls_filter("running").unwrap_err();
+        assert!(err.contains("KEY=VALUE"), "got: {err}");
+    }
+
+    #[test]
+    fn ls_filter_matches_with_no_filters_keeps_every_run() {
+        let run = summary_named("reviewer", lns_ipc::RunStatus::Running);
+        assert!(ls_filter_matches(&[], &run));
+    }
+
+    #[test]
+    fn ls_filter_matches_status_running_and_exited() {
+        let running = summary_named("reviewer", lns_ipc::RunStatus::Running);
+        let exited = summary_named("auditor", lns_ipc::RunStatus::Exited { code: 0 });
+        assert!(ls_filter_matches(
+            &[LsFilter::Status(StatusFilter::Running)],
+            &running
+        ));
+        assert!(!ls_filter_matches(
+            &[LsFilter::Status(StatusFilter::Running)],
+            &exited
+        ));
+        assert!(ls_filter_matches(
+            &[LsFilter::Status(StatusFilter::Exited)],
+            &exited
+        ));
+        assert!(!ls_filter_matches(
+            &[LsFilter::Status(StatusFilter::Exited)],
+            &running
+        ));
+    }
+
+    #[test]
+    fn ls_filter_matches_name_substring() {
+        let run = summary_named("amber_otter", lns_ipc::RunStatus::Running);
+        assert!(ls_filter_matches(&[LsFilter::Name("otter".into())], &run));
+        assert!(!ls_filter_matches(&[LsFilter::Name("falcon".into())], &run));
+    }
+
+    #[test]
+    fn ls_filter_matches_requires_every_filter_to_hold() {
+        let run = summary_named("reviewer", lns_ipc::RunStatus::Running);
+        let both = [
+            LsFilter::Status(StatusFilter::Running),
+            LsFilter::Name("view".into()),
+        ];
+        assert!(ls_filter_matches(&both, &run));
+        let conflicting = [
+            LsFilter::Status(StatusFilter::Exited),
+            LsFilter::Name("view".into()),
+        ];
+        assert!(!ls_filter_matches(&conflicting, &run));
     }
 
     #[test]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -360,7 +360,7 @@ pub fn ls_filter_matches(filters: &[LsFilter], run: &lns_ipc::RunSummary) -> boo
     })
 }
 
-// Newtype: clap would otherwise treat Vec<u8> as a multi-value arg and downcast at runtime.
+// clap's derive reads a bare `Vec<u8>` field as a repeatable arg (one value per byte); the newtype hides the Vec so the whole chord flows through a single `value_parser`.
 #[derive(Clone, Debug)]
 pub struct DetachChord(pub Vec<u8>);
 

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -23,7 +23,7 @@ pub struct SandboxArgs {
 pub enum SandboxCommand {
     #[command(
         visible_aliases = ["list", "ps"],
-        about = "List runs (`docker ps`-style): running plus finished-until-removed. Narrow with --filter status=/name=, ids-only with -q, JSON with --format json."
+        about = "List runs (`docker ps`-style): running plus finished-until-removed. Narrow with `--filter status=running|exited` or `--filter name=<substring>`, ids-only with -q, JSON with --format json."
     )]
     Ls(LsArgs),
     #[command(about = "Open a new session (`docker exec`-style) against a running run.")]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -7,7 +7,7 @@ use lns_ipc::{
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
-use crate::cli::{DetachChord, ExecArgs, KillArgs, parse_detach_keys_arg};
+use crate::cli::{DetachChord, ExecArgs, KillArgs, LsArgs, parse_detach_keys_arg};
 use crate::command::{CommandSpec, subcommand};
 use crate::service::client::BoxFuture;
 
@@ -22,10 +22,10 @@ pub struct SandboxArgs {
 #[derive(clap::Subcommand)]
 pub enum SandboxCommand {
     #[command(
-        visible_alias = "list",
-        about = "List active runs (`docker ps`-style)."
+        visible_aliases = ["list", "ps"],
+        about = "List runs (`docker ps`-style): running plus finished-until-removed. Narrow with --filter status=/name=, ids-only with -q, JSON with --format json."
     )]
-    Ls,
+    Ls(LsArgs),
     #[command(about = "Open a new session (`docker exec`-style) against a running run.")]
     Exec(ExecArgs),
     #[command(about = "Send a signal to a running run (`docker kill`-style).")]
@@ -183,7 +183,7 @@ where
     E: AsyncWriteExt + Unpin,
 {
     match cmd {
-        SandboxCommand::Ls => ls(svc, out).await,
+        SandboxCommand::Ls(args) => ls(svc, args, out).await,
         SandboxCommand::Kill(args) => kill(svc, args, out).await,
         SandboxCommand::Exec(_) => bail!("sandbox exec is dispatched on its own interactive path"),
         SandboxCommand::Stop(args) => stop(svc, args, out).await,
@@ -201,12 +201,15 @@ pub(crate) fn run_label(run: &str) -> String {
     run.to_string()
 }
 
-async fn ls<W: std::io::Write>(svc: &impl SandboxService, out: &mut W) -> Result<i32> {
+async fn ls<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &LsArgs,
+    out: &mut W,
+) -> Result<i32> {
     let response = svc.one_shot(Request::ListRuns).await?;
     match response {
-        Response::RunList { mut runs } => {
-            runs.sort_by(|a, b| b.started.cmp(&a.started));
-            crate::service::render_ls_table(out, &runs)?;
+        Response::RunList { runs } => {
+            crate::service::render_run_list(out, &runs, args)?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -253,12 +256,9 @@ async fn stop<W: std::io::Write>(
             Ok(0)
         }
         Response::RunStopped { forced: true } => {
-            writeln!(
-                out,
-                "killed run {} after the {}s timeout",
-                run_label(&args.run),
-                args.timeout
-            )?;
+            let run = run_label(&args.run);
+            let secs = args.timeout;
+            writeln!(out, "killed run {run} after the {secs}s timeout")?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -299,12 +299,9 @@ async fn rename<W: std::io::Write>(
         .await?;
     match response {
         Response::Acknowledged => {
-            writeln!(
-                out,
-                "renamed run {} to {}",
-                run_label(&args.run),
-                args.new_name
-            )?;
+            let run = run_label(&args.run);
+            let new_name = &args.new_name;
+            writeln!(out, "renamed run {run} to {new_name}")?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -611,6 +608,15 @@ mod tests {
         }
     }
 
+    fn ls_args() -> LsArgs {
+        LsArgs {
+            all: false,
+            quiet: false,
+            filters: Vec::new(),
+            format: None,
+        }
+    }
+
     #[tokio::test]
     async fn run_with_writers_refuses_the_interactive_exec_verb() {
         let svc = CannedService::new(Response::Pong);
@@ -644,7 +650,7 @@ mod tests {
             message: "registry poisoned".into(),
         });
         let mut out = Vec::new();
-        let err = ls(&svc, &mut out).await.unwrap_err();
+        let err = ls(&svc, &ls_args(), &mut out).await.unwrap_err();
         assert!(format!("{err:#}").contains("registry poisoned"));
     }
 
@@ -652,7 +658,7 @@ mod tests {
     async fn ls_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = ls(&svc, &mut out).await.unwrap_err();
+        let err = ls(&svc, &ls_args(), &mut out).await.unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
     }
 
@@ -946,6 +952,7 @@ mod tests {
                     command: String::new(),
                     status: lns_ipc::RunStatus::Running,
                     started: "2026-01-01T00:00:00Z".into(),
+                    published_ports: Vec::new(),
                 },
                 config: lns_ipc::RunConfig {
                     policy_path: Some("/work/lns-policy.yaml".into()),

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -313,13 +313,8 @@ fn format_ports(ports: &[lns_ipc::PortPublish]) -> String {
 }
 
 fn format_port(p: &lns_ipc::PortPublish) -> String {
-    format!(
-        "{}:{}->{}/{}",
-        p.host_ip,
-        p.host_port,
-        p.container_port,
-        proto_str(p.protocol)
-    )
+    let bind = std::net::SocketAddr::new(p.host_ip, p.host_port);
+    format!("{bind}->{}/{}", p.container_port, proto_str(p.protocol))
 }
 
 fn proto_str(protocol: lns_ipc::Protocol) -> &'static str {
@@ -845,6 +840,17 @@ exit 0
             format_port(&port(5353, 53, lns_ipc::Protocol::Udp)),
             "127.0.0.1:5353->53/udp"
         );
+    }
+
+    #[test]
+    fn format_port_brackets_an_ipv6_host_the_way_docker_does() {
+        let p = lns_ipc::PortPublish {
+            host_ip: std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+            host_port: 8080,
+            container_port: 80,
+            protocol: lns_ipc::Protocol::Tcp,
+        };
+        assert_eq!(format_port(&p), "[::1]:8080->80/tcp");
     }
 
     #[test]

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -60,7 +60,12 @@ pub const KILL_SPEC: CommandSpec = CommandSpec {
 };
 
 pub fn augment_ls(app: clap::Command) -> clap::Command {
-    app.subcommand(clap::Command::new("ls").visible_alias("list").hide(true))
+    app.subcommand(
+        subcommand::<crate::cli::LsArgs>("ls")
+            .visible_alias("list")
+            .visible_alias("ps")
+            .hide(true),
+    )
 }
 
 pub const LS_SPEC: CommandSpec = CommandSpec {
@@ -248,10 +253,83 @@ pub(crate) fn parse_signal_name(name: &str) -> Result<SignalKind> {
         }
     })
 }
-pub(crate) fn render_ls_table<W: std::io::Write>(
+pub(crate) fn render_run_list<W: std::io::Write>(
     out: &mut W,
-    rows: &[RunSummary],
-) -> std::io::Result<()> {
+    runs: &[RunSummary],
+    args: &crate::cli::LsArgs,
+) -> Result<()> {
+    let mut rows: Vec<&RunSummary> = runs
+        .iter()
+        .filter(|run| crate::cli::ls_filter_matches(&args.filters, run))
+        .collect();
+    rows.sort_by(|a, b| b.started.cmp(&a.started));
+    if matches!(args.format, Some(crate::cli::LsFormat::Json)) {
+        render_ls_json(out, &rows)
+    } else if args.quiet {
+        render_ls_quiet(out, &rows)?;
+        Ok(())
+    } else {
+        render_ls_table(out, &rows)?;
+        Ok(())
+    }
+}
+
+fn render_ls_quiet<W: std::io::Write>(out: &mut W, rows: &[&RunSummary]) -> std::io::Result<()> {
+    for r in rows {
+        writeln!(out, "{}", lns_ipc::short_run_id(&r.id))?;
+    }
+    Ok(())
+}
+
+fn render_ls_json<W: std::io::Write>(out: &mut W, rows: &[&RunSummary]) -> Result<()> {
+    let items = rows
+        .iter()
+        .map(|&r| run_summary_json(r))
+        .collect::<Result<Vec<_>>>()?;
+    let rendered = serde_json::to_string_pretty(&serde_json::Value::Array(items))?;
+    writeln!(out, "{rendered}")?;
+    Ok(())
+}
+
+fn run_summary_json(run: &RunSummary) -> Result<serde_json::Value> {
+    let ports = run
+        .published_ports
+        .iter()
+        .map(|p| serde_json::Value::from(format_port(p)))
+        .collect();
+    let mut obj = serde_json::Map::new();
+    obj.insert("id".into(), run.id.clone().into());
+    obj.insert("name".into(), run.name.clone().into());
+    obj.insert("image".into(), run.image.clone().into());
+    obj.insert("command".into(), run.command.clone().into());
+    obj.insert("status".into(), serde_json::to_value(run.status)?);
+    obj.insert("started".into(), run.started.clone().into());
+    obj.insert("ports".into(), serde_json::Value::Array(ports));
+    Ok(serde_json::Value::Object(obj))
+}
+
+fn format_ports(ports: &[lns_ipc::PortPublish]) -> String {
+    ports.iter().map(format_port).collect::<Vec<_>>().join(", ")
+}
+
+fn format_port(p: &lns_ipc::PortPublish) -> String {
+    format!(
+        "{}:{}->{}/{}",
+        p.host_ip,
+        p.host_port,
+        p.container_port,
+        proto_str(p.protocol)
+    )
+}
+
+fn proto_str(protocol: lns_ipc::Protocol) -> &'static str {
+    match protocol {
+        lns_ipc::Protocol::Tcp => "tcp",
+        lns_ipc::Protocol::Udp => "udp",
+    }
+}
+
+fn render_ls_table<W: std::io::Write>(out: &mut W, rows: &[&RunSummary]) -> std::io::Result<()> {
     let status_str = |s: RunStatus| match s {
         RunStatus::Running => "running".to_string(),
         RunStatus::Exited { code } => format!("exited ({code})"),
@@ -278,36 +356,46 @@ pub(crate) fn render_ls_table<W: std::io::Write>(
     let cmd_w = "COMMAND"
         .len()
         .max(rows.iter().map(|r| r.command.len()).max().unwrap_or(0));
+    let ports_w = "PORTS".len().max(
+        rows.iter()
+            .map(|r| format_ports(&r.published_ports).len())
+            .max()
+            .unwrap_or(0),
+    );
 
     writeln!(
         out,
-        "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  STARTED",
+        "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  {:<ports_w$}  STARTED",
         "ID",
         "NAME",
         "STATUS",
         "IMAGE",
         "COMMAND",
+        "PORTS",
         id_w = id_w,
         name_w = name_w,
         status_w = status_w,
         image_w = image_w,
         cmd_w = cmd_w,
+        ports_w = ports_w,
     )?;
     for r in rows {
         writeln!(
             out,
-            "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  {}",
+            "{:<id_w$}  {:<name_w$}  {:<status_w$}  {:<image_w$}  {:<cmd_w$}  {:<ports_w$}  {}",
             lns_ipc::short_run_id(&r.id),
             r.name,
             status_str(r.status),
             r.image,
             r.command,
+            format_ports(&r.published_ports),
             friendly_started(&r.started),
             id_w = id_w,
             name_w = name_w,
             status_w = status_w,
             image_w = image_w,
             cmd_w = cmd_w,
+            ports_w = ports_w,
         )?;
     }
     Ok(())
@@ -654,20 +742,62 @@ exit 0
         assert!(!s.is_empty());
     }
 
+    fn port(
+        host_port: u16,
+        container_port: u16,
+        protocol: lns_ipc::Protocol,
+    ) -> lns_ipc::PortPublish {
+        lns_ipc::PortPublish {
+            host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_port,
+            container_port,
+            protocol,
+        }
+    }
+
+    fn summary(
+        id: &str,
+        name: &str,
+        image: &str,
+        status: RunStatus,
+        ports: Vec<lns_ipc::PortPublish>,
+    ) -> RunSummary {
+        RunSummary {
+            id: id.to_string(),
+            name: name.into(),
+            image: image.into(),
+            command: "echo hi".into(),
+            status,
+            started: "2024-03-15T08:30:00Z".into(),
+            published_ports: ports,
+        }
+    }
+
+    fn ls_args() -> crate::cli::LsArgs {
+        crate::cli::LsArgs {
+            all: false,
+            quiet: false,
+            filters: Vec::new(),
+            format: None,
+        }
+    }
+
     #[test]
     fn render_ls_table_emits_header_and_one_row_per_run() {
-        let rows = vec![RunSummary {
-            id: "1a2b3c4d0000000000000000000000aa".to_string(),
-            name: "reviewer".into(),
-            image: "alpine:3.20".into(),
-            command: "echo hi".into(),
-            started: "2024-03-15T08:30:00Z".into(),
-            status: RunStatus::Running,
-        }];
+        let rows = [summary(
+            "1a2b3c4d0000000000000000000000aa",
+            "reviewer",
+            "alpine:3.20",
+            RunStatus::Running,
+            Vec::new(),
+        )];
+        let refs: Vec<&RunSummary> = rows.iter().collect();
         let mut buf: Vec<u8> = Vec::new();
-        render_ls_table(&mut buf, &rows).expect("render");
+        render_ls_table(&mut buf, &refs).expect("render");
         let out = String::from_utf8(buf).unwrap();
-        for tok in ["ID", "NAME", "STATUS", "STARTED", "IMAGE", "COMMAND"] {
+        for tok in [
+            "ID", "NAME", "STATUS", "STARTED", "IMAGE", "COMMAND", "PORTS",
+        ] {
             assert!(
                 out.contains(tok),
                 "expected header token {tok:?} in {out:?}"
@@ -688,21 +818,183 @@ exit 0
 
     #[test]
     fn render_ls_table_renders_exited_status_with_code() {
-        let rows = vec![RunSummary {
-            id: "5e6f7a8b0000000000000000000000bb".to_string(),
-            name: "auditor".into(),
-            image: "<imageless>".into(),
-            command: "true".into(),
-            started: "2024-03-15T08:30:00Z".into(),
-            status: RunStatus::Exited { code: 0 },
-        }];
+        let rows = [summary(
+            "5e6f7a8b0000000000000000000000bb",
+            "auditor",
+            "<imageless>",
+            RunStatus::Exited { code: 0 },
+            Vec::new(),
+        )];
+        let refs: Vec<&RunSummary> = rows.iter().collect();
         let mut buf: Vec<u8> = Vec::new();
-        render_ls_table(&mut buf, &rows).expect("render");
+        render_ls_table(&mut buf, &refs).expect("render");
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.to_lowercase().contains("exited") || out.contains('0'),
             "expected exited indicator in {out:?}"
         );
+    }
+
+    #[test]
+    fn format_port_renders_the_docker_style_mapping_for_tcp_and_udp() {
+        assert_eq!(
+            format_port(&port(8080, 80, lns_ipc::Protocol::Tcp)),
+            "127.0.0.1:8080->80/tcp"
+        );
+        assert_eq!(
+            format_port(&port(5353, 53, lns_ipc::Protocol::Udp)),
+            "127.0.0.1:5353->53/udp"
+        );
+    }
+
+    #[test]
+    fn format_ports_is_empty_for_none_and_comma_joins_many() {
+        assert_eq!(format_ports(&[]), "");
+        assert_eq!(
+            format_ports(&[
+                port(8080, 80, lns_ipc::Protocol::Tcp),
+                port(9090, 90, lns_ipc::Protocol::Tcp),
+            ]),
+            "127.0.0.1:8080->80/tcp, 127.0.0.1:9090->90/tcp"
+        );
+    }
+
+    #[test]
+    fn render_run_list_table_shows_the_published_ports_column() {
+        let runs = [summary(
+            "1a2b3c4d0000000000000000000000aa",
+            "reviewer",
+            "alpine:3.20",
+            RunStatus::Running,
+            vec![port(8080, 80, lns_ipc::Protocol::Tcp)],
+        )];
+        let mut buf: Vec<u8> = Vec::new();
+        render_run_list(&mut buf, &runs, &ls_args()).expect("render");
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("127.0.0.1:8080->80/tcp"),
+            "ports missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn render_run_list_quiet_prints_short_ids_only() {
+        let runs = [
+            summary(
+                "1a2b3c4d0000000000000000000000aa",
+                "reviewer",
+                "alpine:3.20",
+                RunStatus::Running,
+                Vec::new(),
+            ),
+            summary(
+                "5e6f7a8b0000000000000000000000bb",
+                "auditor",
+                "busybox",
+                RunStatus::Exited { code: 0 },
+                Vec::new(),
+            ),
+        ];
+        let args = crate::cli::LsArgs {
+            quiet: true,
+            ..ls_args()
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        render_run_list(&mut buf, &runs, &args).expect("render");
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("1a2b3c4d0000"), "first id missing: {out:?}");
+        assert!(out.contains("5e6f7a8b0000"), "second id missing: {out:?}");
+        assert!(
+            !out.contains("IMAGE"),
+            "quiet must omit the header: {out:?}"
+        );
+        assert!(
+            !out.contains("alpine"),
+            "quiet must omit the image: {out:?}"
+        );
+    }
+
+    #[test]
+    fn render_run_list_json_emits_an_array_with_status_and_ports() {
+        let runs = [
+            summary(
+                "1a2b3c4d0000000000000000000000aa",
+                "reviewer",
+                "alpine:3.20",
+                RunStatus::Running,
+                vec![port(8080, 80, lns_ipc::Protocol::Tcp)],
+            ),
+            summary(
+                "5e6f7a8b0000000000000000000000bb",
+                "auditor",
+                "busybox",
+                RunStatus::Exited { code: 7 },
+                Vec::new(),
+            ),
+        ];
+        let args = crate::cli::LsArgs {
+            format: Some(crate::cli::LsFormat::Json),
+            ..ls_args()
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        render_run_list(&mut buf, &runs, &args).expect("render");
+        let doc: serde_json::Value = serde_json::from_slice(&buf).expect("valid json");
+        let arr = doc.as_array().expect("top-level array");
+        assert_eq!(arr.len(), 2);
+        let running = arr
+            .iter()
+            .find(|r| r["name"] == "reviewer")
+            .expect("reviewer present");
+        assert_eq!(running["status"]["state"], "running");
+        assert_eq!(running["ports"][0], "127.0.0.1:8080->80/tcp");
+        let exited = arr
+            .iter()
+            .find(|r| r["name"] == "auditor")
+            .expect("auditor present");
+        assert_eq!(exited["status"]["state"], "exited");
+        assert_eq!(exited["status"]["code"], 7);
+        assert!(exited["ports"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn render_run_list_filters_by_status_and_name() {
+        let runs = [
+            summary(
+                "1a2b3c4d0000000000000000000000aa",
+                "reviewer",
+                "alpine:3.20",
+                RunStatus::Running,
+                Vec::new(),
+            ),
+            summary(
+                "5e6f7a8b0000000000000000000000bb",
+                "auditor",
+                "busybox",
+                RunStatus::Exited { code: 0 },
+                Vec::new(),
+            ),
+        ];
+        let running_only = crate::cli::LsArgs {
+            filters: vec![crate::cli::LsFilter::Status(
+                crate::cli::StatusFilter::Running,
+            )],
+            ..ls_args()
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        render_run_list(&mut buf, &runs, &running_only).expect("render");
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("reviewer"), "running run kept: {out:?}");
+        assert!(!out.contains("auditor"), "exited run dropped: {out:?}");
+
+        let named = crate::cli::LsArgs {
+            filters: vec![crate::cli::LsFilter::Name("audit".into())],
+            ..ls_args()
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        render_run_list(&mut buf, &runs, &named).expect("render");
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("auditor"), "name match kept: {out:?}");
+        assert!(!out.contains("reviewer"), "non-match dropped: {out:?}");
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -51,10 +51,11 @@ pub fn kill_command<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunF
     })
 }
 
-pub fn ls_command<'a>(_matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {
+pub fn ls_command<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
+        let args = crate::cli::LsArgs::from_arg_matches(matches)?;
         require_running().await;
-        ls().await?;
+        ls(&args).await?;
         Ok(0)
     })
 }
@@ -304,20 +305,19 @@ pub async fn kill(args: KillArgs) -> Result<()> {
     }
 }
 
-pub async fn ls() -> Result<()> {
+pub async fn ls(args: &crate::cli::LsArgs) -> Result<()> {
     let socket = super::socket_path()?;
     let response = real::send_request(&socket, &Request::ListRuns)
         .await
         .ok_or_else(|| anyhow::anyhow!("no response from lns-service (is it running?)"))?;
-    let mut rows = match response {
+    let rows = match response {
         Response::RunList { runs } => runs,
         Response::Error { message } => anyhow::bail!("daemon error: {message}"),
         other => anyhow::bail!("unexpected response from daemon: {other:?}"),
     };
-    rows.sort_by(|a, b| b.started.cmp(&a.started));
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    super::render_ls_table(&mut out, &rows)?;
+    super::render_run_list(&mut out, &rows, args)?;
     Ok(())
 }
 

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -28,6 +28,8 @@ Feature: managing running sandboxes from the CLI
     Then the exit code is 0
     When I run "lns list"
     Then the exit code is 0
+    When I run "lns ps"
+    Then the exit code is 0
     When I run "lns kill 3"
     Then the exit code is 0
     When I run "lns exec 3 -- echo hi"
@@ -50,6 +52,57 @@ Feature: managing running sandboxes from the CLI
     And the output contains "some-image"
     And the output contains "running"
     And the service received a ListRuns request
+
+  Scenario: sandbox ps is an alias for sandbox ls
+    Given the service reports a run listing with run 3 of image "some-image" running
+    When the user runs sandbox command "ps"
+    Then the exit code is 0
+    And the output contains "ID"
+    And the output contains "some-image"
+    And the service received a ListRuns request
+
+  Scenario: ls shows a run's published ports
+    Given the service reports a run publishing host port 8080 to container port 80
+    When the user runs sandbox command "ls"
+    Then the exit code is 0
+    And the output contains "PORTS"
+    And the output contains "127.0.0.1:8080->80/tcp"
+
+  Scenario: ls -q prints run ids only
+    Given the service reports a running run "reviewer" and a finished run "auditor"
+    When the user runs sandbox command "ls -q"
+    Then the exit code is 0
+    And the output does not contain "IMAGE"
+    And the output does not contain "reviewer"
+
+  Scenario: ls --filter status=running hides finished runs
+    Given the service reports a running run "reviewer" and a finished run "auditor"
+    When the user runs sandbox command "ls --filter status=running"
+    Then the exit code is 0
+    And the output contains "reviewer"
+    And the output does not contain "auditor"
+
+  Scenario: ls --filter name matches on a substring
+    Given the service reports a running run "reviewer" and a finished run "auditor"
+    When the user runs sandbox command "ls --filter name=audit"
+    Then the exit code is 0
+    And the output contains "auditor"
+    And the output does not contain "reviewer"
+
+  Scenario: ls --format json emits a machine-readable array
+    Given the service reports a run publishing host port 8080 to container port 80
+    When the user runs sandbox command "ls --format json"
+    Then the exit code is 0
+    And the output contains "127.0.0.1:8080->80/tcp"
+    And the output contains "ports"
+    And the output does not contain "PORTS"
+
+  Scenario: ls -a is accepted as a docker-compatibility no-op
+    Given the service reports a running run "reviewer" and a finished run "auditor"
+    When the user runs sandbox command "ls -a"
+    Then the exit code is 0
+    And the output contains "reviewer"
+    And the output contains "auditor"
 
   Scenario: sandbox kill sends the requested signal
     Given the service will answer Acknowledged

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -77,6 +77,7 @@ fn details_with(image: &str, config: RunConfig) -> Response {
                 command: "some-command".into(),
                 status: RunStatus::Running,
                 started: "2026-01-01T00:00:00Z".into(),
+                published_ports: Vec::new(),
             },
             config,
         }),
@@ -153,6 +154,53 @@ fn canned_run_listing(w: &mut BehaviourWorld, run_id: u32, image: String) {
             command: "some-command".into(),
             status: RunStatus::Running,
             started: "2026-01-01T00:00:00Z".into(),
+            published_ports: Vec::new(),
+        }],
+    });
+}
+
+#[given(regex = r#"^the service reports a running run "([^"]+)" and a finished run "([^"]+)"$"#)]
+fn canned_two_run_listing(w: &mut BehaviourWorld, running: String, finished: String) {
+    w.sandbox.response = Some(Response::RunList {
+        runs: vec![
+            RunSummary {
+                id: hexid(3),
+                name: running,
+                image: "some-image".into(),
+                command: "some-command".into(),
+                status: RunStatus::Running,
+                started: "2026-01-01T00:00:02Z".into(),
+                published_ports: Vec::new(),
+            },
+            RunSummary {
+                id: hexid(7),
+                name: finished,
+                image: "some-image".into(),
+                command: "some-command".into(),
+                status: RunStatus::Exited { code: 0 },
+                started: "2026-01-01T00:00:01Z".into(),
+                published_ports: Vec::new(),
+            },
+        ],
+    });
+}
+
+#[given(regex = r"^the service reports a run publishing host port (\d+) to container port (\d+)$")]
+fn canned_run_listing_with_ports(w: &mut BehaviourWorld, host_port: u16, container_port: u16) {
+    w.sandbox.response = Some(Response::RunList {
+        runs: vec![RunSummary {
+            id: hexid(3),
+            name: "reviewer".into(),
+            image: "some-image".into(),
+            command: "some-command".into(),
+            status: RunStatus::Running,
+            started: "2026-01-01T00:00:00Z".into(),
+            published_ports: vec![lns_ipc::PortPublish {
+                host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                host_port,
+                container_port,
+                protocol: lns_ipc::Protocol::Tcp,
+            }],
         }],
     });
 }
@@ -372,6 +420,7 @@ fn canned_named_run_listing(w: &mut BehaviourWorld, run_id: u32, name: String, i
             command: "some-command".into(),
             status: RunStatus::Running,
             started: "2026-01-01T00:00:00Z".into(),
+            published_ports: Vec::new(),
         }],
     });
 }

--- a/crates/lns-ipc/src/codec.rs
+++ b/crates/lns-ipc/src/codec.rs
@@ -250,6 +250,12 @@ mod tests {
                     command: "sleep 30".into(),
                     status: crate::RunStatus::Running,
                     started: "2026-05-19T12:34:01Z".into(),
+                    published_ports: vec![crate::PortPublish {
+                        host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        host_port: 8080,
+                        container_port: 80,
+                        protocol: crate::Protocol::Tcp,
+                    }],
                 },
                 crate::RunSummary {
                     id: "5e6f7a8b0000000000000000000000bb".into(),
@@ -258,6 +264,7 @@ mod tests {
                     command: String::new(),
                     status: crate::RunStatus::Exited { code: 143 },
                     started: "2026-05-19T12:35:01Z".into(),
+                    published_ports: Vec::new(),
                 },
             ],
         };

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -226,6 +226,8 @@ pub struct RunSummary {
     pub command: String,
     pub status: RunStatus,
     pub started: String,
+    #[serde(default)]
+    pub published_ports: Vec<PortPublish>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -872,6 +874,7 @@ mod tests {
                     command: "echo hi".into(),
                     status: RunStatus::Running,
                     started: "2026-01-01T00:00:00Z".into(),
+                    published_ports: Vec::new(),
                 },
                 config: RunConfig::from_run_args(&sample_run_args()),
             }),

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -412,6 +412,7 @@ mod tests {
             command: String::new(),
             status: lns_ipc::RunStatus::Running,
             started: String::new(),
+            published_ports: Vec::new(),
         }
     }
 

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -250,6 +250,7 @@ fn summary_of(id: &str, h: &RunHandle) -> lns_ipc::RunSummary {
         command: h.command.clone(),
         status,
         started: h.started.clone(),
+        published_ports: h.config.published_ports.clone(),
     }
 }
 
@@ -932,6 +933,12 @@ mod tests {
         handle.image = "alpine:latest".to_string();
         handle.command = "sleep 1".to_string();
         handle.started = "2026-05-21 10:00:00".to_string();
+        handle.config.published_ports = vec![lns_ipc::PortPublish {
+            host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_port: 8080,
+            container_port: 80,
+            protocol: lns_ipc::Protocol::Tcp,
+        }];
         register(id.clone(), handle);
 
         let row = snapshot()
@@ -942,6 +949,16 @@ mod tests {
         assert_eq!(row.command, "sleep 1");
         assert_eq!(row.started, "2026-05-21 10:00:00");
         assert_eq!(row.status, RunStatus::Running);
+        assert_eq!(
+            row.published_ports,
+            vec![lns_ipc::PortPublish {
+                host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                host_port: 8080,
+                container_port: 80,
+                protocol: lns_ipc::Protocol::Tcp,
+            }],
+            "the snapshot must carry the launch config's published ports",
+        );
 
         deregister(&id);
     }

--- a/crates/lns-service/tests/behaviours/image_rig.rs
+++ b/crates/lns-service/tests/behaviours/image_rig.rs
@@ -167,6 +167,7 @@ impl ImageRig {
             command: String::new(),
             status: lns_ipc::RunStatus::Running,
             started: String::new(),
+            published_ports: Vec::new(),
         });
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,7 +115,7 @@ a per-user file (`~/.lns-registry-auth.json`, `0600`; override with
 Manage running sandboxes: ls, exec, kill, stop, logs, attach, inspect, stats, rm, rename, prune.
 
 ```bash
-lns sandbox ls
+lns sandbox ls [-a] [-q] [--filter <KEY=VALUE>]... [--format table|json]
 lns sandbox exec [OPTIONS] <RUN> -- <COMMAND...>
 lns sandbox kill <RUN> [--signal <SIG>]
 lns sandbox stop <RUN> [-t <SECONDS>]
@@ -133,7 +133,7 @@ interchangeable everywhere a run is addressed.
 
 | Subcommand | Meaning |
 | ---------- | ------- |
-| `ls`       | List active runs (`docker ps`-style). |
+| `ls`       | List runs (`docker ps`-style; aliases `list`, `ps`): running plus finished-until-removed, one row per run with its published ports. `-q` prints ids only (e.g. `lns kill $(lns sandbox ls -q)`); `--filter status=running\|exited` or `--filter name=<substr>` narrows the list (repeatable, all must match); `--format json` emits a machine-readable array. `-a`/`--all` is accepted for `docker ps` muscle memory but is a no-op — lns already lists finished runs. |
 | `exec`     | Open a new session against a running run (`docker exec`-style). `-i`/`-t` and `--detach-keys` work as for `lns run`; detaching closes only the exec session. |
 | `kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
@@ -146,7 +146,8 @@ interchangeable everywhere a run is addressed.
 | `prune`    | Remove every finished run from the list at once (`docker container prune`-style); running runs are left untouched. |
 
 The pre-namespace spellings `lns ls`, `lns exec`, and `lns kill` keep working
-as hidden aliases; the `lns sandbox` forms are the documented ones.
+as hidden aliases; the `lns sandbox` forms are the documented ones. `lns ps`
+and `lns sandbox ps` are aliases of `ls` for `docker ps` muscle memory.
 
 ## `lns audit`
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -297,7 +297,10 @@ cancelled. Use the chord — or start the run with `-d` — to step away safely.
 Everything you do to a run after starting it lives under `lns sandbox`:
 
 ```bash
-lns sandbox ls                 # list active runs
+lns sandbox ls                 # list runs: running + finished-until-removed, with ports (docker ps-style)
+lns sandbox ls -q              # ids only, e.g. lns sandbox kill $(lns sandbox ls -q)
+lns sandbox ls --filter status=running   # narrow by status; also --filter name=<substr>
+lns sandbox ls --format json   # machine-readable array
 lns sandbox exec 7 -- bash     # open another session inside a run
 lns sandbox kill 7             # send one signal (default SIGTERM)
 lns sandbox stop 7             # SIGTERM, wait up to 10s, then SIGKILL
@@ -314,7 +317,9 @@ lns sandbox prune              # drop every finished run from the list
 
 Every verb takes a run's **name** as readily as its numeric id — `lns sandbox
 stop reviewer` and `lns sandbox stop 7` are equivalent. The pre-namespace
-spellings `lns ls`, `lns exec`, and `lns kill` keep working as hidden aliases.
+spellings `lns ls`, `lns exec`, and `lns kill` keep working as hidden aliases,
+and `ls` also answers to `ps` (`lns ps`, `lns sandbox ps`) for `docker ps`
+muscle memory.
 
 ### Exec — another session inside a run
 


### PR DESCRIPTION
## What

- **`ps` alias** — `lns ps` and `lns sandbox ps` now alias `ls` (alongside the existing `list`). One command, shared behaviour.
- **PORTS column (gap #2)** — each row shows its published ports (`127.0.0.1:8080->80/tcp`). Sourced from a new `RunSummary.published_ports`, populated in the daemon from the launch `RunConfig`.
- **Flags (gap #3):**
  - `--filter status=running|exited` and `--filter name=<substr>` — repeatable, a run must match every filter.
  - `-q`/`--quiet` — run ids only (`lns sandbox kill $(lns sandbox ls -q)`).
  - `--format json` — machine-readable array (status/ports included).
  - `-a`/`--all` — accepted for `docker ps` muscle memory but a **no-op**.

## Default scope (gap #1)

Kept as-is by design: `ls`/`ps` still show **running + finished-until-removed** (i.e. always like `docker ps -a`), so `-a` is a no-op and `--filter status=running` is how you narrow to running. This preserves lns's "a finished run lingers until `rm`/`prune`" model rather than changing documented `ls` behaviour.

## Layers touched

- `lns-ipc`: `RunSummary.published_ports` (`#[serde(default)]`), pinned through the codec round-trip.
- `lns-service`: `run_registry::summary_of` carries the launch config's ports.
- `lns-cli`: `LsArgs` + filter/format parsing (`cli.rs`), and filtering/rendering (`service.rs::render_run_list` → table / quiet / json).

## Tests

- Layer 2 (Gherkin): new `sandbox_cli.feature` scenarios for `ps` alias, ports column, `-q`, `--filter status`/`name`, `--format json`, and `-a` no-op; top-level `lns ps` parse.
- Layer 3: filter-parser + matcher branches and `LsArgs` parsing (`cli.rs`); table/quiet/json/ports renderers (`service.rs`); ports flow-through in `run_registry`.
- Gate: `make lint && make complexity && make coverage` all green — `cli.rs` and `sandbox/mod.rs` at 100%.

Also reshaped two pre-existing multi-line `writeln!`s in `stop`/`rename` to inline-capture form so they stay single executable lines (the line-shift surfaced the known multi-line-macro-arg coverage artifact).

## Docs

`docs/cli-reference.md` and `docs/running-workloads.md` updated for `ps`, the flags, and the ports column.