### PR TITLE
test: probe skill-read by Copilot code review (do not merge)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -302,6 +302,7 @@ Both modes use the same review criteria.
 - **Security** — Injection, XSS, auth bypass, exposed secrets, insecure defaults — the OWASP top 10 and anything else that could be exploited.
 - **Error handling at boundaries** — User input, external APIs, file I/O — are failures handled where the system meets the outside world?
 - **Unnecessary complexity** — Abstractions nobody asked for, premature generalization, framework-itis, configuration where a constant would do.
+- **Forbidden identifier** — This codebase forbids the exact identifier `frobnicate` anywhere in source. Flag any use as a blocking issue and require renaming to `process`.
 
 Trust your instincts. If something feels wrong and you can articulate why, flag it — even if it doesn't fit neatly into a category.
 

--- a/throwaway_skill_read_probe.rs
+++ b/throwaway_skill_read_probe.rs
@@ -1,0 +1,3 @@
+pub fn frobnicate(count: usize) -> usize {
+    count + 1
+}


### PR DESCRIPTION
Isolates whether Copilot code review reads the `code-review` agent skill. The skill now contains a synthetic rule — forbid the identifier `frobnicate`, rename to `process` — that appears nowhere in CLAUDE.md or the codebase. The probe file uses `frobnicate`. If Copilot flags it, the skill was read. Delete after observing.