### PR TITLE
feat: add declarative sandbox workdir and mounts

### DIFF
--- a/crates/e2e-tests/features/microvm_declarative_launch.feature
+++ b/crates/e2e-tests/features/microvm_declarative_launch.feature
@@ -11,3 +11,13 @@ Feature: declarative workdir and mounts reach a real guest
     And the output contains "project=visible"
     And the output contains "bind=readonly"
     And the output contains "volume=mounted"
+
+  Scenario: a pulled published sandbox launches offline from the consumer project
+    Given a local registry
+    And the Lens Sandbox service is running
+    When the user pulls a published declarative sandbox and runs it with the registry offline from a consumer project
+    Then the exit code is 0
+    And the output contains "wd=/workspace"
+    And the output contains "consumer=visible"
+    And the output contains "bind=readonly"
+    And the output contains "volume=mounted"

--- a/crates/e2e-tests/features/microvm_declarative_launch.feature
+++ b/crates/e2e-tests/features/microvm_declarative_launch.feature
@@ -1,0 +1,13 @@
+@microvm
+Feature: declarative workdir and mounts reach a real guest
+  A local lns.yaml can make the project directory the workload's working tree
+  and attach persistent storage without repeating launch flags.
+
+  Scenario: a declarative project bind, named volume, and workdir are guest-visible
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c 'echo wd=$(/.lens/guest-tools/bin/busybox pwd); if [ -f lns.yaml ]; then echo project=visible; fi; if echo blocked > lns.yaml 2>/dev/null; then echo bind=writable; else echo bind=readonly; fi; echo volume=mounted > /data/marker; read v < /data/marker; echo $v'" from a declarative sandbox
+    Then the exit code is 0
+    And the output contains "wd=/workspace"
+    And the output contains "project=visible"
+    And the output contains "bind=readonly"
+    And the output contains "volume=mounted"

--- a/crates/e2e-tests/features/sandbox_authoring.feature
+++ b/crates/e2e-tests/features/sandbox_authoring.feature
@@ -10,6 +10,8 @@ Feature: authoring a sandbox definition offline
     Then the exit code is 0
     And the output contains "Created lns.yaml"
     And the project file "lns.yaml" contains "kind: Sandbox"
+    And the project file "lns.yaml" contains "workdir: /workspace"
+    And the project file "lns.yaml" contains "volumes:"
 
   Scenario: init refuses to overwrite an existing lns.yaml
     When I run "lns init" in the project directory

--- a/crates/e2e-tests/features/sandbox_distribution.feature
+++ b/crates/e2e-tests/features/sandbox_distribution.feature
@@ -35,6 +35,9 @@ Feature: distributing a sandbox through a registry end to end
     Then the exit code is 0
     And the output contains "kind: Sandbox"
     And the output contains the pushed reference
+    And the output contains "workdir: /workspace"
+    And the output contains "bind . -> /workspace"
+    And the output contains "volume e2e-cache -> /home/sandbox/.cache"
 
   Scenario: rm removes the cached sandbox
     When I run lns "pull <pushed-ref>" against the service

--- a/crates/e2e-tests/tests/registry_selftest.rs
+++ b/crates/e2e-tests/tests/registry_selftest.rs
@@ -11,6 +11,8 @@ use oci_client::{
     client::{ClientConfig, ClientProtocol},
     secrets::RegistryAuth,
 };
