### PR TITLE
feat: confirm a pulled sandbox's host binds and filesets before the run starts

### DIFF
--- a/crates/e2e-tests/features/microvm_declarative_launch.feature
+++ b/crates/e2e-tests/features/microvm_declarative_launch.feature
@@ -46,8 +46,10 @@ Feature: declarative workdir and mounts reach a real guest
   Scenario: a pulled published sandbox launches offline from the consumer project
     Given a local registry
     And the Lens Sandbox service is running
-    When the user pulls a published declarative sandbox and runs it with the registry offline from a consumer project
+    When the user pulls a published declarative sandbox and runs it with --yes with the registry offline from a consumer project
     Then the exit code is 0
+    And the output does not contain "mounts into the workload"
+    And the output does not contain "Continue?"
     And the output contains "wd=/workspace"
     And the output contains "consumer=visible"
     And the output contains "bind=readonly"

--- a/crates/e2e-tests/features/run_pull_confirm.feature
+++ b/crates/e2e-tests/features/run_pull_confirm.feature
@@ -1,0 +1,31 @@
+Feature: running a pulled sandbox asks before mounting into the workload
+  A published sandbox can declare host binds, named volumes, and filesets.
+  Running it by reference discloses what it will mount on this machine and
+  requires consent; with no terminal the run fails closed — before anything
+  is mounted, attached, or booted — and names --yes as the escape hatch.
+  All of it is virt-free: the refusal happens ahead of any VM work.
+
+  Background:
+    Given a clean lns cache home
+    And a local registry
+    And the Lens Sandbox service is running in that home
+
+  Scenario: a pulled sandbox declaring a bind and a volume fails closed without a terminal
+    Given the user pushes a sandbox built from ./lns.yaml in one step
+    When I run "run <pushed-ref>" in the project directory
+    Then the exit code is non-zero
+    And the output contains "mounts into the workload:"
+    And the output contains "the workload can read and write this host directory"
+    And the output contains "this machine's persistent volume"
+    And the output contains "no terminal to confirm"
+    And the output contains "--yes"
+    And the output does not contain "started run"
+
+  Scenario: a pulled sandbox declaring a fileset also requires consent
+    When the user pushes a sandbox declaring a path fileset in one step
+    And I run "run <pushed-ref>" in the project directory
+    Then the exit code is non-zero
+    And the output contains "mounts into the workload:"
+    And the output contains "author-published files the workload will read"
+    And the output contains "no terminal to confirm"
+    And the output does not contain "started run"

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -674,7 +674,7 @@ async fn mirror_microvm_image(host: &str, seq: usize) -> String {
 }
 
 #[when(
-    "the user pulls a published declarative sandbox and runs it with the registry offline from a consumer project"
+    "the user pulls a published declarative sandbox and runs it with --yes with the registry offline from a consumer project"
 )]
 async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
     let host = world
@@ -729,7 +729,12 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
         .set_online(false);
 
     let command = "/bin/sh -c 'echo wd=$(/.lens/guest-tools/bin/busybox pwd); if [ -f consumer-marker ]; then echo consumer=visible; fi; if echo blocked > consumer-marker 2>/dev/null; then echo bind=writable; else echo bind=readonly; fi; echo volume=mounted > /data/marker; read v < /data/marker; echo $v'";
-    let mut args = vec!["run".to_string(), reference, "--".to_string()];
+    let mut args = vec![
+        "run".to_string(),
+        "--yes".to_string(),
+        reference,
+        "--".to_string(),
+    ];
     args.extend(split_args(command));
     let result =
         run_cli_with_timeout_in_dir(&consumer, args, socket_env(world), MICROVM_RUN_TIMEOUT);

