### PR TITLE
chore: speed up the coverage/test edit loop

### DIFF
--- a/.github/workflows/wsl2-smoke.yml
+++ b/.github/workflows/wsl2-smoke.yml
@@ -1,0 +1,71 @@
+name: wsl2-smoke
+
+# Tier A WSL2 smoke: proves the shipping Linux binary installs and runs its
+# non-microVM surface inside a real WSL2 userland. It does NOT boot a guest
+# (that needs nested KVM, which only a self-hosted bare-metal Windows 11 runner
+# can provide). Not a required check.
+on:
+  workflow_dispatch:
+  push:
+    branches: [ci-wsl2-smoke]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wsl2-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wsl2-smoke:
+    name: WSL2 smoke (windows-2022)
+    runs-on: windows-2022
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Report host virtualization + WSL capability
+        continue-on-error: true
+        run: |
+          Write-Host "== OS =="
+          (Get-CimInstance Win32_OperatingSystem).Caption
+          Write-Host "== Optional features =="
+          Get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform, Microsoft-Windows-Subsystem-Linux |
+            Select-Object FeatureName, State | Format-Table -AutoSize
+          Write-Host "== wsl --version =="
+          wsl --version
+          Write-Host "== wsl --status =="
+          wsl --status
+          Write-Host "== wsl --list --online =="
+          wsl --list --online
+
+      - name: Install / update WSL2 + Ubuntu
+        run: |
+          $ErrorActionPreference = 'Stop'
+          wsl --set-default-version 2
+          try { wsl --update } catch { Write-Host "wsl --update failed (continuing): $_" }
+          wsl --install -d Ubuntu-24.04 --no-launch
+          wsl --set-default-version 2
+          wsl --version
+
+      - name: Assert a real WSL2 kernel is present (fail if only WSL1)
+        run: |
+          $ErrorActionPreference = 'Stop'
+          wsl --list --verbose
+          $procVersion = (wsl -d Ubuntu-24.04 -u root -- cat /proc/version) -join "`n"
+          Write-Host "guest /proc/version: $procVersion"
+          if ($procVersion -notmatch 'microsoft|WSL2') {
+            Write-Error "No WSL2 kernel detected. The hosted runner likely lacks the nested virtualization WSL2 requires; Tier A must run on a self-hosted Windows 11 runner."
+            exit 1
+          }
+
+      - name: Install lns via the shipping install script (inside WSL2)
+        run: |
+          $ErrorActionPreference = 'Stop'
+          wsl -d Ubuntu-24.04 -u root -- bash -lc "set -euxo pipefail; apt-get update -y; apt-get install -y curl ca-certificates; export LNS_NO_SERVICE=1; curl -fsSL https://get.lns.run | bash"
+
+      - name: Smoke the non-microVM surface in WSL2
+        run: |
+          $ErrorActionPreference = 'Stop'
+          wsl -d Ubuntu-24.04 -u root -- bash -lc 'set -euxo pipefail; LNS="$HOME/.local/bin/lns"; "$LNS" --version; "$LNS" --help >/dev/null; "$LNS" audit || echo "audit exited non-zero without a service (tolerated in smoke)"'

--- a/.github/workflows/wsl2-smoke.yml
+++ b/.github/workflows/wsl2-smoke.yml
@@ -1,11 +1,15 @@
 name: wsl2-smoke
 
 # Tier A WSL2 smoke: proves the shipping Linux binary installs and runs its
-# non-microVM surface inside a real WSL2 userland. It does NOT boot a guest
-# (that needs nested KVM, which only a self-hosted bare-metal Windows 11 runner
-# can provide). Not a required check.
+# non-microVM surface (install script, --version/--help, audit) inside a real
+# WSL2 userland on a hosted windows-2022 runner. It does NOT boot a guest —
+# that needs nested KVM inside WSL2, which only a self-hosted bare-metal
+# Windows 11 runner can provide. Not a required check — nightly and on demand,
+# mirroring e2e-microvm.
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch: {}
   push:
     branches: [ci-wsl2-smoke]
 
