### PR TITLE
feat(cli): add CLI↔service version/protocol handshake

### DIFF
--- a/crates/e2e-tests/features/service_lifecycle.feature
+++ b/crates/e2e-tests/features/service_lifecycle.feature
@@ -79,3 +79,9 @@ Feature: Lens Sandbox tray-resident background service
     When two `lns service status` commands run concurrently from different terminals
     Then both observe consistent state from the same service instance
     And neither invocation corrupts or races the other
+
+  Scenario: A CLI and service built from the same tree pass the handshake silently
+    Given the Lens Sandbox service is running
+    When I run an `lns` command that requires the service
+    Then the command completes successfully
+    And the output contains no build or protocol drift warning

--- a/crates/e2e-tests/tests/steps/service.rs
+++ b/crates/e2e-tests/tests/steps/service.rs
@@ -288,6 +288,21 @@ fn no_service_side_effect(world: &mut E2eWorld) -> Result<(), String> {
     Ok(())
 }
 
+#[then("the output contains no build or protocol drift warning")]
+fn no_drift_warning(world: &mut E2eWorld) -> Result<(), String> {
+    let res = world.result.as_ref().ok_or("no CLI run captured")?;
+    let combined = format!("{}{}", res.stdout, res.stderr);
+    for needle in ["different build", "incompatible"] {
+        if combined.contains(needle) {
+            return Err(format!(
+                "a same-tree lns/lns-service pair must pass the handshake silently, \
+                 but the output mentions {needle:?}: {combined}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[then("the command reports that the service is running")]
 fn reports_service_running(world: &mut E2eWorld) -> Result<(), String> {
     let res = world.result.as_ref().ok_or("no CLI run captured")?;

--- a/crates/lns-cli/build.rs
+++ b/crates/lns-cli/build.rs
@@ -5,8 +5,11 @@ fn main() {
 }
 
 fn emit_build_sha() {
-    for name in ["HEAD", "index"] {
-        if let Some(path) = git_path(name) {
+    let mut watched = vec!["HEAD".to_string(), "index".to_string()];
+    // A commit moves the branch ref HEAD points at, not the HEAD file itself.
+    watched.extend(git_head_ref());
+    for name in watched {
+        if let Some(path) = git_path(&name) {
             println!("cargo:rerun-if-changed={path}");
         }
     }
@@ -16,6 +19,18 @@ fn emit_build_sha() {
         None => "unknown".to_string(),
     };
     println!("cargo:rustc-env=LNS_BUILD_SHA={stamp}");
+}
+
+fn git_head_ref() -> Option<String> {
+    let out = Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let head_ref = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!head_ref.is_empty()).then_some(head_ref)
 }
 
 fn git_short_sha() -> Option<String> {

--- a/crates/lns-cli/build.rs
+++ b/crates/lns-cli/build.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+fn main() {
+    emit_build_sha();
+}
+
+fn emit_build_sha() {
+    for name in ["HEAD", "index"] {
+        if let Some(path) = git_path(name) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+    let stamp = match git_short_sha() {
+        Some(sha) if git_is_dirty() => format!("{sha}-dirty"),
+        Some(sha) => sha,
+        None => "unknown".to_string(),
+    };
+    println!("cargo:rustc-env=LNS_BUILD_SHA={stamp}");
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+fn git_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|out| out.status.success() && !out.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn git_path(name: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--git-path", name])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!path.is_empty()).then_some(path)
+}

--- a/crates/lns-cli/build.rs
+++ b/crates/lns-cli/build.rs
@@ -47,5 +47,11 @@ fn git_path(name: &str) -> Option<String> {
         return None;
     }
     let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    (!path.is_empty()).then_some(path)
+    if path.is_empty() {
+        return None;
+    }
+    // Absolute so Cargo watches the real file regardless of how it resolves rerun-if-changed.
+    std::fs::canonicalize(&path)
+        .ok()
+        .map(|p| p.display().to_string())
 }

--- a/crates/lns-cli/src/integration/real.rs
+++ b/crates/lns-cli/src/integration/real.rs
@@ -13,6 +13,10 @@ use crate::command::{RunCtx, RunFuture};
 pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = super::IntegrationArgs::from_arg_matches(matches)?;
+        // Connect is the only subcommand that drives the service (sign-in / bind).
+        if matches!(args.command, super::IntegrationCommand::Connect(_)) {
+            crate::service::require_running().await;
+        }
         let cwd = ctx.cwd()?;
         let catalog_path = lns_policy::integrations::default_integrations_path();
         let signin = RealIntegrationSignIn::new(crate::service::socket_path()?);

--- a/crates/lns-cli/src/login/real.rs
+++ b/crates/lns-cli/src/login/real.rs
@@ -14,6 +14,7 @@ use crate::integration::LocalBoxFuture;
 pub fn run_login<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = LoginArgs::from_arg_matches(matches)?;
+        crate::service::require_running().await;
         let default_registry = configured_default_registry()?;
         let auth_path = default_registry_auth_path();
         let verifier = RealRegistryVerifier::new(crate::service::socket_path()?);

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use lns_ipc::{SignalKind, StatusInfo};
 
 pub mod client;
+mod handshake;
 mod login_agent;
 pub(crate) mod real;
 
@@ -37,6 +38,8 @@ pub enum ServiceCommand {
     Start,
     #[command(about = "Stop the Lens Sandbox background service.")]
     Stop,
+    #[command(about = "Restart the Lens Sandbox background service.")]
+    Restart,
     #[command(about = "Show status of the Lens Sandbox background service.")]
     Status,
     #[command(
@@ -71,7 +74,16 @@ fn require_running_check(alive: bool) -> Result<(), &'static str> {
 
 pub(super) async fn cmd_start(client: &impl ServiceClient) -> Result<()> {
     if client.ping().await {
-        println!("Lens Sandbox is already running.");
+        let status = client.status().await;
+        let compat = handshake::classify(
+            handshake::CLI_PROTOCOL,
+            handshake::CLI_BUILD,
+            status.as_ref(),
+        );
+        match handshake::already_running_warning(&compat) {
+            None => println!("Lens Sandbox is already running."),
+            Some(warning) => crate::log::warn!("{warning}"),
+        }
         return Ok(());
     }
 
@@ -103,11 +115,53 @@ pub(super) async fn cmd_stop(client: &impl ServiceClient) -> Result<()> {
     }
 }
 
+pub(super) async fn cmd_restart(client: &impl ServiceClient) -> Result<()> {
+    restart_with_outcome(client, login_agent::restart().await).await
+}
+
+async fn restart_with_outcome(
+    client: &impl ServiceClient,
+    outcome: login_agent::RestartOutcome,
+) -> Result<()> {
+    match outcome {
+        login_agent::RestartOutcome::Relaunched => {
+            if client.wait_for_ready(START_TIMEOUT).await {
+                println!("Lens Sandbox restarted.");
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "lns-service did not become ready within {}s after restart",
+                    START_TIMEOUT.as_secs()
+                );
+            }
+        }
+        login_agent::RestartOutcome::NotRegistered => restart_via_socket(client).await,
+        login_agent::RestartOutcome::Degraded(reason) => {
+            crate::log::warn!(
+                "could not restart via the login agent ({reason}); restarting the service directly"
+            );
+            restart_via_socket(client).await
+        }
+    }
+}
+
+async fn restart_via_socket(client: &impl ServiceClient) -> Result<()> {
+    if client.shutdown().await.is_some() && !client.wait_for_stopped(STOP_TIMEOUT).await {
+        anyhow::bail!(
+            "Lens Sandbox acknowledged shutdown but did not exit within {}s",
+            STOP_TIMEOUT.as_secs()
+        );
+    }
+    cmd_start(client).await
+}
+
 pub(super) async fn cmd_status(client: &impl ServiceClient) -> Result<()> {
     let Some(StatusInfo {
         pid,
         uptime_secs,
         version,
+        protocol,
+        build,
     }) = client.status().await
     else {
         println!("Lens Sandbox is not running.");
@@ -115,9 +169,11 @@ pub(super) async fn cmd_status(client: &impl ServiceClient) -> Result<()> {
     };
 
     println!("Lens Sandbox is running.");
-    println!("  PID:     {pid}");
-    println!("  Uptime:  {uptime_secs}s");
-    println!("  Version: {version}");
+    println!("  PID:      {pid}");
+    println!("  Uptime:   {uptime_secs}s");
+    println!("  Version:  {version}");
+    println!("  Build:    {build}");
+    println!("  Protocol: {protocol}");
     Ok(())
 }
 
@@ -235,6 +291,14 @@ mod tests {
     use client::BoxFuture;
 
     #[test]
+    fn build_sha_is_embedded() {
+        assert!(
+            !env!("LNS_BUILD_SHA").is_empty(),
+            "build.rs must stamp a non-empty LNS_BUILD_SHA"
+        );
+    }
+
+    #[test]
     fn require_running_check_ok_when_alive() {
         assert!(require_running_check(true).is_ok());
     }
@@ -346,14 +410,48 @@ mod tests {
         }
     }
 
+    fn matching_status() -> StatusInfo {
+        StatusInfo {
+            pid: 1,
+            uptime_secs: 1,
+            version: env!("CARGO_PKG_VERSION").into(),
+            protocol: lns_ipc::IPC_PROTOCOL_VERSION,
+            build: env!("LNS_BUILD_SHA").into(),
+        }
+    }
+
     #[tokio::test]
     async fn cmd_start_reports_already_running_when_ping_succeeds() {
         let client = FakeClient::default();
         client.ping_responses.lock().unwrap().push_back(true);
+        *client.status_response.lock().unwrap() = Some(Some(matching_status()));
 
         cmd_start(&client).await.expect("cmd_start should succeed");
 
-        assert_eq!(client.calls(), vec!["ping"]);
+        assert_eq!(client.calls(), vec!["ping", "status"]);
+    }
+
+    #[test]
+    fn cmd_start_warns_to_restart_when_the_running_build_differs() {
+        let client = FakeClient::default();
+        client.ping_responses.lock().unwrap().push_back(true);
+        *client.status_response.lock().unwrap() = Some(Some(StatusInfo {
+            pid: 1,
+            uptime_secs: 1,
+            version: "0.0.0".into(),
+            protocol: lns_ipc::IPC_PROTOCOL_VERSION,
+            build: "a-different-build".into(),
+        }));
+
+        let events = capture_warn(|| {
+            futures_block_on(cmd_start(&client)).expect("a build drift must not fail start");
+        });
+
+        assert_eq!(client.calls(), vec!["ping", "status"]);
+        assert!(
+            events.iter().any(|e| e.contains("lns service restart")),
+            "expected a restart hint: {events:?}"
+        );
     }
 
     #[tokio::test]
@@ -452,6 +550,8 @@ mod tests {
             pid: 4242,
             uptime_secs: 17,
             version: "test-version".into(),
+            protocol: 1,
+            build: "abc123def456".into(),
         }));
 
         cmd_status(&client)
@@ -580,43 +680,7 @@ exit 0
     }
 
     fn capture_warn(emit: impl FnOnce()) -> Vec<String> {
-        use std::sync::{Arc, Mutex, Once};
-        use tracing::field::{Field, Visit};
-        use tracing::{Event, Subscriber};
-        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-
-        static OPEN_GATE: Once = Once::new();
-        OPEN_GATE.call_once(|| {
-            let gate = tracing_subscriber::fmt()
-                .with_writer(std::io::sink)
-                .with_max_level(tracing::Level::TRACE)
-                .finish();
-            tracing::subscriber::set_global_default(gate).ok();
-        });
-
-        type Sink = Arc<Mutex<Vec<String>>>;
-        struct CapturingLayer(Sink);
-        impl<S: Subscriber> Layer<S> for CapturingLayer {
-            fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-                struct V<'a>(&'a mut String);
-                impl Visit for V<'_> {
-                    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-                        if field.name() == "message" {
-                            *self.0 = format!("{value:?}");
-                        }
-                    }
-                }
-                let mut message = String::new();
-                event.record(&mut V(&mut message));
-                self.0.lock().unwrap().push(message);
-            }
-        }
-
-        let sink: Sink = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::registry().with(CapturingLayer(sink.clone()));
-        tracing::subscriber::with_default(subscriber, emit);
-        let captured = sink.lock().unwrap();
-        captured.clone()
+        crate::test_env::capture_events(emit)
     }
 
     #[test]
@@ -733,10 +797,113 @@ exit 0
         let _g = crate::test_env::EnvScope::unset("HOME");
         let client = FakeClient::default();
         client.ping_responses.lock().unwrap().push_back(true);
+        *client.status_response.lock().unwrap() = Some(Some(matching_status()));
 
         cmd_enable(&client).await.expect("enable must not fail");
 
-        assert_eq!(client.calls(), vec!["ping"]);
+        assert_eq!(client.calls(), vec!["ping", "status"]);
+    }
+
+    #[tokio::test]
+    async fn restart_with_outcome_relaunched_waits_for_ready() {
+        let client = FakeClient::default();
+        *client.wait_for_ready_response.lock().unwrap() = Some(true);
+
+        restart_with_outcome(&client, login_agent::RestartOutcome::Relaunched)
+            .await
+            .expect("a relaunched managed service that becomes ready succeeds");
+
+        assert_eq!(client.calls(), vec!["wait_for_ready"]);
+    }
+
+    #[tokio::test]
+    async fn restart_with_outcome_relaunched_bails_when_never_ready() {
+        let client = FakeClient::default();
+        *client.wait_for_ready_response.lock().unwrap() = Some(false);
+
+        let err = restart_with_outcome(&client, login_agent::RestartOutcome::Relaunched)
+            .await
+            .expect_err("a relaunch that never becomes ready must surface");
+        assert!(err.to_string().contains("did not become ready"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn restart_with_outcome_not_registered_stops_then_starts_over_the_socket() {
+        let client = FakeClient::default();
+        *client.shutdown_response.lock().unwrap() = Some(Some(()));
+        *client.wait_for_stopped_response.lock().unwrap() = Some(true);
+        client.ping_responses.lock().unwrap().push_back(false);
+        *client.start_response.lock().unwrap() = Some(Ok(true));
+
+        restart_with_outcome(&client, login_agent::RestartOutcome::NotRegistered)
+            .await
+            .expect("an unmanaged restart stops then starts");
+
+        assert_eq!(
+            client.calls(),
+            vec![
+                "shutdown",
+                "wait_for_stopped",
+                "ping",
+                "start_and_wait_for_ready"
+            ]
+        );
+    }
+
+    #[test]
+    fn restart_with_outcome_degraded_warns_then_restarts_directly() {
+        let client = FakeClient::default();
+        *client.shutdown_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(false);
+        *client.start_response.lock().unwrap() = Some(Ok(true));
+
+        let events = capture_warn(|| {
+            futures_block_on(restart_with_outcome(
+                &client,
+                login_agent::RestartOutcome::Degraded("no gui session".into()),
+            ))
+            .expect("a degraded login-agent restart still restarts directly");
+        });
+
+        assert_eq!(
+            client.calls(),
+            vec!["shutdown", "ping", "start_and_wait_for_ready"]
+        );
+        assert!(
+            events.iter().any(|e| e.contains("no gui session")),
+            "expected the degraded reason in the warning: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_via_socket_bails_when_stop_times_out() {
+        let client = FakeClient::default();
+        *client.shutdown_response.lock().unwrap() = Some(Some(()));
+        *client.wait_for_stopped_response.lock().unwrap() = Some(false);
+
+        let err = restart_via_socket(&client)
+            .await
+            .expect_err("a stop that never completes must surface");
+        assert!(err.to_string().contains("did not exit within"), "{err}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env)]
+    async fn cmd_restart_falls_back_to_socket_when_home_unset() {
+        let _g = crate::test_env::EnvScope::unset("HOME");
+        let client = FakeClient::default();
+        *client.shutdown_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(false);
+        *client.start_response.lock().unwrap() = Some(Ok(true));
+
+        cmd_restart(&client)
+            .await
+            .expect("with no login agent, restart reconciles over the socket");
+
+        assert_eq!(
+            client.calls(),
+            vec!["shutdown", "ping", "start_and_wait_for_ready"]
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -72,6 +72,21 @@ fn require_running_check(alive: bool) -> Result<(), &'static str> {
     }
 }
 
+/// A decodable Status proves liveness by itself; ping only disambiguates a
+/// `None` status so a service that stopped between probes reads as stopped,
+/// never as protocol-incompatible.
+pub(super) async fn gate_running_service(client: &impl ServiceClient) -> Result<(), String> {
+    let status = client.status().await;
+    if status.is_none() {
+        require_running_check(client.ping().await).map_err(str::to_string)?;
+    }
+    handshake::enforce_for_command(handshake::classify(
+        handshake::CLI_PROTOCOL,
+        handshake::CLI_BUILD,
+        status.as_ref(),
+    ))
+}
+
 pub(super) async fn cmd_start(client: &impl ServiceClient) -> Result<()> {
     if client.ping().await {
         let status = client.status().await;
@@ -563,6 +578,51 @@ mod tests {
             .expect("cmd_status should succeed");
 
         assert_eq!(client.calls(), vec!["status", "ping"]);
+    }
+
+    #[tokio::test]
+    async fn gate_reports_not_running_when_the_service_died_between_probes() {
+        let client = FakeClient::default();
+        *client.status_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(false);
+
+        let err = gate_running_service(&client)
+            .await
+            .expect_err("a dead service must not pass the gate");
+        assert!(err.contains("not running"), "{err}");
+        assert!(
+            !err.contains("incompatible"),
+            "a stopped service must never read as a protocol mismatch: {err}"
+        );
+        assert_eq!(client.calls(), vec!["status", "ping"]);
+    }
+
+    #[tokio::test]
+    async fn gate_treats_an_alive_but_unreadable_service_as_a_protocol_mismatch() {
+        let client = FakeClient::default();
+        *client.status_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(true);
+
+        let err = gate_running_service(&client)
+            .await
+            .expect_err("an undecodable status from a live service must abort");
+        assert!(err.contains("incompatible"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn gate_passes_a_matching_service_on_the_status_probe_alone() {
+        let client = FakeClient::default();
+        *client.status_response.lock().unwrap() = Some(Some(matching_status()));
+
+        gate_running_service(&client)
+            .await
+            .expect("a matching pair passes");
+
+        assert_eq!(
+            client.calls(),
+            vec!["status"],
+            "a decodable Status proves liveness; no extra ping round trip"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -155,6 +155,14 @@ async fn restart_via_socket(client: &impl ServiceClient) -> Result<()> {
     cmd_start(client).await
 }
 
+fn absent_status_message(alive: bool) -> &'static str {
+    if alive {
+        "Lens Sandbox is running but reports an unreadable status — likely an incompatible or older lns-service. Run `lns service restart` to reconcile."
+    } else {
+        "Lens Sandbox is not running."
+    }
+}
+
 pub(super) async fn cmd_status(client: &impl ServiceClient) -> Result<()> {
     let Some(StatusInfo {
         pid,
@@ -164,7 +172,7 @@ pub(super) async fn cmd_status(client: &impl ServiceClient) -> Result<()> {
         build,
     }) = client.status().await
     else {
-        println!("Lens Sandbox is not running.");
+        println!("{}", absent_status_message(client.ping().await));
         return Ok(());
     };
 
@@ -532,15 +540,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cmd_status_reports_not_running_when_status_is_none() {
+    async fn cmd_status_reports_not_running_when_status_is_none_and_ping_fails() {
         let client = FakeClient::default();
         *client.status_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(false);
 
         cmd_status(&client)
             .await
             .expect("cmd_status should succeed");
 
-        assert_eq!(client.calls(), vec!["status"]);
+        assert_eq!(client.calls(), vec!["status", "ping"]);
+    }
+
+    #[tokio::test]
+    async fn cmd_status_pings_to_disambiguate_an_alive_but_undecodable_service() {
+        let client = FakeClient::default();
+        *client.status_response.lock().unwrap() = Some(None);
+        client.ping_responses.lock().unwrap().push_back(true);
+
+        cmd_status(&client)
+            .await
+            .expect("cmd_status should succeed");
+
+        assert_eq!(client.calls(), vec!["status", "ping"]);
+    }
+
+    #[test]
+    fn absent_status_message_distinguishes_an_incompatible_service_from_a_stopped_one() {
+        let alive = absent_status_message(true);
+        assert!(
+            alive.contains("lns service restart"),
+            "unexpected: {alive:?}"
+        );
+        assert!(!absent_status_message(false).contains("restart"));
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -141,8 +141,7 @@ async fn restart_with_outcome(
     match outcome {
         login_agent::RestartOutcome::Relaunched => {
             if client.wait_for_ready(START_TIMEOUT).await {
-                println!("Lens Sandbox restarted.");
-                Ok(())
+                report_relaunched(client, login_agent::agent_path().as_deref()).await
             } else {
                 anyhow::bail!(
                     "lns-service did not become ready within {}s after restart",
@@ -158,6 +157,25 @@ async fn restart_with_outcome(
             restart_via_socket(client).await
         }
     }
+}
+
+/// A relaunched login agent re-runs whatever binary its agent file froze at
+/// enable time, so a Pong alone can't prove the mismatch was reconciled.
+async fn report_relaunched(
+    client: &impl ServiceClient,
+    agent_path: Option<&std::path::Path>,
+) -> Result<()> {
+    let status = client.status().await;
+    let compat = handshake::classify(
+        handshake::CLI_PROTOCOL,
+        handshake::CLI_BUILD,
+        status.as_ref(),
+    );
+    match handshake::relaunched_warning(&compat, agent_path) {
+        None => println!("Lens Sandbox restarted."),
+        Some(warning) => crate::log::warn!("{warning}"),
+    }
+    Ok(())
 }
 
 async fn restart_via_socket(client: &impl ServiceClient) -> Result<()> {
@@ -897,15 +915,45 @@ exit 0
     }
 
     #[tokio::test]
-    async fn restart_with_outcome_relaunched_waits_for_ready() {
+    async fn restart_with_outcome_relaunched_verifies_the_running_build_after_ready() {
         let client = FakeClient::default();
         *client.wait_for_ready_response.lock().unwrap() = Some(true);
+        *client.status_response.lock().unwrap() = Some(Some(matching_status()));
 
         restart_with_outcome(&client, login_agent::RestartOutcome::Relaunched)
             .await
             .expect("a relaunched managed service that becomes ready succeeds");
 
-        assert_eq!(client.calls(), vec!["wait_for_ready"]);
+        assert_eq!(client.calls(), vec!["wait_for_ready", "status"]);
+    }
+
+    #[test]
+    fn restart_with_outcome_relaunched_warns_when_the_agent_relaunched_a_stale_binary() {
+        let client = FakeClient::default();
+        *client.wait_for_ready_response.lock().unwrap() = Some(true);
+        *client.status_response.lock().unwrap() = Some(Some(StatusInfo {
+            pid: 1,
+            uptime_secs: 1,
+            version: "0.0.0".into(),
+            protocol: lns_ipc::IPC_PROTOCOL_VERSION,
+            build: "a-stale-build".into(),
+        }));
+
+        let events = capture_warn(|| {
+            futures_block_on(restart_with_outcome(
+                &client,
+                login_agent::RestartOutcome::Relaunched,
+            ))
+            .expect("a hollow relaunch warns instead of failing");
+        });
+
+        assert_eq!(client.calls(), vec!["wait_for_ready", "status"]);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.contains("a-stale-build") && e.contains("lns service enable")),
+            "expected a stale-binary warning with the repoint remedy: {events:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service/handshake.rs
+++ b/crates/lns-cli/src/service/handshake.rs
@@ -223,7 +223,9 @@ mod tests {
             &Compat::BuildDrift {
                 running: "0ldbuild".into(),
             },
-            Some(std::path::Path::new("/Users/alice/Library/LaunchAgents/run.lns.service.plist")),
+            Some(std::path::Path::new(
+                "/Users/alice/Library/LaunchAgents/run.lns.service.plist",
+            )),
         )
         .expect("a persisting drift after relaunch must warn");
         assert!(w.contains("0ldbuild"), "{w}");

--- a/crates/lns-cli/src/service/handshake.rs
+++ b/crates/lns-cli/src/service/handshake.rs
@@ -1,0 +1,217 @@
+use lns_ipc::StatusInfo;
+
+pub(crate) const CLI_PROTOCOL: u32 = lns_ipc::IPC_PROTOCOL_VERSION;
+pub(crate) const CLI_BUILD: &str = env!("LNS_BUILD_SHA");
+
+pub(crate) const REMEDY: &str =
+    "reinstall Lens Sandbox or run `lns service restart` to reconcile the two binaries";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Compat {
+    Match,
+    BuildDrift { running: String },
+    ProtocolMismatch { cli: u32, running: Option<u32> },
+}
+
+/// Precondition: the caller already confirmed the service is alive (Ping), so a
+/// `None` status means "alive but its Status is undecodable" — an old,
+/// wire-incompatible service — not "not running".
+pub(crate) fn classify(cli_protocol: u32, cli_build: &str, running: Option<&StatusInfo>) -> Compat {
+    match running {
+        None => Compat::ProtocolMismatch {
+            cli: cli_protocol,
+            running: None,
+        },
+        Some(s) if s.protocol != cli_protocol => Compat::ProtocolMismatch {
+            cli: cli_protocol,
+            running: Some(s.protocol),
+        },
+        Some(s) if s.build != cli_build => Compat::BuildDrift {
+            running: s.build.clone(),
+        },
+        Some(_) => Compat::Match,
+    }
+}
+
+pub(crate) fn build_drift_message(running: &str, cli: &str) -> String {
+    format!(
+        "the running lns-service is a different build ({running}) than this lns ({cli}); {REMEDY}."
+    )
+}
+
+fn protocol_mismatch_message(cli: u32, running: Option<u32>) -> String {
+    let running = running.map_or_else(
+        || "an older, unreadable version".to_string(),
+        |p| p.to_string(),
+    );
+    format!(
+        "the running lns-service speaks IPC protocol {running} but this lns speaks {cli}; \
+         they are incompatible. {REMEDY}."
+    )
+}
+
+/// For `lns service start` against an already-running service: `None` means a
+/// clean already-running (print normally); `Some(warning)` means a build or
+/// protocol mismatch the user should reconcile with `lns service restart`.
+pub(crate) fn already_running_warning(compat: &Compat) -> Option<String> {
+    match compat {
+        Compat::Match => None,
+        Compat::BuildDrift { running } => Some(format!(
+            "Lens Sandbox is already running as a different build ({running}) than this lns ({CLI_BUILD}); \
+             run `lns service restart` to adopt the freshly installed binary."
+        )),
+        Compat::ProtocolMismatch { running, .. } => {
+            let running = running.map_or_else(
+                || "an older version".to_string(),
+                |p| format!("protocol {p}"),
+            );
+            Some(format!(
+                "Lens Sandbox is already running but speaks an incompatible IPC version ({running}); \
+                 run `lns service restart` to adopt the freshly installed binary."
+            ))
+        }
+    }
+}
+
+/// Gate for the substantive-command path: `Err` aborts the command; a build-only
+/// drift logs one warning and proceeds; a matching pair is silent.
+pub(crate) fn enforce_for_command(compat: Compat) -> Result<(), String> {
+    match compat {
+        Compat::Match => Ok(()),
+        Compat::BuildDrift { running } => {
+            crate::log::warn!("{}", build_drift_message(&running, CLI_BUILD));
+            Ok(())
+        }
+        Compat::ProtocolMismatch { cli, running } => Err(protocol_mismatch_message(cli, running)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(protocol: u32, build: &str) -> StatusInfo {
+        StatusInfo {
+            pid: 1,
+            uptime_secs: 1,
+            version: "0.0.0".into(),
+            protocol,
+            build: build.into(),
+        }
+    }
+
+    #[test]
+    fn matching_protocol_and_build_is_a_match() {
+        let s = status(7, "deadbeef");
+        assert_eq!(classify(7, "deadbeef", Some(&s)), Compat::Match);
+    }
+
+    #[test]
+    fn matching_protocol_but_differing_build_is_drift() {
+        let s = status(7, "olddddd");
+        assert_eq!(
+            classify(7, "newwwww", Some(&s)),
+            Compat::BuildDrift {
+                running: "olddddd".into()
+            }
+        );
+    }
+
+    #[test]
+    fn differing_protocol_is_a_mismatch_naming_both_versions() {
+        let s = status(2, "whatever");
+        assert_eq!(
+            classify(7, "whatever", Some(&s)),
+            Compat::ProtocolMismatch {
+                cli: 7,
+                running: Some(2)
+            }
+        );
+    }
+
+    #[test]
+    fn an_alive_service_with_no_readable_status_is_a_mismatch() {
+        assert_eq!(
+            classify(7, "deadbeef", None),
+            Compat::ProtocolMismatch {
+                cli: 7,
+                running: None
+            }
+        );
+    }
+
+    #[test]
+    fn enforce_is_silent_and_ok_on_a_match() {
+        let events = crate::test_env::capture_events(|| {
+            enforce_for_command(Compat::Match).expect("a match proceeds");
+        });
+        assert!(
+            events.is_empty(),
+            "a matching pair must not warn: {events:?}"
+        );
+    }
+
+    #[test]
+    fn enforce_warns_exactly_once_and_proceeds_on_build_drift() {
+        let events = crate::test_env::capture_events(|| {
+            enforce_for_command(Compat::BuildDrift {
+                running: "0ldbuild".into(),
+            })
+            .expect("build drift is not fatal");
+        });
+        assert_eq!(events.len(), 1, "exactly one warning: {events:?}");
+        assert!(events[0].contains("0ldbuild"), "{:?}", events[0]);
+        assert!(events[0].contains("lns service restart"), "{:?}", events[0]);
+    }
+
+    #[test]
+    fn enforce_hard_fails_with_the_remedy_on_protocol_mismatch() {
+        let err = enforce_for_command(Compat::ProtocolMismatch {
+            cli: 7,
+            running: Some(2),
+        })
+        .expect_err("a protocol mismatch must abort the command");
+        assert!(err.contains('7') && err.contains('2'), "names both: {err}");
+        assert!(err.contains(REMEDY), "carries the remedy: {err}");
+    }
+
+    #[test]
+    fn protocol_mismatch_message_handles_an_unreadable_running_version() {
+        let msg = protocol_mismatch_message(7, None);
+        assert!(msg.contains("unreadable"), "{msg}");
+        assert!(msg.contains(REMEDY), "{msg}");
+    }
+
+    #[test]
+    fn already_running_warning_is_none_on_a_match() {
+        assert!(already_running_warning(&Compat::Match).is_none());
+    }
+
+    #[test]
+    fn already_running_warning_names_the_drifted_build_and_suggests_restart() {
+        let w = already_running_warning(&Compat::BuildDrift {
+            running: "0ldbuild".into(),
+        })
+        .expect("drift must warn");
+        assert!(w.contains("0ldbuild"), "{w}");
+        assert!(w.contains("lns service restart"), "{w}");
+    }
+
+    #[test]
+    fn already_running_warning_covers_protocol_mismatch_known_and_unknown() {
+        let known = already_running_warning(&Compat::ProtocolMismatch {
+            cli: 7,
+            running: Some(2),
+        })
+        .expect("mismatch must warn");
+        assert!(known.contains("protocol 2"), "{known}");
+        assert!(known.contains("lns service restart"), "{known}");
+
+        let unknown = already_running_warning(&Compat::ProtocolMismatch {
+            cli: 7,
+            running: None,
+        })
+        .expect("mismatch must warn");
+        assert!(unknown.contains("older version"), "{unknown}");
+    }
+}

--- a/crates/lns-cli/src/service/handshake.rs
+++ b/crates/lns-cli/src/service/handshake.rs
@@ -73,6 +73,36 @@ pub(crate) fn already_running_warning(compat: &Compat) -> Option<String> {
     }
 }
 
+/// For `lns service restart` after the login agent relaunched: `None` means the
+/// relaunch reconciled the pair; `Some(warning)` means the agent relaunched a
+/// stale binary and the mismatch is still in place.
+pub(crate) fn relaunched_warning(
+    compat: &Compat,
+    agent_path: Option<&std::path::Path>,
+) -> Option<String> {
+    let still = match compat {
+        Compat::Match => return None,
+        Compat::BuildDrift { running } => {
+            format!("still a different build ({running}) than this lns ({CLI_BUILD})")
+        }
+        Compat::ProtocolMismatch { cli, running } => {
+            let running = running.map_or_else(
+                || "an older, unreadable version".to_string(),
+                |p| format!("protocol {p}"),
+            );
+            format!("still speaking an incompatible IPC version ({running}; this lns speaks {cli})")
+        }
+    };
+    let agent = agent_path.map_or_else(
+        || "the login agent".to_string(),
+        |p| format!("the login agent at {}", p.display()),
+    );
+    Some(format!(
+        "Lens Sandbox restarted, but the running service is {still}; \
+         {agent} points at a stale binary — run `lns service enable` to repoint it."
+    ))
+}
+
 /// Gate for the substantive-command path: `Err` aborts the command; a build-only
 /// drift logs one warning and proceeds; a matching pair is silent.
 pub(crate) fn enforce_for_command(compat: Compat) -> Result<(), String> {
@@ -180,6 +210,50 @@ mod tests {
         let msg = protocol_mismatch_message(7, None);
         assert!(msg.contains("unreadable"), "{msg}");
         assert!(msg.contains(REMEDY), "{msg}");
+    }
+
+    #[test]
+    fn relaunched_warning_is_none_when_the_relaunch_reconciled_the_pair() {
+        assert!(relaunched_warning(&Compat::Match, None).is_none());
+    }
+
+    #[test]
+    fn relaunched_warning_names_the_stale_build_the_agent_path_and_the_repoint_remedy() {
+        let w = relaunched_warning(
+            &Compat::BuildDrift {
+                running: "0ldbuild".into(),
+            },
+            Some(std::path::Path::new("/Users/alice/Library/LaunchAgents/run.lns.service.plist")),
+        )
+        .expect("a persisting drift after relaunch must warn");
+        assert!(w.contains("0ldbuild"), "{w}");
+        assert!(w.contains("run.lns.service.plist"), "{w}");
+        assert!(w.contains("lns service enable"), "{w}");
+        assert!(!w.contains("restarted."), "must not read as success: {w}");
+    }
+
+    #[test]
+    fn relaunched_warning_covers_protocol_mismatch_and_an_unresolvable_agent_path() {
+        let known = relaunched_warning(
+            &Compat::ProtocolMismatch {
+                cli: 7,
+                running: Some(2),
+            },
+            None,
+        )
+        .expect("a persisting mismatch after relaunch must warn");
+        assert!(known.contains("protocol 2"), "{known}");
+        assert!(known.contains("the login agent points"), "{known}");
+
+        let unknown = relaunched_warning(
+            &Compat::ProtocolMismatch {
+                cli: 7,
+                running: None,
+            },
+            None,
+        )
+        .expect("mismatch must warn");
+        assert!(unknown.contains("unreadable"), "{unknown}");
     }
 
     #[test]

--- a/crates/lns-cli/src/service/login_agent.rs
+++ b/crates/lns-cli/src/service/login_agent.rs
@@ -35,6 +35,13 @@ pub(super) enum DisableOutcome {
     WasNotRegistered,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum RestartOutcome {
+    Relaunched,
+    NotRegistered,
+    Degraded(String),
+}
+
 fn platform_for_os(os: &str) -> Platform {
     match os {
         "macos" => Platform::MacOs,
@@ -311,6 +318,47 @@ async fn disable_linux(runner: &impl CommandRunner) {
     let _ = runner.run("systemctl", &reload).await;
 }
 
+async fn restart_with(
+    fs: &impl Fs,
+    runner: &impl CommandRunner,
+    spec: &AgentSpec,
+) -> RestartOutcome {
+    if !fs.exists(&spec.agent_path).await {
+        return RestartOutcome::NotRegistered;
+    }
+    match spec.platform {
+        Platform::MacOs => restart_macos(runner, spec).await,
+        Platform::Linux => restart_linux(runner).await,
+    }
+}
+
+async fn restart_macos(runner: &impl CommandRunner, spec: &AgentSpec) -> RestartOutcome {
+    let target = format!("gui/{}/{}", spec.uid, spec.label);
+    let _ = runner
+        .run("launchctl", &["bootout".to_string(), target])
+        .await;
+    let plist = spec.agent_path.to_string_lossy().into_owned();
+    let bootstrap = vec!["bootstrap".to_string(), format!("gui/{}", spec.uid), plist];
+    match runner.run("launchctl", &bootstrap).await {
+        Ok(out) if out.status == 0 => RestartOutcome::Relaunched,
+        Ok(out) => RestartOutcome::Degraded(degraded_reason("launchctl", &out)),
+        Err(e) => RestartOutcome::Degraded(classify_runner_error("launchctl", &e)),
+    }
+}
+
+async fn restart_linux(runner: &impl CommandRunner) -> RestartOutcome {
+    let restart = vec![
+        "--user".to_string(),
+        "restart".to_string(),
+        SYSTEMD_UNIT_NAME.to_string(),
+    ];
+    match runner.run("systemctl", &restart).await {
+        Ok(out) if out.status == 0 => RestartOutcome::Relaunched,
+        Ok(out) => RestartOutcome::Degraded(degraded_reason("systemctl", &out)),
+        Err(e) => RestartOutcome::Degraded(classify_runner_error("systemctl", &e)),
+    }
+}
+
 fn home_dir() -> Result<PathBuf, String> {
     home_dir_with(|k| std::env::var_os(k))
 }
@@ -338,7 +386,7 @@ fn production_spec() -> Result<AgentSpec, String> {
     ))
 }
 
-pub(super) use real::{disable, enable};
+pub(super) use real::{disable, enable, restart};
 
 #[cfg(test)]
 mod tests {
@@ -888,6 +936,128 @@ mod tests {
 
         let outcome = disable_with(&fs, &runner, &spec).await;
         assert_eq!(outcome, DisableOutcome::WasNotRegistered);
+    }
+
+    #[tokio::test]
+    async fn restart_returns_not_registered_when_no_agent_file() {
+        let fs = FakeFs::default();
+        let runner = FakeRunner::default();
+        let spec = macos_spec();
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert_eq!(outcome, RestartOutcome::NotRegistered);
+        assert!(
+            runner.calls().is_empty(),
+            "an unregistered agent must not touch launchctl"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_macos_boots_out_then_bootstraps_the_plist() {
+        let fs = FakeFs::default();
+        let spec = macos_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_ok(0, "");
+        runner.push_ok(0, "");
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert_eq!(outcome, RestartOutcome::Relaunched);
+        let calls = runner.calls();
+        assert_eq!(calls[0].1, vec!["bootout", "gui/501/run.lns.service"]);
+        assert_eq!(
+            calls[1].1,
+            vec![
+                "bootstrap",
+                "gui/501",
+                "/Users/alice/Library/LaunchAgents/run.lns.service.plist"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_macos_degrades_when_bootstrap_fails() {
+        let fs = FakeFs::default();
+        let spec = macos_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_ok(0, "");
+        runner.push_ok(125, "Bootstrap failed: 125: Could not find domain for");
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert!(
+            matches!(&outcome, RestartOutcome::Degraded(r) if r.contains("Bootstrap failed: 125")),
+            "{outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_macos_degrades_when_launchctl_missing() {
+        let fs = FakeFs::default();
+        let spec = macos_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_ok(0, "");
+        runner.push_err(io::Error::from(io::ErrorKind::NotFound));
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert!(
+            matches!(&outcome, RestartOutcome::Degraded(r) if r.contains("launchctl not found")),
+            "{outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_linux_restarts_the_user_unit() {
+        let fs = FakeFs::default();
+        let spec = linux_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_ok(0, "");
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert_eq!(outcome, RestartOutcome::Relaunched);
+        assert_eq!(
+            runner.calls()[0].1,
+            vec!["--user", "restart", "lns-service"]
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_linux_degrades_on_failure() {
+        let fs = FakeFs::default();
+        let spec = linux_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_ok(1, "Failed to connect to bus: No medium found");
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert!(
+            matches!(&outcome, RestartOutcome::Degraded(r) if r.contains("Failed to connect to bus")),
+            "{outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_linux_degrades_when_systemctl_missing() {
+        let fs = FakeFs::default();
+        let spec = linux_spec();
+        fs.put(&spec.agent_path);
+        let runner = FakeRunner::default();
+        runner.push_err(io::Error::from(io::ErrorKind::NotFound));
+
+        let outcome = restart_with(&fs, &runner, &spec).await;
+        assert!(
+            matches!(&outcome, RestartOutcome::Degraded(r) if r.contains("systemctl not found")),
+            "{outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env)]
+    async fn restart_production_entry_not_registered_when_home_unset() {
+        let _g = crate::test_env::EnvScope::unset("HOME");
+        assert_eq!(restart().await, RestartOutcome::NotRegistered);
     }
 
     #[test]

--- a/crates/lns-cli/src/service/login_agent.rs
+++ b/crates/lns-cli/src/service/login_agent.rs
@@ -388,6 +388,10 @@ fn production_spec() -> Result<AgentSpec, String> {
 
 pub(super) use real::{disable, enable, restart};
 
+pub(super) fn agent_path() -> Option<PathBuf> {
+    production_spec().ok().map(|spec| spec.agent_path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lns-cli/src/service/login_agent/real.rs
+++ b/crates/lns-cli/src/service/login_agent/real.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::path::Path;
 
-use super::{CommandOutput, CommandRunner, DisableOutcome, EnableOutcome, Fs};
+use super::{CommandOutput, CommandRunner, DisableOutcome, EnableOutcome, Fs, RestartOutcome};
 
 pub(super) struct RealFs;
 
@@ -52,4 +52,12 @@ pub(in crate::service) async fn disable() -> DisableOutcome {
         Err(_) => return DisableOutcome::WasNotRegistered,
     };
     super::disable_with(&RealFs, &RealCommandRunner, &spec).await
+}
+
+pub(in crate::service) async fn restart() -> RestartOutcome {
+    let spec = match super::production_spec() {
+        Ok(s) => s,
+        Err(_) => return RestartOutcome::NotRegistered,
+    };
+    super::restart_with(&RealFs, &RealCommandRunner, &spec).await
 }

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -19,7 +19,7 @@ use crate::cli::{ExecArgs, RunArgs};
 use crate::command::{RunCtx, RunFuture};
 use lns_ipc::{ExecImageArgs, RunImageArgs};
 
-use super::{client::ServiceClient, real, require_running_check};
+use super::{client::ServiceClient, real};
 use crate::run::summary::print_run_summary;
 
 const PUBLISHED_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -84,20 +84,10 @@ pub async fn require_running() {
             std::process::exit(1);
         }
     };
-    if let Err(msg) = gate_running_service(&client).await {
+    if let Err(msg) = super::gate_running_service(&client).await {
         crate::log::error!("{msg}");
         std::process::exit(1);
     }
-}
-
-async fn gate_running_service(client: &impl ServiceClient) -> Result<(), String> {
-    require_running_check(client.ping().await).map_err(str::to_string)?;
-    let status = client.status().await;
-    super::handshake::enforce_for_command(super::handshake::classify(
-        super::handshake::CLI_PROTOCOL,
-        super::handshake::CLI_BUILD,
-        status.as_ref(),
-    ))
 }
 fn real_client() -> Result<real::RealServiceClient> {
     Ok(real::RealServiceClient::new(

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -69,6 +69,7 @@ pub async fn dispatch(cmd: &super::ServiceCommand) -> Result<()> {
     match cmd {
         super::ServiceCommand::Start => super::cmd_start(&client).await,
         super::ServiceCommand::Stop => super::cmd_stop(&client).await,
+        super::ServiceCommand::Restart => super::cmd_restart(&client).await,
         super::ServiceCommand::Status => super::cmd_status(&client).await,
         super::ServiceCommand::Enable => super::cmd_enable(&client).await,
         super::ServiceCommand::Disable => super::cmd_disable(&client).await,
@@ -83,11 +84,20 @@ pub async fn require_running() {
             std::process::exit(1);
         }
     };
-    let alive = client.ping().await;
-    if let Err(msg) = require_running_check(alive) {
+    if let Err(msg) = gate_running_service(&client).await {
         crate::log::error!("{msg}");
         std::process::exit(1);
     }
+}
+
+async fn gate_running_service(client: &impl ServiceClient) -> Result<(), String> {
+    require_running_check(client.ping().await).map_err(str::to_string)?;
+    let status = client.status().await;
+    super::handshake::enforce_for_command(super::handshake::classify(
+        super::handshake::CLI_PROTOCOL,
+        super::handshake::CLI_BUILD,
+        status.as_ref(),
+    ))
 }
 fn real_client() -> Result<real::RealServiceClient> {
     Ok(real::RealServiceClient::new(

--- a/crates/lns-cli/src/service/real.rs
+++ b/crates/lns-cli/src/service/real.rs
@@ -381,4 +381,28 @@ mod tests {
 
         assert!(!result);
     }
+
+    #[tokio::test(start_paused = true)]
+    async fn readiness_is_pong_only_and_survives_a_protocol_bump() {
+        let ready_pinger = FakePinger::scripted([true]);
+        assert!(
+            poll_until_ready_with(&ready_pinger, Duration::from_millis(100)).await,
+            "lns update pings a swapped service across a protocol bump; readiness must never gate on the handshake"
+        );
+
+        let start_pinger = FakePinger::scripted([true]);
+        let mut child = FakeChild::scripted([]);
+        let socket = PathBuf::from("/tmp/test.sock");
+        assert!(
+            wait_for_ready_with(
+                &start_pinger,
+                &mut child,
+                &socket,
+                Duration::from_millis(100)
+            )
+            .await
+            .unwrap(),
+            "a Pong-answering service is ready regardless of Status compatibility"
+        );
+    }
 }

--- a/crates/lns-cli/src/test_env.rs
+++ b/crates/lns-cli/src/test_env.rs
@@ -35,6 +35,46 @@ impl Drop for EnvScope {
     }
 }
 
+pub(crate) fn capture_events(emit: impl FnOnce()) -> Vec<String> {
+    use std::sync::{Arc, Mutex, Once};
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+
+    static OPEN_GATE: Once = Once::new();
+    OPEN_GATE.call_once(|| {
+        let gate = tracing_subscriber::fmt()
+            .with_writer(std::io::sink)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+        tracing::subscriber::set_global_default(gate).ok();
+    });
+
+    type Sink = Arc<Mutex<Vec<String>>>;
+    struct CapturingLayer(Sink);
+    impl<S: Subscriber> Layer<S> for CapturingLayer {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            struct V<'a>(&'a mut String);
+            impl Visit for V<'_> {
+                fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                    if field.name() == "message" {
+                        *self.0 = format!("{value:?}");
+                    }
+                }
+            }
+            let mut message = String::new();
+            event.record(&mut V(&mut message));
+            self.0.lock().unwrap().push(message);
+        }
+    }
+
+    let sink: Sink = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(CapturingLayer(sink.clone()));
+    tracing::subscriber::with_default(subscriber, emit);
+    let captured = sink.lock().unwrap();
+    captured.clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::EnvScope;

--- a/crates/lns-cli/tests/behaviours/service_restart.feature
+++ b/crates/lns-cli/tests/behaviours/service_restart.feature
@@ -1,0 +1,23 @@
+Feature: lns service restart CLI surface
+  `lns service restart` reconciles a running service with the freshly
+  installed binary by stopping it and starting it again. It must be
+  discoverable from the service help and parse cleanly. Behavioural
+  depth (the stop→start orchestration, the version/protocol handshake,
+  and the build-drift warning) is pinned by Layer 3 unit tests, because
+  the Layer 2 harness only parses argv — it never dispatches to the
+  service.
+
+  Scenario: service help lists restart
+    When I run "lns service --help"
+    Then the exit code is 0
+    And the output contains "restart"
+
+  Scenario: service restart --help describes the subcommand
+    When I run "lns service restart --help"
+    Then the exit code is 0
+    And the output contains "Usage: lns service restart"
+
+  Scenario: service restart rejects unknown flags
+    When I run "lns service restart --not-a-real-flag"
+    Then the exit code is 2
+    And the output contains "unexpected argument"

--- a/crates/lns-ipc/src/codec.rs
+++ b/crates/lns-ipc/src/codec.rs
@@ -199,6 +199,8 @@ mod tests {
             pid: 12345,
             uptime_secs: 3600,
             version: "0.0.0".into(),
+            protocol: crate::IPC_PROTOCOL_VERSION,
+            build: "abc123def456".into(),
         });
         let frame = encode_frame(&resp).unwrap();
         let decoded: Response = decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -20,11 +20,11 @@ pub use paths::{
     cache_root, connection_ledger, connection_ledger_anchor, data_root, short_run_id,
 };
 pub use protocol::{
-    ArtifactInspection, BindMount, BindSpec, CredentialBindDecision, ExecImageArgs, ImageInfo,
-    ImageView, LogLevel, MountSpec, PortPublish, Protocol, Request, Response, RunConfig,
-    RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SandboxCredential,
-    SandboxFileset, SandboxMount, SandboxMountKind, SandboxPort, SandboxView, SignalKind,
-    StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, cmdline_unsafe_char,
+    ArtifactInspection, BindMount, BindSpec, CredentialBindDecision, ExecImageArgs,
+    IPC_PROTOCOL_VERSION, ImageInfo, ImageView, LogLevel, MountSpec, PortPublish, Protocol,
+    Request, Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary,
+    SandboxCredential, SandboxFileset, SandboxMount, SandboxMountKind, SandboxPort, SandboxView,
+    SignalKind, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, cmdline_unsafe_char,
     validate_bind_source, validate_run_name, validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -2,6 +2,9 @@ use std::net::IpAddr;
 
 use serde::{Deserialize, Serialize};
 
+/// Wire-protocol version for the lns-cli ↔ lns-service IPC contract; bump only on wire-breaking changes.
+pub const IPC_PROTOCOL_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Request {
@@ -405,6 +408,8 @@ pub struct StatusInfo {
     pub pid: u32,
     pub uptime_secs: u64,
     pub version: String,
+    pub protocol: u32,
+    pub build: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/lns-service/build.rs
+++ b/crates/lns-service/build.rs
@@ -159,7 +159,13 @@ fn git_path(name: &str) -> Option<String> {
         return None;
     }
     let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    (!path.is_empty()).then_some(path)
+    if path.is_empty() {
+        return None;
+    }
+    // Absolute so Cargo watches the real file regardless of how it resolves rerun-if-changed.
+    std::fs::canonicalize(&path)
+        .ok()
+        .map(|p| p.display().to_string())
 }
 
 fn stage_static_nft(workspace: &Path, out_dir: &Path) {

--- a/crates/lns-service/build.rs
+++ b/crates/lns-service/build.rs
@@ -52,6 +52,8 @@ struct KernelCurrent {
 }
 
 fn main() {
+    emit_build_sha();
+
     let manifest_dir =
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
     let workspace = PathBuf::from(&manifest_dir)
@@ -112,6 +114,52 @@ fn main() {
     );
 
     stage_static_nft(&workspace, &out_dir);
+}
+
+fn emit_build_sha() {
+    for name in ["HEAD", "index"] {
+        if let Some(path) = git_path(name) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+    let stamp = match git_short_sha() {
+        Some(sha) if git_is_dirty() => format!("{sha}-dirty"),
+        Some(sha) => sha,
+        None => "unknown".to_string(),
+    };
+    println!("cargo:rustc-env=LNS_BUILD_SHA={stamp}");
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+fn git_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|out| out.status.success() && !out.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn git_path(name: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--git-path", name])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!path.is_empty()).then_some(path)
 }
 
 fn stage_static_nft(workspace: &Path, out_dir: &Path) {

--- a/crates/lns-service/build.rs
+++ b/crates/lns-service/build.rs
@@ -117,8 +117,11 @@ fn main() {
 }
 
 fn emit_build_sha() {
-    for name in ["HEAD", "index"] {
-        if let Some(path) = git_path(name) {
+    let mut watched = vec!["HEAD".to_string(), "index".to_string()];
+    // A commit moves the branch ref HEAD points at, not the HEAD file itself.
+    watched.extend(git_head_ref());
+    for name in watched {
+        if let Some(path) = git_path(&name) {
             println!("cargo:rerun-if-changed={path}");
         }
     }
@@ -128,6 +131,18 @@ fn emit_build_sha() {
         None => "unknown".to_string(),
     };
     println!("cargo:rustc-env=LNS_BUILD_SHA={stamp}");
+}
+
+fn git_head_ref() -> Option<String> {
+    let out = Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let head_ref = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!head_ref.is_empty()).then_some(head_ref)
 }
 
 fn git_short_sha() -> Option<String> {

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -99,6 +99,8 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             pid: std::process::id(),
             uptime_secs: started_at.elapsed().as_secs(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: lns_ipc::IPC_PROTOCOL_VERSION,
+            build: env!("LNS_BUILD_SHA").to_string(),
         }),
         Request::Shutdown => Response::ShuttingDown,
         Request::RunImage(_) => {
@@ -489,6 +491,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn build_sha_is_embedded() {
+        assert!(
+            !env!("LNS_BUILD_SHA").is_empty(),
+            "build.rs must stamp a non-empty LNS_BUILD_SHA"
+        );
+    }
+
+    #[test]
     fn peer_with_the_services_own_uid_is_authorized() {
         assert!(peer_is_authorized(1000, 1000));
     }
@@ -516,6 +526,8 @@ mod tests {
             Response::Status(info) => {
                 assert_eq!(info.pid, std::process::id());
                 assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+                assert_eq!(info.protocol, lns_ipc::IPC_PROTOCOL_VERSION);
+                assert!(!info.build.is_empty(), "build stamp must be populated");
             }
             _ => panic!("expected Status response"),
         }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -239,7 +239,7 @@ lns service start | stop | restart | status | enable | disable
 | `start`    | Start the background service and wait until it's ready.                 |
 | `stop`     | Stop the background service.                                            |
 | `restart`  | Stop it, then start the currently installed binary.                     |
-| `status`   | Show whether it's running (PID, uptime, version, build).                |
+| `status`   | Show whether it's running (PID, uptime, version, build, protocol).      |
 | `enable`   | Register a per-user login agent and start the service now and on every login. |
 | `disable`  | Stop the service and unregister the per-user login agent.               |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -231,14 +231,15 @@ untrustworthy. There is no separate verify step. See [Audit](audit.md).
 Manage the background service.
 
 ```bash
-lns service start | stop | status | enable | disable
+lns service start | stop | restart | status | enable | disable
 ```
 
 | Subcommand | Meaning                                                                 |
 | ---------- | ----------------------------------------------------------------------- |
 | `start`    | Start the background service and wait until it's ready.                 |
 | `stop`     | Stop the background service.                                            |
-| `status`   | Show whether it's running (PID, uptime, version).                       |
+| `restart`  | Stop it, then start the currently installed binary.                     |
+| `status`   | Show whether it's running (PID, uptime, version, build).                |
 | `enable`   | Register a per-user login agent and start the service now and on every login. |
 | `disable`  | Stop the service and unregister the per-user login agent.               |
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -16,14 +16,24 @@ it's meant to stay running so the sandbox is always ready.
 
 ```bash
 lns service start    # launch it and wait until it's ready
-lns service status   # report whether it's running (PID, uptime, version)
+lns service status   # report whether it's running (PID, uptime, version, build)
 lns service stop     # ask it to shut down
+lns service restart  # stop it, then start the currently installed binary
 ```
 
 You can also quit it from the **Quit** item in its tray menu.
 
 If `lns run` reports that it can't reach the service, start it with
 `lns service start`.
+
+### Reconciling a stale service
+
+`lns` and `lns-service` are released together and speak a versioned local
+protocol. If a command warns that the running service is a different build — or
+refuses to run because the two are protocol-incompatible — the running service
+predates the binaries now on disk (a common outcome of an in-place upgrade,
+since the old process keeps serving until it is relaunched). Run
+`lns service restart` to stop it and start the currently installed binary.
 
 ### Socket and binary locations
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -16,7 +16,7 @@ it's meant to stay running so the sandbox is always ready.
 
 ```bash
 lns service start    # launch it and wait until it's ready
-lns service status   # report whether it's running (PID, uptime, version, build)
+lns service status   # report whether it's running (PID, uptime, version, build, protocol)
 lns service stop     # ask it to shut down
 lns service restart  # stop it, then start the currently installed binary
 ```

--- a/scripts/coverage-floor.sh
+++ b/scripts/coverage-floor.sh
@@ -47,8 +47,9 @@ crates/lns-supervisor/src/config/mod.rs                  load_config: process en
 
 # Vendored / host-build glue — not our source.
 crates/lns-service/src/composefs/vendor/                 vendored upstream composefs (erofs/fsverity); tracked upstream
-crates/lns-service/build.rs                              host cross-build glue (parses kernels.toml)
+crates/lns-service/build.rs                              host cross-build glue (parses kernels.toml) + LNS_BUILD_SHA git-stamp emission
 crates/lns-policy/build.rs                               OAuth env-substitution codegen: scans integrations.yaml for ${VAR} refs and resolves them from the build env; the substitution logic is host-tested at 100% in env_subst.rs
+crates/lns-cli/build.rs                                  LNS_BUILD_SHA git-stamp emission (short sha + -dirty / unknown); coverage-exempt build glue like the sibling build scripts
 
 # Production-wiring adapters — thin pass-throughs; if logic is added, write a unit test and drop the entry.
 crates/lns-service/src/browser.rs                        process-spawn leaf (`open`/`xdg-open`); only caller is the tray's sign-in card (itself IGNORES'd GUI). Pinned by manual `lns integration connect github_oauth` smoke.


### PR DESCRIPTION
## Summary

A release `lns` could silently drive an `lns-service` built from a different tree — inheriting its behavior with zero indication — because the CLI↔service hop compared neither wire-protocol compatibility nor build provenance. A version *string* can't catch this class of mismatch: `lns` and `lns-service` are released in lockstep, so a dev build of unreleased `main` reports the *same* `CARGO_PKG_VERSION` as the release. This PR closes that gap with a versioned handshake plus a build-provenance stamp, mirroring the host↔guest hop's existing `SANDBOX_PROTOCOL_DATE` negotiation.

### 1. Protocol version + build stamp on the wire

- `lns-ipc` gains `IPC_PROTOCOL_VERSION: u32` (monotonic; bump only on wire-breaking changes) and extends `StatusInfo` with `protocol: u32` + `build: String`.
- A new `lns-cli/build.rs` and the existing `lns-service/build.rs` emit `LNS_BUILD_SHA` — the short git SHA, suffixed `-dirty` when the tree is dirty, and `unknown` when git is absent (never fails the build). The stamp stays fresh across checkouts and commits: the build scripts watch the absolute `.git/HEAD`, `.git/index`, and the resolved branch ref. The service reports both fields via `Status`, and `lns service status` now shows them.

### 2. Connect-time handshake gate

Every substantive command funnels through `require_running` (including `lns login` and `lns integration connect`), which probes **`status()` first** — a decodable Status proves liveness by itself — pings only to disambiguate a `None` (so a service that stops mid-probe reads as stopped, never as incompatible), and classifies the result:

| Result | Action |
|--------|--------|
| matching protocol + build | proceed silently |
| matching protocol, different build | one-line **warn** (dev iteration runs mismatched pairs legitimately) |
| incompatible protocol (or an alive service whose `Status` can't be decoded — i.e. an old service) | **hard-fail** with an actionable remedy |

The gate lives on the substantive-request path only. It **never** touches the `Ping`/`Pong` liveness frame — `lns update` and `lns service enable` poll that to confirm readiness after swapping binaries, and gating it would make `lns update` falsely report "service didn't become ready" across a protocol bump. A regression test pins that readiness is Pong-only.

### 3. Reconcile: `cmd_start` warning + `lns service restart`

- `lns service start` against an already-running service now compares provenance and warns to restart instead of a bare "already running" when the build differs.
- New `lns service restart` is **launchd-aware**: on macOS it does `launchctl bootout` + `bootstrap`, on Linux `systemctl --user restart`, falling back to a socket stop→start when no login agent is registered. This matters because the stale service is typically launchd-managed, so a socket-only restart wouldn't actually adopt the freshly installed binary — the remedy the handshake points to would be hollow.
- After a login-agent relaunch, `restart` re-probes status/classify: if the agent file still points at a stale binary, it warns with the agent path and `lns service enable` as the repoint remedy instead of reporting hollow success.

## Docs

`docs/service.md` documents `lns service restart` and a "Reconciling a stale service" note; `docs/cli-reference.md` adds `restart` to the `lns service` table.

## Testing

- **Layer 2** (`service_restart.feature`): `restart` argv surface — discoverable in help, parses cleanly, rejects unknown flags.
- **Layer 3**: classify trichotomy (incl. alive-but-undecodable → mismatch), the warn/hard-fail enforcement (captured tracing events + remedy string), `cmd_start` build-drift warning, the launchd-aware restart core + macOS/Linux platform arms (via `FakeRunner`), `cmd_restart` orchestration (via `FakeClient`), and the Pong-only readiness regression.
- **Layer 3** also pins the gate ordering (dead-between-probes → not-running, alive-but-undecodable → mismatch, matching pair passes on the status probe alone) and the post-relaunch verification (happy relaunch vs. stale-binary warning).
- **Layer 1**: a `service_lifecycle.feature` scenario asserts a same-tree `lns`/`lns-service` pair passes the handshake with no drift warning, so the two build scripts' stamp formats can't silently diverge.
- Full gate green: `make lint` / `make complexity` / `make coverage` (every file at 100% or IGNORE'd — `build.rs` sits with the sibling build scripts) and `make e2e`.

## Test instructions

1. `lns service status` reports a `Build:` and `Protocol:` line alongside PID/uptime/version.
2. With a matching `lns` + `lns-service`, any command (`lns ls`) runs with no handshake noise.
3. Build `lns-service` from a different commit, start it, then run `lns ls` with a differently-stamped `lns`: a one-line build-drift warning appears and the command proceeds.
4. `lns service restart` stops the running service and starts the currently installed binary (on macOS this is a `launchctl bootout`+`bootstrap`); a subsequent command is silent again.
5. `lns update`'s post-swap readiness check still succeeds across a protocol bump (Ping path is unaffected).

Closes #149. Lays groundwork for #8 (installer adoption) — does **not** close it.