--- a/crates/e2e-tests/tests/steps/sandbox.rs
+++ b/crates/e2e-tests/tests/steps/sandbox.rs
@@ -48,6 +48,7 @@ fn imageless_definition_at(world: &mut E2eWorld, rel: String) {
 
 #[when(regex = r#"^I run "([^"]*)" in the project directory$"#)]
 fn run_in_project_dir(world: &mut E2eWorld, cmd_line: String) {
+    let cmd_line = substitute_pushed_ref(world, &cmd_line);
     let project = project_dir(world);
     let mut envs: Vec<(String, std::ffi::OsString)> = Vec::new();
     if let Some(home) = &world.home {

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -216,7 +216,7 @@ pub struct RunArgs {
     #[arg(
         long = "yes",
         default_value_t = false,
-        help = "Accept without prompting the host binds and filesets a pulled sandbox mounts into the workload. Required for non-interactive runs of a pulled sandbox that declares them."
+        help = "Accept without prompting the host binds, named volumes, and filesets a pulled sandbox mounts into the workload. Required for non-interactive runs of a pulled sandbox that declares them."
     )]
     pub assume_yes: bool,
 

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -214,6 +214,13 @@ pub struct RunArgs {
     pub mounts: Vec<lns_ipc::MountSpec>,
 
     #[arg(
+        long = "yes",
+        default_value_t = false,
+        help = "Accept without prompting the host binds and filesets a pulled sandbox mounts into the workload. Required for non-interactive runs of a pulled sandbox that declares them."
+    )]
+    pub assume_yes: bool,
+
+    #[arg(
         short = 'q',
         long = "quiet",
         default_value_t = false,

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -655,6 +655,7 @@ mod tests {
             declared_unpublished: Vec::new(),
             filesets: Vec::new(),
             mounts: Vec::new(),
+            assume_yes: false,
             quiet: false,
             cmd: Vec::new(),
         }

--- a/crates/lns-cli/src/run/mod.rs
+++ b/crates/lns-cli/src/run/mod.rs
@@ -2,6 +2,7 @@ pub mod declarative;
 pub mod env_file;
 pub mod host_bind;
 pub mod progress;
+pub mod pull_confirm;
 pub mod summary;
 pub mod target;
 

--- a/crates/lns-cli/src/run/pull_confirm.rs
+++ b/crates/lns-cli/src/run/pull_confirm.rs
@@ -17,6 +17,23 @@ impl PulledMounts<'_> {
     }
 }
 
+/// The disclosure covers what the pulled artifact itself will mount: author-declared mounts that survived the consumer's -v overrides, never the consumer's own entries.
+pub fn artifact_declared_mounts(
+    resolved_mounts: &[lns_ipc::MountSpec],
+    consumer_targets: &[String],
+) -> (Vec<lns_ipc::VolumeMount>, Vec<lns_ipc::BindSpec>) {
+    let declared: Vec<lns_ipc::MountSpec> = resolved_mounts
+        .iter()
+        .filter(|mount| {
+            !consumer_targets
+                .iter()
+                .any(|target| target == mount.target())
+        })
+        .cloned()
+        .collect();
+    crate::cli::split_mounts(&declared)
+}
+
 pub fn confirm_pulled_mounts(
     mounts: &PulledMounts,
     assume_yes: bool,
@@ -135,6 +152,65 @@ mod tests {
             volumes,
             filesets,
         }
+    }
+
+    fn named_spec(name: &str, target: &str) -> lns_ipc::MountSpec {
+        lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
+            name: name.into(),
+            target: target.into(),
+            read_only: false,
+        })
+    }
+
+    fn bind_spec(source: &str, target: &str) -> lns_ipc::MountSpec {
+        lns_ipc::MountSpec::Bind(lns_ipc::BindSpec {
+            host_source: source.into(),
+            target: target.into(),
+            read_only: false,
+        })
+    }
+
+    #[test]
+    fn a_consumer_override_of_a_declared_target_is_not_disclosed() {
+        let resolved = [bind_spec("/tmp/safe", "/workspace")];
+        let (volumes, binds) = artifact_declared_mounts(&resolved, &["/workspace".to_string()]);
+        assert!(
+            volumes.is_empty() && binds.is_empty(),
+            "the prompt must not name a declared mount the consumer's -v override dropped"
+        );
+    }
+
+    #[test]
+    fn consumer_added_mounts_are_not_disclosed_but_declared_survivors_are() {
+        let resolved = [
+            named_spec("cache", "/cache"),
+            bind_spec("/tmp/extra", "/extra"),
+        ];
+        let (volumes, binds) = artifact_declared_mounts(&resolved, &["/extra".to_string()]);
+        assert_eq!(
+            volumes,
+            vec![lns_ipc::VolumeMount {
+                name: "cache".into(),
+                target: "/cache".into(),
+                read_only: false,
+            }],
+            "a declared mount the consumer did not touch stays disclosed"
+        );
+        assert!(
+            binds.is_empty(),
+            "the consumer's own -v mount needs no consent prompt"
+        );
+    }
+
+    #[test]
+    fn without_consumer_mounts_every_declared_mount_is_disclosed() {
+        let resolved = [
+            bind_spec("/Users/me/proj", "/workspace"),
+            named_spec("cache", "/cache"),
+        ];
+        let (volumes, binds) = artifact_declared_mounts(&resolved, &[]);
+        assert_eq!(binds.len(), 1);
+        assert_eq!(volumes.len(), 1);
     }
 
     #[test]

