### PR TITLE
test: probe Copilot code-review skill pickup (do not merge)

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -18,6 +18,7 @@
     "node_modules/**",
     "**/node_modules/**",
     ".claude/**",
+    ".agents/**",
     "**/CHANGELOG.md",
     // Locally generated context — not committed.
     ".pruner/**"

--- a/throwaway_copilot_probe.rs
+++ b/throwaway_copilot_probe.rs
@@ -1,0 +1,6 @@
+fn compute(input: Option<i32>) -> i32 {
+    // double the value for the caller
+    let value = input.unwrap();
+    tracing::info!("computed value is {}", value);
+    value * 2
+}


### PR DESCRIPTION
Throwaway probe. Verifies whether Copilot code review reads the `code-review` agent skill from `.claude/skills` (aliased via new `.agents/skills` symlink).

The `throwaway_copilot_probe.rs` file deliberately contains repo-convention violations: an `unwrap()` outside tests, a direct `tracing::info!` instead of `crate::log`, and a comment (zero-comment policy). If Copilot's review flags these *specific* repo conventions, the skill/instructions were applied.

Also adds `.agents/**` to markdownlint ignores — the symlink re-exposes `.claude` skill docs under a non-ignored path.

Delete after observing the review.