### PR TITLE
chore: add .agents/skills symlink for cross-agent skill discovery

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -18,6 +18,7 @@
     "node_modules/**",
     "**/node_modules/**",
     ".claude/**",
+    ".agents/**",
     "**/CHANGELOG.md",
     // Locally generated context — not committed.
     ".pruner/**"


### PR DESCRIPTION
## What

- Add `.agents/skills` → `../.claude/skills` symlink, exposing the existing skills under the neutral `.agents/skills` path read by Codex/Cursor and other agents. `.claude/skills` stays the real directory Claude Code reads.
- Add `.agents/**` to `.markdownlint-cli2.jsonc` ignores.

## Why the lint-ignore is part of the same change

The skill docs are exempt from markdownlint only via the existing `.claude/**` ignore. The symlink aliases those same files under `.agents/skills/**`, which the `**/*.md` glob would otherwise lint — failing the husky pre-commit/pre-push hooks. Ignoring `.agents/**` keeps them exempt through the alias.

## Scope

No Rust touched. Does not add anything Copilot-code-review-specific — repo conventions already reach Copilot review via `CLAUDE.md`. Whether code review reads skills from `.claude`/`.agents` remains a separate open question, testable once this is on `main`.