### PR TITLE
chore(coverage): Reach 100% on phantom-DA files, drop 5 IGNORES entries

### DIFF
--- a/crates/coverage-strip-ast/src/lib.rs
+++ b/crates/coverage-strip-ast/src/lib.rs
@@ -250,6 +250,50 @@ impl<'a> ExecutableLineCollector<'a> {
         }
     }
 
+    /// Macro tokens are opaque to syn, so only the invocation line carries a real counter; the arg lines below it are LLVM phantoms, so mark the invocation and drop the interior.
+    fn note_macro_interior_phantom(&mut self, m: &syn::Macro) {
+        let open_line = m.path.span().start().line;
+        self.mark_line(open_line);
+        let close_line = match &m.delimiter {
+            syn::MacroDelimiter::Paren(d) => d.span.close().end().line,
+            syn::MacroDelimiter::Brace(d) => d.span.close().end().line,
+            syn::MacroDelimiter::Bracket(d) => d.span.close().end().line,
+        };
+        for line in (open_line + 1)..=close_line {
+            self.phantom_entry_lines.insert(line);
+        }
+    }
+
+    /// A plain `} else {` line is a connector with no condition; LLVM maps the else region's counter to the body's first line, so drop the connector when the body starts lower.
+    fn note_plain_else_connector_phantom(&mut self, node: &syn::ExprIf) {
+        let Some((else_token, else_branch)) = &node.else_branch else {
+            return;
+        };
+        let syn::Expr::Block(b) = &**else_branch else {
+            return;
+        };
+        let else_line = else_token.span().start().line;
+        if b.block
+            .stmts
+            .first()
+            .is_some_and(|s| s.span().start().line > else_line)
+        {
+            self.phantom_entry_lines.insert(else_line);
+        }
+    }
+
+    /// A multi-line struct's `..base` update line carries no independent counter — LLVM maps it to the field body — so drop it while the field-value lines keep the real signal.
+    fn note_struct_rest_phantom(&mut self, node: &syn::ExprStruct) {
+        let Some(rest) = &node.rest else {
+            return;
+        };
+        let open_line = node.brace_token.span.open().start().line;
+        let rest_line = rest.span().start().line;
+        if rest_line > open_line {
+            self.phantom_entry_lines.insert(rest_line);
+        }
+    }
+
     fn mark_line(&mut self, line: usize) {
         if line == 0 {
             return;
@@ -270,7 +314,7 @@ impl<'a> ExecutableLineCollector<'a> {
         }
         if trimmed
             .chars()
-            .all(|c| matches!(c, '}' | ')' | ']' | ';' | ',' | '?' | ' ' | '\t'))
+            .all(|c| matches!(c, '}' | ')' | '(' | ']' | ';' | ',' | '?' | ' ' | '\t'))
         {
             return;
         }
@@ -326,9 +370,22 @@ impl<'ast, 'a> Visit<'ast> for ExecutableLineCollector<'a> {
     }
 
     fn visit_expr(&mut self, expr: &'ast syn::Expr) {
-        let span = expr.span();
-        self.mark_span(span.start(), span.end());
+        // A macro's arg lines are opaque tokens LLVM never counts; visit_macro marks the one line that carries the counter.
+        if !matches!(expr, syn::Expr::Macro(_)) {
+            let span = expr.span();
+            self.mark_span(span.start(), span.end());
+        }
         syn::visit::visit_expr(self, expr);
+    }
+
+    fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+        self.note_plain_else_connector_phantom(node);
+        syn::visit::visit_expr_if(self, node);
+    }
+
+    fn visit_expr_struct(&mut self, node: &'ast syn::ExprStruct) {
+        self.note_struct_rest_phantom(node);
+        syn::visit::visit_expr_struct(self, node);
     }
 
     fn visit_macro(&mut self, m: &'ast syn::Macro) {
@@ -336,15 +393,7 @@ impl<'ast, 'a> Visit<'ast> for ExecutableLineCollector<'a> {
         if is_macro_rules_path(&m.path) {
             return;
         }
-        let path_start = m.path.span().start();
-        let tail_end = m
-            .tokens
-            .clone()
-            .into_iter()
-            .last()
-            .map(|t| t.span().end())
-            .unwrap_or_else(|| m.path.span().end());
-        self.mark_span(path_start, tail_end);
+        self.note_macro_interior_phantom(m);
         syn::visit::visit_macro(self, m);
     }
 
@@ -774,5 +823,126 @@ mod tests {
         assert!(is_macro_rules_path(&mac.mac.path));
         let other: syn::ItemMacro = syn::parse_str("other! { x }").unwrap();
         assert!(!is_macro_rules_path(&other.mac.path));
+    }
+
+    #[test]
+    fn collector_skips_closure_invocation_closer() {
+        let src = "fn f() {\n    let r = (|| {\n        work();\n        Ok::<(), ()>(())\n    })();\n    let _ = r;\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(c.lines.contains(&3), "closure body stmt kept");
+        assert!(
+            !c.lines.contains(&5),
+            "closer line is pure invocation punctuation"
+        );
+    }
+
+    #[test]
+    fn collector_drops_plain_else_connector_but_keeps_body() {
+        let src =
+            "fn f(n: u32) {\n    if n > 0 {\n        a();\n    } else {\n        b();\n    }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(c.lines.contains(&2), "if header kept");
+        assert!(c.lines.contains(&3), "then body kept");
+        assert!(!c.lines.contains(&4), "else connector line dropped");
+        assert!(
+            c.lines.contains(&5),
+            "else body kept — a never-taken else still shows 0"
+        );
+    }
+
+    #[test]
+    fn collector_keeps_else_if_connector_line() {
+        let src = "fn f(n: u32) {\n    if n > 2 {\n        a();\n    } else if n > 0 {\n        b();\n    }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(
+            c.lines.contains(&4),
+            "else-if header carries a condition — kept"
+        );
+        assert!(c.lines.contains(&5), "else-if body kept");
+    }
+
+    #[test]
+    fn collector_keeps_single_line_else() {
+        let src = "fn f(n: u32) -> u32 {\n    if n > 0 { 1 } else { 2 }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(
+            c.lines.contains(&2),
+            "single-line if/else kept (body shares the line)"
+        );
+    }
+
+    #[test]
+    fn collector_drops_multiline_struct_rest_but_keeps_field_values() {
+        let src = "fn f() -> S {\n    S {\n        a: compute(),\n        ..Default::default()\n    }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(
+            c.lines.contains(&3),
+            "field value expr kept — a never-built struct still shows 0 here"
+        );
+        assert!(
+            !c.lines.contains(&4),
+            "`..Default::default()` struct-update line dropped"
+        );
+    }
+
+    #[test]
+    fn collector_leaves_struct_without_base_update_untouched() {
+        let src = "fn f() -> S {\n    S {\n        a: 1,\n        b: 2,\n    }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(c.lines.contains(&3), "field value line kept");
+        assert!(c.lines.contains(&4), "field value line kept");
+    }
+
+    #[test]
+    fn collector_keeps_single_line_struct_rest() {
+        let src = "fn f() -> S {\n    S { a: 1, ..d() }\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(
+            c.lines.contains(&2),
+            "single-line struct-update line kept (fields share the line)"
+        );
+    }
+
+    #[test]
+    fn collector_marks_only_macro_invocation_line_not_arg_lines() {
+        let src = "fn f() {\n    assert_eq!(\n        got(),\n        want(),\n        \"msg {:?}\",\n        detail(),\n    );\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(
+            c.lines.contains(&2),
+            "macro invocation line kept — a never-run assert shows 0 here"
+        );
+        assert!(!c.lines.contains(&3), "macro arg line dropped");
+        assert!(!c.lines.contains(&5), "macro format-string line dropped");
+        assert!(!c.lines.contains(&6), "macro arg continuation line dropped");
+    }
+
+    #[test]
+    fn collector_skips_interior_of_expr_position_macro() {
+        let src = "fn f() {\n    let v = vec![\n        Item { a: 1 },\n        Item { a: 2 },\n    ];\n    let _ = v;\n}\n";
+        let ast = syn::parse_file(src).unwrap();
+        let mut c = ExecutableLineCollector::new(src);
+        c.visit_file(&ast);
+        assert!(c.lines.contains(&2), "let-with-vec! invocation line kept");
+        assert!(
+            !c.lines.contains(&3),
+            "vec! interior line dropped (opaque macro tokens)"
+        );
+        assert!(!c.lines.contains(&4), "vec! interior line dropped");
     }
 }

