### PR TITLE
chore: nest coverage target dir inside target/ so cargo clean sweeps it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,10 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          # Coverage uses target-cov/ — Makefile owns the path
-          # (COVERAGE_TARGET_DIR). Cache key matches its layout.
+          # Coverage uses target/llvm-cov-target/ — Makefile owns the
+          # path (COVERAGE_TARGET_DIR). Cache key matches its layout.
           cache-workspaces: |
-            . -> target-cov
+            . -> target/llvm-cov-target
           cache-on-failure: true
           cache-shared-key: lns-ci-coverage
 
@@ -253,7 +253,6 @@ jobs:
         if: github.event_name != 'pull_request' || steps.affected.outputs.skip != 'true'
         run: make coverage
         env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target-cov
           # Empty on push: main and on __FULL__ PRs => Makefile runs full
           # workspace. Non-empty on per-crate PRs => Makefile narrows the
           # cargo invocation and the floor loop. See COVERAGE_CRATES in

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 target
-target-cov
 dist
 .DS_Store
 coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The **local pre-push gate** is `make lint && make complexity && make coverage` �
 
 - `make lint` — `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`. Also the gate's compile signal (clippy is a strict superset of `cargo check`).
 - `make complexity` — per-crate `cargo clippy -- -D clippy::cognitive_complexity` (per-crate because workspace feature unification disagrees with per-crate runs). For genuinely-branchy functions, use `#[allow(clippy::cognitive_complexity)]` with a one-line reason.
-- `make coverage` — compiles and runs all tests **instrumented** in `target-cov/`, then enforces every file at 100% line coverage unless listed in `scripts/coverage-floor.sh`'s IGNORES table. Test failures surface here. See [Per-file coverage gate](#per-file-coverage-gate) below.
+- `make coverage` — compiles and runs all tests **instrumented** in `target/llvm-cov-target/`, then enforces every file at 100% line coverage unless listed in `scripts/coverage-floor.sh`'s IGNORES table. Test failures surface here. See [Per-file coverage gate](#per-file-coverage-gate) below.
 
 `make install-hooks` wires the gate into pre-push. Bypass: `git push --no-verify`.
 
