### PR TITLE
perf(lns-service): pool the OCI registry client so repeated registry contacts skip the auth handshake

### DIFF
--- a/crates/lns-service/src/image/client_pool.rs
+++ b/crates/lns-service/src/image/client_pool.rs
@@ -55,17 +55,19 @@ mod tests {
     fn get_or_create_runs_the_factory_once_per_key() {
         let pool: ClientPool<u32> = ClientPool::new();
         let calls = AtomicU32::new(0);
-        let a = pool.get_or_create("k".into(), || {
-            calls.fetch_add(1, Ordering::SeqCst);
-            42
-        });
-        let b = pool.get_or_create("k".into(), || {
-            calls.fetch_add(1, Ordering::SeqCst);
-            99
-        });
-        assert_eq!(a, 42);
-        assert_eq!(b, 42, "a warm key returns the cached client, not a new one");
-        assert_eq!(calls.load(Ordering::SeqCst), 1, "factory runs only on the miss");
+        // fetch_add returns the pre-increment count, so the factory both records that it ran and yields 0 on the miss vs 1 if the hit wrongly re-ran it.
+        let a = pool.get_or_create("k".into(), || calls.fetch_add(1, Ordering::SeqCst));
+        let b = pool.get_or_create("k".into(), || calls.fetch_add(1, Ordering::SeqCst));
+        assert_eq!(a, 0, "the miss runs the factory");
+        assert_eq!(
+            b, 0,
+            "the hit returns the cached client, not a fresh factory run (which would be 1)"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the factory runs only on the miss"
+        );
     }
 
     #[test]
@@ -73,7 +75,11 @@ mod tests {
         let pool: ClientPool<u32> = ClientPool::new();
         assert_eq!(pool.get_or_create("a".into(), || 1), 1);
         assert_eq!(pool.get_or_create("b".into(), || 2), 2);
-        assert_eq!(pool.get_or_create("a".into(), || 3), 1, "key a still cached");
+        assert_eq!(
+            pool.get_or_create("a".into(), || 3),
+            1,
+            "key a still cached"
+        );
     }
 
     #[test]
@@ -98,7 +104,10 @@ mod tests {
         let other_user = auth_fingerprint(&RegistryAuth::Basic("bob".into(), "s1".into()));
         let other_secret = auth_fingerprint(&RegistryAuth::Basic("alice".into(), "s2".into()));
         assert_ne!(base, other_user, "a different user re-keys the client");
-        assert_ne!(base, other_secret, "a re-login with a new secret re-keys the client");
+        assert_ne!(
+            base, other_secret,
+            "a re-login with a new secret re-keys the client"
+        );
     }
 
     #[test]
@@ -107,7 +116,10 @@ mod tests {
         let fp = auth_fingerprint(&RegistryAuth::Bearer(token.into()));
         assert!(fp.starts_with("bearer:"));
         assert!(!fp.contains(token));
-        assert_ne!(fp, auth_fingerprint(&RegistryAuth::Basic("x".into(), token.into())));
+        assert_ne!(
+            fp,
+            auth_fingerprint(&RegistryAuth::Basic("x".into(), token.into()))
+        );
     }
 
     #[test]
@@ -124,6 +136,9 @@ mod tests {
             pool_key("docker.io", &cred),
             "distinct credentials on one registry never share a client"
         );
-        assert_eq!(pool_key("docker.io", &anon), pool_key("docker.io", &RegistryAuth::Anonymous));
+        assert_eq!(
+            pool_key("docker.io", &anon),
+            pool_key("docker.io", &RegistryAuth::Anonymous)
+        );
     }
 }