--- a/crates/lns-service/src/content_store/mod.rs
+++ b/crates/lns-service/src/content_store/mod.rs
@@ -341,6 +341,31 @@ mod tests {
     }
 
     #[test]
+    fn install_from_reader_returns_cached_blob_when_already_present() {
+        let d = tempdir();
+        let store = ContentStore::new(d.path());
+        let bytes = b"streamed twice, stored once";
+        let first = store
+            .install_from_reader(std::io::Cursor::new(&bytes[..]))
+            .unwrap();
+        let second = store
+            .install_from_reader(std::io::Cursor::new(&bytes[..]))
+            .unwrap();
+        assert_eq!(first, second, "second stream returns the cached blob");
+        let dir = d.path().join("sha256");
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            1,
+            "identical content is stored once"
+        );
+        let stray_tmp = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_str().is_some_and(|s| s.contains(".tmp.")));
+        assert!(!stray_tmp, "cache-hit path removes its temp file");
+    }
+
+    #[test]
     fn install_is_idempotent_for_same_bytes() {
         let d = tempdir();
         let store = ContentStore::new(d.path());

--- a/scripts/coverage-floor.sh
+++ b/scripts/coverage-floor.sh
@@ -89,17 +89,6 @@ crates/lns-service/src/tray.rs                           eframe main-loop adapte
 crates/lns-service/examples/approval_preview.rs          dev-only egui preview harness — seeds fixtures and calls the production render_stack so style edits preview live; run manually via `cargo run -p lns-service --example approval_preview`, never run by `cargo test --all-targets`.
 crates/lns-service/src/dashboard/mod.rs                  egui render surface — panels/areas/modal/immediate-viewport need a live frame + pointer input (no headless egui harness in-crate). The pure residue (value/label formatting, friendly/relative time bucketing) lives at 100% in dashboard/{filter,sandboxes,live,format}.rs; load/apply_theme/viewport_builder and now_unix_secs are thin wiring exercised by the audit_dashboard example and driven live from tray.rs.
 crates/lns-service/examples/audit_dashboard.rs           dev-only egui preview harness — seeds fixtures and calls the production dashboard::render so style edits preview live; run manually via `cargo run -p lns-service --example audit_dashboard`, never run by `cargo test --all-targets`.
-
-# LLVM opener-line phantom DAs — LLVM maps the execution counter for a multi-line construct to
-# the first instruction of the body, leaving the opener line with 0 count even when the body runs.
-# Drop these entries when coverage-strip-ast is extended to recognise and strip opener lines for
-# `} else {`, multi-line struct/enum literals, match-arm `=>` patterns, and `()` closure
-# invocation sites.
-crates/lns-cli/src/service.rs                            99%+ — `println!` string literal, `} else {` opener, `anyhow::bail!` format-arg lines, named `writeln!` args, and `assert!` message-string lines in full-workspace builds; LLVM maps counters to body lines. Drop when opener-line and macro-arg stripping lands in coverage-strip-ast.
-crates/lns-service/src/content_store/mod.rs              99%+ — `})();` closure-invocation expression; LLVM maps counter past the opener. Drop when opener-line stripping lands in coverage-strip-ast.
-crates/lns-service/src/ingest.rs                         99%+ — `..Default::default()` struct-update in test helper; LLVM maps counter to initialiser body. Drop when opener-line stripping lands in coverage-strip-ast.
-crates/lns-service/src/log.rs                            99%+ — a single multi-line `assert!` format-arg closer (`buf.text(),`) in a test; LLVM maps the counter to the macro body, not the arg line. The local-render tty gate (local_log_layer_accepts target/in_run_scope/stderr_is_tty) and detect_color are host-tested at 100%. Drop when macro-arg-line stripping lands in coverage-strip-ast.
-crates/lns-service/src/runtime_layer/mod.rs              99%+ — `} else {` branch-opener and a struct-literal opener inside a test vec; LLVM maps counters to body lines. Drop when opener-line stripping lands in coverage-strip-ast.
 EOF
 
 # LF==0 means no executable lines after AST strip — vacuously 100%.


### PR DESCRIPTION
## Summary

`scripts/coverage-floor.sh` gates every file at 100% line coverage unless it's in the IGNORES table — and the table is the tracker (a file leaves it when it reaches 100%). Five files were parked under a **"LLVM opener-line phantom DAs"** block: each sat at 99%+ and was ignored *only because* `coverage-strip-ast` didn't yet strip a handful of non-executable source-mapping artifact lines. Every one of those entries' reasons literally ended with "Drop when … stripping lands in coverage-strip-ast." This PR lands that stripping and removes the entries.

### 1. Four artifact-stripping rules in `coverage-strip-ast`

The AST classifier gains four narrow rules. The invariant that makes each safe: **only lines with no independently-measurable executable content are dropped; the real execution counter always lives on a sibling line that is kept** — so a never-taken `else` body or never-built struct field still reads `0`.

| Rule | Artifact | Cleared in |
|------|----------|------------|
| `(` added to the pure-punctuation closer set | `})();` closure-invocation closers | `content_store/mod.rs` |
| plain `} else {` connector (else-branch is a `Block`, body starts lower) | branch-connector line with no condition | `runtime_layer/mod.rs`, `lns-cli/src/service.rs` |
| multi-line struct `..base` update line | `..Default::default()` | `ingest.rs` |
| macro invocation keeps only its call line; interior arg lines dropped | `println!`/`writeln!`/`bail!`/`assert!` arg + string-literal lines | `log.rs`, `lns-cli/src/service.rs`, `runtime_layer/mod.rs` |

`else if` connectors (they carry a condition) and single-line forms are explicitly kept — each rule ships with a negative guardrail test proving a genuinely-uncovered executable line inside the construct is still measured.

The macro rule is deliberately broad (all interior lines of every invocation, workspace-wide): syn treats macro tokens as opaque and LLVM maps the counter to the invocation line, so interior arg lines are inherently phantom. The invocation line is always preserved, so "did this macro run" is still measured.

### 2. Retire the five IGNORES entries

The five phantom-DA entries and their explanatory comment block are removed from `scripts/coverage-floor.sh`; all five files now report 100% under the full-workspace gate.

### 3. Pin a real dedup gap surfaced by dropping the `content_store` ignore

Removing the blanket ignore on `content_store/mod.rs` exposed a genuinely untested branch — `install_from_reader`'s cache-hit path (identical content streamed twice returns the cached blob and removes the temp file). This was masked by the file-level ignore, not a phantom; it's now pinned by a Layer 3 test rather than re-ignored.

## Test instructions

1. `cd crates/coverage-strip-ast && cargo test` — 40 unit tests pass, including the eight new rule tests and their guardrails.
2. `make coverage` (full workspace — required here because touching `coverage-floor.sh` and `crates/coverage-strip-ast/*` both force `__FULL__`). Confirm the five files (`lns-cli/src/service.rs`, `content_store/mod.rs`, `ingest.rs`, `log.rs`, `runtime_layer/mod.rs`) each report `OK … 100.00%`, `coverage-strip-ast/src/lib.rs` is at 100%, and no other file regresses to FAIL.
3. `make lint && make complexity` — clean.