--- a/crates/lns-cli/src/run/pull_confirm.rs
+++ b/crates/lns-cli/src/run/pull_confirm.rs
@@ -1,0 +1,197 @@
+use std::fmt::Write as _;
+use std::io::{BufRead, Write};
+
+use anyhow::{Result, bail};
+
+/// What a pulled-by-reference sandbox will mount into the workload: host binds it declared (resolved against this machine) and author-published filesets.
+pub struct PulledMounts<'a> {
+    pub reference: &'a str,
+    pub binds: &'a [lns_ipc::BindSpec],
+    pub filesets: &'a [(String, String)],
+}
+
+impl PulledMounts<'_> {
+    fn is_empty(&self) -> bool {
+        self.binds.is_empty() && self.filesets.is_empty()
+    }
+}
+
+pub fn confirm_pulled_mounts(
+    mounts: &PulledMounts,
+    assume_yes: bool,
+    interactive: bool,
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<()> {
+    if mounts.is_empty() || assume_yes {
+        return Ok(());
+    }
+    output.write_all(disclosure(mounts).as_bytes())?;
+    if !interactive {
+        bail!(
+            "{} mounts the paths above into the workload and there is no terminal to confirm — run interactively, or pass --yes to accept them",
+            mounts.reference
+        );
+    }
+    write!(output, "Continue? [y/N]: ")?;
+    output.flush()?;
+    let mut line = String::new();
+    input.read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    if answer == "y" || answer == "yes" {
+        Ok(())
+    } else {
+        bail!("run declined; nothing was mounted or started");
+    }
+}
+
+fn disclosure(mounts: &PulledMounts) -> String {
+    let mut s = String::new();
+    writeln!(s, "{} mounts into the workload:", mounts.reference).unwrap();
+    for bind in mounts.binds {
+        let mode = if bind.read_only {
+            "read"
+        } else {
+            "read and write"
+        };
+        writeln!(
+            s,
+            "  Host bind: {} → {} — the workload can {mode} this host directory",
+            bind.host_source, bind.target
+        )
+        .unwrap();
+    }
+    for (source, mount_path) in mounts.filesets {
+        writeln!(
+            s,
+            "  Fileset:   {source} → {mount_path} — author-published files the workload will read"
+        )
+        .unwrap();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bind(host_source: &str, read_only: bool) -> lns_ipc::BindSpec {
+        lns_ipc::BindSpec {
+            host_source: host_source.into(),
+            target: "/work".into(),
+            read_only,
+        }
+    }
+
+    fn confirm(
+        mounts: &PulledMounts,
+        assume_yes: bool,
+        interactive: bool,
+        answer: &str,
+    ) -> (Result<()>, String) {
+        let mut input = std::io::Cursor::new(answer.to_string());
+        let mut out = Vec::new();
+        let r = confirm_pulled_mounts(mounts, assume_yes, interactive, &mut input, &mut out);
+        (r, String::from_utf8(out).unwrap())
+    }
+
+    fn mounts<'a>(
+        binds: &'a [lns_ipc::BindSpec],
+        filesets: &'a [(String, String)],
+    ) -> PulledMounts<'a> {
+        PulledMounts {
+            reference: "ghcr.io/team/hermes:1",
+            binds,
+            filesets,
+        }
+    }
+
+    #[test]
+    fn a_pulled_sandbox_with_no_mounts_never_prompts() {
+        let (r, out) = confirm(&mounts(&[], &[]), false, true, "");
+        r.unwrap();
+        assert!(out.is_empty(), "no mounts must mean no prompt: {out:?}");
+    }
+
+    #[test]
+    fn yes_flag_accepts_the_mounts_without_prompting() {
+        let binds = [bind("/Users/me/proj", false)];
+        let (r, out) = confirm(&mounts(&binds, &[]), true, true, "");
+        r.unwrap();
+        assert!(out.is_empty(), "--yes must skip the prompt: {out:?}");
+    }
+
+    #[test]
+    fn disclosure_names_each_bind_with_its_resolved_host_path_and_mode() {
+        let binds = [bind("/Users/me/proj", false), bind("/Users/me/cfg", true)];
+        let (r, out) = confirm(&mounts(&binds, &[]), false, true, "y\n");
+        r.unwrap();
+        assert!(
+            out.contains("ghcr.io/team/hermes:1 mounts into the workload:"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("Host bind: /Users/me/proj → /work — the workload can read and write this host directory"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains(
+                "Host bind: /Users/me/cfg → /work — the workload can read this host directory"
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn disclosure_names_each_fileset_with_its_mount_path() {
+        let filesets = [(
+            "reg/skills@sha256:abcabcabcabc…".to_string(),
+            "/root/.agent/skills".to_string(),
+        )];
+        let (r, out) = confirm(&mounts(&[], &filesets), false, true, "yes\n");
+        r.unwrap();
+        assert!(
+            out.contains(
+                "Fileset:   reg/skills@sha256:abcabcabcabc… → /root/.agent/skills — author-published files the workload will read"
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn an_empty_answer_declines_and_the_run_never_starts() {
+        let binds = [bind("/Users/me/proj", false)];
+        let err = confirm(&mounts(&binds, &[]), false, true, "\n")
+            .0
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("declined"),
+            "default must be No: {err}"
+        );
+    }
+
+    #[test]
+    fn an_explicit_no_declines() {
+        let binds = [bind("/Users/me/proj", false)];
+        let err = confirm(&mounts(&binds, &[]), false, true, "n\n")
+            .0
+            .unwrap_err();
+        assert!(err.to_string().contains("declined"), "got: {err}");
+    }
+
+    #[test]
+    fn no_terminal_fails_closed_and_points_at_the_yes_flag() {
+        let filesets = [("reg/skills@sha256:abc".to_string(), "/skills".to_string())];
+        let (r, out) = confirm(&mounts(&[], &filesets), false, false, "");
+        let err = r.unwrap_err().to_string();
+        assert!(err.contains("--yes"), "must name the escape hatch: {err}");
+        assert!(
+            err.contains("ghcr.io/team/hermes:1"),
+            "must name the sandbox: {err}"
+        );
+        assert!(
+            out.contains("Fileset:"),
+            "the refusal must still disclose what it refused: {out}"
+        );
+    }
+}

--- a/crates/lns-cli/src/run/pull_confirm.rs
+++ b/crates/lns-cli/src/run/pull_confirm.rs
@@ -3,16 +3,17 @@ use std::io::{BufRead, Write};
 
 use anyhow::{Result, bail};
 
-/// What a pulled-by-reference sandbox will mount into the workload: host binds it declared (resolved against this machine) and author-published filesets.
+/// What a pulled-by-reference sandbox will mount into the workload: host binds it declared (resolved against this machine), named volumes from this machine's shared volume store, and author-published filesets.
 pub struct PulledMounts<'a> {
     pub reference: &'a str,
     pub binds: &'a [lns_ipc::BindSpec],
+    pub volumes: &'a [lns_ipc::VolumeMount],
     pub filesets: &'a [(String, String)],
 }
 
 impl PulledMounts<'_> {
     fn is_empty(&self) -> bool {
-        self.binds.is_empty() && self.filesets.is_empty()
+        self.binds.is_empty() && self.volumes.is_empty() && self.filesets.is_empty()
     }
 }
 
@@ -61,6 +62,19 @@ fn disclosure(mounts: &PulledMounts) -> String {
         )
         .unwrap();
     }
+    for volume in mounts.volumes {
+        let mode = if volume.read_only {
+            "read"
+        } else {
+            "read and write"
+        };
+        writeln!(
+            s,
+            "  Volume:    {} → {} — the workload can {mode} this machine's persistent volume",
+            volume.name, volume.target
+        )
+        .unwrap();
+    }
     for (source, mount_path) in mounts.filesets {
         writeln!(
             s,
@@ -95,13 +109,30 @@ mod tests {
         (r, String::from_utf8(out).unwrap())
     }
 
+    fn volume(name: &str, read_only: bool) -> lns_ipc::VolumeMount {
+        lns_ipc::VolumeMount {
+            name: name.into(),
+            target: "/data".into(),
+            read_only,
+        }
+    }
+
     fn mounts<'a>(
         binds: &'a [lns_ipc::BindSpec],
+        filesets: &'a [(String, String)],
+    ) -> PulledMounts<'a> {
+        volume_mounts(binds, &[], filesets)
+    }
+
+    fn volume_mounts<'a>(
+        binds: &'a [lns_ipc::BindSpec],
+        volumes: &'a [lns_ipc::VolumeMount],
         filesets: &'a [(String, String)],
     ) -> PulledMounts<'a> {
         PulledMounts {
             reference: "ghcr.io/team/hermes:1",
             binds,
+            volumes,
             filesets,
         }
     }
@@ -155,6 +186,37 @@ mod tests {
                 "Fileset:   reg/skills@sha256:abcabcabcabc… → /root/.agent/skills — author-published files the workload will read"
             ),
             "got: {out}"
+        );
+    }
+
+    #[test]
+    fn disclosure_names_each_named_volume_with_its_mode() {
+        let volumes = [volume("home", false), volume("cfg", true)];
+        let (r, out) = confirm(&volume_mounts(&[], &volumes, &[]), false, true, "y\n");
+        r.unwrap();
+        assert!(
+            out.contains(
+                "Volume:    home → /data — the workload can read and write this machine's persistent volume"
+            ),
+            "got: {out}"
+        );
+        assert!(
+            out.contains(
+                "Volume:    cfg → /data — the workload can read this machine's persistent volume"
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn a_named_volume_alone_is_enough_to_prompt() {
+        let volumes = [volume("home", false)];
+        let err = confirm(&volume_mounts(&[], &volumes, &[]), false, true, "\n")
+            .0
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("declined"),
+            "an author-named volume must not attach without consent: {err}"
         );
     }
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -290,6 +290,7 @@ mod tests {
             declared_unpublished: Vec::new(),
             filesets: Vec::new(),
             mounts: Vec::new(),
+            assume_yes: false,
             quiet: false,
             cmd: Vec::new(),
         }

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -245,6 +245,23 @@ pub async fn run_image(
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
     let interactive = host_binds_interactive(args.detach, crate::raw_mode::stdin_is_tty());
+    if published.is_some() {
+        let reference = target.image();
+        let mounts = crate::run::pull_confirm::PulledMounts {
+            reference: &reference,
+            binds: &bind_specs,
+            filesets: &args.filesets,
+        };
+        let stdin = std::io::stdin();
+        let mut input = stdin.lock();
+        crate::run::pull_confirm::confirm_pulled_mounts(
+            &mounts,
+            args.assume_yes,
+            interactive,
+            &mut input,
+            &mut std::io::stderr(),
+        )?;
+    }
     let resolved_binds = resolve_host_binds(&bind_specs, interactive)?;
     if !quiet {
         let dispositions = crate::run::summary::format_bind_dispositions(&resolved_binds);

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -250,6 +250,7 @@ pub async fn run_image(
         let mounts = crate::run::pull_confirm::PulledMounts {
             reference: &reference,
             binds: &bind_specs,
+            volumes: &volumes,
             filesets: &args.filesets,
         };
         let stdin = std::io::stdin();

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -127,13 +127,6 @@ struct PublishedTarget {
     filesets: Vec<(String, String)>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-struct PublishedMountDisclosure {
-    volumes: Vec<lns_ipc::VolumeMount>,
-    binds: Vec<lns_ipc::BindSpec>,
-    filesets: Vec<(String, String)>,
-}
-
 fn published_target(
     reference: &str,
     inspection: lns_ipc::ArtifactInspection,
@@ -163,22 +156,6 @@ async fn preflight_published(socket: &Path, reference: &str) -> Result<Published
         image: reference.to_string(),
     };
     await_published_preflight(reference, real::send_request(socket, &request)).await
-}
-
-fn published_mount_disclosure(
-    published: Option<&PublishedTarget>,
-    cwd: &Path,
-) -> Result<Option<PublishedMountDisclosure>> {
-    let Some(published) = published else {
-        return Ok(None);
-    };
-    let resolved = crate::run::declarative::resolve(&published.defaults, cwd, None, Vec::new())?;
-    let (volumes, binds) = crate::cli::split_mounts(&resolved.mounts);
-    Ok(Some(PublishedMountDisclosure {
-        volumes,
-        binds,
-        filesets: published.filesets.clone(),
-    }))
 }
 
 async fn await_published_preflight(
@@ -227,6 +204,11 @@ pub async fn run_image(
         (_, Some(published)) => published.defaults.clone(),
         _ => crate::run::declarative::Defaults::default(),
     };
+    let consumer_mount_targets: Vec<String> = args
+        .mounts
+        .iter()
+        .map(|mount| mount.target().to_string())
+        .collect();
     let resolved = crate::run::declarative::resolve(
         &defaults,
         target.project_dir().unwrap_or(&cwd),
@@ -258,7 +240,6 @@ pub async fn run_image(
         (_, Some(published)) => published.filesets.clone(),
         _ => Vec::new(),
     };
-    let pull_confirm_mounts = published_mount_disclosure(published.as_ref(), &cwd)?;
     let quiet = args.quiet;
     let resolved_policy = if quiet {
         let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), &cwd)?;
@@ -269,13 +250,17 @@ pub async fn run_image(
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
     let interactive = host_binds_interactive(args.detach, crate::raw_mode::stdin_is_tty());
-    if let Some(pull_confirm_mounts) = pull_confirm_mounts.as_ref() {
+    if published.is_some() {
+        let (declared_volumes, declared_binds) = crate::run::pull_confirm::artifact_declared_mounts(
+            &args.mounts,
+            &consumer_mount_targets,
+        );
         let reference = target.image();
         let mounts = crate::run::pull_confirm::PulledMounts {
             reference: &reference,
-            binds: &pull_confirm_mounts.binds,
-            volumes: &pull_confirm_mounts.volumes,
-            filesets: &pull_confirm_mounts.filesets,
+            binds: &declared_binds,
+            volumes: &declared_volumes,
+            filesets: &args.filesets,
         };
         let stdin = std::io::stdin();
         let mut input = stdin.lock();
@@ -1164,64 +1149,6 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("no manifest digest"));
-    }
-
-    #[test]
-    fn published_mount_disclosure_resolves_only_the_pulled_sandbox_mounts() {
-        let published = PublishedTarget {
-            image: "registry.example.test/team/sandbox@sha256:abc".into(),
-            defaults: crate::run::declarative::Defaults {
-                workdir: None,
-                mounts: vec![
-                    crate::run::declarative::MountDefault {
-                        bind: true,
-                        source: ".".into(),
-                        target: "/workspace".into(),
-                        read_only: false,
-                    },
-                    crate::run::declarative::MountDefault {
-                        bind: false,
-                        source: "cache".into(),
-                        target: "/cache".into(),
-                        read_only: true,
-                    },
-                ],
-                ports: Vec::new(),
-            },
-            filesets: vec![(
-                "registry.example.test/team/skills@sha256:bbbbbbbbbbbb…".into(),
-                "/root/.agent/skills".into(),
-            )],
-        };
-
-        let mounts = published_mount_disclosure(Some(&published), Path::new("/consumer")).unwrap();
-        assert_eq!(
-            mounts,
-            Some(PublishedMountDisclosure {
-                volumes: vec![lns_ipc::VolumeMount {
-                    name: "cache".into(),
-                    target: "/cache".into(),
-                    read_only: true,
-                }],
-                binds: vec![lns_ipc::BindSpec {
-                    host_source: "/consumer".into(),
-                    target: "/workspace".into(),
-                    read_only: false,
-                }],
-                filesets: vec![(
-                    "registry.example.test/team/skills@sha256:bbbbbbbbbbbb…".into(),
-                    "/root/.agent/skills".into(),
-                )],
-            })
-        );
-    }
-
-    #[test]
-    fn published_mount_disclosure_is_absent_for_a_local_run() {
-        assert_eq!(
-            published_mount_disclosure(None, Path::new("/consumer")).unwrap(),
-            None
-        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -127,6 +127,13 @@ struct PublishedTarget {
     filesets: Vec<(String, String)>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct PublishedMountDisclosure {
+    volumes: Vec<lns_ipc::VolumeMount>,
+    binds: Vec<lns_ipc::BindSpec>,
+    filesets: Vec<(String, String)>,
+}
+
 fn published_target(
     reference: &str,
     inspection: lns_ipc::ArtifactInspection,
@@ -156,6 +163,22 @@ async fn preflight_published(socket: &Path, reference: &str) -> Result<Published
         image: reference.to_string(),
     };
     await_published_preflight(reference, real::send_request(socket, &request)).await
+}
+
+fn published_mount_disclosure(
+    published: Option<&PublishedTarget>,
+    cwd: &Path,
+) -> Result<Option<PublishedMountDisclosure>> {
+    let Some(published) = published else {
+        return Ok(None);
+    };
+    let resolved = crate::run::declarative::resolve(&published.defaults, cwd, None, Vec::new())?;
+    let (volumes, binds) = crate::cli::split_mounts(&resolved.mounts);
+    Ok(Some(PublishedMountDisclosure {
+        volumes,
+        binds,
+        filesets: published.filesets.clone(),
+    }))
 }
 
 async fn await_published_preflight(
@@ -235,6 +258,7 @@ pub async fn run_image(
         (_, Some(published)) => published.filesets.clone(),
         _ => Vec::new(),
     };
+    let pull_confirm_mounts = published_mount_disclosure(published.as_ref(), &cwd)?;
     let quiet = args.quiet;
     let resolved_policy = if quiet {
         let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), &cwd)?;
@@ -245,13 +269,13 @@ pub async fn run_image(
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
     let interactive = host_binds_interactive(args.detach, crate::raw_mode::stdin_is_tty());
-    if published.is_some() {
+    if let Some(pull_confirm_mounts) = pull_confirm_mounts.as_ref() {
         let reference = target.image();
         let mounts = crate::run::pull_confirm::PulledMounts {
             reference: &reference,
-            binds: &bind_specs,
-            volumes: &volumes,
-            filesets: &args.filesets,
+            binds: &pull_confirm_mounts.binds,
+            volumes: &pull_confirm_mounts.volumes,
+            filesets: &pull_confirm_mounts.filesets,
         };
         let stdin = std::io::stdin();
         let mut input = stdin.lock();
@@ -1140,6 +1164,64 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("no manifest digest"));
+    }
+
+    #[test]
+    fn published_mount_disclosure_resolves_only_the_pulled_sandbox_mounts() {
+        let published = PublishedTarget {
+            image: "registry.example.test/team/sandbox@sha256:abc".into(),
+            defaults: crate::run::declarative::Defaults {
+                workdir: None,
+                mounts: vec![
+                    crate::run::declarative::MountDefault {
+                        bind: true,
+                        source: ".".into(),
+                        target: "/workspace".into(),
+                        read_only: false,
+                    },
+                    crate::run::declarative::MountDefault {
+                        bind: false,
+                        source: "cache".into(),
+                        target: "/cache".into(),
+                        read_only: true,
+                    },
+                ],
+                ports: Vec::new(),
+            },
+            filesets: vec![(
+                "registry.example.test/team/skills@sha256:bbbbbbbbbbbb…".into(),
+                "/root/.agent/skills".into(),
+            )],
+        };
+
+        let mounts = published_mount_disclosure(Some(&published), Path::new("/consumer")).unwrap();
+        assert_eq!(
+            mounts,
+            Some(PublishedMountDisclosure {
+                volumes: vec![lns_ipc::VolumeMount {
+                    name: "cache".into(),
+                    target: "/cache".into(),
+                    read_only: true,
+                }],
+                binds: vec![lns_ipc::BindSpec {
+                    host_source: "/consumer".into(),
+                    target: "/workspace".into(),
+                    read_only: false,
+                }],
+                filesets: vec![(
+                    "registry.example.test/team/skills@sha256:bbbbbbbbbbbb…".into(),
+                    "/root/.agent/skills".into(),
+                )],
+            })
+        );
+    }
+
+    #[test]
+    fn published_mount_disclosure_is_absent_for_a_local_run() {
+        assert_eq!(
+            published_mount_disclosure(None, Path::new("/consumer")).unwrap(),
+            None
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Problem

A published sandbox artifact can declare host binds (`spec.volumes` with `type: bind`), named volumes (`type: volume`), and filesets. When another user runs it by reference, those are honored with no gate: a relative bind source like `.` resolves against the consumer's cwd and is virtiofs-shared into the guest; an author-chosen volume name attaches from the consumer's global volume store (`<cache_root>/volumes/<name>.img` — unscoped, so it can name another project's persisted data) read-write across runs; and filesets materialize author-published files the workload will read. The only UX today is an informational run summary (suppressed by `--quiet`) — the run proceeds immediately.

## Change

`lns run <ref>` now discloses every host bind (resolved host path, target, mode), named volume (name, target, mode), and fileset (source, mount path) the pulled sandbox will mount, and asks `Continue? [y/N]` before anything is mounted or started. Default is No.

- **Fails closed without a terminal**: a non-interactive or detached run of a pulled sandbox that declares any of them refuses with an error naming the sandbox and pointing at the escape hatch.
- **`--yes`** accepts the mounts without prompting (scripted/CI callers).
- Local `./lns.yaml` runs are unaffected — the user authored those declarations.
- The confirmation prints its own disclosure, so `--quiet` cannot hide it.
- Runs where the pulled artifact declares none of the three are unchanged (no prompt).

## What the user sees

Interactive run of someone else's published sandbox:

```
$ cd ~/some-project
$ lns run ghcr.io/acme/reviewer:1.0.0
lns run
  Image:     ghcr.io/acme/reviewer:1.0.0 (resolving…)
  ...

ghcr.io/acme/reviewer:1.0.0 mounts into the workload:
  Host bind: /Users/you/some-project → /workspace — the workload can read and write this host directory
  Volume:    review-cache → /cache — the workload can read and write this machine's persistent volume
  Fileset:   ghcr.io/acme/reviewer-skills@sha256:9f2ab314c0de… → /root/.agent/skills — author-published files the workload will read
Continue? [y/N]:
```

- Enter (or `n`) — the default — aborts: `Error: run declined; nothing was mounted or started`. Nothing is shared, attached, or booted.
- `y` proceeds into the existing flow (per-secret KEEP/DROP scan on the bind, then boot).

Piped/detached (no terminal), without `--yes`:

```
$ lns run ghcr.io/acme/reviewer:1.0.0 </dev/null
...
ghcr.io/acme/reviewer:1.0.0 mounts into the workload:
  Host bind: /Users/you/some-project → /workspace — the workload can read and write this host directory
  ...
Error: ghcr.io/acme/reviewer:1.0.0 mounts the paths above into the workload and there is no terminal to confirm — run interactively, or pass --yes to accept them
```

Scripted opt-in: `lns run --yes ghcr.io/acme/reviewer:1.0.0` skips the prompt entirely.

## Implementation

The prompt logic lives in a new pure module `crates/lns-cli/src/run/pull_confirm.rs` (Layer 3 tested at 100%, no IGNORES entry), wired into `run_image` for `RunTarget::Reference` targets only, ahead of the existing per-secret KEEP/DROP scan.

## Tests

- **Layer 3**: full behavior matrix in `pull_confirm.rs` (no-mounts silence, disclosure lines per kind, default-No, explicit decline, fail-closed pointing at `--yes`, `--yes` silence).
- **Layer 1, virt-free** (`features/run_pull_confirm.feature`): a real pushed bind+volume sandbox and a fileset sandbox each fail closed without a terminal, disclose their mounts, and never reach `started run`.
- **Layer 1, `@microvm`**: the pulled-published-sandbox scenario now runs with `--yes` (required — the harness has no TTY, so the gate would otherwise fail it closed) and additionally asserts the gate stays silent; verified locally on Vz through a real boot with the registry kept online.

## Pre-existing gap surfaced (not introduced here)

The `@microvm` scenario "a pulled published sandbox launches offline from the consumer project" (landed on main today in fdfb2961, never yet run by a nightly) fails **before this PR's gate**: the CLI preflight inspects the tag reference, and tags always re-resolve against the registry (`image/manifest_cache.rs` — by design, so republishes stay visible), so the deliberately-offline registry 503s. Offline run-by-tag of a pulled sandbox needs a daemon-side tag→digest fallback (e.g. via the sandbox index) — separate fix. With the registry online, the scenario passes end-to-end including the `--yes` assertions.

Follow-up worth filing separately: scope the volume store per reference so an author-chosen volume name can't collide with another project's data.