@@ -119,9 +119,9 @@ make complexity      per-crate cargo clippy -- -D clippy::cognitive_complexity (
 make fmt             cargo fmt --all
 make coverage          full workspace coverage gate (all crates, 100% floor)
 make coverage-affected coverage gate narrowed to crates touched since origin/main
-make coverage-lcov     re-emit the last coverage run as target/llvm-cov/lcov.info (no rerun)
+make coverage-lcov     re-emit the last coverage run as target/llvm-cov-target/llvm-cov/lcov.info (no rerun)
 make e2e             Layer 1 cucumber harness against real lns + lns-service binaries
-make clean           rm -rf bin/ target/ target-cov/
+make clean           rm -rf bin/ + cargo clean (coverage artifacts live inside target/)
 
 # CI invokes the same gate targets with strictness toggled on:
 CARGO_LOCKED=--locked make lint
@@ -149,7 +149,7 @@ The gate decomposes into two layers:
 - `make coverage-data` (workspace one-shot) builds the AST-stripped `lcov.info` from `cargo test --workspace --exclude e2e-tests --all-targets`. The single-pass approach is a deliberate simplification — now that Layer 2 is in-process and Layer 1 is excluded entirely, a per-crate `cargo llvm-cov test -p <crate>` rotation would produce equivalent data; the workspace pass keeps the Makefile small.
 - `make coverage` runs `coverage-data` and then iterates every `crates/*/` directory, invoking `scripts/coverage-floor.sh <lcov> <crate-prefix>/` once per crate. Each crate reports its own OK/SKIP/FAIL block. The lcov is shared; the per-file gate is per-crate.
 
-For crate-scoped coverage inspection during development, run `scripts/coverage-floor.sh target-cov/llvm-cov/lcov.info crates/<crate>/` directly (assumes `make coverage-data` has already built the lcov).
+For crate-scoped coverage inspection during development, run `scripts/coverage-floor.sh target/llvm-cov-target/llvm-cov/lcov.info crates/<crate>/` directly (assumes `make coverage-data` has already built the lcov).
 
 **Every file in the (post-strip) lcov must be at 100% UNLESS it's listed in IGNORES**. The IGNORES table lives at the top of `scripts/coverage-floor.sh`. Each entry is `<path-suffix>  <reason>`; the reason is mandatory — reviewers should reject ignore entries without one. **The table is the tracker.** There's no parallel Jira/issue list; the entry's reason names the design move that gets the file to 100%, and the entry leaving the table is the completion signal. Reasons fall in three buckets:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ default-members = [
 lto = true
 strip = true
 
+# Same trade as [profile.test] below, applied to dev builds — which is
+# where all *dependencies* compile, and full DWARF on deps is the bulk
+# of target/'s multi-GiB footprint. Panics still show file:line.
+[profile.dev]
+debug = "line-tables-only"
+
 # Test builds drop full DWARF in favour of `line-tables-only`. Panics
 # still show file:line; `cargo test` gets noticeably faster — the
 # linker has far less debug info to chew through.

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,7 @@ audit:
 clean:
 	rm -rf bin/
 	$(CARGO) clean
+	rm -rf $(WORKSPACE_ROOT)/target-cov
 
 # One-time setup per checkout: point git at the in-tree hooks dir so
 # pre-push runs the gate automatically.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-lns build-lns-service test lint fmt complexity complexity-all clean clean-guard coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks
+.PHONY: dev build build-lns build-lns-service test lint fmt complexity complexity-all clean coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks
 
 CARGO ?= cargo
 
@@ -95,22 +95,6 @@ build-lns-service:
 # disk here (cargo never prunes them), so the gates opt out while
 # `make dev` and raw cargo iteration keep incremental speed.
 lint test complexity coverage-data: export CARGO_INCREMENTAL := 0
-
-# Repeated gate cycles accumulate stale artifacts that cargo never
-# GCs; on a space-limited host that wedges the loop mid-run. Reset
-# target/ once it crosses the cap — a full rebuild beats a full disk.
-# Pinned to $(WORKSPACE_ROOT)/target (not $(CARGO_TARGET_DIR)):
-# coverage-data's target-specific CARGO_TARGET_DIR export propagates
-# to prerequisites and would narrow the guard to the coverage subdir.
-LNS_TARGET_MAX_GB ?= 20
-lint test complexity coverage-data: clean-guard
-clean-guard:
-	@size_kb=$$(du -sk $(WORKSPACE_ROOT)/target 2>/dev/null | cut -f1); \
-	limit_kb=$$(( $(LNS_TARGET_MAX_GB) * 1024 * 1024 )); \
-	if [ -n "$$size_kb" ] && [ "$$size_kb" -gt "$$limit_kb" ]; then \
-		echo "target/ at $$(( size_kb / 1024 / 1024 ))GiB exceeds $(LNS_TARGET_MAX_GB)GiB cap — removing"; \
-		rm -rf $(WORKSPACE_ROOT)/target; \
-	fi
 
 lint: export LNS_INIT_BIN := skip
 lint: export LNS_SESSION_BROKER_BIN := skip

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ build-lns-service:
 # below). CI invokes these targets as parallel jobs, with
 # `CARGO_LOCKED=--locked make <step>` for strictness on lint/test.
 
+# Gate targets are one-shot full passes; incremental caches only cost
+# disk here (cargo never prunes them), so the gates opt out while
+# `make dev` and raw cargo iteration keep incremental speed.
+lint test complexity coverage-data: export CARGO_INCREMENTAL := 0
+
 lint: export LNS_INIT_BIN := skip
 lint: export LNS_SESSION_BROKER_BIN := skip
 lint: export LNS_NFT_BIN := skip

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,16 @@ CARGO_TARGET_DIR = $(shell $(CARGO) metadata --format-version 1 --no-deps | \
 	(jq -r .target_directory 2>/dev/null || \
 	 sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'))
 
-# Coverage isolates instrumented builds from `target/`: cargo-llvm-cov
-# injects -Cinstrument-coverage via RUSTC_WRAPPER which cargo's
-# fingerprint doesn't track. Sharing target/ with `make test`'s
-# non-instrumented artifacts silently reuses them, emits no profraw,
-# and the report step fails with "not found *.profraw files".
-COVERAGE_TARGET_DIR = $(WORKSPACE_ROOT)/target-cov
+# Coverage isolates instrumented builds from `make test`'s artifacts:
+# cargo-llvm-cov injects -Cinstrument-coverage via RUSTC_WRAPPER which
+# cargo's fingerprint doesn't track — sharing the artifact dir silently
+# reuses non-instrumented builds, emits no profraw, and the report step
+# fails with "not found *.profraw files". Nesting inside target/
+# (cargo-llvm-cov's own default layout) keeps the isolation while
+# letting `cargo clean` sweep it. Derived from WORKSPACE_ROOT, not
+# CARGO_TARGET_DIR — the coverage recipes' target-specific
+# `export CARGO_TARGET_DIR` would shadow it into double-nesting.
+COVERAGE_TARGET_DIR = $(WORKSPACE_ROOT)/target/llvm-cov-target
 
 # Crates whose code is enforced by the per-crate `complexity` gate,
 # which iterates this list with `cd crates/<crate> && cargo …` so each
@@ -247,7 +251,6 @@ audit:
 clean:
 	rm -rf bin/
 	$(CARGO) clean
-	rm -rf $(COVERAGE_TARGET_DIR)
 
 # One-time setup per checkout: point git at the in-tree hooks dir so
 # pre-push runs the gate automatically.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-lns build-lns-service test lint fmt complexity complexity-all clean coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks
+.PHONY: dev build build-lns build-lns-service test lint fmt complexity complexity-all clean clean-guard coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks
 
 CARGO ?= cargo
 
@@ -95,6 +95,22 @@ build-lns-service:
 # disk here (cargo never prunes them), so the gates opt out while
 # `make dev` and raw cargo iteration keep incremental speed.
 lint test complexity coverage-data: export CARGO_INCREMENTAL := 0
+
+# Repeated gate cycles accumulate stale artifacts that cargo never
+# GCs; on a space-limited host that wedges the loop mid-run. Reset
+# target/ once it crosses the cap — a full rebuild beats a full disk.
+# Pinned to $(WORKSPACE_ROOT)/target (not $(CARGO_TARGET_DIR)):
+# coverage-data's target-specific CARGO_TARGET_DIR export propagates
+# to prerequisites and would narrow the guard to the coverage subdir.
+LNS_TARGET_MAX_GB ?= 20
+lint test complexity coverage-data: clean-guard
+clean-guard:
+	@size_kb=$$(du -sk $(WORKSPACE_ROOT)/target 2>/dev/null | cut -f1); \
+	limit_kb=$$(( $(LNS_TARGET_MAX_GB) * 1024 * 1024 )); \
+	if [ -n "$$size_kb" ] && [ "$$size_kb" -gt "$$limit_kb" ]; then \
+		echo "target/ at $$(( size_kb / 1024 / 1024 ))GiB exceeds $(LNS_TARGET_MAX_GB)GiB cap — removing"; \
+		rm -rf $(WORKSPACE_ROOT)/target; \
+	fi
 
 lint: export LNS_INIT_BIN := skip
 lint: export LNS_SESSION_BROKER_BIN := skip


### PR DESCRIPTION
## Why

The verification gates fill the disk on space-constrained dev hosts (a full gate cycle left ~59GiB in `target/` + `target-cov/`), which wedges agent loops mid-run — and `cargo clean` didn't even reclaim the coverage half because it lived outside `target/`.

## What

**1. Coverage target dir nests inside `target/`** (`target-cov` → `target/llvm-cov-target`, cargo-llvm-cov's own default layout), so `cargo clean` sweeps it. The isolation that motivated a separate dir (instrumentation injected via RUSTC_WRAPPER isn't tracked by cargo's fingerprint, so sharing artifacts with `make test` yields no profraw) is preserved — it's still a self-contained target dir, just inside the swept tree.

- `Makefile`: `COVERAGE_TARGET_DIR = $(WORKSPACE_ROOT)/target/llvm-cov-target`. Derived from `WORKSPACE_ROOT` rather than `CARGO_TARGET_DIR` because the coverage recipes' target-specific `export CARGO_TARGET_DIR` shadows the global during recipe expansion and would double-nest the path. `clean` drops its extra `rm -rf`.
- `ci.yml`: coverage cache workspace follows the new path; the redundant `CARGO_TARGET_DIR` env on the coverage step is removed (the Makefile owns the path).
- `.gitignore` / `CLAUDE.md`: references updated.

**2. Dev profile drops full DWARF** (`[profile.dev] debug = "line-tables-only"`) — the same trade `[profile.test]` already makes, extended to where all *dependencies* compile. Panics still show file:line.

**3. Gate targets disable incremental compilation** (`lint test complexity coverage-data: export CARGO_INCREMENTAL := 0`). Gates are one-shot full passes; their incremental caches only cost disk (1.2GiB after a single fresh build, growing with every edit-rebuild cycle) and cargo never prunes them. `make dev` and raw cargo iteration keep incremental speed.

A size-capped auto-clean before gates was added and then reverted in-branch (kept out to avoid implicit side effects); reclaiming space stays an explicit `cargo clean`.

## Measured

Fresh `cargo test --workspace --exclude e2e-tests --all-targets --no-run` builds: 3.9GiB with old settings (1.2GiB incremental + 2.5GiB deps) → 3.1GiB with new settings (~−21%). The larger effect is on accumulation: incremental growth is eliminated from gate rebuilds, and `cargo clean` now reclaims everything in one shot.

## Verification

- `COVERAGE_CRATES=lns-ipc make coverage` — instrumented build, profraw collection, lcov emit, AST strip, and the per-file floor gate all pass against the new location.
- `cargo clean` afterwards removes `target/` including `llvm-cov-target/`.
- `cargo metadata` + `cargo build -p lns-ipc` validate the profile addition; `make -n lint`/`coverage-data` validate the Makefile.