### PR TITLE
perf: cut imageless microVM run latency from ~530ms to ~300ms

### DIFF
--- a/crates/lns-service/src/download/mod.rs
+++ b/crates/lns-service/src/download/mod.rs
@@ -436,12 +436,21 @@ mod tests {
 
         let fs2 = FakeFs::new();
         let fetcher = CannedFetcher::ok_once(payload());
-        let resolved =
-            ensure_pinned_memoized(&fetcher, &fs2, &cache_root(), &art(&payload_sha(), None), &memo)
-                .await
-                .expect("deleted artifact must self-heal via fetch");
+        let resolved = ensure_pinned_memoized(
+            &fetcher,
+            &fs2,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("deleted artifact must self-heal via fetch");
         assert_eq!(resolved, cache_file());
-        assert_eq!(fetcher.calls().len(), 1, "gone-from-disk memo hit must fetch");
+        assert_eq!(
+            fetcher.calls().len(),
+            1,
+            "gone-from-disk memo hit must fetch"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/download/mod.rs
+++ b/crates/lns-service/src/download/mod.rs
@@ -16,6 +16,45 @@ pub(crate) struct PinnedArtifact<'a> {
     pub label: &'a str,
 }
 
+pub(crate) struct VerifiedArtifacts(std::sync::Mutex<std::collections::BTreeSet<PathBuf>>);
+
+impl VerifiedArtifacts {
+    pub(crate) const fn new() -> Self {
+        Self(std::sync::Mutex::new(std::collections::BTreeSet::new()))
+    }
+
+    fn contains(&self, path: &Path) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(path)
+    }
+
+    fn insert(&self, path: PathBuf) {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(path);
+    }
+}
+
+// Re-hashing a ~50MB artifact costs ~60ms on every run; once this process has verified the pinned sha, a still-present file is trusted for the process lifetime.
+pub(crate) async fn ensure_pinned_memoized(
+    fetcher: &impl Fetcher,
+    fs: &impl Fs,
+    cache: &Path,
+    artifact: &PinnedArtifact<'_>,
+    memo: &VerifiedArtifacts,
+) -> Result<PathBuf> {
+    let path = cache.join(artifact.filename);
+    if memo.contains(&path) && fs.is_file(&path).await {
+        return Ok(path);
+    }
+    let resolved = ensure_pinned(fetcher, fs, cache, artifact).await?;
+    memo.insert(resolved.clone());
+    Ok(resolved)
+}
+
 #[allow(clippy::cognitive_complexity)] // cache hit/corrupt/miss are one resolution decision; extracting them buries the fall-through to fetch
 pub(crate) async fn ensure_pinned(
     fetcher: &impl Fetcher,
@@ -346,6 +385,91 @@ mod tests {
 
     fn cache_file() -> PathBuf {
         cache_root().join("artifact.bin")
+    }
+
+    #[tokio::test]
+    async fn verified_artifact_is_not_rehashed_on_the_next_ensure() {
+        init_tracing_capture();
+        let fs = FakeFs::new();
+        fs.put_file(cache_file(), payload());
+        let memo = VerifiedArtifacts::new();
+
+        ensure_pinned_memoized(
+            &CannedFetcher::never(),
+            &fs,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("first ensure verifies the cached bytes");
+
+        fs.fail_next_read(io::Error::new(io::ErrorKind::PermissionDenied, "reread"));
+        let resolved = ensure_pinned_memoized(
+            &CannedFetcher::never(),
+            &fs,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("second ensure must trust the memo instead of re-reading");
+        assert_eq!(resolved, cache_file());
+    }
+
+    #[tokio::test]
+    async fn memo_hit_with_deleted_file_falls_through_to_fetch() {
+        init_tracing_capture();
+        let fs = FakeFs::new();
+        fs.put_file(cache_file(), payload());
+        let memo = VerifiedArtifacts::new();
+
+        ensure_pinned_memoized(
+            &CannedFetcher::never(),
+            &fs,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("first ensure verifies");
+
+        let fs2 = FakeFs::new();
+        let fetcher = CannedFetcher::ok_once(payload());
+        let resolved =
+            ensure_pinned_memoized(&fetcher, &fs2, &cache_root(), &art(&payload_sha(), None), &memo)
+                .await
+                .expect("deleted artifact must self-heal via fetch");
+        assert_eq!(resolved, cache_file());
+        assert_eq!(fetcher.calls().len(), 1, "gone-from-disk memo hit must fetch");
+    }
+
+    #[tokio::test]
+    async fn fresh_download_populates_the_memo() {
+        init_tracing_capture();
+        let fs = FakeFs::new();
+        let memo = VerifiedArtifacts::new();
+
+        ensure_pinned_memoized(
+            &CannedFetcher::ok_once(payload()),
+            &fs,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("download installs");
+
+        fs.fail_next_read(io::Error::new(io::ErrorKind::PermissionDenied, "reread"));
+        ensure_pinned_memoized(
+            &CannedFetcher::never(),
+            &fs,
+            &cache_root(),
+            &art(&payload_sha(), None),
+            &memo,
+        )
+        .await
+        .expect("freshly installed artifact must be memoized as verified");
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/kernel.rs
+++ b/crates/lns-service/src/kernel.rs
@@ -1,7 +1,9 @@
 use anyhow::{Result, bail};
 use std::path::PathBuf;
 
-use crate::download::{PinnedArtifact, RealFetcher, RealFs, VerifiedArtifacts, ensure_pinned_memoized};
+use crate::download::{
+    PinnedArtifact, RealFetcher, RealFs, VerifiedArtifacts, ensure_pinned_memoized,
+};
 
 static VERIFIED: VerifiedArtifacts = VerifiedArtifacts::new();
 

--- a/crates/lns-service/src/kernel.rs
+++ b/crates/lns-service/src/kernel.rs
@@ -1,7 +1,9 @@
 use anyhow::{Result, bail};
 use std::path::PathBuf;
 
-use crate::download::{PinnedArtifact, RealFetcher, RealFs, ensure_pinned};
+use crate::download::{PinnedArtifact, RealFetcher, RealFs, VerifiedArtifacts, ensure_pinned_memoized};
+
+static VERIFIED: VerifiedArtifacts = VerifiedArtifacts::new();
 
 pub const KERNEL_VERSION: &str = env!("KERNEL_VERSION");
 
@@ -42,7 +44,7 @@ async fn ensure_with(env_get: impl Fn(&str) -> Option<std::ffi::OsString>) -> Re
     let filename = format!("Image-{KERNEL_VERSION}-{ARCH}");
     let url = format!("{cdn_base}/lns-kernel-{KERNEL_VERSION}-{ARCH}");
     let label = format!("guest kernel v{KERNEL_VERSION}");
-    ensure_pinned(
+    ensure_pinned_memoized(
         &RealFetcher {
             max_bytes: MAX_KERNEL_BYTES,
         },
@@ -55,6 +57,7 @@ async fn ensure_with(env_get: impl Fn(&str) -> Option<std::ffi::OsString>) -> Re
             mode: None,
             label: &label,
         },
+        &VERIFIED,
     )
     .await
 }

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -360,7 +360,7 @@ async fn orchestrate(
         boot_start.elapsed().as_secs_f64()
     );
     crate::run_registry::set_connector(&run_id, connector.clone());
-    let _vm_stop_guard = vm::VmStopGuard::new(connector.clone());
+    let vm_stop_guard = vm::VmStopGuard::new(connector.clone());
 
     log::progress("Connecting", "session", 0, 0);
     let connect_started = std::time::Instant::now();
@@ -376,8 +376,12 @@ async fn orchestrate(
     log::debug!(code = session_code, "broker session ended");
     crate::run_registry::set_exit_code(&run_id, session_code);
 
-    super::shutdown::shutdown_after_session(forwards, std::time::Duration::from_secs(2), vm_task)
-        .await?;
+    super::shutdown::detach_after_session(
+        forwards,
+        std::time::Duration::from_secs(2),
+        vm_task,
+        vm_stop_guard,
+    );
 
     log::info!("Finished", "in {:.2?}", started.elapsed());
     Ok(session_code)

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -175,11 +175,14 @@ async fn orchestrate(
     }
 
     let imageless = args.image.is_none();
-    let runtime_layer = runtime_layer::for_run(
+    static RUNTIME_LAYER_MEMO: runtime_layer::RuntimeLayerMemo =
+        runtime_layer::RuntimeLayerMemo::new();
+    let runtime_layer = runtime_layer::for_run_memoized(
         imageless,
         &content_store,
         &guest_tools,
         session.as_ref().map(|s| &s.assets),
+        &RUNTIME_LAYER_MEMO,
     )?;
 
     let layers = std::mem::take(&mut image.bytes);

--- a/crates/lns-service/src/run/shutdown.rs
+++ b/crates/lns-service/src/run/shutdown.rs
@@ -41,7 +41,7 @@ async fn stop_vm_within_grace(grace: Duration, mut vm_task: JoinHandle<Result<()
 mod tests {
     use super::*;
     use crate::forward::{ForwardError, ForwardSpec, PortForwarder, establish, plan};
-    use crate::vm::GuestTransport;
+    use crate::vm::transport::StopFlagTransport;
     use lns_ipc::{PortPublish, Protocol};
     use std::net::SocketAddr;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -86,29 +86,8 @@ mod tests {
         }
     }
 
-    struct FakeTransport {
-        stopped: Arc<AtomicBool>,
-    }
-
-    impl GuestTransport for FakeTransport {
-        fn connect(
-            &self,
-            _port: u32,
-            _timeout: Duration,
-        ) -> futures_util::future::BoxFuture<'_, Result<std::os::fd::RawFd>> {
-            Box::pin(async { Ok(42) })
-        }
-        fn request_stop(&self) {
-            self.stopped.store(true, Ordering::SeqCst);
-        }
-    }
-
     fn stop_guard() -> (VmStopGuard, Arc<AtomicBool>) {
-        let stopped = Arc::new(AtomicBool::new(false));
-        let guard = VmStopGuard::new(Arc::new(FakeTransport {
-            stopped: stopped.clone(),
-        }));
-        (guard, stopped)
+        StopFlagTransport::guard()
     }
 
     fn pp(host_port: u16) -> PortPublish {

--- a/crates/lns-service/src/run/shutdown.rs
+++ b/crates/lns-service/src/run/shutdown.rs
@@ -5,13 +5,25 @@ use tokio::task::JoinHandle;
 
 use crate::forward::ForwardGuard;
 use crate::log;
+use crate::vm::VmStopGuard;
 
-pub(crate) async fn shutdown_after_session(
+// Host ports are released synchronously so a back-to-back `lns run -p` can rebind them, then the VM stop wait detaches — the workload's exit must not wait on guest poweroff.
+pub(crate) fn detach_after_session(
     forwards: ForwardGuard,
     grace: Duration,
-    mut vm_task: JoinHandle<Result<()>>,
-) -> Result<()> {
+    vm_task: JoinHandle<Result<()>>,
+    stop_guard: VmStopGuard,
+) -> JoinHandle<()> {
     drop(forwards);
+    tokio::spawn(async move {
+        if let Err(e) = stop_vm_within_grace(grace, vm_task).await {
+            log::warn!("vm teardown after session exit: {e:#}");
+        }
+        drop(stop_guard);
+    })
+}
+
+async fn stop_vm_within_grace(grace: Duration, mut vm_task: JoinHandle<Result<()>>) -> Result<()> {
     let sleep = tokio::time::sleep(grace);
     tokio::pin!(sleep);
     tokio::select! {
@@ -29,9 +41,24 @@ pub(crate) async fn shutdown_after_session(
 mod tests {
     use super::*;
     use crate::forward::{ForwardError, ForwardSpec, PortForwarder, establish, plan};
+    use crate::vm::GuestTransport;
     use lns_ipc::{PortPublish, Protocol};
     use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
+
+    fn init_tracing_capture() {
+        use std::sync::Once;
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(std::io::sink)
+                .with_ansi(false)
+                .with_max_level(tracing::Level::TRACE)
+                .finish();
+            tracing::subscriber::set_global_default(subscriber).ok();
+        });
+    }
 
     #[derive(Default)]
     struct TimestampForwarder {
@@ -59,6 +86,31 @@ mod tests {
         }
     }
 
+    struct FakeTransport {
+        stopped: Arc<AtomicBool>,
+    }
+
+    impl GuestTransport for FakeTransport {
+        fn connect(
+            &self,
+            _port: u32,
+            _timeout: Duration,
+        ) -> futures_util::future::BoxFuture<'_, Result<std::os::fd::RawFd>> {
+            Box::pin(async { Ok(42) })
+        }
+        fn request_stop(&self) {
+            self.stopped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn stop_guard() -> (VmStopGuard, Arc<AtomicBool>) {
+        let stopped = Arc::new(AtomicBool::new(false));
+        let guard = VmStopGuard::new(Arc::new(FakeTransport {
+            stopped: stopped.clone(),
+        }));
+        (guard, stopped)
+    }
+
     fn pp(host_port: u16) -> PortPublish {
         PortPublish {
             host_ip: "127.0.0.1".parse().unwrap(),
@@ -69,70 +121,88 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn ports_released_before_grace_sleep() {
+    async fn ports_are_released_synchronously_before_the_detached_wait() {
         let fake = Arc::new(TimestampForwarder::default());
         let specs = plan(&[pp(3003)]);
         let guard = establish(fake.clone(), &specs).unwrap();
         let t0 = tokio::time::Instant::now();
+        let (stop_guard, _stopped) = stop_guard();
 
-        // VM task that never completes — guarantees the grace timer wins and
-        // exercises the "vm did not stop within grace period" branch.
+        // VM task that never completes — the caller must still get its ports back immediately.
         let vm_task = tokio::spawn(std::future::pending::<Result<()>>());
-
-        shutdown_after_session(guard, Duration::from_secs(2), vm_task)
-            .await
-            .unwrap();
+        let teardown = detach_after_session(guard, Duration::from_secs(2), vm_task, stop_guard);
 
         let instants = fake.unbind_instants();
         assert_eq!(instants.len(), 1);
         assert_eq!(
             instants[0], t0,
-            "unbind must happen at T=0, before the 2s grace sleep"
+            "unbind must happen inside the detach call, before any await"
+        );
+        teardown.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn detached_teardown_stops_the_vm_after_the_grace_period() {
+        init_tracing_capture();
+        let fake = Arc::new(TimestampForwarder::default());
+        let guard = establish(fake.clone(), &plan(&[pp(8080)])).unwrap();
+        let t0 = tokio::time::Instant::now();
+        let (stop_guard, stopped) = stop_guard();
+
+        let vm_task = tokio::spawn(std::future::pending::<Result<()>>());
+        let teardown = detach_after_session(guard, Duration::from_secs(2), vm_task, stop_guard);
+        teardown.await.unwrap();
+
+        assert!(
+            stopped.load(Ordering::SeqCst),
+            "a hung guest must still get a stop request after the grace period"
+        );
+        assert_eq!(
+            tokio::time::Instant::now().duration_since(t0),
+            Duration::from_secs(2),
+            "the stop request waits out the full grace for a hung guest"
         );
     }
 
     #[tokio::test(start_paused = true)]
-    async fn ports_released_when_vm_exits_within_grace() {
+    async fn detached_teardown_completes_early_when_the_vm_exits_within_grace() {
         let fake = Arc::new(TimestampForwarder::default());
-        let specs = plan(&[pp(8080)]);
-        let guard = establish(fake.clone(), &specs).unwrap();
+        let guard = establish(fake.clone(), &plan(&[pp(8081)])).unwrap();
         let t0 = tokio::time::Instant::now();
+        let (stop_guard, stopped) = stop_guard();
 
         let vm_task = tokio::spawn(async {
             tokio::time::sleep(Duration::from_millis(100)).await;
             Ok(())
         });
+        let teardown = detach_after_session(guard, Duration::from_secs(2), vm_task, stop_guard);
+        teardown.await.unwrap();
 
-        shutdown_after_session(guard, Duration::from_secs(2), vm_task)
-            .await
-            .unwrap();
-
-        let instants = fake.unbind_instants();
-        assert_eq!(instants.len(), 1);
-        assert_eq!(instants[0], t0, "unbind still happens at T=0");
+        assert!(stopped.load(Ordering::SeqCst), "guard dropped after wait");
         assert_eq!(
             tokio::time::Instant::now().duration_since(t0),
             Duration::from_millis(100),
-            "helper returns when VM exits, not after full grace"
+            "teardown returns when the VM exits, not after full grace"
         );
     }
 
     #[tokio::test(start_paused = true)]
-    async fn ports_released_even_when_vm_task_panics() {
+    async fn detached_teardown_survives_a_panicked_vm_task_and_still_stops_the_vm() {
+        init_tracing_capture();
         let fake = Arc::new(TimestampForwarder::default());
-        let specs = plan(&[pp(9090)]);
-        let guard = establish(fake.clone(), &specs).unwrap();
+        let guard = establish(fake.clone(), &plan(&[pp(9090)])).unwrap();
+        let (stop_guard, stopped) = stop_guard();
 
         let vm_task = tokio::spawn(async { panic!("vm exploded") });
         tokio::task::yield_now().await;
 
-        let result = shutdown_after_session(guard, Duration::from_secs(2), vm_task).await;
+        let teardown = detach_after_session(guard, Duration::from_secs(2), vm_task, stop_guard);
+        teardown.await.unwrap();
 
-        assert!(result.is_err());
-        assert_eq!(
-            fake.unbind_instants().len(),
-            1,
-            "ports still released on panic"
+        assert_eq!(fake.unbind_instants().len(), 1, "ports released on panic");
+        assert!(
+            stopped.load(Ordering::SeqCst),
+            "the stop guard must fire even when the vm task panicked"
         );
     }
 }

--- a/crates/lns-service/src/runtime_layer/mod.rs
+++ b/crates/lns-service/src/runtime_layer/mod.rs
@@ -300,6 +300,12 @@ type MemoKey = (bool, Option<PathBuf>, PathBuf);
 
 pub struct RuntimeLayerMemo(std::sync::Mutex<std::collections::BTreeMap<MemoKey, RuntimeLayer>>);
 
+impl Default for RuntimeLayerMemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RuntimeLayerMemo {
     pub const fn new() -> Self {
         Self(std::sync::Mutex::new(std::collections::BTreeMap::new()))
@@ -995,9 +1001,13 @@ mod tests {
         std::fs::write(gt.root.join("marker"), b"x").unwrap();
         let memo = RuntimeLayerMemo::new();
 
-        let first = for_run_memoized(false, &s, &gt, None, &memo).unwrap().unwrap();
+        let first = for_run_memoized(false, &s, &gt, None, &memo)
+            .unwrap()
+            .unwrap();
         std::fs::remove_file(gt.root.join("marker")).unwrap();
-        let hit = for_run_memoized(false, &s, &gt, None, &memo).unwrap().unwrap();
+        let hit = for_run_memoized(false, &s, &gt, None, &memo)
+            .unwrap()
+            .unwrap();
         assert_eq!(hit.digest(), first.digest());
     }
 

--- a/crates/lns-service/src/runtime_layer/mod.rs
+++ b/crates/lns-service/src/runtime_layer/mod.rs
@@ -296,6 +296,79 @@ fn split_path(normalized: &str) -> Vec<String> {
         .collect()
 }
 
+type MemoKey = (bool, Option<PathBuf>, PathBuf);
+
+pub struct RuntimeLayerMemo(std::sync::Mutex<std::collections::BTreeMap<MemoKey, RuntimeLayer>>);
+
+impl RuntimeLayerMemo {
+    pub const fn new() -> Self {
+        Self(std::sync::Mutex::new(std::collections::BTreeMap::new()))
+    }
+
+    fn get(&self, key: &MemoKey) -> Option<RuntimeLayer> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(key)
+            .cloned()
+    }
+
+    fn insert(&self, key: MemoKey, layer: RuntimeLayer) {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(key, layer);
+    }
+}
+
+// The layer is a pure function of these source paths (immutable per guest-tools build-id and service binary), so one process-wide build per key replaces re-reading and re-hashing every blob on each run.
+pub fn for_run_memoized(
+    imageless: bool,
+    content_store: &crate::content_store::ContentStore,
+    guest_tools: &crate::guest_tools::GuestTools,
+    assets: Option<&crate::supervisor::SupervisorAssets>,
+    memo: &RuntimeLayerMemo,
+) -> Result<Option<RuntimeLayer>> {
+    for_run_memoized_with(
+        |k| std::env::var_os(k),
+        imageless,
+        content_store,
+        guest_tools,
+        assets,
+        memo,
+    )
+}
+
+fn for_run_memoized_with(
+    env_get: impl Fn(&str) -> Option<std::ffi::OsString>,
+    imageless: bool,
+    content_store: &crate::content_store::ContentStore,
+    guest_tools: &crate::guest_tools::GuestTools,
+    assets: Option<&crate::supervisor::SupervisorAssets>,
+    memo: &RuntimeLayerMemo,
+) -> Result<Option<RuntimeLayer>> {
+    let dev_overrides_active =
+        env_get("LNS_DEBUG_WRAP").is_some() || env_get("LNS_NFT_BIN").is_some();
+    if dev_overrides_active {
+        return for_run(imageless, content_store, guest_tools, assets);
+    }
+    let key = (
+        imageless,
+        assets.map(|a| a.supervisor_bin.clone()),
+        assets
+            .map(|a| a.guest_tools_root.clone())
+            .unwrap_or_else(|| guest_tools.root.clone()),
+    );
+    if let Some(hit) = memo.get(&key) {
+        return Ok(Some(hit));
+    }
+    let layer = for_run(imageless, content_store, guest_tools, assets)?;
+    if let Some(l) = &layer {
+        memo.insert(key, l.clone());
+    }
+    Ok(layer)
+}
+
 pub fn for_run(
     imageless: bool,
     content_store: &crate::content_store::ContentStore,
@@ -833,6 +906,99 @@ mod tests {
             "imageless+supervised must carry /bin/sh"
         );
         assert!(layer.manifest.label.ends_with("+imageless"));
+    }
+
+    fn no_env(_k: &str) -> Option<std::ffi::OsString> {
+        None
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn for_run_memoized_serves_the_second_run_without_rereading_sources() {
+        let _env = NftEnvOverride::install();
+        let d = tempdir();
+        let s = store(&d);
+        let gt = fake_guest_tools(&d);
+        let assets = fake_assets(&d);
+        let memo = RuntimeLayerMemo::new();
+        let nft_env = std::env::var_os("LNS_NFT_BIN");
+        let env_get = |k: &str| (k == "LNS_NFT_BIN").then(|| nft_env.clone()).flatten();
+
+        let first = for_run_memoized_with(env_get, true, &s, &gt, Some(&assets), &memo);
+        // The nft override is active, so the first call bypasses the memo and re-reads.
+        let first_again = for_run_memoized_with(no_env, true, &s, &gt, Some(&assets), &memo)
+            .unwrap()
+            .unwrap();
+        std::fs::remove_file(&assets.supervisor_bin).unwrap();
+        let hit = for_run_memoized_with(no_env, true, &s, &gt, Some(&assets), &memo)
+            .unwrap()
+            .unwrap();
+        assert!(first.is_ok(), "override path builds: {first:?}");
+        assert_eq!(
+            hit.digest(),
+            first_again.digest(),
+            "a memo hit must serve the identical layer without touching the deleted source"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn for_run_memoized_dev_override_bypasses_the_memo() {
+        let _env = NftEnvOverride::install();
+        let d = tempdir();
+        let s = store(&d);
+        let gt = fake_guest_tools(&d);
+        let assets = fake_assets(&d);
+        let memo = RuntimeLayerMemo::new();
+        let nft_env = std::env::var_os("LNS_NFT_BIN");
+        let env_get = |k: &str| (k == "LNS_NFT_BIN").then(|| nft_env.clone()).flatten();
+
+        for_run_memoized_with(env_get, true, &s, &gt, Some(&assets), &memo)
+            .unwrap()
+            .unwrap();
+        std::fs::remove_file(&assets.supervisor_bin).unwrap();
+        let err = for_run_memoized_with(env_get, true, &s, &gt, Some(&assets), &memo).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("reading"),
+            "an active dev override must rebuild from sources every run: {err:#}"
+        );
+    }
+
+    #[test]
+    fn for_run_memoized_keys_on_the_imageless_flag() {
+        let d = tempdir();
+        let s = store(&d);
+        let gt = fake_guest_tools(&d);
+        let memo = RuntimeLayerMemo::new();
+
+        let imageless = for_run_memoized_with(no_env, true, &s, &gt, None, &memo)
+            .unwrap()
+            .unwrap();
+        let oci = for_run_memoized_with(no_env, false, &s, &gt, None, &memo)
+            .unwrap()
+            .unwrap();
+        assert_ne!(
+            imageless.digest(),
+            oci.digest(),
+            "imageless and oci layers must not share a memo slot"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn for_run_memoized_real_env_wrapper_builds_and_serves_hits() {
+        let _wrap = crate::test_env::EnvVarGuard::unset("LNS_DEBUG_WRAP");
+        let _nft = crate::test_env::EnvVarGuard::unset("LNS_NFT_BIN");
+        let d = tempdir();
+        let s = store(&d);
+        let gt = fake_guest_tools(&d);
+        std::fs::write(gt.root.join("marker"), b"x").unwrap();
+        let memo = RuntimeLayerMemo::new();
+
+        let first = for_run_memoized(false, &s, &gt, None, &memo).unwrap().unwrap();
+        std::fs::remove_file(gt.root.join("marker")).unwrap();
+        let hit = for_run_memoized(false, &s, &gt, None, &memo).unwrap().unwrap();
+        assert_eq!(hit.digest(), first.digest());
     }
 
     #[test]

--- a/crates/lns-service/src/runtime_layer/mod.rs
+++ b/crates/lns-service/src/runtime_layer/mod.rs
@@ -298,13 +298,8 @@ fn split_path(normalized: &str) -> Vec<String> {
 
 type MemoKey = (bool, Option<PathBuf>, PathBuf);
 
+#[derive(Default)]
 pub struct RuntimeLayerMemo(std::sync::Mutex<std::collections::BTreeMap<MemoKey, RuntimeLayer>>);
-
-impl Default for RuntimeLayerMemo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl RuntimeLayerMemo {
     pub const fn new() -> Self {
@@ -353,8 +348,9 @@ fn for_run_memoized_with(
     assets: Option<&crate::supervisor::SupervisorAssets>,
     memo: &RuntimeLayerMemo,
 ) -> Result<Option<RuntimeLayer>> {
-    let dev_overrides_active =
-        env_get("LNS_DEBUG_WRAP").is_some() || env_get("LNS_NFT_BIN").is_some();
+    let dev_overrides_active = env_get("LNS_DEBUG_WRAP").is_some()
+        || env_get("LNS_NFT_BIN").is_some()
+        || env_get("LNS_SUPERVISOR_BIN").is_some();
     if dev_overrides_active {
         return for_run(imageless, content_store, guest_tools, assets);
     }
@@ -967,6 +963,29 @@ mod tests {
         assert!(
             format!("{err:#}").contains("reading"),
             "an active dev override must rebuild from sources every run: {err:#}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn for_run_memoized_supervisor_bin_override_bypasses_the_memo() {
+        let _env = NftEnvOverride::install();
+        let d = tempdir();
+        let s = store(&d);
+        let gt = fake_guest_tools(&d);
+        let assets = fake_assets(&d);
+        let memo = RuntimeLayerMemo::new();
+        let env_get = |k: &str| (k == "LNS_SUPERVISOR_BIN").then(|| std::ffi::OsString::from("x"));
+
+        for_run_memoized_with(env_get, true, &s, &gt, Some(&assets), &memo)
+            .unwrap()
+            .unwrap();
+        std::fs::remove_file(&assets.supervisor_bin).unwrap();
+        let err = for_run_memoized_with(env_get, true, &s, &gt, Some(&assets), &memo).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("reading"),
+            "a rebuilt supervisor at a fixed LNS_SUPERVISOR_BIN path must be re-read every \
+             run, not served stale from the memo: {err:#}"
         );
     }
 

--- a/crates/lns-service/src/upperfs/mod.rs
+++ b/crates/lns-service/src/upperfs/mod.rs
@@ -65,23 +65,30 @@ mod tests {
         });
     }
 
+    fn clone_marker(_src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+        std::fs::write(dst, b"cloned")
+    }
+
+    fn write_direct(p: &std::path::Path) -> anyhow::Result<()> {
+        std::fs::write(p, b"direct").map_err(Into::into)
+    }
+
     #[test]
     fn template_clone_success_skips_the_direct_writer() {
         let root = tempfile::TempDir::new().unwrap();
-        let cloned = Cell::new(false);
         let path = provision_image_from_template(
             root.path(),
             "aa08",
             std::path::Path::new("/fake/template.img"),
-            |_src, dst| {
-                cloned.set(true);
-                std::fs::write(dst, b"cloned")
-            },
-            |_| panic!("fallback must not run when the clone succeeds"),
+            clone_marker,
+            write_direct,
         )
         .unwrap();
-        assert!(cloned.get(), "clone was invoked");
-        assert_eq!(std::fs::read(&path).unwrap(), b"cloned");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"cloned",
+            "a successful clone must not be overwritten by the direct writer"
+        );
         assert_eq!(
             path,
             root.path().join("runs").join("aa08").join("upper.img")
@@ -97,7 +104,7 @@ mod tests {
             "aa09",
             std::path::Path::new("/fake/template.img"),
             |_, _| Err(std::io::Error::other("not on APFS")),
-            |p| std::fs::write(p, b"direct").map_err(Into::into),
+            write_direct,
         )
         .unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"direct");
@@ -125,8 +132,8 @@ mod tests {
             file.path(),
             "aa0b",
             std::path::Path::new("/fake/template.img"),
-            |_, _| Ok(()),
-            |_| Ok(()),
+            clone_marker,
+            write_direct,
         )
         .unwrap_err();
         assert!(

--- a/crates/lns-service/src/upperfs/mod.rs
+++ b/crates/lns-service/src/upperfs/mod.rs
@@ -75,7 +75,7 @@ mod tests {
             std::path::Path::new("/fake/template.img"),
             |_src, dst| {
                 cloned.set(true);
-                std::fs::write(dst, b"cloned").map_err(Into::into)
+                std::fs::write(dst, b"cloned")
             },
             |_| panic!("fallback must not run when the clone succeeds"),
         )

--- a/crates/lns-service/src/upperfs/mod.rs
+++ b/crates/lns-service/src/upperfs/mod.rs
@@ -13,6 +13,7 @@ pub use writer::write_ext4;
 
 pub const DEFAULT_SIZE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn provision_image(
     root: &std::path::Path,
     run_id: &str,
@@ -28,10 +29,111 @@ fn provision_image(
     Ok(path)
 }
 
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn provision_image_from_template(
+    root: &std::path::Path,
+    run_id: &str,
+    template: &std::path::Path,
+    clone: impl FnOnce(&std::path::Path, &std::path::Path) -> std::io::Result<()>,
+    fallback: impl FnOnce(&std::path::Path) -> anyhow::Result<()>,
+) -> anyhow::Result<std::path::PathBuf> {
+    let run_dir = root.join("runs").join(run_id);
+    std::fs::create_dir_all(&run_dir)?;
+    let path = run_dir.join("upper.img");
+    if let Err(e) = clone(template, &path) {
+        crate::log::debug!("cloning upper template failed ({e:#}); writing the image directly");
+        fallback(&path)?;
+    }
+    Ok(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    fn init_tracing_capture() {
+        use std::sync::Once;
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(std::io::sink)
+                .with_ansi(false)
+                .with_max_level(tracing::Level::TRACE)
+                .finish();
+            tracing::subscriber::set_global_default(subscriber).ok();
+        });
+    }
+
+    #[test]
+    fn template_clone_success_skips_the_direct_writer() {
+        let root = tempfile::TempDir::new().unwrap();
+        let cloned = Cell::new(false);
+        let path = provision_image_from_template(
+            root.path(),
+            "aa08",
+            std::path::Path::new("/fake/template.img"),
+            |_src, dst| {
+                cloned.set(true);
+                std::fs::write(dst, b"cloned").map_err(Into::into)
+            },
+            |_| panic!("fallback must not run when the clone succeeds"),
+        )
+        .unwrap();
+        assert!(cloned.get(), "clone was invoked");
+        assert_eq!(std::fs::read(&path).unwrap(), b"cloned");
+        assert_eq!(
+            path,
+            root.path().join("runs").join("aa08").join("upper.img")
+        );
+    }
+
+    #[test]
+    fn template_clone_failure_falls_back_to_the_direct_writer() {
+        init_tracing_capture();
+        let root = tempfile::TempDir::new().unwrap();
+        let path = provision_image_from_template(
+            root.path(),
+            "aa09",
+            std::path::Path::new("/fake/template.img"),
+            |_, _| Err(std::io::Error::other("not on APFS")),
+            |p| std::fs::write(p, b"direct").map_err(Into::into),
+        )
+        .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"direct");
+    }
+
+    #[test]
+    fn template_clone_failure_propagates_fallback_errors() {
+        init_tracing_capture();
+        let root = tempfile::TempDir::new().unwrap();
+        let err = provision_image_from_template(
+            root.path(),
+            "aa0a",
+            std::path::Path::new("/fake/template.img"),
+            |_, _| Err(std::io::Error::other("not on APFS")),
+            |_| Err(anyhow::anyhow!("writer boom")),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("writer boom"));
+    }
+
+    #[test]
+    fn template_provision_errors_when_run_dir_cannot_be_created() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let err = provision_image_from_template(
+            file.path(),
+            "aa0b",
+            std::path::Path::new("/fake/template.img"),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+        assert!(
+            err.downcast_ref::<std::io::Error>().is_some(),
+            "io error from create_dir_all: {err}"
+        );
+    }
 
     #[test]
     fn provision_image_creates_run_dir_and_writes_through() {

--- a/crates/lns-service/src/upperfs/real.rs
+++ b/crates/lns-service/src/upperfs/real.rs
@@ -1,18 +1,75 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::{provision_image, write_ext4};
+use super::write_ext4;
 
+fn mkfs_time_now() -> u32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(target_os = "macos")]
+fn fresh_plan() -> super::Plan {
+    super::Plan::new(
+        super::DEFAULT_SIZE_BYTES,
+        rand::random(),
+        "lns-upper",
+        mkfs_time_now(),
+    )
+}
+
+#[cfg(target_os = "macos")]
+static TEMPLATE: tokio::sync::OnceCell<std::path::PathBuf> = tokio::sync::OnceCell::const_new();
+
+// The template carries one random uuid per service process; every clone shares it, which is harmless because each run's guest kernel only ever mounts its own upper disk.
+#[cfg(target_os = "macos")]
+async fn ensure_template(root: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
+    let path = TEMPLATE
+        .get_or_try_init(|| async {
+            let path = root.join("upper-template.img");
+            let write_target = path.clone();
+            tokio::task::spawn_blocking(move || write_ext4(&fresh_plan(), &write_target))
+                .await??;
+            Ok::<_, anyhow::Error>(path)
+        })
+        .await?;
+    Ok(path.clone())
+}
+
+#[cfg(target_os = "macos")]
+fn clonefile(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let src = std::ffi::CString::new(src.as_os_str().as_bytes())?;
+    let dst = std::ffi::CString::new(dst.as_os_str().as_bytes())?;
+    // SAFETY: both pointers reference NUL-terminated buffers that outlive the call.
+    let rc = unsafe { libc::clonefile(src.as_ptr(), dst.as_ptr(), 0) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub async fn provision(run_id: &str) -> anyhow::Result<std::path::PathBuf> {
+    let root = crate::cache::root()?;
+    let template = ensure_template(&root).await?;
+    let run_id = run_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        super::provision_image_from_template(&root, &run_id, &template, clonefile, |path| {
+            write_ext4(&fresh_plan(), path)
+        })
+    })
+    .await?
+}
+
+#[cfg(not(target_os = "macos"))]
 pub async fn provision(run_id: &str) -> anyhow::Result<std::path::PathBuf> {
     let root = crate::cache::root()?;
     let run_id = run_id.to_string();
-    let uuid: [u8; 16] = rand::random();
-    let mkfs_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as u32)
-        .unwrap_or(0);
-
     tokio::task::spawn_blocking(move || {
-        provision_image(&root, &run_id, uuid, mkfs_time, write_ext4)
+        super::provision_image(&root, &run_id, rand::random(), mkfs_time_now(), write_ext4)
     })
     .await?
 }

--- a/crates/lns-service/src/upperfs/real.rs
+++ b/crates/lns-service/src/upperfs/real.rs
@@ -29,8 +29,7 @@ async fn ensure_template(root: &std::path::Path) -> anyhow::Result<std::path::Pa
         .get_or_try_init(|| async {
             let path = root.join("upper-template.img");
             let write_target = path.clone();
-            tokio::task::spawn_blocking(move || write_ext4(&fresh_plan(), &write_target))
-                .await??;
+            tokio::task::spawn_blocking(move || write_ext4(&fresh_plan(), &write_target)).await??;
             Ok::<_, anyhow::Error>(path)
         })
         .await?;

--- a/crates/lns-service/src/vm/connect.rs
+++ b/crates/lns-service/src/vm/connect.rs
@@ -8,10 +8,8 @@ pub(crate) trait ConnectOnce {
     fn connect_once(&self, port: u32) -> impl Future<Output = Result<RawFd>> + Send;
 }
 
-const CONNECT_INITIAL_DELAY: Duration = Duration::from_millis(10);
-
-// Capped low because every ms spent past guest readiness is added to every single run's boot time, while a refused vsock connect costs near nothing.
-const CONNECT_MAX_DELAY: Duration = Duration::from_millis(100);
+// Constant and low because every ms spent past guest readiness is added to every single run's boot time, while a refused vsock connect costs near nothing.
+const CONNECT_POLL_DELAY: Duration = Duration::from_millis(10);
 
 pub(crate) async fn connect_with<C: ConnectOnce + Sync>(
     connector: &C,
@@ -19,7 +17,6 @@ pub(crate) async fn connect_with<C: ConnectOnce + Sync>(
     timeout: Duration,
 ) -> Result<RawFd> {
     let deadline = Instant::now() + timeout;
-    let mut delay = CONNECT_INITIAL_DELAY;
     loop {
         match connector.connect_once(port).await {
             Ok(fd) => return Ok(fd),
@@ -29,8 +26,7 @@ pub(crate) async fn connect_with<C: ConnectOnce + Sync>(
                         format!("connect_to_guest_port({port}) timed out after {timeout:?}")
                     });
                 }
-                tokio::time::sleep(delay).await;
-                delay = (delay * 2).min(CONNECT_MAX_DELAY);
+                tokio::time::sleep(CONNECT_POLL_DELAY).await;
             }
         }
     }
@@ -114,9 +110,9 @@ mod tests {
         let waited = started.elapsed();
         assert_eq!(
             waited,
-            Duration::from_millis(10 + 20 + 40 + 80 + 100 + 100),
-            "backoff schedule regressed — a guest ready after the 6th probe \
-             must be reached in 350ms, not the old 1.27s",
+            Duration::from_millis(6 * 10),
+            "poll schedule regressed — a guest ready after the 6th probe \
+             must be reached in 60ms; every extra ms here is added to every run's boot",
         );
     }
 }

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -7,7 +7,7 @@ mod connect;
 #[cfg(target_os = "macos")]
 pub mod diag_console;
 pub mod session_client;
-mod transport;
+pub(crate) mod transport;
 #[cfg(target_os = "macos")]
 mod vz;
 

--- a/crates/lns-service/src/vm/transport.rs
+++ b/crates/lns-service/src/vm/transport.rs
@@ -28,32 +28,41 @@ impl Drop for VmStopGuard {
 }
 
 #[cfg(test)]
+pub(crate) struct StopFlagTransport {
+    pub(crate) stopped: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(test)]
+impl StopFlagTransport {
+    pub(crate) fn guard() -> (VmStopGuard, Arc<std::sync::atomic::AtomicBool>) {
+        let stopped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let guard = VmStopGuard::new(Arc::new(Self {
+            stopped: stopped.clone(),
+        }));
+        (guard, stopped)
+    }
+}
+
+#[cfg(test)]
+impl GuestTransport for StopFlagTransport {
+    fn connect(&self, _port: u32, _timeout: Duration) -> BoxFuture<'_, Result<RawFd>> {
+        Box::pin(async { Ok(42) })
+    }
+    fn request_stop(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    struct FakeTransport {
-        stopped: Arc<AtomicBool>,
-    }
-
-    impl GuestTransport for FakeTransport {
-        fn connect(&self, _port: u32, _timeout: Duration) -> BoxFuture<'_, Result<RawFd>> {
-            Box::pin(async { Ok(42) })
-        }
-        fn request_stop(&self) {
-            self.stopped.store(true, Ordering::SeqCst);
-        }
-    }
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn dropping_the_guard_requests_stop() {
-        let stopped = Arc::new(AtomicBool::new(false));
-        let transport = Arc::new(FakeTransport {
-            stopped: stopped.clone(),
-        });
-        {
-            let _guard = VmStopGuard::new(transport);
-        }
+        let (guard, stopped) = StopFlagTransport::guard();
+        drop(guard);
         assert!(
             stopped.load(Ordering::SeqCst),
             "the stop guard must signal the VM to stop when dropped"
@@ -62,8 +71,8 @@ mod tests {
 
     #[tokio::test]
     async fn connect_delegates_to_the_transport() {
-        let transport = FakeTransport {
-            stopped: Arc::new(AtomicBool::new(false)),
+        let transport = StopFlagTransport {
+            stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let fd = transport
             .connect(1029, Duration::from_secs(1))


### PR DESCRIPTION
Warm `lns run -- echo hello` drops from ~535ms to ~300ms median (measured CLI start → CLI exit, macOS Vz, release build). Cold first-run stays ~740ms — it pays the one-time per-process work below once.

The ~530ms warm budget decomposed into five independent costs; each gets its own commit:

| Cost | Before | After | Change |
|---|---|---|---|
| Kernel pin re-verified per run | 61ms | 57µs | `ensure_pinned_memoized`: once a process has hashed the cached kernel against the pin, a still-present file is trusted for the process lifetime |
| Upper ext4 disk written from scratch per run | 61ms | 24ms | one pristine template per service process, `clonefile`d per run (APFS); any clone failure falls back to the direct writer; Linux keeps the direct path |
| Runtime layer re-read + re-hashed per run | 33ms | 9ms | `for_run_memoized` keyed by (imageless, supervisor bin, guest-tools root); bypassed while any of the `LNS_DEBUG_WRAP` / `LNS_NFT_BIN` / `LNS_SUPERVISOR_BIN` dev overrides are set |
| Broker vsock connect backoff quantized at 100ms | up to 100ms overshoot | ≤10ms | constant 10ms poll — a refused vsock connect is near-free, and every ms past guest readiness lands on every run |
| CLI exit waits for guest poweroff + VMM stop | 130–155ms | ~0 | teardown detaches after the session: host ports release synchronously, then the grace-wait + `VmStopGuard` run in a spawned task, so `RunExit` reaches the CLI at workload exit |

Semantics notes:

- `RunExit` no longer implies the VM is fully stopped (docker-like). Teardown errors are logged service-side instead of overriding the workload's exit code. Verified manually: non-zero exit codes still propagate, and back-to-back `-p` runs on the same host port rebind cleanly because port release stays synchronous.
- The upper-disk template carries one random ext4 UUID per service process, so runs within one service lifetime share it. Each run's guest kernel only ever mounts its own upper disk, so nothing observes the collision.
- The runtime-layer memo keys on source paths, so every dev override that can repoint those sources between runs (`LNS_DEBUG_WRAP`, `LNS_NFT_BIN`, `LNS_SUPERVISOR_BIN`) bypasses it; otherwise a rebuilt supervisor would be served stale until a service restart.
- The runtime-layer memo assumes content-store blobs installed for the memoized layer stay present for the process lifetime — the same assumption the composefs descriptor cache already makes.

Remaining warm budget is guest-side: ~250ms of kernel boot (the Kata mainline config spends ~50ms registering IPVS schedulers alone, plus XFRM/bridge/etc.) and ~25ms of nftables setup in the supervisor. The kernel cost needs a trimmed config through the bump-kernel/publish pipeline — follow-up work, not this PR.