@@ -31,8 +35,9 @@ jobs:
           Write-Host "== OS =="
           (Get-CimInstance Win32_OperatingSystem).Caption
           Write-Host "== Optional features =="
-          Get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform, Microsoft-Windows-Subsystem-Linux |
-            Select-Object FeatureName, State | Format-Table -AutoSize
+          foreach ($f in 'VirtualMachinePlatform', 'Microsoft-Windows-Subsystem-Linux') {
+            Get-WindowsOptionalFeature -Online -FeatureName $f | Select-Object FeatureName, State
+          }
           Write-Host "== wsl --version =="
           wsl --version
           Write-Host "== wsl --status =="

--- a/.github/workflows/wsl2-smoke.yml
+++ b/.github/workflows/wsl2-smoke.yml
@@ -65,7 +65,17 @@ jobs:
           $ErrorActionPreference = 'Stop'
           wsl -d Ubuntu-24.04 -u root -- bash -lc "set -euxo pipefail; apt-get update -y; apt-get install -y curl ca-certificates; export LNS_NO_SERVICE=1; curl -fsSL https://get.lns.run | bash"
 
-      - name: Smoke the non-microVM surface in WSL2
+      - name: Show installed lns binary
+        run: wsl -d Ubuntu-24.04 -u root -- ls -la /root/.local/bin
+
+      - name: Smoke lns --version / --help in WSL2
         run: |
           $ErrorActionPreference = 'Stop'
-          wsl -d Ubuntu-24.04 -u root -- bash -lc 'set -euxo pipefail; LNS="$HOME/.local/bin/lns"; "$LNS" --version; "$LNS" --help >/dev/null; "$LNS" audit || echo "audit exited non-zero without a service (tolerated in smoke)"'
+          $PSNativeCommandUseErrorActionPreference = $true
+          wsl -d Ubuntu-24.04 -u root -- /root/.local/bin/lns --version
+          wsl -d Ubuntu-24.04 -u root -- /root/.local/bin/lns --help
+          Write-Host "lns runs in WSL2 (--version / --help OK)"
+
+      - name: Smoke lns audit in WSL2 (informational)
+        continue-on-error: true
+        run: wsl -d Ubuntu-24.04 -u root -- /root/.local/bin/lns audit

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,14 @@ build-lns-service:
 # below). CI invokes these targets as parallel jobs, with
 # `CARGO_LOCKED=--locked make <step>` for strictness on lint/test.
 
-# Gate targets are one-shot full passes; incremental caches only cost
-# disk here (cargo never prunes them), so the gates opt out while
-# `make dev` and raw cargo iteration keep incremental speed.
-lint test complexity coverage-data: export CARGO_INCREMENTAL := 0
+# lint/complexity are one-shot full passes; incremental caches only cost
+# disk there (cargo never prunes them), so they opt out. test and coverage
+# are re-run in the local edit loop, where incremental turns a full crate
+# rebuild into a partial one — so keep them on off-CI, where the disk cost
+# buys a much faster iteration, and off under CI (cold one-shot, no speedup
+# to gain). `make dev` and raw cargo iteration keep incremental regardless.
+lint complexity: export CARGO_INCREMENTAL := 0
+test coverage-data: export CARGO_INCREMENTAL := $(if $(CI),0,1)
 
 lint: export LNS_INIT_BIN := skip
 lint: export LNS_SESSION_BROKER_BIN := skip
@@ -162,21 +166,28 @@ coverage-data:
 		eval "$$($(CARGO) llvm-cov show-env --export-prefix)"; \
 		$(if $(strip $(COVERAGE_CRATES)),$(if $(filter lns-service,$(COVERAGE_CRATES)),$(CARGO) build -p lns-service;,),$(CARGO) build -p lns-service;) \
 		$(CARGO) test $(COVERAGE_CARGO_SCOPE) --all-targets; \