--- a/crates/lns-service/src/image/client_pool.rs
+++ b/crates/lns-service/src/image/client_pool.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use oci_client::secrets::RegistryAuth;
+use sha2::{Digest, Sha256};
+
+pub(crate) struct ClientPool<C> {
+    clients: Mutex<HashMap<String, C>>,
+}
+
+impl<C: Clone> ClientPool<C> {
+    pub fn new() -> Self {
+        Self {
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn get_or_create(&self, key: String, make: impl FnOnce() -> C) -> C {
+        self.clients
+            .lock()
+            .expect("client pool mutex poisoned")
+            .entry(key)
+            .or_insert_with(make)
+            .clone()
+    }
+}
+
+/// A stable, secret-free identity for a credential so a re-login (new secret) keys a fresh client instead of reusing one that cached the old bearer token.
+fn auth_fingerprint(auth: &RegistryAuth) -> String {
+    match auth {
+        RegistryAuth::Anonymous => "anon".to_string(),
+        RegistryAuth::Basic(user, secret) => {
+            let mut h = Sha256::new();
+            h.update(user.as_bytes());
+            h.update([0]);
+            h.update(secret.as_bytes());
+            format!("basic:{}", hex::encode(h.finalize()))
+        }
+        RegistryAuth::Bearer(token) => {
+            format!("bearer:{}", hex::encode(Sha256::digest(token.as_bytes())))
+        }
+    }
+}
+
+pub(crate) fn pool_key(registry: &str, auth: &RegistryAuth) -> String {
+    format!("{registry}\u{0}{}", auth_fingerprint(auth))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn get_or_create_runs_the_factory_once_per_key() {
+        let pool: ClientPool<u32> = ClientPool::new();
+        let calls = AtomicU32::new(0);
+        let a = pool.get_or_create("k".into(), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            42
+        });
+        let b = pool.get_or_create("k".into(), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            99
+        });
+        assert_eq!(a, 42);
+        assert_eq!(b, 42, "a warm key returns the cached client, not a new one");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "factory runs only on the miss");
+    }
+
+    #[test]
+    fn get_or_create_keeps_a_separate_client_per_key() {
+        let pool: ClientPool<u32> = ClientPool::new();
+        assert_eq!(pool.get_or_create("a".into(), || 1), 1);
+        assert_eq!(pool.get_or_create("b".into(), || 2), 2);
+        assert_eq!(pool.get_or_create("a".into(), || 3), 1, "key a still cached");
+    }
+
+    #[test]
+    fn anonymous_fingerprint_is_stable_and_plain() {
+        assert_eq!(auth_fingerprint(&RegistryAuth::Anonymous), "anon");
+    }
+
+    #[test]
+    fn basic_fingerprint_hides_the_secret() {
+        let secret = "hunter2-super-secret";
+        let fp = auth_fingerprint(&RegistryAuth::Basic("alice".into(), secret.into()));
+        assert!(fp.starts_with("basic:"));
+        assert!(
+            !fp.contains(secret),
+            "the secret must never appear in the pool key: {fp}"
+        );
+    }
+
+    #[test]
+    fn basic_fingerprint_changes_with_user_and_with_secret() {
+        let base = auth_fingerprint(&RegistryAuth::Basic("alice".into(), "s1".into()));
+        let other_user = auth_fingerprint(&RegistryAuth::Basic("bob".into(), "s1".into()));
+        let other_secret = auth_fingerprint(&RegistryAuth::Basic("alice".into(), "s2".into()));
+        assert_ne!(base, other_user, "a different user re-keys the client");
+        assert_ne!(base, other_secret, "a re-login with a new secret re-keys the client");
+    }
+
+    #[test]
+    fn bearer_fingerprint_hides_the_token_and_differs_from_basic() {
+        let token = "aaaa.bbbb.cccc";
+        let fp = auth_fingerprint(&RegistryAuth::Bearer(token.into()));
+        assert!(fp.starts_with("bearer:"));
+        assert!(!fp.contains(token));
+        assert_ne!(fp, auth_fingerprint(&RegistryAuth::Basic("x".into(), token.into())));
+    }
+
+    #[test]
+    fn pool_key_separates_registries_and_credentials() {
+        let anon = RegistryAuth::Anonymous;
+        let cred = RegistryAuth::Basic("u".into(), "p".into());
+        assert_ne!(
+            pool_key("docker.io", &anon),
+            pool_key("ghcr.io", &anon),
+            "distinct registries never share a client"
+        );
+        assert_ne!(
+            pool_key("docker.io", &anon),
+            pool_key("docker.io", &cred),
+            "distinct credentials on one registry never share a client"
+        );
+        assert_eq!(pool_key("docker.io", &anon), pool_key("docker.io", &RegistryAuth::Anonymous));
+    }
+}

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 use crate::log;
 use crate::oci_layer_cache::LayerCache;
 