+use std::io::{Read, Write};
+use std::net::TcpStream;
 
 fn sandbox_manifest() -> Vec<u8> {
     format!(
@@ -58,4 +60,19 @@ async fn build_push_and_pull_round_trip_through_the_local_registry() {
     let parsed = lns_artifact::spec::parse_sandbox(config.as_bytes())
         .expect("the pulled config is the sandbox spec");
     assert_eq!(parsed.metadata.name, "some-sandbox");
+}
+
+#[test]
+fn registry_offline_mode_rejects_requests() {
+    let reg = registry::LocalRegistry::start();
+    reg.set_online(false);
+    let mut stream = TcpStream::connect(reg.host()).expect("connect to offline registry");
+    stream
+        .write_all(b"GET /v2/ HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .expect("write registry request");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read registry response");
+    assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
 }

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -250,6 +250,24 @@ fn run_command(world: &mut E2eWorld, cmd_line: String) {
     run_microvm(world, vec![], &cmd_line);
 }
 
+#[when(regex = r#"^the user runs a microVM command "([^"]*)" from a declarative sandbox$"#)]
+fn run_command_from_declarative_sandbox(world: &mut E2eWorld, cmd_line: String) {
+    let project = microvm_project(world);
+    let definition = format!(
+        "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: e2e-declarative\nspec:\n  image: {}\n  workdir: /workspace\n  volumes:\n    - type: bind\n      source: .\n      target: /workspace\n      readOnly: true\n    - type: volume\n      source: e2e-declarative\n      target: /data\n",
+        pinned_microvm_image()
+    );
+    std::fs::write(project.join("lns.yaml"), definition)
+        .expect("write declarative project lns.yaml");
+    track_volume(world, "e2e-declarative");
+    let mut args = vec!["run".to_string(), "--".to_string()];
+    args.extend(split_args(&cmd_line));
+    let result =
+        run_cli_with_timeout_in_dir(&project, args, socket_env(world), MICROVM_RUN_TIMEOUT);
+    world.last_run_id = parse_run_id(&format!("{}\n{}", result.stdout, result.stderr));
+    world.result = Some(result);
+}
+
 #[when(regex = r#"^the user runs a microVM command "([^"]*)" with hostname "([^"]+)"$"#)]
 fn run_command_with_hostname(world: &mut E2eWorld, cmd_line: String, hostname: String) {
     run_microvm(world, vec!["-h".into(), hostname], &cmd_line);

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -551,6 +551,119 @@ fn run_command_with_env(world: &mut E2eWorld, cmd_line: String, env: String) {
 }
 
 static RUN_SANDBOX_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static PUBLISHED_DECLARATIVE_SEQ: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+async fn mirror_microvm_image(host: &str, seq: usize) -> String {
+    let source: oci_client::Reference = pinned_microvm_image()
+        .parse()
+        .expect("pinned image ref parses");
+    let remote = oci_client::Client::new(oci_client::client::ClientConfig::default());
+    let oci_client::client::ImageData {
+        layers,
+        digest: _,
+        config,
+        manifest,
+    } = remote
+        .pull(
+            &source,
+            &oci_client::secrets::RegistryAuth::Anonymous,
+            vec![
+                oci_client::manifest::IMAGE_LAYER_MEDIA_TYPE,
+                oci_client::manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE,
+                oci_client::manifest::IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE,
+                oci_client::manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE,
+            ],
+        )
+        .await
+        .expect("pull the microVM image for the offline registry");
+    let destination: oci_client::Reference = format!("{host}/e2e-offline-base:{seq}")
+        .parse()
+        .expect("offline base ref parses");
+    let local = oci_client::Client::new(oci_client::client::ClientConfig {
+        protocol: oci_client::client::ClientProtocol::Http,
+        ..Default::default()
+    });
+    local
+        .push(
+            &destination,
+            &layers,
+            config,
+            &oci_client::secrets::RegistryAuth::Anonymous,
+            manifest,
+        )
+        .await
+        .expect("push the microVM image into the offline registry");
+    let (_, digest, _) = local
+        .pull_manifest_and_config(&destination, &oci_client::secrets::RegistryAuth::Anonymous)
+        .await
+        .expect("resolve the mirrored image digest");
+    destination.clone_with_digest(digest).whole()
+}
+
+#[when(
+    "the user pulls a published declarative sandbox and runs it with the registry offline from a consumer project"
+)]
+async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
+    let host = world
+        .registry
+        .get_or_insert_with(crate::registry::LocalRegistry::start)
+        .host();
+    let seq = PUBLISHED_DECLARATIVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let base = mirror_microvm_image(&host, seq).await;
+    let reference = format!("{host}/e2e-declarative-sandbox:{seq}");
+    let volume = format!("e2e-declarative-published-{seq}");
+    let publisher = tempfile::TempDir::new().expect("publisher project tempdir");
+    let definition = format!(
+        "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: e2e-declarative-published\nspec:\n  image: {base}\n  workdir: /workspace\n  volumes:\n    - type: bind\n      source: .\n      target: /workspace\n      readOnly: true\n    - type: volume\n      source: {volume}\n      target: /data\n"
+    );
+    std::fs::write(publisher.path().join("lns.yaml"), definition)
+        .expect("write published declarative lns.yaml");
+    let pushed = run_cli_with_timeout_in_dir(
+        publisher.path(),
+        vec!["push".to_string(), reference.clone()],
+        std::iter::empty::<(&str, &str)>(),
+        MICROVM_RUN_TIMEOUT,
+    );
+    assert_eq!(
+        pushed.exit_code, 0,
+        "push published declarative sandbox:\n{}\n{}",
+        pushed.stdout, pushed.stderr
+    );
+    let pulled = world.run_with_service_env(&["pull", &reference]);
+    assert_eq!(
+        pulled.exit_code, 0,
+        "pull published declarative sandbox:\n{}\n{}",
+        pulled.stdout, pulled.stderr
+    );
+
+    let consumer = world
+        .project
+        .get_or_insert_with(|| tempfile::TempDir::new().expect("consumer project tempdir"))
+        .path()
+        .to_path_buf();
+    std::fs::write(consumer.join("consumer-marker"), "consumer project\n")
+        .expect("write consumer marker");
+    std::fs::write(
+        consumer.join("lns-policy.yaml"),
+        "network:\n  defaultVerdict: deny\n",
+    )
+    .expect("write consumer policy");
+    track_volume(world, &volume);
+    world
+        .registry
+        .as_ref()
+        .expect("the local registry exists")
+        .set_online(false);
+
+    let command = "/bin/sh -c 'echo wd=$(/.lens/guest-tools/bin/busybox pwd); if [ -f consumer-marker ]; then echo consumer=visible; fi; if echo blocked > consumer-marker 2>/dev/null; then echo bind=writable; else echo bind=readonly; fi; echo volume=mounted > /data/marker; read v < /data/marker; echo $v'";
+    let mut args = vec!["run".to_string(), reference, "--".to_string()];
+    args.extend(split_args(command));
+    let result =
+        run_cli_with_timeout_in_dir(&consumer, args, socket_env(world), MICROVM_RUN_TIMEOUT);
+    world.last_run_id = parse_run_id(&format!("{}\n{}", result.stdout, result.stderr));
+    world.result = Some(result);
+}
 
 // `lns run` refuses a plain OCI image, so image-driven scenarios publish a minimal sandbox over it to the in-process registry and run that reference.
 async fn published_sandbox_wrapping(world: &mut E2eWorld, image: &str) -> String {

--- a/crates/e2e-tests/tests/steps/producer.rs
+++ b/crates/e2e-tests/tests/steps/producer.rs
@@ -90,7 +90,7 @@ async fn push_sandbox_from_lns_yaml(world: &mut E2eWorld) {
     let reference = format!("{host}/e2e-cache-sandbox:1");
     let base = seed_base_image(&host).await;
     let definition = format!(
-        "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: e2e-cache-sandbox\nspec:\n  image: {base}\n"
+        "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: e2e-cache-sandbox\nspec:\n  image: {base}\n  workdir: /workspace\n  volumes:\n    - type: bind\n      source: .\n      target: /workspace\n    - type: volume\n      source: e2e-cache\n      target: /home/sandbox/.cache\n      readOnly: true\n"
     );
     let env = cache_env(world);
     let project = world.home.as_ref().expect("home set by cache_env").path();

--- a/crates/e2e-tests/tests/support/registry.rs
+++ b/crates/e2e-tests/tests/support/registry.rs
@@ -8,7 +8,10 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 
 #[derive(Default)]
 struct Store {
@@ -28,6 +31,7 @@ struct Manifest {
 #[derive(Debug)]
 pub struct LocalRegistry {
     port: u16,
+    online: Arc<AtomicBool>,
 }
 
 impl LocalRegistry {
@@ -36,20 +40,27 @@ impl LocalRegistry {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind local registry");
         let port = listener.local_addr().expect("registry addr").port();
         let store = Arc::new(Mutex::new(Store::default()));
+        let online = Arc::new(AtomicBool::new(true));
+        let server_online = online.clone();
         std::thread::spawn(move || {
             for stream in listener.incoming().flatten() {
                 let store = store.clone();
+                let online = server_online.clone();
                 std::thread::spawn(move || {
-                    let _ = serve(stream, &store);
+                    let _ = serve(stream, &store, &online);
                 });
             }
         });
-        Self { port }
+        Self { port, online }
     }
 
     /// The `host:port` a ref should target (e.g. `127.0.0.1:5000/some/repo:1`).
     pub fn host(&self) -> String {
         format!("127.0.0.1:{}", self.port)
+    }
+
+    pub fn set_online(&self, online: bool) {
+        self.online.store(online, Ordering::SeqCst);
     }
 }
 
@@ -138,10 +149,17 @@ fn route(path: &str) -> Option<(String, Vec<String>)> {
     Some((name, tail))
 }
 
-fn serve(mut stream: TcpStream, store: &Arc<Mutex<Store>>) -> std::io::Result<()> {
+fn serve(
+    mut stream: TcpStream,
+    store: &Arc<Mutex<Store>>,
+    online: &AtomicBool,
+) -> std::io::Result<()> {
     let Some(req) = read_request(&mut stream)? else {
         return Ok(());
     };
+    if !online.load(Ordering::SeqCst) {
+        return respond(&mut stream, "503 Service Unavailable", &[], b"offline");
+    }
     // Version check.
     if req.path == "/v2" || req.path == "/v2/" {
         return respond(&mut stream, "200 OK", &[], b"{}");

--- a/crates/lns-artifact/src/build.rs
+++ b/crates/lns-artifact/src/build.rs
@@ -324,6 +324,21 @@ mod tests {
     }
 
     #[test]
+    fn build_artifact_preserves_declarative_workdir_and_mounts() {
+        let doc = br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","workdir":"/workspace","volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"some-cache","target":"/home/node/.cache","readOnly":true}]}}"#;
+        let built = build_artifact(doc).unwrap();
+        let config = built
+            .blobs
+            .iter()
+            .find(|blob| blob.media_type.contains("sandbox.config"))
+            .expect("the sandbox config blob must be present");
+        let value: Value = serde_json::from_slice(&config.data).unwrap();
+        assert_eq!(value["spec"]["workdir"], "/workspace");
+        assert_eq!(value["spec"]["volumes"][0]["source"], ".");
+        assert_eq!(value["spec"]["volumes"][1]["readOnly"], true);
+    }
+
+    #[test]
     fn build_artifact_attaches_the_oci_empty_layer() {
         let built = build_artifact(&sandbox()).unwrap();
         let empty = built

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result, bail};
 use lns_policy::NetworkPolicy;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::spec::{self, CredentialSlot, Metadata, Port, Resources, Volume};
+use crate::spec::{self, CredentialSlot, Metadata, Port, Resources};
 
 pub const API_VERSION: &str = "lns.run/v1";
 pub const KIND: &str = "Sandbox";
@@ -26,6 +26,44 @@ pub struct Definition {
     pub spec: SandboxSpec,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VolumeType {
+    Bind,
+    Volume,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Volume {
+    #[serde(rename = "type", default)]
+    volume_type: Option<VolumeType>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    pub target: String,
+    #[serde(default)]
+    read_only: bool,
+}
+
+impl Volume {
+    pub fn source(&self) -> &str {
+        self.source
+            .as_deref()
+            .or(self.name.as_deref())
+            .unwrap_or_default()
+    }
+
+    pub fn is_bind(&self) -> bool {
+        self.volume_type == Some(VolumeType::Bind)
+    }
+
+    pub fn read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
 /// The whole sandbox in one document: the base image plus its config, env, embedded network policy, mounts, and the integration ids it needs.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -34,6 +72,8 @@ pub struct SandboxSpec {
     pub image: String,
     #[serde(default)]
     pub command: Option<String>,
+    #[serde(default)]
+    pub workdir: Option<String>,
     #[serde(default)]
     pub env: BTreeMap<String, String>,
     #[serde(default)]
@@ -82,9 +122,17 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
     if doc.spec.image.trim().is_empty() {
         bail!("sandbox must carry an image; it is the base OCI image the sandbox runs");
     }
+    if let Some(workdir) = &doc.spec.workdir {
+        spec::validate_mount_path(workdir).context("workdir")?;
+    }
+    let mut targets = BTreeSet::new();
     for volume in &doc.spec.volumes {
         spec::validate_mount_path(&volume.target)
-            .with_context(|| format!("volume {}", volume.name))?;
+            .with_context(|| format!("volume targeting {}", volume.target))?;
+        validate_volume(volume)?;
+        if !targets.insert(&volume.target) {
+            bail!("duplicate volume target {}", volume.target);
+        }
     }
     for integration in &doc.spec.integrations {
         if !spec::is_valid_name(integration) {
@@ -116,6 +164,61 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
     })
 }
 
+fn validate_volume(volume: &Volume) -> Result<()> {
+    match volume.volume_type {
+        Some(VolumeType::Bind) => {
+            if volume.name.is_some() {
+                bail!("bind volume must use source, not name");
+            }
+            validate_bind_source(volume.source.as_deref().unwrap_or_default())
+        }
+        Some(VolumeType::Volume) => {
+            if volume.source.is_some() && volume.name.is_some() {
+                bail!("named volume must use either source or name, not both");
+            }
+            validate_volume_name(volume.source())
+        }
+        None => {
+            if volume.source.is_some() {
+                bail!("volume with source must declare type: bind or type: volume");
+            }
+            validate_volume_name(volume.name.as_deref().unwrap_or_default())
+        }
+    }
+}
+
+fn validate_bind_source(source: &str) -> Result<()> {
+    if source.is_empty() {
+        bail!("bind source must not be empty");
+    }
+    if source
+        .chars()
+        .any(|c| c.is_whitespace() || c.is_control() || c == '"')
+    {
+        bail!("bind source {source:?} must not contain whitespace, quotes, or control characters");
+    }
+    if source.split('/').any(|segment| segment == "..") {
+        bail!("bind source {source:?} must not contain a `..` path segment");
+    }
+    Ok(())
+}
+
+fn validate_volume_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("named volume source must not be empty");
+    }
+    if name == "." || name == ".." {
+        bail!("invalid named volume source {name:?}: reserved");
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-')))
+    {
+        bail!("invalid named volume source {name:?}: character {bad:?} not allowed");
+    }
+    Ok(())
+}
+
 /// Schema + cross-field guards for a sandbox definition (the secret guard runs separately in `validate`).
 pub fn validate(config_json: &[u8]) -> Result<()> {
     parse(config_json).map(|_| ())
@@ -136,12 +239,13 @@ mod tests {
     #[test]
     fn parse_reads_the_whole_flat_definition() {
         let json = def_json(
-            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"policy":{"defaultVerdict":"deny","allowedRoutes":[{"match":"api.example.test","verdict":"allow"}]},"integrations":["some-provider"],"credentials":[{"name":"some-provider","env":"SOME_TOKEN"}],"volumes":[{"name":"home","target":"/root/.home"}],"ports":[{"container":8080}]}"#,
+            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","workdir":"/workspace","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"policy":{"defaultVerdict":"deny","allowedRoutes":[{"match":"api.example.test","verdict":"allow"}]},"integrations":["some-provider"],"credentials":[{"name":"some-provider","env":"SOME_TOKEN"}],"volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"home","target":"/root/.home","readOnly":true}],"ports":[{"container":8080}]}"#,
         );
         let def = parse(&json).unwrap();
         assert_eq!(def.metadata.name, "hermes");
         assert_eq!(def.spec.image, "ghcr.io/team/base:1");
         assert_eq!(def.spec.command.as_deref(), Some("agent --serve"));
+        assert_eq!(def.spec.workdir.as_deref(), Some("/workspace"));
         assert_eq!(
             def.spec.env.get("MODE").map(String::as_str),
             Some("research")
@@ -150,7 +254,10 @@ mod tests {
         assert_eq!(def.spec.policy.allowed_routes.len(), 1);
         assert_eq!(def.spec.integrations, vec!["some-provider".to_string()]);
         assert_eq!(def.spec.credentials[0].env, "SOME_TOKEN");
-        assert_eq!(def.spec.volumes[0].target, "/root/.home");
+        assert_eq!(def.spec.volumes[0].source(), ".");
+        assert!(def.spec.volumes[0].is_bind());
+        assert_eq!(def.spec.volumes[1].source(), "home");
+        assert!(def.spec.volumes[1].read_only());
         assert_eq!(def.spec.ports[0].container, 8080);
     }
 
@@ -216,6 +323,92 @@ mod tests {
         ))
         .unwrap_err();
         assert!(format!("{err:#}").contains("`..` segment"), "got: {err:#}");
+    }
+
+    #[test]
+    fn parse_accepts_the_legacy_named_volume_shape() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"name":"home","target":"/root/.home","readOnly":true}]}"#,
+        ))
+        .unwrap();
+        assert_eq!(def.spec.volumes[0].source(), "home");
+        assert!(!def.spec.volumes[0].is_bind());
+        assert!(def.spec.volumes[0].read_only());
+    }
+
+    #[test]
+    fn parse_rejects_a_relative_workdir() {
+        let err = parse(&def_json(r#"{"image":"x:1","workdir":"workspace"}"#)).unwrap_err();
+        assert!(format!("{err:#}").contains("workdir"), "got: {err:#}");
+        assert!(format!("{err:#}").contains("absolute"), "got: {err:#}");
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_mount_targets() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"cache","target":"/workspace"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("duplicate volume target /workspace"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_bind_source_that_escapes_the_project() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"../outside","target":"/workspace"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("bind source"), "got: {err:#}");
+        assert!(format!("{err:#}").contains("`..`"), "got: {err:#}");
+    }
+
+    #[test]
+    fn parse_rejects_ambiguous_or_invalid_volume_sources() {
+        let cases = [
+            (
+                r#"{"type":"bind","name":"some-bind","target":"/data"}"#,
+                "bind volume must use source",
+            ),
+            (
+                r#"{"type":"volume","source":"some-cache","name":"other-cache","target":"/data"}"#,
+                "either source or name",
+            ),
+            (
+                r#"{"source":"some-cache","target":"/data"}"#,
+                "must declare type",
+            ),
+            (
+                r#"{"type":"bind","target":"/data"}"#,
+                "bind source must not be empty",
+            ),
+            (
+                r#"{"type":"bind","source":"project files","target":"/data"}"#,
+                "must not contain whitespace",
+            ),
+            (
+                r#"{"type":"volume","target":"/data"}"#,
+                "named volume source must not be empty",
+            ),
+            (
+                r#"{"type":"volume","source":".","target":"/data"}"#,
+                "reserved",
+            ),
+            (
+                r#"{"type":"volume","source":"some/cache","target":"/data"}"#,
+                "character '/' not allowed",
+            ),
+        ];
+        for (volume, expected) in cases {
+            let spec = format!(r#"{{"image":"x:1","volumes":[{volume}]}}"#);
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains(expected),
+                "expected {expected:?}, got: {err:#}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -162,7 +162,7 @@ pub struct RunArgs {
         long,
         value_name = "DIR",
         value_parser = parse_workdir_arg,
-        help = "Working directory inside the sandbox (absolute path; created if missing). Defaults to the image's WORKDIR."
+        help = "Working directory inside the sandbox (absolute path; created if missing). Overrides spec.workdir and the image's WORKDIR."
     )]
     pub workdir: Option<String>,
 

--- a/crates/lns-cli/src/run/declarative.rs
+++ b/crates/lns-cli/src/run/declarative.rs
@@ -1,0 +1,169 @@
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Result, bail};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountDefault {
+    pub bind: bool,
+    pub source: String,
+    pub target: String,
+    pub read_only: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Defaults {
+    pub workdir: Option<String>,
+    pub mounts: Vec<MountDefault>,
+}
+
+impl Defaults {
+    pub fn from_definition(definition: &lns_artifact::sandbox::Definition) -> Self {
+        Self {
+            workdir: definition.spec.workdir.clone(),
+            mounts: definition
+                .spec
+                .volumes
+                .iter()
+                .map(|volume| MountDefault {
+                    bind: volume.is_bind(),
+                    source: volume.source().to_string(),
+                    target: volume.target.clone(),
+                    read_only: volume.read_only(),
+                })
+                .collect(),
+        }
+    }
+
+    pub fn from_view(view: &lns_ipc::SandboxView) -> Self {
+        Self {
+            workdir: view.workdir.clone(),
+            mounts: view
+                .mounts
+                .iter()
+                .map(|mount| MountDefault {
+                    bind: mount.kind == lns_ipc::SandboxMountKind::Bind,
+                    source: mount.source.clone(),
+                    target: mount.target.clone(),
+                    read_only: mount.read_only,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolved {
+    pub workdir: Option<String>,
+    pub mounts: Vec<lns_ipc::MountSpec>,
+}
+
+pub fn resolve(
+    defaults: &Defaults,
+    project_dir: &Path,
+    explicit_workdir: Option<String>,
+    explicit_mounts: Vec<lns_ipc::MountSpec>,
+) -> Result<Resolved> {
+    let overridden_targets: BTreeSet<&str> = explicit_mounts
+        .iter()
+        .map(lns_ipc::MountSpec::target)
+        .collect();
+    let mut mounts = defaults
+        .mounts
+        .iter()
+        .filter(|mount| !overridden_targets.contains(mount.target.as_str()))
+        .map(|mount| resolve_mount(mount, project_dir))
+        .collect::<Result<Vec<_>>>()?;
+    mounts.extend(explicit_mounts);
+    Ok(Resolved {
+        workdir: explicit_workdir.or_else(|| defaults.workdir.clone()),
+        mounts,
+    })
+}
+
+fn resolve_mount(mount: &MountDefault, project_dir: &Path) -> Result<lns_ipc::MountSpec> {
+    lns_ipc::validate_volume_target(&mount.target).map_err(anyhow::Error::msg)?;
+    if mount.bind {
+        let source = resolve_bind_source(&mount.source, project_dir)?;
+        lns_ipc::validate_bind_source(&source).map_err(anyhow::Error::msg)?;
+        return Ok(lns_ipc::MountSpec::Bind(lns_ipc::BindSpec {
+            host_source: source,
+            target: mount.target.clone(),
+            read_only: mount.read_only,
+        }));
+    }
+    lns_ipc::validate_volume_name(&mount.source).map_err(anyhow::Error::msg)?;
+    Ok(lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
+        name: mount.source.clone(),
+        target: mount.target.clone(),
+        read_only: mount.read_only,
+    }))
+}
+
+fn resolve_bind_source(source: &str, project_dir: &Path) -> Result<String> {
+    let source = Path::new(source);
+    let joined = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        project_dir.join(source)
+    };
+    let normalized = normalize_absolute(&joined)?;
+    normalized
+        .into_os_string()
+        .into_string()
+        .map_err(|_| anyhow::anyhow!("bind source is not valid UTF-8"))
+}
+
+fn normalize_absolute(path: &Path) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!("project directory must be absolute: {}", path.display());
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    bail!(
+                        "bind source escapes the filesystem root: {}",
+                        path.display()
+                    );
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_bind_sources_are_normalized_under_the_project_directory() {
+        assert_eq!(
+            resolve_bind_source("./src", Path::new("/work/project")).unwrap(),
+            "/work/project/src"
+        );
+    }
+
+    #[test]
+    fn absolute_bind_sources_are_normalized_without_using_the_project_directory() {
+        assert_eq!(
+            resolve_bind_source("/work/./project", Path::new("/elsewhere")).unwrap(),
+            "/work/project"
+        );
+    }
+
+    #[test]
+    fn resolution_rejects_a_relative_project_directory() {
+        let err = resolve_bind_source(".", Path::new("relative")).unwrap_err();
+        assert!(format!("{err:#}").contains("project directory must be absolute"));
+    }
+
+    #[test]
+    fn normalization_rejects_parent_traversal_above_root() {
+        let err = normalize_absolute(Path::new("/../work")).unwrap_err();
+        assert!(format!("{err:#}").contains("escapes"));
+    }
+}

--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -1,3 +1,4 @@
+pub mod declarative;
 pub mod env_file;
 pub mod host_bind;
 pub mod progress;

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -15,11 +15,19 @@ spec:
   # The base OCI image this sandbox runs; pin it by digest before you publish.
   image: docker.io/library/alpine:3.20
   # command: sh
+  # workdir: /workspace
   # env:
   #   MODE: production
   # policy:
   #   defaultVerdict: ask
   # integrations: []
+  # volumes:
+  #   - type: bind
+  #     source: .
+  #     target: /workspace
+  #   - type: volume
+  #     source: sandbox-cache
+  #     target: /home/sandbox/.cache
 ";
 
 /// A minimal filesystem seam so the author verbs are host-tested with an in-memory fake; `RealFs` in `real.rs` is the std::fs leaf.
@@ -93,6 +101,23 @@ fn render_effective<W: Write>(def: &lns_artifact::sandbox::Definition, out: &mut
     writeln!(out, "  image:        {}", def.spec.image)?;
     if let Some(command) = &def.spec.command {
         writeln!(out, "  command:      {command}")?;
+    }
+    if let Some(workdir) = &def.spec.workdir {
+        writeln!(out, "  workdir:      {workdir}")?;
+    }
+    for volume in &def.spec.volumes {
+        let kind = if volume.is_bind() { "bind" } else { "volume" };
+        let mode = if volume.read_only() {
+            "read-only"
+        } else {
+            "read-write"
+        };
+        writeln!(
+            out,
+            "  mount:        {kind} {} -> {} ({mode})",
+            volume.source(),
+            volume.target
+        )?;
     }
     writeln!(
         out,

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -704,7 +704,25 @@ fn render_cached_inspect<W: std::io::Write>(
         lns_ipc::ArtifactInspection::Sandbox(view) => {
             writeln!(out, "kind: Sandbox")?;
             writeln!(out, "reference: {}", view.reference)?;
+            if !view.digest.is_empty() {
+                writeln!(out, "digest: {}", view.digest)?;
+            }
             writeln!(out, "image: {}", view.image)?;
+            if let Some(workdir) = &view.workdir {
+                writeln!(out, "workdir: {workdir}")?;
+            }
+            for mount in &view.mounts {
+                let kind = match mount.kind {
+                    lns_ipc::SandboxMountKind::Bind => "bind",
+                    lns_ipc::SandboxMountKind::Volume => "volume",
+                };
+                let mode = if mount.read_only { " (read-only)" } else { "" };
+                writeln!(
+                    out,
+                    "mount: {kind} {} -> {}{mode}",
+                    mount.source, mount.target
+                )?;
+            }
             render_integrations(out, &view.integrations)?;
             render_policy_flags(out, &view.policy_flags)?;
         }
@@ -774,6 +792,10 @@ fn render_inspect<W: std::io::Write>(
     config.insert("cpus".into(), details.config.cpus.into());
     config.insert("memMib".into(), details.config.mem_mib.into());
     config.insert("env".into(), serde_json::to_value(&details.config.env)?);
+    config.insert(
+        "workdir".into(),
+        serde_json::to_value(&details.config.workdir)?,
+    );
     config.insert(
         "publishedPorts".into(),
         serde_json::to_value(&details.config.published_ports)?,
@@ -1414,7 +1436,10 @@ mod tests {
             Response::ImageInspected {
                 inspection: lns_ipc::ArtifactInspection::Sandbox(lns_ipc::SandboxView {
                     reference: "hermes:1.4.0".into(),
+                    digest: format!("sha256:{}", "a".repeat(64)),
                     image: "docker.io/library/alpine@sha256:abc".into(),
+                    workdir: None,
+                    mounts: Vec::new(),
                     integrations: vec!["some-provider".into()],
                     policy_flags: Vec::new(),
                 }),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -1034,6 +1034,24 @@ mod tests {
     }
 
     #[test]
+    fn published_sandbox_preflight_refuses_an_unpinned_result() {
+        let err = published_target(
+            "registry.example.test/team/sandbox:1",
+            lns_ipc::ArtifactInspection::Sandbox(lns_ipc::SandboxView {
+                reference: "registry.example.test/team/sandbox:1".into(),
+                digest: String::new(),
+                image: "registry.example.test/runtime:1".into(),
+                workdir: Some("/workspace".into()),
+                mounts: Vec::new(),
+                integrations: Vec::new(),
+                policy_flags: Vec::new(),
+            }),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("no manifest digest"));
+    }
+
+    #[test]
     fn published_preflight_keeps_agent_system_bundles_compatible() {
         let target = published_target(
             "registry.example.test/team/system:1",

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -22,6 +22,8 @@ use lns_ipc::{ExecImageArgs, RunImageArgs};
 use super::{client::ServiceClient, real, require_running_check};
 use crate::run::summary::print_run_summary;
 
+const PUBLISHED_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let mut args = RunArgs::from_arg_matches(matches)?;
@@ -144,14 +146,25 @@ fn published_target(
 }
 
 async fn preflight_published(socket: &Path, reference: &str) -> Result<PublishedTarget> {
-    match real::send_request(
-        socket,
-        &Request::InspectImage {
-            image: reference.to_string(),
-        },
-    )
-    .await
-    {
+    let request = Request::InspectImage {
+        image: reference.to_string(),
+    };
+    await_published_preflight(reference, real::send_request(socket, &request)).await
+}
+
+async fn await_published_preflight(
+    reference: &str,
+    response: impl std::future::Future<Output = Option<Response>>,
+) -> Result<PublishedTarget> {
+    let response = timeout(PUBLISHED_PREFLIGHT_TIMEOUT, response)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "published sandbox preflight timed out after {}s while inspecting {reference}",
+                PUBLISHED_PREFLIGHT_TIMEOUT.as_secs()
+            )
+        })?;
+    match response {
         Some(Response::ImageInspected { inspection }) => published_target(reference, inspection),
         Some(Response::Error { message }) => anyhow::bail!("daemon error: {message}"),
         Some(other) => anyhow::bail!("expected sandbox preflight, got {other:?}"),
@@ -1067,6 +1080,20 @@ mod tests {
         .unwrap();
         assert_eq!(target.image, "registry.example.test/team/system:1");
         assert!(target.defaults.mounts.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn published_preflight_times_out_when_the_service_never_responds() {
+        let err = await_published_preflight(
+            "registry.example.test/team/sandbox:1",
+            std::future::pending::<Option<Response>>(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "published sandbox preflight timed out after 30s while inspecting registry.example.test/team/sandbox:1"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -110,10 +110,81 @@ fn resolve_host_binds(
     )
 }
 
-pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
+#[derive(Debug)]
+struct PublishedTarget {
+    image: String,
+    defaults: crate::run::declarative::Defaults,
+}
+
+fn published_target(
+    reference: &str,
+    inspection: lns_ipc::ArtifactInspection,
+) -> Result<PublishedTarget> {
+    match inspection {
+        lns_ipc::ArtifactInspection::Sandbox(view) => {
+            if view.digest.is_empty() {
+                anyhow::bail!("published sandbox preflight returned no manifest digest");
+            }
+            let parsed: oci_client::Reference = reference
+                .parse()
+                .with_context(|| format!("invalid sandbox reference {reference}"))?;
+            Ok(PublishedTarget {
+                image: parsed.clone_with_digest(view.digest.clone()).to_string(),
+                defaults: crate::run::declarative::Defaults::from_view(&view),
+            })
+        }
+        lns_ipc::ArtifactInspection::Bundle(_) => Ok(PublishedTarget {
+            image: reference.to_string(),
+            defaults: crate::run::declarative::Defaults::default(),
+        }),
+        lns_ipc::ArtifactInspection::Image(_) => anyhow::bail!(
+            "{reference} is not a sandbox; run `lns init` to author an lns.yaml, or pass a published sandbox reference"
+        ),
+    }
+}
+
+async fn preflight_published(socket: &Path, reference: &str) -> Result<PublishedTarget> {
+    match real::send_request(
+        socket,
+        &Request::InspectImage {
+            image: reference.to_string(),
+        },
+    )
+    .await
+    {
+        Some(Response::ImageInspected { inspection }) => published_target(reference, inspection),
+        Some(Response::Error { message }) => anyhow::bail!("daemon error: {message}"),
+        Some(other) => anyhow::bail!("expected sandbox preflight, got {other:?}"),
+        None => anyhow::bail!("no response from lns-service during sandbox preflight"),
+    }
+}
+
+pub async fn run_image(mut args: RunArgs, debug: bool) -> Result<i32> {
     let cwd = std::env::current_dir().context("reading current directory")?;
     let target =
         crate::run::target::resolve(args.image.as_deref(), &crate::sandbox::real::RealFs, &cwd)?;
+    let client = real_client()?;
+    let published = match &target {
+        crate::run::target::RunTarget::Reference(reference) => {
+            Some(preflight_published(client.socket(), reference).await?)
+        }
+        crate::run::target::RunTarget::Local { .. } => None,
+    };
+    let defaults = match (&target, &published) {
+        (crate::run::target::RunTarget::Local { def, .. }, _) => {
+            crate::run::declarative::Defaults::from_definition(def)
+        }
+        (_, Some(published)) => published.defaults.clone(),
+        _ => crate::run::declarative::Defaults::default(),
+    };
+    let resolved = crate::run::declarative::resolve(
+        &defaults,
+        &cwd,
+        args.workdir.take(),
+        std::mem::take(&mut args.mounts),
+    )?;
+    args.workdir = resolved.workdir;
+    args.mounts = resolved.mounts;
     let quiet = args.quiet;
     let resolved_policy = if quiet {
         let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), &cwd)?;
@@ -133,7 +204,6 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
     }
     let binds: Vec<lns_ipc::BindMount> = resolved_binds.iter().map(|b| b.to_wire()).collect();
 
-    let client = real_client()?;
     let socket = client.socket();
     let mut stream = UnixStream::connect(socket)
         .await
@@ -159,6 +229,7 @@ pub async fn run_image(args: RunArgs, debug: bool) -> Result<i32> {
         cmd: args.cmd,
         env: args.env,
         image: Some(target.image()),
+        resolved_image: published.as_ref().map(|published| published.image.clone()),
         name: args.name,
         policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user,
@@ -919,6 +990,66 @@ fn phrase_for_verb(verb: &str) -> String {
 mod tests {
     use super::*;
     use tokio::io::AsyncWriteExt;
+
+    #[test]
+    fn published_sandbox_preflight_pins_the_artifact_and_keeps_launch_defaults() {
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let target = published_target(
+            "registry.example.test/team/sandbox:1",
+            lns_ipc::ArtifactInspection::Sandbox(lns_ipc::SandboxView {
+                reference: "registry.example.test/team/sandbox:1".into(),
+                digest: digest.clone(),
+                image: "registry.example.test/runtime:1".into(),
+                workdir: Some("/workspace".into()),
+                mounts: vec![lns_ipc::SandboxMount {
+                    kind: lns_ipc::SandboxMountKind::Bind,
+                    source: ".".into(),
+                    target: "/workspace".into(),
+                    read_only: false,
+                }],
+                integrations: Vec::new(),
+                policy_flags: Vec::new(),
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            target.image,
+            format!("registry.example.test/team/sandbox@{digest}")
+        );
+        assert_eq!(target.defaults.workdir.as_deref(), Some("/workspace"));
+        assert_eq!(target.defaults.mounts[0].source, ".");
+    }
+
+    #[test]
+    fn published_preflight_refuses_a_plain_image() {
+        let err = published_target(
+            "registry.example.test/team/image:1",
+            lns_ipc::ArtifactInspection::Image(lns_ipc::ImageView {
+                reference: "registry.example.test/team/image:1".into(),
+                digest: format!("sha256:{}", "a".repeat(64)),
+            }),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("not a sandbox"));
+    }
+
+    #[test]
+    fn published_preflight_keeps_agent_system_bundles_compatible() {
+        let target = published_target(
+            "registry.example.test/team/system:1",
+            lns_ipc::ArtifactInspection::Bundle(lns_ipc::BundleView {
+                reference: "registry.example.test/team/system:1".into(),
+                sandbox_base_image: None,
+                filesets: Vec::new(),
+                integrations: Vec::new(),
+                signature: lns_ipc::SignatureView::Unsigned,
+                policy_flags: Vec::new(),
+            }),
+        )
+        .unwrap();
+        assert_eq!(target.image, "registry.example.test/team/system:1");
+        assert!(target.defaults.mounts.is_empty());
+    }
 
     #[tokio::test]
     async fn drive_attached_session_returns_exit_code_from_run_exit_frame() {

--- a/crates/lns-cli/src/service/real.rs
+++ b/crates/lns-cli/src/service/real.rs
@@ -65,23 +65,20 @@ impl RealServiceClient {
 }
 
 pub(crate) async fn send_request(socket: &Path, request: &Request) -> Option<Response> {
-    let attempt = async {
-        let mut stream = UnixStream::connect(socket).await.ok()?;
-        let frame = encode_frame(request).ok()?;
-        stream.write_all(&frame).await.ok()?;
-        stream.shutdown().await.ok()?;
+    let mut stream = UnixStream::connect(socket).await.ok()?;
+    let frame = encode_frame(request).ok()?;
+    stream.write_all(&frame).await.ok()?;
+    stream.shutdown().await.ok()?;
 
-        let mut buf = Vec::new();
-        stream.read_to_end(&mut buf).await.ok()?;
-        decode_frame(&mut &buf[..]).ok()
-    };
-    timeout(PROBE_TIMEOUT, attempt).await.ok().flatten()
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.ok()?;
+    decode_frame(&mut &buf[..]).ok()
 }
 
 async fn try_ping_impl(socket: &Path) -> bool {
     matches!(
-        send_request(socket, &Request::Ping).await,
-        Some(Response::Pong)
+        timeout(PROBE_TIMEOUT, send_request(socket, &Request::Ping)).await,
+        Ok(Some(Response::Pong))
     )
 }
 

--- a/crates/lns-cli/tests/behaviours/declarative_run.feature
+++ b/crates/lns-cli/tests/behaviours/declarative_run.feature
@@ -1,0 +1,44 @@
+Feature: applying declarative sandbox launch settings
+  Workdir and mounts in lns.yaml are portable launch settings. Relative bind
+  sources are rooted in the consumer's project directory, explicit run flags
+  win per setting and per guest target, and declarative binds enter the same
+  host-side secret decision flow as flag-provided binds.
+
+  Scenario: a local definition supplies workdir, a project bind, and a named volume
+    Given an lns.yaml declaring workdir and declarative mounts
+    When the local sandbox launch settings are resolved with no overrides
+    Then the resolved workdir is "/workspace"
+    And the resolved host binds are exactly "/work -> /workspace"
+    And the resolved volumes are exactly "some-cache:/home/node/.cache:ro"
+
+  Scenario: explicit workdir and mount flags override matching declarative settings
+    Given an lns.yaml declaring workdir and declarative mounts
+    When the local sandbox launch settings are resolved with "--workdir /src -v cli-cache:/home/node/.cache -v /other:/workspace:ro"
+    Then the resolved workdir is "/src"
+    And the resolved host binds are exactly "/other -> /workspace:ro"
+    And the resolved volumes are exactly "cli-cache:/home/node/.cache"
+
+  Scenario: an unrelated CLI mount is kept alongside declarative mounts
+    Given an lns.yaml declaring workdir and declarative mounts
+    When the local sandbox launch settings are resolved with "-v scratch:/scratch"
+    Then the resolved host binds are exactly "/work -> /workspace"
+    And the resolved volumes are exactly "some-cache:/home/node/.cache:ro, scratch:/scratch"
+
+  Scenario: a published definition roots its relative bind in the consumer project
+    Given a published sandbox declaring a relative bind and workdir
+    When the published sandbox launch settings are resolved from "/consumer/project"
+    Then the resolved workdir is "/workspace"
+    And the resolved host binds are exactly "/consumer/project -> /workspace"
+
+  Scenario: bind source text is not shell or environment interpolated
+    Given an lns.yaml declaring a bind source "$PWD"
+    When the local sandbox launch settings are resolved with no overrides
+    Then the resolved host binds are exactly "/work/$PWD -> /workspace"
+
+  Scenario: a declarative bind uses the host secret decision flow
+    Given an lns.yaml declaring workdir and declarative mounts
+    And the host directory "/work" contains ".env"
+    And the operator will answer the secret prompt with "drop"
+    When the declarative host binds are resolved interactively
+    Then ".env" is dropped from the bind
+    And a per-machine DROP decision is recorded for "/work/.env"

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -9,6 +9,8 @@ Feature: authoring a sandbox
     And a file "lns.yaml" is created
     And the file "lns.yaml" contains "kind: Sandbox"
     And the file "lns.yaml" contains "apiVersion: lns.run/v1"
+    And the file "lns.yaml" contains "workdir: /workspace"
+    And the file "lns.yaml" contains "volumes:"
 
   Scenario: init refuses to clobber an existing definition
     Given the current directory already has an lns.yaml
@@ -43,3 +45,13 @@ Feature: authoring a sandbox
     And the output contains "image"
     And the output contains "policy"
     And the service received no request
+
+  Scenario: validate and show understand declarative workdir and mounts
+    Given an lns.yaml declaring workdir and declarative mounts
+    When the user runs sandbox command "validate"
+    Then the exit code is 0
+    When the user runs sandbox command "show"
+    Then the exit code is 0
+    And the output contains "/workspace"
+    And the output contains "bind ."
+    And the output contains "volume some-cache"

--- a/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
@@ -17,6 +17,14 @@ Feature: inspecting a typed artifact before running it
     Then the exit code is 0
     And the output contains "Image"
 
+  Scenario: inspecting a sandbox shows its workdir and declared mounts
+    Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox with launch settings
+    When the user runs "lns inspect registry.example.test/some-sandbox:1.0"
+    Then the exit code is 0
+    And the output contains "workdir: /workspace"
+    And the output contains "bind . -> /workspace"
+    And the output contains "volume some-cache -> /home/node/.cache"
+
   Scenario: inspecting a bundle lists what it composes
     Given the service inspects "some-registry.example/some-agent:research" as a bundle composing:
       | sandbox base | registry.example.test/base:1                    |

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -1,0 +1,197 @@
+use std::path::Path;
+
+use cucumber::{given, then, when};
+use lns_cli::cli::RunArgs;
+use lns_cli::command::parse_args;
+use lns_cli::run::declarative::{Defaults, resolve};
+use lns_cli::run::host_bind::{DirScan, resolve_binds};
+use lns_policy::host_bind_decisions::{HostBindDecisionFile, HostBindDecisionStore};
+
+use crate::world::{BehaviourWorld, HostBindOutcome, ResolvedRunView};
+
+fn definition(world: &BehaviourWorld) -> lns_artifact::sandbox::Definition {
+    let yaml = world
+        .author_files
+        .get(Path::new("/work/lns.yaml"))
+        .expect("the scenario must install lns.yaml");
+    let value: serde_json::Value = serde_yaml::from_str(yaml).expect("valid fixture yaml");
+    let json = serde_json::to_vec(&value).expect("serializable fixture yaml");
+    lns_artifact::sandbox::parse(&json).expect("valid sandbox fixture")
+}
+
+fn declarative_yaml(bind_source: &str) -> String {
+    format!(
+        "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: some-sandbox\nspec:\n  image: example.test/runtime:1\n  workdir: /workspace\n  volumes:\n    - type: bind\n      source: {bind_source}\n      target: /workspace\n    - type: volume\n      source: some-cache\n      target: /home/node/.cache\n      readOnly: true\n"
+    )
+}
+
+#[given("an lns.yaml declaring workdir and declarative mounts")]
+fn definition_with_settings(world: &mut BehaviourWorld) {
+    world
+        .author_files
+        .insert("/work/lns.yaml".into(), declarative_yaml("."));
+}
+
+#[given(regex = r#"^an lns.yaml declaring a bind source "([^"]+)"$"#)]
+fn definition_with_bind_source(world: &mut BehaviourWorld, source: String) {
+    world.author_files.insert(
+        "/work/lns.yaml".into(),
+        format!(
+            "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: some-sandbox\nspec:\n  image: example.test/runtime:1\n  volumes:\n    - type: bind\n      source: '{source}'\n      target: /workspace\n"
+        ),
+    );
+}
+
+#[given("a published sandbox declaring a relative bind and workdir")]
+fn published_settings(world: &mut BehaviourWorld) {
+    world
+        .author_files
+        .insert("/work/lns.yaml".into(), declarative_yaml("."));
+}
+
+fn resolve_defaults(world: &mut BehaviourWorld, defaults: &Defaults, project: &Path, flags: &str) {
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    let args: RunArgs = parse_args(&argv).expect("override flags must parse");
+    let resolved = resolve(defaults, project, args.workdir, args.mounts)
+        .expect("declarative settings must resolve");
+    let (volumes, binds) = lns_cli::cli::split_mounts(&resolved.mounts);
+    world.resolved_run = Some(ResolvedRunView {
+        workdir: resolved.workdir,
+        volumes: volumes
+            .iter()
+            .map(|v| {
+                format!(
+                    "{}:{}{}",
+                    v.name,
+                    v.target,
+                    if v.read_only { ":ro" } else { "" }
+                )
+            })
+            .collect(),
+        binds: binds
+            .iter()
+            .map(|b| {
+                format!(
+                    "{} -> {}{}",
+                    b.host_source,
+                    b.target,
+                    if b.read_only { ":ro" } else { "" }
+                )
+            })
+            .collect(),
+        ..Default::default()
+    });
+}
+
+#[when("the local sandbox launch settings are resolved with no overrides")]
+fn resolve_local_without_overrides(world: &mut BehaviourWorld) {
+    let defaults = Defaults::from_definition(&definition(world));
+    resolve_defaults(world, &defaults, Path::new("/work"), "");
+}
+
+#[when(regex = r#"^the local sandbox launch settings are resolved with "([^"]+)"$"#)]
+fn resolve_local_with_overrides(world: &mut BehaviourWorld, flags: String) {
+    let defaults = Defaults::from_definition(&definition(world));
+    resolve_defaults(world, &defaults, Path::new("/work"), &flags);
+}
+
+#[when(regex = r#"^the published sandbox launch settings are resolved from "([^"]+)"$"#)]
+fn resolve_published(world: &mut BehaviourWorld, project: String) {
+    let def = definition(world);
+    let view = lns_ipc::SandboxView {
+        reference: "registry.example.test/team/sandbox:1".into(),
+        digest: format!("sha256:{}", "a".repeat(64)),
+        image: def.spec.image.clone(),
+        workdir: def.spec.workdir.clone(),
+        mounts: def
+            .spec
+            .volumes
+            .iter()
+            .map(|volume| lns_ipc::SandboxMount {
+                kind: if volume.is_bind() {
+                    lns_ipc::SandboxMountKind::Bind
+                } else {
+                    lns_ipc::SandboxMountKind::Volume
+                },
+                source: volume.source().to_string(),
+                target: volume.target.clone(),
+                read_only: volume.read_only(),
+            })
+            .collect(),
+        integrations: Vec::new(),
+        policy_flags: Vec::new(),
+    };
+    resolve_defaults(world, &Defaults::from_view(&view), Path::new(&project), "");
+}
+
+struct FakeDir {
+    entries: Vec<String>,
+    lensignore: Option<String>,
+    missing: bool,
+}
+
+impl DirScan for FakeDir {
+    fn exists(&self, _path: &Path) -> bool {
+        !self.missing
+    }
+
+    fn entries(&self, _dir: &Path) -> Vec<String> {
+        self.entries.clone()
+    }
+
+    fn read_to_string(&self, path: &Path) -> Option<String> {
+        path.ends_with(".lensignore")
+            .then(|| self.lensignore.clone())
+            .flatten()
+    }
+}
+
+struct FakeStore(std::sync::Mutex<HostBindDecisionFile>);
+
+impl HostBindDecisionStore for FakeStore {
+    fn load(&self) -> std::io::Result<HostBindDecisionFile> {
+        Ok(self.0.lock().unwrap().clone())
+    }
+
+    fn save(&self, state: &HostBindDecisionFile) -> std::io::Result<()> {
+        *self.0.lock().unwrap() = state.clone();
+        Ok(())
+    }
+}
+
+#[when("the declarative host binds are resolved interactively")]
+fn resolve_declarative_binds(world: &mut BehaviourWorld) {
+    let defaults = Defaults::from_definition(&definition(world));
+    let resolved = resolve(&defaults, Path::new("/work"), None, Vec::new()).unwrap();
+    let bind_specs = lns_cli::cli::split_mounts(&resolved.mounts).1;
+    let dir = FakeDir {
+        entries: world.host_bind.entries.clone(),
+        lensignore: world.host_bind.lensignore.clone(),
+        missing: world.host_bind.missing,
+    };
+    let store = FakeStore(std::sync::Mutex::new(world.host_bind.decisions.clone()));
+    let mut input = std::io::Cursor::new(world.host_bind.answer.clone().unwrap_or_default());
+    let mut output = Vec::new();
+    let result = resolve_binds(&bind_specs, &dir, &store, true, &mut input, &mut output)
+        .map_err(|error| error.to_string());
+    world.host_bind.outcome = Some(HostBindOutcome {
+        result,
+        prompt: String::from_utf8(output).unwrap(),
+        persisted: store.0.into_inner().unwrap(),
+        summary: String::new(),
+    });
+}
+
+#[then(regex = r#"^the resolved workdir is "([^"]+)"$"#)]
+fn resolved_workdir(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    let actual = world
+        .resolved_run
+        .as_ref()
+        .and_then(|view| view.workdir.as_deref());
+    if actual == Some(expected.as_str()) {
+        Ok(())
+    } else {
+        Err(format!("expected workdir {expected:?}, got {actual:?}"))
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod config_cli;
+pub mod declarative_run;
 pub mod env_file;
 pub mod host_bind;
 pub mod integration_cli;

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -1,7 +1,10 @@
 use crate::world::BehaviourWorld;
 use cucumber::gherkin::Step;
 use cucumber::given;
-use lns_ipc::{ArtifactInspection, BundleView, FilesetView, ImageView, Response, SignatureView};
+use lns_ipc::{
+    ArtifactInspection, BundleView, FilesetView, ImageView, Response, SandboxMount,
+    SandboxMountKind, SandboxView, SignatureView,
+};
 
 fn full_digest() -> String {
     format!("sha256:{}", "a".repeat(64))
@@ -34,6 +37,33 @@ fn inspects_plain_image(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Image(ImageView {
         reference: reference.clone(),
         digest: full_digest(),
+    });
+    cached_artifact(world, &reference, inspection);
+}
+
+#[given(regex = r#"^the service inspects "([^"]+)" as a sandbox with launch settings$"#)]
+fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
+    let inspection = ArtifactInspection::Sandbox(SandboxView {
+        reference: reference.clone(),
+        digest: full_digest(),
+        image: "registry.example.test/runtime:1".into(),
+        workdir: Some("/workspace".into()),
+        mounts: vec![
+            SandboxMount {
+                kind: SandboxMountKind::Bind,
+                source: ".".into(),
+                target: "/workspace".into(),
+                read_only: false,
+            },
+            SandboxMount {
+                kind: SandboxMountKind::Volume,
+                source: "some-cache".into(),
+                target: "/home/node/.cache".into(),
+                read_only: true,
+            },
+        ],
+        integrations: Vec::new(),
+        policy_flags: Vec::new(),
     });
     cached_artifact(world, &reference, inspection);
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -35,7 +35,10 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Sandbox(SandboxView {
             reference,
+            digest: format!("sha256:{}", "a".repeat(64)),
             image: "docker.io/library/alpine@sha256:abc".into(),
+            workdir: None,
+            mounts: Vec::new(),
             integrations: Vec::new(),
             policy_flags: Vec::new(),
         }),

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -60,6 +60,7 @@ pub struct HostBindOutcome {
 #[derive(Debug, Default)]
 pub struct ResolvedRunView {
     pub summary: String,
+    pub workdir: Option<String>,
     pub volumes: Vec<String>,
     pub binds: Vec<String>,
 }

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -23,9 +23,9 @@ pub use protocol::{
     ArtifactInspection, BindMount, BindSpec, BundleView, CredentialBindDecision, ExecImageArgs,
     FilesetView, ImageInfo, ImageView, LogLevel, MountSpec, PortPublish, Protocol, Request,
     Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary,
-    SandboxView, SignalKind, SignatureView, StatusInfo, VolumeInfo, VolumeMount,
-    VolumePruneFailure, WithOverride, cmdline_unsafe_char, validate_bind_source, validate_run_name,
-    validate_volume_name, validate_volume_target,
+    SandboxMount, SandboxMountKind, SandboxView, SignalKind, SignatureView, StatusInfo, VolumeInfo,
+    VolumeMount, VolumePruneFailure, WithOverride, cmdline_unsafe_char, validate_bind_source,
+    validate_run_name, validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -806,10 +806,10 @@ mod tests {
     }
 
     #[test]
-    fn run_image_args_volumes_and_binds_survive_postcard_round_trip() {
+    fn run_image_args_declarative_launch_settings_survive_postcard_round_trip() {
         let args = RunImageArgs {
             image: Some("ubuntu".into()),
-            resolved_image: None,
+            resolved_image: Some(format!("ubuntu@sha256:{}", "a".repeat(64))),
             name: None,
             cpus: 1,
             mem: 512,
@@ -822,7 +822,7 @@ mod tests {
             hostname: None,
             cmd: vec![],
             env: vec![],
-            workdir: None,
+            workdir: Some("/workspace".into()),
             debug: false,
             tty: true,
             stdin: true,

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -267,11 +267,32 @@ pub struct ImageView {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxView {
     pub reference: String,
+    #[serde(default)]
+    pub digest: String,
     pub image: String,
+    #[serde(default)]
+    pub workdir: Option<String>,
+    #[serde(default)]
+    pub mounts: Vec<SandboxMount>,
     #[serde(default)]
     pub integrations: Vec<String>,
     #[serde(default)]
     pub policy_flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SandboxMountKind {
+    Bind,
+    Volume,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxMount {
+    pub kind: SandboxMountKind,
+    pub source: String,
+    pub target: String,
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -339,6 +360,8 @@ pub struct RunConfig {
     #[serde(default)]
     pub hostname: Option<String>,
     pub env: Vec<String>,
+    #[serde(default)]
+    pub workdir: Option<String>,
     pub published_ports: Vec<PortPublish>,
     pub volumes: Vec<VolumeMount>,
     #[serde(default)]
@@ -359,6 +382,7 @@ impl RunConfig {
             entrypoint: args.entrypoint.clone(),
             hostname: args.hostname.clone(),
             env: args.env.clone(),
+            workdir: args.workdir.clone(),
             published_ports: args.published_ports.clone(),
             volumes: args.volumes.clone(),
             binds: args.binds.clone(),
@@ -393,6 +417,8 @@ pub struct PortPublish {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunImageArgs {
     pub image: Option<String>,
+    #[serde(default)]
+    pub resolved_image: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
     pub cpus: u8,
@@ -746,6 +772,7 @@ mod tests {
         };
         let req = Request::RunImage(Box::new(RunImageArgs {
             image: Some("prism".into()),
+            resolved_image: None,
             name: None,
             cpus: 1,
             mem: 512,
@@ -782,6 +809,7 @@ mod tests {
     fn run_image_args_volumes_and_binds_survive_postcard_round_trip() {
         let args = RunImageArgs {
             image: Some("ubuntu".into()),
+            resolved_image: None,
             name: None,
             cpus: 1,
             mem: 512,
@@ -911,6 +939,7 @@ mod tests {
     fn sample_run_args() -> RunImageArgs {
         RunImageArgs {
             image: Some("some-image:1".into()),
+            resolved_image: None,
             name: None,
             cpus: 2,
             mem: 1024,
@@ -923,7 +952,7 @@ mod tests {
             hostname: Some("demo".into()),
             cmd: vec!["echo".into(), "hi".into()],
             env: vec!["FOO=bar".into()],
-            workdir: None,
+            workdir: Some("/workspace".into()),
             debug: false,
             tty: false,
             stdin: false,
@@ -968,6 +997,7 @@ mod tests {
         assert!(config.auto_remove);
         assert_eq!(config.sandbox_uid, Some(65534));
         assert_eq!(config.env, vec!["FOO=bar".to_string()]);
+        assert_eq!(config.workdir.as_deref(), Some("/workspace"));
         assert_eq!(config.published_ports, args.published_ports);
         assert_eq!(config.volumes, args.volumes);
         assert_eq!(config.binds, args.binds);
@@ -1298,6 +1328,30 @@ mod tests {
         assert_eq!(json["reference"], "registry.example.test/some/image:1.0");
         assert_eq!(json["size_bytes"], 4096);
         assert_eq!(json["layers"], 1);
+    }
+
+    #[test]
+    fn sandbox_view_round_trips_declarative_launch_settings() {
+        let view = SandboxView {
+            reference: "registry.example.test/team/sandbox:1".into(),
+            digest: format!("sha256:{}", "a".repeat(64)),
+            image: "registry.example.test/runtime:1".into(),
+            workdir: Some("/workspace".into()),
+            mounts: vec![SandboxMount {
+                kind: SandboxMountKind::Bind,
+                source: ".".into(),
+                target: "/workspace".into(),
+                read_only: true,
+            }],
+            integrations: Vec::new(),
+            policy_flags: Vec::new(),
+        };
+        let response = Response::ImageInspected {
+            inspection: ArtifactInspection::Sandbox(view),
+        };
+        let frame = crate::encode_frame(&response).unwrap();
+        let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, response);
     }
 
     #[test]

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -7,7 +7,10 @@ use crate::artifact::{RunPath, dispatch, dispatch_run, plan_bundle, resolved_fro
 use crate::image::{RealRegistry, Registry, registry_auth_for, want_arch};
 use crate::runtime_layer::RuntimeFileSpec;
 use anyhow::{Context, Result};
-use lns_ipc::{ArtifactInspection, BundleView, FilesetView, ImageView, SignatureView};
+use lns_ipc::{
+    ArtifactInspection, BundleView, FilesetView, ImageView, SandboxMount, SandboxMountKind,
+    SignatureView,
+};
 use oci_client::Reference;
 
 /// A resolved bundle ready to boot: the assembled workload plus the guest-write specs that materialize its filesets into the microVM.
@@ -255,10 +258,18 @@ fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
 
 /// Peek a reference's manifest and produce the pre-run inspection: a plain image reports its digest, a bundle reports its base image, filesets, declared integrations, and any over-broad-policy flags; signature trust awaits the verification follow-up.
 pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
-    let reference: Reference = image_ref
+    let requested: Reference = image_ref
         .parse()
         .with_context(|| format!("invalid image reference {image_ref}"))?;
-    let registry = RealRegistry::for_reference(&reference, registry_auth_for(image_ref));
+    let reference = if requested.digest().is_none() {
+        match crate::image_store::cached_digest(image_ref).await? {
+            Some(digest) => requested.clone_with_digest(digest),
+            None => requested,
+        }
+    } else {
+        requested
+    };
+    let registry = crate::image::caching_registry_for(&reference.to_string())?;
     let (manifest, digest, config_json) = registry
         .pull_manifest_and_config(&reference)
         .await
@@ -277,7 +288,24 @@ pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
             let resolved = resolved_from_sandbox(&def);
             Ok(ArtifactInspection::Sandbox(lns_ipc::SandboxView {
                 reference: image_ref.to_string(),
+                digest,
                 image: resolved.base_image,
+                workdir: def.spec.workdir.clone(),
+                mounts: def
+                    .spec
+                    .volumes
+                    .iter()
+                    .map(|volume| SandboxMount {
+                        kind: if volume.is_bind() {
+                            SandboxMountKind::Bind
+                        } else {
+                            SandboxMountKind::Volume
+                        },
+                        source: volume.source().to_string(),
+                        target: volume.target.clone(),
+                        read_only: volume.read_only(),
+                    })
+                    .collect(),
                 integrations: def.spec.integrations,
                 policy_flags: resolved
                     .policy

--- a/crates/lns-service/src/image/manifest_cache.rs
+++ b/crates/lns-service/src/image/manifest_cache.rs
@@ -65,9 +65,20 @@ impl<R: Registry> Registry for CachingRegistry<R> {
         &self,
         reference: &Reference,
     ) -> Result<(OciImageManifest, String, String)> {
-        // Only digest-pinned references are immutable; caching a tag would freeze it past upstream republishes.
+        // Only digest-pinned references are read from cache; tags always re-resolve so upstream republishes remain visible.
         if reference.digest().is_none() {
-            return self.inner.pull_manifest_and_config(reference).await;
+            let (manifest, manifest_digest, config) =
+                self.inner.pull_manifest_and_config(reference).await?;
+            let pinned = reference.clone_with_digest(manifest_digest.clone()).whole();
+            let entry = CachedManifest {
+                manifest: manifest.clone(),
+                manifest_digest: manifest_digest.clone(),
+                config: config.clone(),
+            };
+            if let Err(e) = self.cache.put(&pinned, &entry) {
+                crate::log::warn!("manifest cache write failed for {pinned} ({e:#}); continuing");
+            }
+            return Ok((manifest, manifest_digest, config));
         }
         let key = reference.whole();
         if let Some(c) = self.cache.get(&key) {
@@ -244,7 +255,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tag_references_are_never_cached_and_always_re_resolve() {
+    async fn tags_re_resolve_but_cache_the_resolved_digest_for_offline_use() {
         let d = tempfile::tempdir().unwrap();
         let caching = CachingRegistry::new(
             CountingRegistry {
@@ -261,9 +272,12 @@ mod tests {
             2,
             "a mutable tag must re-resolve every pull so upstream republishes are picked up"
         );
+        let pinned = reference
+            .clone_with_digest("sha256:manifest".into())
+            .whole();
         assert!(
-            std::fs::read_dir(d.path()).unwrap().next().is_none(),
-            "no manifest cache file may be written for a tag reference"
+            ManifestCache::new(d.path()).get(&pinned).is_some(),
+            "the immutable result must be cached under its digest for an offline run"
         );
     }
 
@@ -283,6 +297,25 @@ mod tests {
             .pull_manifest_and_config(&reference)
             .await
             .expect("an uncacheable manifest must still pull successfully");
+        assert_eq!(digest, "sha256:manifest");
+    }
+
+    #[tokio::test]
+    async fn a_cache_write_failure_does_not_break_a_tagged_pull() {
+        let d = tempfile::tempdir().unwrap();
+        let blocked = d.path().join("blocked");
+        std::fs::write(&blocked, b"i am a file, not a dir").unwrap();
+        let caching = CachingRegistry::new(
+            CountingRegistry {
+                manifest_calls: Mutex::new(0),
+            },
+            ManifestCache::new(&blocked),
+        );
+        let reference: Reference = "ghcr.io/x/y:latest".parse().unwrap();
+        let (_, digest, _) = caching
+            .pull_manifest_and_config(&reference)
+            .await
+            .expect("a tagged manifest must still resolve when its cache write fails");
         assert_eq!(digest, "sha256:manifest");
     }
 

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -50,6 +50,13 @@ fn record_path(images_root: &Path, reference: &str) -> PathBuf {
     images_root.join(format!("{key}.json"))
 }
 
+fn pinned_reference(reference: &str, digest: &str) -> Result<String> {
+    let parsed: oci_client::Reference = reference
+        .parse()
+        .with_context(|| format!("invalid image reference: {reference}"))?;
+    Ok(parsed.clone_with_digest(digest.to_string()).whole())
+}
+
 pub fn artifact_record_for(
     artifact: &crate::image::PulledArtifact,
     pulled_unix_secs: u64,
@@ -108,6 +115,19 @@ async fn load_records<F: Fs>(fs: &F, images_root: &Path) -> Result<Vec<ImageReco
     Ok(records)
 }
 
+async fn cached_digest_with<F: Fs>(
+    fs: &F,
+    images_root: &Path,
+    image: &str,
+) -> Result<Option<String>> {
+    let reference = normalize_reference(image)?;
+    Ok(load_records(fs, images_root)
+        .await?
+        .into_iter()
+        .find(|record| record.reference == reference)
+        .map(|record| record.digest))
+}
+
 fn holder(active: &[lns_ipc::RunSummary], reference: &str) -> Option<String> {
     active
         .iter()
@@ -154,9 +174,10 @@ pub async fn remove_with<F: Fs, C: Caches>(
 ) -> Result<RemovedImage> {
     let reference = normalize_reference(image)?;
     let records = load_records(fs, images_root).await?;
-    if !records.iter().any(|r| r.reference == reference) {
-        bail!("no such image: {reference}");
-    }
+    let record = records
+        .iter()
+        .find(|record| record.reference == reference)
+        .ok_or_else(|| anyhow::anyhow!("no such image: {reference}"))?;
     if let Some(run_id) = holder(active, &reference) {
         bail!(
             "image {reference:?} in use by run {}",
@@ -167,6 +188,10 @@ pub async fn remove_with<F: Fs, C: Caches>(
         .await
         .with_context(|| format!("removing image record for {reference}"))?;
     caches.remove_manifest(&reference)?;
+    let pinned = pinned_reference(&reference, &record.digest)?;
+    if pinned != reference {
+        caches.remove_manifest(&pinned)?;
+    }
     let keep = layer_keep_set(records.iter().filter(|r| r.reference != reference));
     let reclaimed_bytes = caches.sweep_layers(&keep)?;
     Ok(RemovedImage {
@@ -204,6 +229,10 @@ pub async fn prune_with<F: Fs, C: Caches>(
             .await
             .with_context(|| format!("removing image record for {}", record.reference))?;
         caches.remove_manifest(&record.reference)?;
+        let pinned = pinned_reference(&record.reference, &record.digest)?;
+        if pinned != record.reference {
+            caches.remove_manifest(&pinned)?;
+        }
         removed.push(record.reference.clone());
     }
     let reclaimed_bytes = caches.sweep_layers(&layer_keep_set(kept.iter()))?;
@@ -282,6 +311,10 @@ pub async fn list() -> Result<Vec<lns_ipc::ImageInfo>> {
         &crate::run_registry::snapshot(),
     )
     .await
+}
+
+pub(crate) async fn cached_digest(image: &str) -> Result<Option<String>> {
+    cached_digest_with(&real::RealFs, &images_root()?, image).await
 }
 
 pub async fn remove(image: &str) -> Result<RemovedImage> {
@@ -480,6 +513,33 @@ mod tests {
     fn normalize_reference_rejects_garbage() {
         let err = normalize_reference("###").unwrap_err().to_string();
         assert!(err.contains("invalid image reference"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn cached_digest_finds_the_digest_recorded_for_a_tag() {
+        let fs = FakeFs::with_records(&[rec("registry.example.test/team/sandbox:1", &[])]);
+        let digest =
+            cached_digest_with(&fs, Path::new(ROOT), "registry.example.test/team/sandbox:1")
+                .await
+                .unwrap();
+        assert_eq!(
+            digest.as_deref(),
+            Some(format!("sha256:{}", "d".repeat(64)).as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_digest_is_none_for_an_uncached_reference() {
+        assert_eq!(
+            cached_digest_with(
+                &FakeFs::default(),
+                Path::new(ROOT),
+                "registry.example.test/team/missing:1",
+            )
+            .await
+            .unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -778,7 +838,10 @@ mod tests {
         )));
         assert_eq!(
             *caches.removed_manifests.lock().unwrap(),
-            vec!["registry.example.test/gone:1".to_string()]
+            vec![
+                "registry.example.test/gone:1".to_string(),
+                format!("registry.example.test/gone@sha256:{}", "d".repeat(64))
+            ]
         );
         let swept = caches.swept_with.lock().unwrap();
         assert_eq!(swept.len(), 1);
@@ -1004,6 +1067,14 @@ mod tests {
             config_media_type: "application/vnd.oci.image.config.v1+json".into(),
         };
         record(&pulled).await.unwrap();
+
+        assert_eq!(
+            cached_digest("registry.example.test/cov/lifecycle:1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(format!("sha256:{}", "c".repeat(64)).as_str())
+        );
 
         let listed = list().await.unwrap();
         assert_eq!(listed.len(), 1);

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -536,6 +536,7 @@ mod tests {
         let _ = handle_request(
             &Request::RunImage(Box::new(lns_ipc::RunImageArgs {
                 image: None,
+                resolved_image: None,
                 name: None,
                 cpus: 1,
                 mem: 0,

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -77,7 +77,8 @@ async fn orchestrate(
 
     // A local definition plans directly; a bundle reference resolves its component graph and boots its sandbox base image; a plain image passes through unchanged.
     let overrides = super::bundle_overrides(&args.with);
-    let bundle = match (args.definition.as_deref(), args.image.as_deref()) {
+    let resolved_image = args.resolved_image.as_deref().or(args.image.as_deref());
+    let bundle = match (args.definition.as_deref(), resolved_image) {
         (Some(definition), _) => Some(crate::artifact::real::plan_local(definition)?),
         (None, Some(image_ref)) => {
             crate::artifact::real::peek_and_plan(
@@ -111,7 +112,7 @@ async fn orchestrate(
         .map(|plan| super::bundle_launch(&plan.workload, &args.cmd, &args.env));
     let image_ref: Option<String> = match &launch {
         Some(l) => Some(l.image.clone()),
-        None => args.image.clone(),
+        None => resolved_image.map(str::to_string),
     };
     let cmd: Vec<String> = launch
         .as_ref()

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -63,7 +63,7 @@ run (`lns run -- echo hi`).
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `docker.io`      | Registry to qualify a bare image reference (e.g. `ghcr.io`); falls back to the `run.registry` config default. A fully-qualified reference is used as-is. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with `defaultVerdict: ask` if absent.         |
-| `-w`, `--workdir <DIR>`      | image `WORKDIR`  | Working directory inside the sandbox (absolute path; created if missing). |
+| `-w`, `--workdir <DIR>`      | `spec.workdir`, then image `WORKDIR` | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
 | `--env-file <FILE>`          |                  | Read `KEY=VALUE` lines from a file into the workload env (repeatable; later files and `-e` win). |
 | `-v`, `--volume`, `--mount <SPEC>` |            | Mount into the workload (repeatable): a named volume `name:/path[:ro]` (persists across runs) or a host bind `/host/path:/path[:ro]` (live host files; prompts to keep/drop secret-shaped files). Also accepts Docker keyed syntax: `type=bind\|volume,source=...,target=...[,readonly]`. |
@@ -142,7 +142,9 @@ interchangeable everywhere a run is addressed.
 
 The `./lns.yaml` definition (`apiVersion: lns.run/v1`, `kind: Sandbox`) carries a
 `spec` with `image` (**required** base OCI image), and the optional `command`,
-`env`, `policy`, and `integrations`. See
+`workdir`, `volumes`, `env`, `policy`, and `integrations`. Declarative mounts
+accept `type: bind` or `type: volume`, `source`, an absolute `target`, and optional
+`readOnly`; explicit run mounts replace declarations with the same target. See
 [Running workloads — defining a sandbox](running-workloads.md#defining-a-sandbox).
 
 ## `lns volume`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,9 +104,10 @@ lns run
 You run Lens Sandbox from a project directory — that's where it looks for
 `lns-policy.yaml`, creating one with a default verdict of `ask` the first time. To
 give the workload your actual project files, bind-mount the directory with
-`-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for scratch
-space that persists across runs instead, attach a named volume. The workload's own
-working directory comes from the image.
+`-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for a
+portable definition use a declarative bind with `source: .`; for scratch
+space that persists across runs instead, attach a named volume. The workload's
+working directory comes from `spec.workdir` when declared, otherwise from the image.
 
 ## Define a sandbox
 
@@ -129,11 +130,16 @@ spec:
   # The base OCI image this sandbox runs; pin it by digest before you publish.
   image: docker.io/library/alpine:3.20
   # command: sh
+  # workdir: /workspace
   # env:
   #   MODE: production
   # policy:
   #   defaultVerdict: ask
   # integrations: []
+  # volumes:
+  #   - type: bind
+  #     source: .
+  #     target: /workspace
 ```
 
 Edit `spec.image` (and uncomment the fields you need), then check it offline —

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -33,11 +33,19 @@ spec:
   # The base OCI image this sandbox runs; pin it by digest before you publish.
   image: docker.io/library/alpine:3.20
   # command: sh
+  # workdir: /workspace
   # env:
   #   MODE: production
   # policy:
   #   defaultVerdict: ask
   # integrations: []
+  # volumes:
+  #   - type: bind
+  #     source: .
+  #     target: /workspace
+  #   - type: volume
+  #     source: sandbox-cache
+  #     target: /home/sandbox/.cache
 ```
 
 The `spec` fields:
@@ -46,12 +54,13 @@ The `spec` fields:
 | -------------- | --------------------------------------------------------------------------- |
 | `image`        | The base OCI image the sandbox runs (**required**). Pin it by digest before publishing. |
 | `command`      | Command to run in the workload, replacing the image's default command.       |
+| `workdir`      | Absolute guest working directory. It is created when missing.                 |
 | `env`          | Non-secret environment variables seeded into the workload.                   |
 | `policy`       | The network policy — `defaultVerdict` and `allowedRoutes` (see [Policy](policy.md)). |
 | `integrations` | Ids of the [integrations](integrations.md) whose credentials and routes the sandbox needs. Declared ids arm at launch on any machine — no `lns integration connect` step; an id the machine's catalog doesn't know refuses the launch. |
 | `credentials`  | Credential slots: each names an integration (`name`), the env var it is injected as (`env`, remapping the catalog default), and optionally `required: true`. A slot arms like a declared integration; a **required** slot with no value bound on the machine refuses the launch before boot, pointing at `lns integration connect` (see [Credentials](credentials.md#value-decisions)). |
 | `resources`    | vCPUs and memory the sandbox boots with (`cpu`, `memory` with a unit suffix); per-run `--cpus` / `--mem` flags win. |
-| `volumes`      | Named volume mounts (`name`, `target`), validated offline. Attaching volumes at launch is flag-driven today — `lns run -v name:/path`. |
+| `volumes`      | Named volumes and host binds mounted into the guest; see [Declarative mounts](#declarative-mounts). |
 | `ports`        | Container ports the sandbox serves (`container`, optional `host`), validated offline. Publishing at launch is flag-driven today — `lns run -p HOST:CONTAINER`. |
 
 Check the definition offline — no network, no service — with `validate` and
@@ -180,8 +189,15 @@ lns run --mem 2048 ghcr.io/acme/builder        # same thing, in MiB
 
 ### Working directory
 
-The workload starts in the image's `WORKDIR`, like `docker run`. Override it
-with `-w` (an absolute guest path, created inside the sandbox if missing):
+Set a portable working directory in `lns.yaml`, or override it for one run with
+`-w`. The precedence is explicit `--workdir`, then `spec.workdir`, then the
+image's `WORKDIR`. Every form must be an absolute guest path, and the directory
+is created inside the sandbox when it is missing.
+
+```yaml
+spec:
+  workdir: /workspace
+```
 
 ```bash
 lns run -w /workspace ghcr.io/acme/agent
@@ -273,6 +289,40 @@ asks for confirmation unless you pass `-f`/`--force`. Everything else in a
 sandbox is ephemeral by design — volumes are the one place data persists, so
 removing one is permanent.
 
+### Declarative mounts
+
+Mounts that are part of the sandbox belong in `spec.volumes`. A named volume
+uses `type: volume`; a host bind uses `type: bind`:
+
+```yaml
+spec:
+  volumes:
+    - type: bind
+      source: .
+      target: /workspace
+    - type: volume
+      source: agent-config
+      target: /home/node/.config/agent
+      readOnly: true
+```
+
+`target` is always an absolute guest path. A named-volume `source` follows the
+same naming rules as `lns run -v name:/path`. The older
+`{name: agent-config, target: /path, readOnly: true}` shape remains accepted.
+Duplicate targets in one `lns.yaml` are rejected.
+
+A relative bind source is resolved from the directory containing the local
+`lns.yaml`. For a published sandbox it is resolved from the directory where the
+consumer invokes `lns run`; this keeps `source: .` aligned with one directory =
+one project. Sources are paths, not shell expressions: Lens Sandbox performs no
+shell or environment-variable interpolation, so use `source: .`, not `$PWD`.
+Paths are normalized, and a relative source cannot escape the project with
+`..`.
+
+Launch flags are the final override layer. Lens Sandbox starts with the mounts
+from `lns.yaml`, replaces a declarative mount when an explicit `--volume` or
+`--mount` targets the same guest path, and keeps mounts with other targets.
+
 ### Host bind mounts
 
 When the source of a `-v` is an **absolute host path** rather than a name, it's a
@@ -317,6 +367,11 @@ Host bind: /Users/you/proj/.env looks like a secret. Expose it to the workload? 
 
 The run summary lists each bind, its mode, and the disposition of every detected
 secret (`kept (exposed)` / `dropped`).
+
+Declarative binds use this exact scan, prompt, remembered KEEP/DROP decision,
+masking, validation, and audit path. A published sandbox is inspected and pinned
+before launch so its bind declarations can be shown and approved on the consumer
+host; publishing a sandbox never grants it silent access to host files.
 
 > **The automatic scan is top-level only.** Only the immediate contents of the bind
 > root are scanned for secret shapes, so a secret nested in a subdirectory
@@ -397,6 +452,12 @@ the local cache, and `lns run` can boot it straight from the reference:
 lns pull ghcr.io/acme/reviewer:1.0.0     # pre-warm the cache
 lns run  ghcr.io/acme/reviewer:1.0.0     # run it
 ```
+
+`lns push` preserves `workdir` and every mount declaration in the artifact.
+Consumers resolve relative binds against their own project directory, not the
+publisher's. Preflight pins the resolved artifact digest; after `lns pull` has
+cached that artifact and its referenced OCI content, the published sandbox can
+start offline from the cached snapshot.
 
 Re-reference a cached sandbox under another tag with `lns tag` (docker-tag style):
 


### PR DESCRIPTION
## Summary
- Add declarative sandbox workdir and mount support across artifact parsing, CLI rendering, and IPC payloads
- Teach `lns run`, `inspect`, and sandbox authoring flows to surface resolved workdir and mounts
- Preflight published sandboxes so launch defaults come from the artifact digest and sandbox config
- Expand e2e and unit coverage for declarative workdir, bind mounts, and named volumes

## Testing
- Added and updated behavioral and unit tests covering parsing, rendering, preflight resolution, and e2e sandbox authoring/distribution flows
- Not run (not requested)