-		$(CARGO) llvm-cov report --manifest-path $(WORKSPACE_MANIFEST); \
 		$(CARGO) llvm-cov report --manifest-path $(WORKSPACE_MANIFEST) --html; \
 		$(CARGO) llvm-cov report --manifest-path $(WORKSPACE_MANIFEST) --lcov \
 			--output-path $(COVERAGE_TARGET_DIR)/llvm-cov/lcov.info; \
 		$(COVERAGE_TARGET_DIR)/debug/coverage-strip-ast $(COVERAGE_TARGET_DIR)/llvm-cov/lcov.info; \
 		echo "HTML report: $(COVERAGE_TARGET_DIR)/llvm-cov/html/index.html"
 
+# Full mode: one lcov pass over all crates (the `crates/` prefix keeps the
+# per-crate loop's stale-check suppression, so gate semantics are unchanged
+# — just no 8x re-parse). Affected mode: narrow per-crate loop so only the
+# touched crates' files are gated.
 coverage: coverage-data
-	@status=0; \
+	@if [ -z "$(strip $(COVERAGE_CRATES))" ]; then \
+		./scripts/coverage-floor.sh $(COVERAGE_TARGET_DIR)/llvm-cov/lcov.info "crates/"; \
+	else \
+		status=0; \
 		for pkg in $(COVERAGE_CRATES_LIST); do \
 			echo ""; \
 			echo "── $$pkg ──"; \
 			./scripts/coverage-floor.sh $(COVERAGE_TARGET_DIR)/llvm-cov/lcov.info "$$pkg/" || status=$$?; \
 		done; \
-		exit $$status
+		exit $$status; \
+	fi
 
 BASE_REF ?= origin/main
 coverage-affected:


### PR DESCRIPTION
## Problem

`make coverage` (and `make test`) felt like ~40s "with no incremental" on every run. Profiling showed why: `CARGO_INCREMENTAL := 0` was applied to `coverage-data` and `test`, so any crate touched in the local edit→run loop recompiled **from scratch**.

Isolated measurement — a one-line edit to `lns-cli`, then testing it:

| CARGO_INCREMENTAL | recompile + test |
| --- | --- |
| `0` (previous) | **25.9s** |
| `1` | **5.7s** |

That ~4.5× is the "no incremental" pain. `CARGO_INCREMENTAL=0` was deliberate — incremental caches cost disk (cargo never prunes them) and a cold one-shot build gains nothing from them. That reasoning holds for **CI**, but not for the **local** edit loop, where the same targets are re-run repeatedly.

## Change

- **Incremental on off-CI for `test` + `coverage-data`** (`export CARGO_INCREMENTAL := $(if $(CI),0,1)`). CI stays cold/one-shot/disk-lean; locally you get the fast loop. `lint`/`complexity` stay off — no edit-loop benefit.
- **Trim coverage reporting**: drop the redundant plain `llvm-cov report` (the `--html` report already shows the aggregate %); keep `--html` + `--lcov`.
- **Full-mode floor gate in one `crates/` lcov pass** instead of re-parsing the lcov once per crate. Affected mode keeps the narrow per-crate loop. Gate semantics unchanged.

`cargo llvm-cov clean` is intentionally left as `--workspace` (considered `--profraw-only` but the speed delta was marginal and it risks stale coverage on file rename/delete).

## Notes

- For the fastest loop, narrow scope so incremental compounds: `COVERAGE_CRATES=<crate> make coverage` or `make coverage-affected`.
- Disk tradeoff: incremental grows `target/llvm-cov-target/…/incremental/`; reclaim with `make clean` when tight.

## Verification

- `make test` — green
- `make lint` — green
- `make coverage` — green (146 files at 100%, 0 failures)