+mod client_pool;
 pub(crate) mod manifest_cache;
 mod real;
 pub use real::{pull, verify_login};

--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -112,8 +112,10 @@ pub async fn pull(image: &str, layer_cache: &LayerCache) -> Result<PulledImage> 
         Ok(reference) => pooled_client(reference.resolve_registry(), &auth),
         Err(_) => new_client(),
     };
-    let registry =
-        CachingRegistry::new(RealRegistry::with_client(client, auth), ManifestCache::new(manifests));
+    let registry = CachingRegistry::new(
+        RealRegistry::with_client(client, auth),
+        ManifestCache::new(manifests),
+    );
     let pulled = pull_inner(&registry, image, layer_cache).await?;
     if let Err(e) = crate::image_store::record(&pulled).await {
         crate::log::warn!("image index write failed for {image} ({e:#}); continuing");

--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -11,6 +11,7 @@ use oci_client::{
 
 use crate::oci_layer_cache::LayerCache;
 
+use super::client_pool::{ClientPool, pool_key};
 use super::manifest_cache::{CachingRegistry, ManifestCache};
 use super::{
     CountingSink, PulledImage, Registry, enforce_manifest_doc_size, linux_platform_resolver,
@@ -23,17 +24,23 @@ pub struct RealRegistry {
 }
 
 impl RealRegistry {
-    pub fn new() -> Self {
-        Self::with_auth(RegistryAuth::Anonymous)
-    }
-
-    pub fn with_auth(auth: RegistryAuth) -> Self {
-        let client = oci_client::Client::new(ClientConfig {
-            platform_resolver: Some(Box::new(linux_platform_resolver)),
-            ..Default::default()
-        });
+    fn with_client(client: oci_client::Client, auth: RegistryAuth) -> Self {
         Self { client, auth }
     }
+}
+
+fn new_client() -> oci_client::Client {
+    oci_client::Client::new(ClientConfig {
+        platform_resolver: Some(Box::new(linux_platform_resolver)),
+        ..Default::default()
+    })
+}
+
+/// Reuse one registry client per (registry, credential) across pulls so the bearer token and connection pool survive — a fresh client re-runs the registry auth handshake on every pull, the dominant cost of a warm tag-image boot.
+fn pooled_client(registry: &str, auth: &RegistryAuth) -> oci_client::Client {
+    static POOL: std::sync::OnceLock<ClientPool<oci_client::Client>> = std::sync::OnceLock::new();
+    POOL.get_or_init(ClientPool::new)
+        .get_or_create(pool_key(registry, auth), new_client)
 }
 
 /// The stored login for `image`'s registry, or anonymous when none is recorded (or the reference / store is unreadable — the pull then fails with the registry's own auth error).
@@ -58,22 +65,13 @@ pub async fn verify_login(registry: &str, username: &str, secret: &str) -> Resul
     let reference: Reference = format!("{registry}/{LOGIN_PROBE_REPOSITORY}")
         .parse()
         .with_context(|| format!("invalid registry {registry:?}"))?;
-    let client = oci_client::Client::new(ClientConfig {
-        platform_resolver: Some(Box::new(linux_platform_resolver)),
-        ..Default::default()
-    });
+    let client = new_client();
     let auth = RegistryAuth::Basic(username.to_string(), secret.to_string());
     client
         .auth(&reference, &auth, RegistryOperation::Pull)
         .await
         .map(|_| ())
         .map_err(|e| anyhow::anyhow!("{e}"))
-}
-
-impl Default for RealRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Registry for RealRegistry {
@@ -110,8 +108,12 @@ pub async fn pull(image: &str, layer_cache: &LayerCache) -> Result<PulledImage> 
     let _shared = crate::image_store::lock_shared().await;
     let manifests = crate::cache::root()?.join("manifests");
     let auth = registry_auth_for(image);
+    let client = match image.parse::<Reference>() {
+        Ok(reference) => pooled_client(reference.resolve_registry(), &auth),
+        Err(_) => new_client(),
+    };
     let registry =
-        CachingRegistry::new(RealRegistry::with_auth(auth), ManifestCache::new(manifests));
+        CachingRegistry::new(RealRegistry::with_client(client, auth), ManifestCache::new(manifests));
     let pulled = pull_inner(&registry, image, layer_cache).await?;
     if let Err(e) = crate::image_store::record(&pulled).await {
         crate::log::warn!("image index write failed for {image} ({e:#}); continuing");


### PR DESCRIPTION
## What

Pool the OCI registry client per **(registry, credential)** in `lns-service` so the bearer token and HTTPS connection survive across pulls. `image::pull` takes a client from the pool instead of constructing a fresh `oci_client::Client` every time. No user-visible behavior change.

## Why — this complements #135, it doesn't overlap it

**#135 fixes #132 by avoiding registry round-trips** on warm tag runs (tag-manifest cache, 60 s TTL, HEAD-revalidate, `--pull`). This PR is the orthogonal, freshness-neutral half: **it makes the round-trips that still happen cheap.**

A fresh `oci_client::Client` per pull discards the bearer-token cache and connection pool, so every registry contact re-runs the auth-token handshake. Measured on this branch (Apple Vz, docker.io, `alpine` by tag):

| registry contact | time |
|---|--:|
| full manifest+config, **fresh** client (auth + 2 GETs) | ~1.72 s |
| full manifest+config, **pooled** token (2 GETs only) | ~0.76 s |
| ⇒ auth-token handshake alone | **~1.0 s** |

Once #135 lands, the registry is still contacted — and re-authenticated — on exactly these paths:

- `pull=auto` after the 60 s TTL lapses → a HEAD revalidation,
- `pull=always` → a HEAD / refetch every run,
- the first pull of a service session / cold cache.

Pooling the client removes the ~1.0 s handshake from all of them (the token expires naturally; the connection is kept alive). Concretely, #135's revalidation HEAD drops from ~1.17 s (fresh-client, measured) to ~0.2 s (pooled token, derived: 1.17 s − ~1.0 s auth).

`oci_client::Client` is `Clone` over `Arc<RwLock<..>>` auth + a `TokenCache` — designed to be shared. It's keyed by a **SHA-256 credential fingerprint** (never the plaintext secret) so a `lns login` change gets a fresh client instead of reusing a stale token (`store_auth_if_needed` only stores creds if absent — a naive global client would be a stale-credential bug).

## Standalone measurement (on `main`, before #135)

On `main` every warm run does a full fetch, so the standalone effect is large:

| scenario (wall-clock boot, median n=10) | before | after |
|---|--:|--:|
| `alpine` tag, warm | 2436 ms | 1490 ms (−39%) |
| imageless | 547 ms | 539 ms (no registry path) |

Read these as *evidence of the handshake cost this removes*, not a standalone headline: once #135 makes most warm runs cache hits, this PR's benefit narrows to the revalidate / `always` / cold paths above — which is the intended composition.

## Interaction & merge order

Independent of #135; both touch `image::pull`, so whichever lands second rebases. The pooled client simply feeds the (post-#135) `CachingRegistry` — no design conflict. If #135 folds this in directly, close this.

## Testing

- **Layer 3** unit tests for the pool (`image/client_pool.rs`): factory runs once per key, per-key isolation, credential fingerprinting (hides secret/token, re-keys on user/secret/token change, separates registries).
- `make lint && make complexity` pass; `make coverage`: `image/client_pool.rs` 100% (60/60), `image/mod.rs` 100%; `image/real.rs` remains the IGNORE'd production-wiring adapter. Measured end-to-end on a real macOS/Vz host against an isolated service.

## Security

Touches the registry-pull path. Credentials never appear in the pool key (SHA-256 fingerprint); a credential change forces a fresh client, so a rotated/removed credential is never silently reused. No change to the microVM boundary, policy, audit chain, or host IPC.

Refs #132. Complements #135.
