### PR TITLE
test: failing tests demonstrating PR #131 untrusted-artifact findings

### DIFF
--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -713,6 +713,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_a_fileset_mount_path_that_smuggles_a_control_char() {
+        let result = parse(&def_json(
+            r#"{"image":"x:1","filesets":[{"path":"./seed","mountPath":"/.lens\n/x"}]}"#,
+        ));
+        assert!(
+            result.is_err(),
+            "a mountPath of `/.lens\\n/x` slips past overlaps_runtime_namespace (first segment `.lens\\n` != `.lens`) and injects a `/x`-rooted line into the workload-owned chown manifest; it must be refused"
+        );
+    }
+
+    #[test]
     fn parse_rejects_a_relative_or_traversing_fileset_mount_path() {
         for mount in ["skills", "/root/../etc"] {
             let spec = format!(

--- a/crates/lns-artifact/src/spec.rs
+++ b/crates/lns-artifact/src/spec.rs
@@ -209,6 +209,9 @@ pub fn validate_mount_path(path: &str) -> Result<()> {
     if path.is_empty() {
         bail!("mount path must not be empty");
     }
+    if path.chars().any(char::is_control) {
+        bail!("mount path {path:?} must not contain control characters");
+    }
     if !path.starts_with('/') {
         bail!("mount path {path} must be absolute (start with `/`)");
     }

--- a/crates/lns-artifact/src/spec.rs
+++ b/crates/lns-artifact/src/spec.rs
@@ -487,6 +487,18 @@ mod tests {
     }
 
     #[test]
+    fn validate_mount_path_rejects_control_characters() {
+        assert!(
+            validate_mount_path("/.lens\n/etc").is_err(),
+            "a newline in a mount path is line-injected into the newline-delimited /.lens/fileset-owned chown manifest and must be refused at the validation chokepoint"
+        );
+        assert!(
+            validate_mount_path("/ok\u{7f}/x").is_err(),
+            "any control character in a mount path must be refused"
+        );
+    }
+
+    #[test]
     fn from_kind_str_round_trips_and_rejects_unknown() {
         for kind in ALL_KINDS {
             assert_eq!(Kind::from_kind_str(kind.as_str()), Some(kind));

--- a/crates/lns-service/src/artifact/fileset.rs
+++ b/crates/lns-service/src/artifact/fileset.rs
@@ -195,13 +195,16 @@ pub(crate) fn fileset_runtime_specs_with_budget<R: Read>(
         {
             bail!("fileset entry {} escapes its mount path", path.display());
         }
+        if path.to_string_lossy().chars().any(char::is_control) {
+            bail!("fileset entry {path:?} must not contain control characters");
+        }
         if !entry_type.is_file() {
             bail!(
                 "fileset entry {} is not a regular file (filesets carry only regular files)",
                 path.display()
             );
         }
-        let mode = entry.header().mode().unwrap_or(0o644);
+        let mode = entry.header().mode().unwrap_or(0o644) & 0o777;
         let installed = content_store
             .install_from_reader(&mut entry)
             .with_context(|| format!("installing fileset entry {}", path.display()))?;
@@ -304,11 +307,7 @@ mod tests {
             fileset_runtime_specs("/root/skills", &tar[..], &ContentStore::new(dir.path()));
         assert!(
             result.is_err(),
-            "a newline in a fileset entry name splits into an extra line of the /.lens/fileset-owned chown manifest, letting lns-init lchown an arbitrary absolute path (/etc/shadow); it must be refused, but was accepted as: {:?}",
-            result.map(|specs| specs
-                .iter()
-                .map(|s| s.guest_path.clone())
-                .collect::<Vec<_>>())
+            "a newline in a fileset entry name splits into an extra line of the /.lens/fileset-owned chown manifest, letting lns-init lchown an arbitrary absolute path (/etc/shadow); it must be refused, but was accepted: {result:?}"
         );
     }
 

--- a/crates/lns-service/src/artifact/fileset.rs
+++ b/crates/lns-service/src/artifact/fileset.rs
@@ -297,6 +297,44 @@ mod tests {
     }
 
     #[test]
+    fn a_fileset_entry_name_with_a_newline_is_refused() {
+        let tar = raw_tar("seed\n/etc/shadow", b"x");
+        let dir = tempfile::tempdir().unwrap();
+        let result =
+            fileset_runtime_specs("/root/skills", &tar[..], &ContentStore::new(dir.path()));
+        assert!(
+            result.is_err(),
+            "a newline in a fileset entry name splits into an extra line of the /.lens/fileset-owned chown manifest, letting lns-init lchown an arbitrary absolute path (/etc/shadow); it must be refused, but was accepted as: {:?}",
+            result.map(|specs| specs
+                .iter()
+                .map(|s| s.guest_path.clone())
+                .collect::<Vec<_>>())
+        );
+    }
+
+    #[test]
+    fn expansion_strips_the_setuid_bit_from_a_fileset_file() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(1);
+        header.set_mode(0o4755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "helper", &b"x"[..])
+            .unwrap();
+        let tar = builder.into_inner().unwrap();
+        let (_dir, specs) = expand("/opt/tools", &tar);
+        assert_eq!(specs.len(), 1);
+        assert_eq!(
+            specs[0].mode & 0o7000,
+            0,
+            "a pulled fileset must not carry setuid/setgid/sticky bits — push strips them with & 0o777 and pull must match, else a ref fileset with owner: root ships a setuid-root binary; got mode {:o}",
+            specs[0].mode
+        );
+    }
+
+    #[test]
     fn expands_files_under_the_mount_path_as_streamed_content_specs() {
         let tar = tar_with(&[("deep.md", b"research"), ("nested/tools.md", b"tools")]);
         let (dir, specs) = expand("/root/.some-agent/skills", &tar);

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -182,6 +182,19 @@ mod tests {
     }
 
     #[test]
+    fn published_fileset_problems_refuses_a_truncated_or_malformed_digest_ref() {
+        let def = lns_artifact::sandbox::parse(
+            br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"s"},"spec":{"image":"x:1","filesets":[{"ref":"reg/skills@sha256:abc","mountPath":"/a"}]}}"#,
+        )
+        .unwrap();
+        let problems = published_fileset_problems(&resolved_from_sandbox(&def));
+        assert!(
+            !problems.is_empty(),
+            "a fileset ref with a truncated @sha256 digest is not digest-pinned and must be refused by the trust gate, not admitted by a loose contains(\"@sha256:\") check: {problems:?}"
+        );
+    }
+
+    #[test]
     fn an_empty_artifact_type_and_config_type_is_treated_as_a_plain_image() {
         assert_eq!(dispatch(Some(""), Some("")).unwrap(), RunPath::SingleImage);
     }

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -122,7 +122,7 @@ pub fn published_fileset_problems(resolved: &ResolvedSandbox) -> Vec<String> {
         resolved
             .filesets
             .iter()
-            .filter(|fileset| !fileset.reference.contains("@sha256:"))
+            .filter(|fileset| !lns_artifact::spec::is_digest_pinned_image(&fileset.reference))
             .map(|fileset| {
                 format!(
                     "fileset ref {} is not digest-pinned; refusing to run it",
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn published_fileset_problems_refuse_paths_and_floating_refs_but_pass_pinned_refs() {
         let def = lns_artifact::sandbox::parse(
-            br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"s"},"spec":{"image":"x:1","filesets":[{"path":"./skills","mountPath":"/a"},{"ref":"reg/skills:latest","mountPath":"/b"},{"ref":"reg/settings@sha256:abc","mountPath":"/c"}]}}"#,
+            br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"s"},"spec":{"image":"x:1","filesets":[{"path":"./skills","mountPath":"/a"},{"ref":"reg/skills:latest","mountPath":"/b"},{"ref":"reg/settings@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mountPath":"/c"}]}}"#,
         )
         .unwrap();
         let problems = published_fileset_problems(&resolved_from_sandbox(&def));

--- a/crates/lns-service/src/credential_flow/integrations.rs
+++ b/crates/lns-service/src/credential_flow/integrations.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use lns_policy::integrations::{AuthKind, Integration, OauthAuth, OauthFlow};
 use lns_policy::providers::ProviderDef;
-use lns_policy::{Policy, RouteRule};
+use lns_policy::{Policy, RouteRule, Verdict};
 
 use crate::credential_flow::providers::DefProvider;
 
@@ -135,6 +135,7 @@ pub fn resolve_applied_with_slots(
     base.integrations
         .retain(|id| !slot_ids.contains(id.as_str()));
     let mut out = resolve_applied_integrations(&base, catalog);
+    let ceiling_denies = policy.network.default_verdict == Verdict::Deny;
     for slot in slots {
         let Some(integ) = catalog.iter().find(|i| i.id == slot.name) else {
             continue;
@@ -143,8 +144,11 @@ pub fn resolve_applied_with_slots(
             def.env_var = slot.env.clone();
             out.providers.push(DefProvider::new(def));
         }
-        out.routes
-            .extend(integ.routes.iter().map(|r| r.to_route_rule()));
+        // A slot is artifact-declared, so its route must not widen the user's deny-by-default lockdown.
+        if !ceiling_denies {
+            out.routes
+                .extend(integ.routes.iter().map(|r| r.to_route_rule()));
+        }
         if let Some(o) = signin_oauth(integ) {
             out.oauth_configs.insert(integ.id.clone(), o.clone());
         }
@@ -159,13 +163,14 @@ pub fn resolve_applied_with_slots(
 pub fn resolve_connectable_with_slots(
     policy: &Policy,
     slots: &[lns_artifact::spec::CredentialSlot],
+    declared: &[String],
     catalog: &[Integration],
 ) -> ConnectableIntegrations {
     let mut owned = policy.clone();
     owned
         .integrations
         .extend(slots.iter().map(|s| s.name.clone()));
-    resolve_connectable_integrations(&owned, catalog)
+    resolve_connectable_with_declared(&owned, declared, catalog)
 }
 
 /// Two route patterns collide if either matches the other as a host under the gate's own wildcard- and case-insensitive rule, so an applied domain suppresses a connectable that shares it even when the patterns aren't byte-identical.
@@ -199,12 +204,20 @@ pub fn resolve_connectable_integrations(
     policy: &Policy,
     catalog: &[Integration],
 ) -> ConnectableIntegrations {
+    resolve_connectable_with_declared(policy, &[], catalog)
+}
+
+/// Connectables minus any colliding with a domain already spoken for — by an applied credential (`policy.integrations`) or by an artifact-declared, offered-not-armed integration (`declared`) — so a colliding entry's machine-global stored value can never inject over the credential that owns that domain (e.g. a leftover `anthropic` value clobbering a declared `claude-code-subscription` on api.anthropic.com, even when that domain is an injection target rather than a declared route).
+fn resolve_connectable_with_declared(
+    policy: &Policy,
+    declared: &[String],
+    catalog: &[Integration],
+) -> ConnectableIntegrations {
     let owned: HashSet<&str> = policy.integrations.iter().map(String::as_str).collect();
-    // A connectable that shares an applied integration's route or injection domain must not ride the same run — otherwise its machine-global stored value would inject over the applied integration's credential (e.g. a leftover `anthropic` value clobbering a declared `claude-code-subscription` on api.anthropic.com, even when that domain is an injection target rather than a declared route).
-    let owned_domains: Vec<&str> = catalog
+    let protected: HashSet<&str> = owned
         .iter()
-        .filter(|integ| owned.contains(integ.id.as_str()))
-        .flat_map(claimed_domains)
+        .copied()
+        .chain(declared.iter().map(String::as_str))
         .collect();
 
     let mut out = ConnectableIntegrations::default();
@@ -212,12 +225,18 @@ pub fn resolve_connectable_integrations(
         if owned.contains(integ.id.as_str()) {
             continue;
         }
-        if claimed_domains(integ).any(|domain| {
-            owned_domains
-                .iter()
-                .copied()
-                .any(|owned_domain| domains_overlap(owned_domain, domain))
-        }) {
+        let integ_domains: Vec<&str> = claimed_domains(integ).collect();
+        let collides = catalog
+            .iter()
+            .filter(|other| other.id != integ.id && protected.contains(other.id.as_str()))
+            .flat_map(claimed_domains)
+            .any(|guarded| {
+                integ_domains
+                    .iter()
+                    .copied()
+                    .any(|d| domains_overlap(guarded, d))
+            });
+        if collides {
             continue;
         }
         if let Some(p) = wire_provider(integ) {
@@ -796,6 +815,7 @@ mod tests {
         let c = resolve_connectable_with_slots(
             &policy_applying(&[]),
             &[slot("some-provider", "SOME_TOKEN", false)],
+            &[],
             &catalog,
         );
         assert!(

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -1126,6 +1126,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prune_keeps_the_base_of_a_by_reference_sandbox_run_by_tag() {
+        let sandbox_tag = "registry.example.test/team/sandbox:1";
+        let sandbox_pinned = format!(
+            "registry.example.test/team/sandbox@sha256:{}",
+            "b".repeat(64)
+        );
+        let base = "registry.example.test/team/base:1";
+        let mut sandbox_record = rec(&sandbox_pinned, &[]);
+        sandbox_record.dependencies.push(base.to_string());
+        let fs = FakeFs::with_records(&[sandbox_record, rec(base, &[("sha256:base-layer", 9)])]);
+        let caches = FakeCaches {
+            freed: 4,
+            ..Default::default()
+        };
+
+        let report = prune_with(
+            &fs,
+            &caches,
+            Path::new(ROOT),
+            &[running("aa03", sandbox_tag)],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            fs.has(&record_path(Path::new(ROOT), base)),
+            "an auto-pulled sandbox registers its run under the raw tag but records base retention under the resolved digest; prune must still recognize the run as the holder and keep the base, but it was reclaimed: {report:?}"
+        );
+        assert_eq!(
+            caches.swept_with.lock().unwrap()[0],
+            HashSet::from(["sha256:base-layer".to_string()]),
+            "the base image's layer blobs must be kept while the sandbox is running"
+        );
+    }
+
+    #[tokio::test]
     async fn remove_of_a_sandbox_removes_its_unshared_base_image_and_layers() {
         let sandbox = "registry.example.test/team/sandbox:1";
         let base = "registry.example.test/team/base:1";

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -136,11 +136,27 @@ async fn load_records<F: Fs>(fs: &F, images_root: &Path) -> Result<Vec<ImageReco
     Ok(records)
 }
 
+/// Whether a run's registered image and a record's reference name the same image, bridging the by-reference case where the run holds the tag it was given while the record is keyed by the digest that tag resolved to.
+fn same_image(run_image: &str, reference: &str) -> bool {
+    let (Ok(run), Ok(record)) = (
+        run_image.parse::<oci_client::Reference>(),
+        reference.parse::<oci_client::Reference>(),
+    ) else {
+        return false;
+    };
+    if run.whole() == record.whole() {
+        return true;
+    }
+    run.registry() == record.registry()
+        && run.repository() == record.repository()
+        && (run.digest().is_some() != record.digest().is_some())
+}
+
 fn holder(active: &[lns_ipc::RunSummary], reference: &str) -> Option<String> {
     active
         .iter()
         .filter(|r| matches!(r.status, lns_ipc::RunStatus::Running))
-        .find(|r| normalize_reference(&r.image).is_ok_and(|whole| whole == reference))
+        .find(|r| same_image(&r.image, reference))
         .map(|r| r.id.clone())
 }
 
@@ -1122,6 +1138,46 @@ mod tests {
         assert_eq!(
             caches.swept_with.lock().unwrap()[0],
             HashSet::from(["sha256:base-layer".to_string()])
+        );
+    }
+
+    #[test]
+    fn same_image_bridges_a_by_reference_run_tag_to_its_resolved_digest_record() {
+        let tag = "registry.example.test/team/sandbox:1";
+        let digest = format!(
+            "registry.example.test/team/sandbox@sha256:{}",
+            "c".repeat(64)
+        );
+        assert!(same_image(tag, tag), "an exact reference is the same image");
+        assert!(
+            same_image(tag, &digest),
+            "a run registered by tag holds the record keyed by the digest that tag resolved to"
+        );
+        assert!(
+            same_image(&digest, tag),
+            "the bridge holds in both directions"
+        );
+        assert!(
+            !same_image(tag, "registry.example.test/team/sandbox:2"),
+            "two distinct tags of one repository are not the same image"
+        );
+        assert!(
+            !same_image(
+                &digest,
+                &format!(
+                    "registry.example.test/team/sandbox@sha256:{}",
+                    "d".repeat(64)
+                )
+            ),
+            "two distinct digests of one repository are not the same image"
+        );
+        assert!(
+            !same_image(tag, "registry.example.test/team/base:1"),
+            "different repositories are never the same image"
+        );
+        assert!(
+            !same_image("", tag),
+            "an unparseable reference matches nothing"
         );
     }
 

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -492,7 +492,15 @@ pub(super) async fn start(
     let catalog = lns_policy::integrations::effective_integrations(&user_catalog);
     let applied = resolve_applied_with_slots(&policy, sandbox_credentials, &catalog);
     // Un-connected catalog integrations are seeded unarmed so their use offers a live connect.
-    let connectable = resolve_connectable_with_slots(&policy, sandbox_credentials, &catalog);
+    let declared_integrations = sandbox_policy
+        .map(|p| p.integrations.clone())
+        .unwrap_or_default();
+    let connectable = resolve_connectable_with_slots(
+        &policy,
+        sandbox_credentials,
+        &declared_integrations,
+        &catalog,
+    );
     policy.network.allowed_routes.extend(applied.routes);
     let connectable_ids: HashSet<String> = connectable
         .providers

--- a/crates/lns-service/tests/behaviours/declared_integrations.feature
+++ b/crates/lns-service/tests/behaviours/declared_integrations.feature
@@ -59,6 +59,21 @@ Feature: a sandbox definition's declared integrations are offered, not armed
     Then the allow rule is written to the directory's lns-policy.yaml
     And the sandbox definition is not modified
 
+  Scenario: A credential slot does not open a route past a local deny-by-default
+    Given the machine catalog has a credential integration "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
+    And the sandbox definition declares an optional credential slot "some-provider" injected as "SOME_TOKEN"
+    And the directory's lns-policy.yaml denies all by default
+    When the sandbox is launched
+    Then a workload request to "api.some-provider.example" is denied by policy
+
+  Scenario: A connectable sharing a declared integration's domain is suppressed, not offered
+    Given the machine catalog has a credential integration "some-primary" managing "PRIMARY_TOKEN" with a route to "api.shared.example"
+    And the machine catalog has a credential integration "some-secondary" managing "SECONDARY_TOKEN" with a route to "api.shared.example"
+    And the sandbox definition declares integration "some-primary"
+    And the directory's lns-policy.yaml connects no integrations
+    When the sandbox is launched
+    Then "some-secondary" is not offered for a reactive connect
+
   Scenario: An unknown declared integration refuses the launch
     Given the sandbox definition declares integration "some-unknown"
     And the machine catalog has no integration "some-unknown"

--- a/crates/lns-service/tests/behaviours/steps/declared_integrations.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_integrations.rs
@@ -518,3 +518,30 @@ fn integration_is_offered(w: &mut BehaviourWorld, id: String) -> Result<(), Stri
         ))
     }
 }
+
+fn definition_with_credential_slot(id: &str, env: &str) -> String {
+    format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","credentials":[{{"name":"{id}","env":"{env}"}}]}}}}"#
+    )
+}
+
+#[given(
+    regex = r#"^the sandbox definition declares an optional credential slot "([^"]+)" injected as "([^"]+)"$"#
+)]
+fn definition_declares_credential_slot(w: &mut BehaviourWorld, id: String, env: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.definition = Some(definition_with_credential_slot(&id, &env));
+}
+
+#[then(regex = r#"^"([^"]+)" is not offered for a reactive connect$"#)]
+fn integration_is_not_offered(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if rig.offered.contains(&id) {
+        Err(format!(
+            "{id} shares a declared integration's domain and must be suppressed; instead it was offered, so its machine-stored value would arm and inject over the declared credential: {:?}",
+            rig.offered
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/declared_integrations.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_integrations.rs
@@ -105,7 +105,17 @@ fn launch(
         .network
         .allowed_routes
         .extend(applied.routes.iter().cloned());
-    let connectable = resolve_connectable_with_slots(&policy, &resolved.credentials, &rig.catalog);
+    let declared_integrations = resolved
+        .policy
+        .as_ref()
+        .map(|p| p.integrations.clone())
+        .unwrap_or_default();
+    let connectable = resolve_connectable_with_slots(
+        &policy,
+        &resolved.credentials,
+        &declared_integrations,
+        &rig.catalog,
+    );
     rig.providers = applied
         .providers
         .iter()


### PR DESCRIPTION
Draft — stacked on top of #131 (`oci-registry`). These tests **fail on purpose**: each pins the intended secure behavior for a security finding on the pulled-sandbox path, so the red is the proof the hole is real. They go green once the matching fix lands.

All findings are new to #131 (there is no artifact/fileset/push/pull surface on `main`). The through-line: a pulled artifact is attacker-controlled input and isn't consistently treated as such.

## Tests (8) → findings

| Test | Finding |
|---|---|
| `spec::validate_mount_path_rejects_control_characters`, `sandbox::parse_rejects_a_fileset_mount_path_that_smuggles_a_control_char` | **chown injection.** `/.lens\n/x` slips past `overlaps_runtime_namespace` (first segment `.lens\n` != `.lens`) and injects a line into the newline-delimited `/.lens/fileset-owned` chown manifest. |
| `fileset::a_fileset_entry_name_with_a_newline_is_refused` | **chown injection (2nd entry point).** A `ref` fileset tar entry named `seed\n/etc/shadow` → lns-init `lchown`s `/etc/shadow` to the workload uid → guest root. |
| `fileset::expansion_strips_the_setuid_bit_from_a_fileset_file` | **setuid survives pull.** Push masks `& 0o777`; pull keeps `& 0o7777`, so a `ref` fileset with `owner: root` ships a setuid-root binary. |
| `artifact::published_fileset_problems_refuses_a_truncated_or_malformed_digest_ref` | **loose digest gate.** The published-fileset trust gate admits a truncated `@sha256:abc` via a `contains("@sha256:")` substring check instead of the strict validator. |
| `image_store::prune_keeps_the_base_of_a_by_reference_sandbox_run_by_tag` | **prune reclaims a live base.** Retention record keyed on the digest, run registry keyed on the raw tag; `holder()` can't bridge, so `prune` sweeps the base out from under a running by-reference sandbox. |
| Gherkin: *A credential slot does not open a route past a local deny-by-default* | **credential-slot route bypass.** An optional/unbound `spec.credentials` slot's catalog routes are appended after the deny clamp — the exact hole #131 closed for `spec.integrations`, reopened via `spec.credentials`. |
| Gherkin: *A connectable sharing a declared integration's domain is suppressed, not offered* | **connectable Bearer bleed.** Same-domain suppression keys only on the applied set; a `spec.integrations`-declared id (dropped by `merge_effective`) doesn't suppress a colliding connectable, so a machine-stored value injects over it. Reproducible with the shipped `claude-code` example. |

Local run: only these two Gherkin scenarios fail (`153 scenarios (151 passed, 2 failed)`); the unit tests fail as shown above. The pre-existing *"A declared integration does not open a route past a local deny-by-default"* still passes beside the new credential-slot version — that side-by-side is the asymmetry.

Not covered by tests, by choice: the ask-default auto-approve question (a design call) and the over-broad `*.co.uk` warning gap (fix needs a public-suffix list).

---

## Fixes added — these tests now pass

The four commits on top of the test commit implement the fixes for the six test-backed findings. The two Gherkin scenarios and the six unit tests now pass, and the full local gate is green: `cargo fmt --check`, `clippy -D warnings`, per-crate cognitive-complexity, and 100% per-file coverage on `lns-artifact` + `lns-service`.

| Commit | Finding(s) | Fix |
|---|---|---|
| reject control-char fileset paths and strip setuid on fileset pull | chown-manifest injection (both entry points) + setuid survives pull | Reject control characters in `validate_mount_path` and the tar-entry guard; mask the pulled fileset mode with `& 0o777` to match push. |
| keep artifact-declared credentials within the user's network boundary | credential-slot route bypass + connectable Bearer bleed | A credential slot's routes respect a deny-by-default ceiling; a declared integration's domain now suppresses a colliding connectable. |
| match a by-reference sandbox run to its digest-keyed retention record | prune reclaims a live base | `holder()` bridges a run's tag to its record's resolved digest (shared repo, exactly one side digest-pinned), fixing prune / `ls` / `rm`. |
| gate published filesets with the strict digest-pin validator | loose digest gate | Use `is_digest_pinned_image` (shared with `push`) instead of a `.contains("@sha256:")` substring check. |

Not implemented, by decision:
- Ask-default auto-approve of raw artifact `allowedRoutes` (the design call) — accepted as-is; the explicit-deny clamp guarantee holds.
- The over-broad-warning gaps for whole-public-suffix wildcards (`*.co.uk`) and mid-range IPv6 CIDRs — lower severity, left as a follow-up (the `*.co.uk` case needs a public-suffix list). Note: `::/0` and `::/1` are already flagged; the real IPv6 gap is `/17`–`/64`.
