### PR TITLE
feat(cli): select the sandbox definition file by yaml path or -f/--file

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -38,6 +38,15 @@ pub struct RunArgs {
     pub image: Option<String>,
 
     #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        conflicts_with = "image",
+        help = "Definition file to run instead of ./lns.yaml (e.g. lns.dev.yaml); its directory roots the definition's relative binds and filesets. Cannot be combined with REF."
+    )]
+    pub file: Option<PathBuf>,
+
+    #[arg(
         long,
         help = "Name the run, addressable in place of its id by every `lns sandbox` verb. Auto-generated (adjective_noun) when omitted; must not be all digits."
     )]

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -632,6 +632,7 @@ mod tests {
     fn bare_run_args() -> RunArgs {
         RunArgs {
             image: Some("alpine".to_string()),
+            file: None,
             name: None,
             registry: None,
             cpus: None,

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -122,9 +122,10 @@ pub fn format_summary(
 }
 
 fn image_line(args: &RunArgs) -> String {
-    match &args.image {
-        Some(image) => format!("{image} (resolving…)"),
-        None => "./lns.yaml (resolving…)".to_string(),
+    match (&args.image, &args.file) {
+        (Some(image), _) => format!("{image} (resolving…)"),
+        (None, Some(file)) => format!("{} (resolving…)", file.display()),
+        (None, None) => "./lns.yaml (resolving…)".to_string(),
     }
 }
 
@@ -596,6 +597,20 @@ mod tests {
             !s.contains("imageless"),
             "the imageless marker is retired: {s}"
         );
+    }
+
+    #[test]
+    fn a_file_selector_run_shows_the_selected_definition_as_the_image() {
+        let mut args = run_args(None);
+        args.file = Some(std::path::PathBuf::from("lns.dev.yaml"));
+        let s = format_summary(
+            &args,
+            &Policy::default(),
+            Path::new("/x/lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(s.contains("lns.dev.yaml (resolving…)"), "got: {s}");
+        assert!(!s.contains("./lns.yaml"), "got: {s}");
     }
 
     #[test]

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -267,6 +267,7 @@ mod tests {
     fn run_args(image: Option<&str>) -> RunArgs {
         RunArgs {
             image: image.map(str::to_string),
+            file: None,
             name: None,
             registry: None,
             cpus: None,

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -15,14 +15,21 @@ pub enum RunTarget {
     },
 }
 
-/// Resolve the run reference: a path-shaped REF (`.`, `lns.yaml`, `./…`, `../…`, `/…`) names a local definition, an omitted REF runs the current directory's `lns.yaml`, and anything else is a registry coordinate.
-pub fn resolve<F: Fs>(reference: Option<&str>, fs: &F, cwd: &Path) -> Result<RunTarget> {
-    let file = match reference {
-        Some(reference) if !is_definition_path(reference) => {
+/// Resolve the run reference: a path-shaped REF (`.`, `lns.yaml`, `./…`, `../…`, `/…`) or the `--file` selector names a local definition, an omitted REF runs the current directory's `lns.yaml`, and anything else is a registry coordinate.
+pub fn resolve<F: Fs>(
+    reference: Option<&str>,
+    file: Option<&Path>,
+    fs: &F,
+    cwd: &Path,
+) -> Result<RunTarget> {
+    let file = match (reference, file) {
+        (Some(_), Some(_)) => bail!("pass a sandbox reference or --file, not both"),
+        (Some(reference), None) if !is_definition_path(reference) => {
             return Ok(RunTarget::Reference(reference.to_string()));
         }
-        Some(reference) => definition_file(reference, cwd),
-        None => cwd.join(LNS_YAML),
+        (Some(reference), None) => definition_file(reference, cwd),
+        (None, Some(file)) => normalize(&cwd.join(file)),
+        (None, None) => cwd.join(LNS_YAML),
     };
     let project_dir = file
         .parent()
@@ -169,7 +176,7 @@ mod tests {
     #[test]
     fn a_reference_is_passed_through_for_the_service_to_classify() {
         let fs = MapFs::default();
-        let target = resolve(Some("ghcr.io/team/hermes:1.4.0"), &fs, cwd()).unwrap();
+        let target = resolve(Some("ghcr.io/team/hermes:1.4.0"), None, &fs, cwd()).unwrap();
         assert_eq!(target.image(), "ghcr.io/team/hermes:1.4.0");
         assert!(
             target.verify_sandbox(),
@@ -180,7 +187,7 @@ mod tests {
     #[test]
     fn no_reference_resolves_the_local_definition() {
         let fs = fake("/work/lns.yaml", local_yaml());
-        let target = resolve(None, &fs, cwd()).unwrap();
+        let target = resolve(None, None, &fs, cwd()).unwrap();
         assert_eq!(target.image(), "ghcr.io/team/base:1");
         assert!(
             !target.verify_sandbox(),
@@ -191,7 +198,7 @@ mod tests {
     #[test]
     fn a_local_definition_travels_as_canonical_json() {
         let fs = fake("/work/lns.yaml", local_yaml());
-        let target = resolve(None, &fs, cwd()).unwrap();
+        let target = resolve(None, None, &fs, cwd()).unwrap();
         let json = target
             .definition_json()
             .expect("a local run carries its definition");
@@ -204,7 +211,7 @@ mod tests {
     #[test]
     fn a_reference_carries_no_definition_and_no_project_dir() {
         let fs = MapFs::default();
-        let target = resolve(Some("alpine:3.20"), &fs, cwd()).unwrap();
+        let target = resolve(Some("alpine:3.20"), None, &fs, cwd()).unwrap();
         assert_eq!(target.definition_json(), None);
         assert_eq!(target.project_dir(), None);
     }
@@ -212,7 +219,7 @@ mod tests {
     #[test]
     fn no_reference_without_a_definition_names_lns_init() {
         let fs = MapFs::default();
-        let err = resolve(None, &fs, cwd()).unwrap_err();
+        let err = resolve(None, None, &fs, cwd()).unwrap_err();
         assert!(format!("{err:#}").contains("no lns.yaml"), "got: {err:#}");
         assert!(format!("{err:#}").contains("lns init"), "got: {err:#}");
     }
@@ -221,7 +228,7 @@ mod tests {
     fn dot_and_yaml_shaped_references_resolve_the_local_definition() {
         let fs = fake("/work/lns.yaml", local_yaml());
         for reference in [".", "lns.yaml", "./lns.yaml", "./"] {
-            let target = resolve(Some(reference), &fs, cwd()).unwrap();
+            let target = resolve(Some(reference), None, &fs, cwd()).unwrap();
             assert_eq!(target.image(), "ghcr.io/team/base:1", "ref {reference:?}");
             assert!(!target.verify_sandbox(), "ref {reference:?}");
             assert_eq!(target.project_dir(), Some(Path::new("/work")));
@@ -232,7 +239,7 @@ mod tests {
     fn a_relative_or_absolute_path_resolves_that_directorys_definition() {
         let fs = fake("/other/lns.yaml", local_yaml());
         for reference in ["../other", "../other/lns.yaml", "/other", "/other/lns.yaml"] {
-            let target = resolve(Some(reference), &fs, cwd()).unwrap();
+            let target = resolve(Some(reference), None, &fs, cwd()).unwrap();
             assert_eq!(target.image(), "ghcr.io/team/base:1", "ref {reference:?}");
             assert_eq!(
                 target.project_dir(),
@@ -251,7 +258,7 @@ mod tests {
             ),
             ("/other/skills/prompts.md", "p"),
         ]);
-        let target = resolve(Some("/other"), &fs, cwd()).unwrap();
+        let target = resolve(Some("/other"), None, &fs, cwd()).unwrap();
         let json = target.definition_json().expect("local definition");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value["spec"]["filesets"][0]["path"], "/other/skills");
@@ -268,7 +275,7 @@ mod tests {
             ("/other/app.yml", "/other"),
             ("../other/app.yml", "/other"),
         ] {
-            let target = resolve(Some(reference), &fs, cwd()).unwrap();
+            let target = resolve(Some(reference), None, &fs, cwd()).unwrap();
             assert_eq!(target.image(), "ghcr.io/team/base:1", "ref {reference:?}");
             assert_eq!(
                 target.project_dir(),
@@ -285,14 +292,56 @@ mod tests {
             ("/work/lns.yaml", local_yaml()),
             ("/work/lns.dev.yaml", variant),
         ]);
-        let target = resolve(Some("./lns.dev.yaml"), &fs, cwd()).unwrap();
+        let target = resolve(Some("./lns.dev.yaml"), None, &fs, cwd()).unwrap();
         assert_eq!(target.image(), "ghcr.io/team/dev:1");
+    }
+
+    #[test]
+    fn the_file_selector_resolves_the_named_definition() {
+        let variant = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev\nspec:\n  image: ghcr.io/team/dev:1\n";
+        let fs = MapFs::with(&[
+            ("/work/lns.yaml", local_yaml()),
+            ("/work/lns.dev.yaml", variant),
+        ]);
+        let target = resolve(None, Some(Path::new("lns.dev.yaml")), &fs, cwd()).unwrap();
+        assert_eq!(target.image(), "ghcr.io/team/dev:1");
+        assert_eq!(target.project_dir(), Some(Path::new("/work")));
+    }
+
+    #[test]
+    fn the_file_selector_roots_the_project_at_the_files_directory() {
+        let fs = fake("/other/lns.dev.yaml", local_yaml());
+        let target = resolve(None, Some(Path::new("../other/lns.dev.yaml")), &fs, cwd()).unwrap();
+        assert_eq!(target.project_dir(), Some(Path::new("/other")));
+    }
+
+    #[test]
+    fn a_reference_and_the_file_selector_together_are_refused() {
+        let fs = fake("/work/lns.dev.yaml", local_yaml());
+        let err = resolve(
+            Some("ghcr.io/team/hermes:1"),
+            Some(Path::new("lns.dev.yaml")),
+            &fs,
+            cwd(),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("not both"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_missing_file_selector_errors_with_its_path() {
+        let fs = MapFs::default();
+        let err = resolve(None, Some(Path::new("lns.dev.yaml")), &fs, cwd()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("no sandbox definition at /work/lns.dev.yaml"),
+            "got: {err:#}"
+        );
     }
 
     #[test]
     fn a_missing_named_definition_file_errors_with_its_path() {
         let fs = MapFs::default();
-        let err = resolve(Some("./lns.dev.yaml"), &fs, cwd()).unwrap_err();
+        let err = resolve(Some("./lns.dev.yaml"), None, &fs, cwd()).unwrap_err();
         let text = format!("{err:#}");
         assert!(
             text.contains("no sandbox definition at /work/lns.dev.yaml"),
@@ -304,7 +353,7 @@ mod tests {
     #[test]
     fn a_path_shaped_reference_without_a_definition_names_its_directory() {
         let fs = MapFs::default();
-        let err = resolve(Some("../other"), &fs, cwd()).unwrap_err();
+        let err = resolve(Some("../other"), None, &fs, cwd()).unwrap_err();
         let text = format!("{err:#}");
         assert!(text.contains("no lns.yaml in /other"), "got: {text}");
         assert!(text.contains("lns init"), "got: {text}");
@@ -313,7 +362,7 @@ mod tests {
     #[test]
     fn a_repository_name_ending_in_yaml_stays_a_registry_reference() {
         let fs = MapFs::default();
-        let target = resolve(Some("team/config.yaml"), &fs, cwd()).unwrap();
+        let target = resolve(Some("team/config.yaml"), None, &fs, cwd()).unwrap();
         assert!(target.verify_sandbox());
         assert_eq!(target.image(), "team/config.yaml");
     }
@@ -327,7 +376,7 @@ mod tests {
             ),
             ("/work/skills/prompts.md", "p"),
         ]);
-        let target = resolve(None, &fs, cwd()).unwrap();
+        let target = resolve(None, None, &fs, cwd()).unwrap();
         let json = target.definition_json().expect("local definition");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value["spec"]["filesets"][0]["path"], "/work/skills");
@@ -347,7 +396,7 @@ mod tests {
             "/work/lns.yaml",
             "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n",
         );
-        let err = resolve(None, &fs, cwd()).unwrap_err();
+        let err = resolve(None, None, &fs, cwd()).unwrap_err();
         assert!(format!("{err:#}").contains("./skills"), "got: {err:#}");
     }
 
@@ -357,7 +406,7 @@ mod tests {
             "/work/lns.yaml",
             "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec: {}\n",
         );
-        let err = resolve(None, &fs, cwd()).unwrap_err();
+        let err = resolve(None, None, &fs, cwd()).unwrap_err();
         assert!(
             format!("{err:#}").contains("must carry an image"),
             "got: {err:#}"

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -29,6 +29,9 @@ pub fn resolve<F: Fs>(reference: Option<&str>, fs: &F, cwd: &Path) -> Result<Run
         .context("resolving the definition's directory")?
         .to_path_buf();
     if !fs.exists(&file) {
+        if file.file_name() != Some(LNS_YAML.as_ref()) {
+            bail!("no sandbox definition at {}", file.display());
+        }
         bail!(
             "no {LNS_YAML} in {}; run `lns init` there to create one",
             project_dir.display()
@@ -62,11 +65,18 @@ pub(crate) fn is_definition_path(reference: &str) -> bool {
 
 pub(crate) fn definition_file(reference: &str, cwd: &Path) -> PathBuf {
     let path = normalize(&cwd.join(reference));
-    if path.file_name() == Some(LNS_YAML.as_ref()) {
+    if is_yaml_file_name(&path) {
         path
     } else {
         path.join(LNS_YAML)
     }
+}
+
+fn is_yaml_file_name(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(std::ffi::OsStr::to_str),
+        Some("yaml" | "yml")
+    )
 }
 
 // components() already normalizes interior `.` away, so only ParentDir needs lexical handling.
@@ -245,6 +255,50 @@ mod tests {
         let json = target.definition_json().expect("local definition");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value["spec"]["filesets"][0]["path"], "/other/skills");
+    }
+
+    #[test]
+    fn a_yaml_file_reference_resolves_that_files_definition() {
+        let fs = MapFs::with(&[
+            ("/work/lns.dev.yaml", local_yaml()),
+            ("/other/app.yml", local_yaml()),
+        ]);
+        for (reference, project) in [
+            ("./lns.dev.yaml", "/work"),
+            ("/other/app.yml", "/other"),
+            ("../other/app.yml", "/other"),
+        ] {
+            let target = resolve(Some(reference), &fs, cwd()).unwrap();
+            assert_eq!(target.image(), "ghcr.io/team/base:1", "ref {reference:?}");
+            assert_eq!(
+                target.project_dir(),
+                Some(Path::new(project)),
+                "ref {reference:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_yaml_file_reference_selects_the_variant_over_the_default() {
+        let variant = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev\nspec:\n  image: ghcr.io/team/dev:1\n";
+        let fs = MapFs::with(&[
+            ("/work/lns.yaml", local_yaml()),
+            ("/work/lns.dev.yaml", variant),
+        ]);
+        let target = resolve(Some("./lns.dev.yaml"), &fs, cwd()).unwrap();
+        assert_eq!(target.image(), "ghcr.io/team/dev:1");
+    }
+
+    #[test]
+    fn a_missing_named_definition_file_errors_with_its_path() {
+        let fs = MapFs::default();
+        let err = resolve(Some("./lns.dev.yaml"), &fs, cwd()).unwrap_err();
+        let text = format!("{err:#}");
+        assert!(
+            text.contains("no sandbox definition at /work/lns.dev.yaml"),
+            "got: {text}"
+        );
+        assert!(!text.contains("lns init"), "got: {text}");
     }
 
     #[test]

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -87,7 +87,7 @@ fn is_yaml_file_name(path: &Path) -> bool {
 }
 
 // components() already normalizes interior `.` away, so only ParentDir needs lexical handling.
-fn normalize(path: &Path) -> PathBuf {
+pub(crate) fn normalize(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for component in path.components() {
         match component {

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -85,7 +85,9 @@ pub fn map_dir_entries<'a>(
 pub fn is_offline(cmd: &SandboxCommand) -> bool {
     match cmd {
         SandboxCommand::Init | SandboxCommand::Validate(_) => true,
-        SandboxCommand::Inspect(args) => is_local_inspect(args.run.as_deref()),
+        SandboxCommand::Inspect(args) => {
+            args.file.is_some() || is_local_inspect(args.run.as_deref())
+        }
         _ => false,
     }
 }
@@ -168,11 +170,13 @@ pub fn inspect_local<F: Fs, W: Write>(
     fs: &F,
     cwd: &Path,
     target: Option<&str>,
+    file: Option<&Path>,
     out: &mut W,
 ) -> Result<i32> {
-    let path = match target {
-        Some(target) => crate::run::target::definition_file(target, cwd),
-        None => yaml_path(cwd),
+    let path = match (target, file) {
+        (Some(_), Some(_)) => bail!("pass an inspect target or --file, not both"),
+        (Some(target), None) => crate::run::target::definition_file(target, cwd),
+        (None, file) => selected_definition_path(file, cwd),
     };
     let json = load_definition_json_at(fs, &path)?;
     let def = lns_artifact::sandbox::parse(&json)
@@ -262,6 +266,7 @@ mod tests {
     fn inspect_cmd(target: Option<&str>) -> SandboxCommand {
         SandboxCommand::Inspect(crate::sandbox::SandboxInspectArgs {
             run: target.map(str::to_string),
+            file: None,
         })
     }
 
@@ -380,7 +385,7 @@ mod tests {
     fn inspect_local_renders_the_effective_definition() {
         let fs = fake("/work/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = inspect_local(&fs, cwd(), None, &mut out).unwrap();
+        let code = inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(
@@ -399,7 +404,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  command: agent --serve\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
         assert!(
             String::from_utf8(out)
                 .unwrap()
@@ -412,7 +417,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  env:\n    SHELL: /bin/sh\n    FOO: bar\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("env:          FOO=bar"), "got: {text}");
         assert!(text.contains("env:          SHELL=/bin/sh"), "got: {text}");
@@ -448,7 +453,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n    - ref: registry.example.test/team/settings@sha256:abc\n      mountPath: /root/.agent/settings\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), Some("."), &mut out).unwrap();
+        inspect_local(&fs, cwd(), Some("."), None, &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(
             text.contains("fileset:      ./skills -> /root/.agent/skills"),
@@ -466,10 +471,50 @@ mod tests {
     fn inspect_local_renders_another_directorys_definition_by_path() {
         let fs = fake("/other/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = inspect_local(&fs, cwd(), Some("../other"), &mut out).unwrap();
+        let code = inspect_local(&fs, cwd(), Some("../other"), None, &mut out).unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("ghcr.io/team/base:1"), "got: {text}");
+    }
+
+    #[test]
+    fn inspect_file_selector_renders_the_named_definition() {
+        let variant = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev\nspec:\n  image: ghcr.io/team/dev:1\n";
+        let fs = MapFs::with(&[
+            ("/work/lns.yaml", valid_yaml()),
+            ("/work/lns.dev.yaml", variant),
+        ]);
+        let mut out = Vec::new();
+        let code =
+            inspect_local(&fs, cwd(), None, Some(Path::new("lns.dev.yaml")), &mut out).unwrap();
+        assert_eq!(code, 0);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("ghcr.io/team/dev:1"), "got: {text}");
+    }
+
+    #[test]
+    fn inspect_refuses_a_target_and_file_selector_together() {
+        let fs = fake("/work/lns.yaml", valid_yaml());
+        let mut out = Vec::new();
+        let err = inspect_local(
+            &fs,
+            cwd(),
+            Some("."),
+            Some(Path::new("lns.dev.yaml")),
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("not both"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_file_selector_inspect_is_offline() {
+        assert!(is_offline(&SandboxCommand::Inspect(
+            crate::sandbox::SandboxInspectArgs {
+                run: None,
+                file: Some(std::path::PathBuf::from("lns.dev.yaml")),
+            }
+        )));
     }
 
     #[test]
@@ -479,7 +524,7 @@ mod tests {
             "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec: {}\n",
         );
         let mut out = Vec::new();
-        let err = inspect_local(&fs, cwd(), None, &mut out).unwrap_err();
+        let err = inspect_local(&fs, cwd(), None, None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("not a valid sandbox"));
     }
 }

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -84,7 +84,7 @@ pub fn map_dir_entries<'a>(
 /// The author verbs run offline, against the working directory rather than the service; inspect joins them when its target is a local definition (or omitted).
 pub fn is_offline(cmd: &SandboxCommand) -> bool {
     match cmd {
-        SandboxCommand::Init | SandboxCommand::Validate => true,
+        SandboxCommand::Init | SandboxCommand::Validate(_) => true,
         SandboxCommand::Inspect(args) => is_local_inspect(args.run.as_deref()),
         _ => false,
     }
@@ -99,6 +99,14 @@ pub fn is_local_inspect(target: Option<&str>) -> bool {
 
 fn yaml_path(cwd: &Path) -> PathBuf {
     cwd.join(LNS_YAML)
+}
+
+/// The `--file` selector names the definition to operate on; the default stays `./lns.yaml`.
+pub fn selected_definition_path(file: Option<&Path>, cwd: &Path) -> PathBuf {
+    match file {
+        Some(file) => crate::run::target::normalize(&cwd.join(file)),
+        None => yaml_path(cwd),
+    }
 }
 
 pub fn init<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32> {
@@ -128,8 +136,18 @@ pub fn load_definition_json_at<F: Fs>(fs: &F, path: &Path) -> Result<Vec<u8>> {
     serde_json::to_vec(&value).context("normalizing the definition to json")
 }
 
-pub fn validate<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32> {
-    let json = load_definition_json(fs, cwd)?;
+pub fn validate<F: Fs, W: Write>(
+    fs: &F,
+    cwd: &Path,
+    file: Option<&Path>,
+    out: &mut W,
+) -> Result<i32> {
+    let path = selected_definition_path(file, cwd);
+    let project_dir = path.parent().unwrap_or(cwd);
+    let name = file
+        .map(|f| f.display().to_string())
+        .unwrap_or_else(|| LNS_YAML.to_string());
+    let json = load_definition_json_at(fs, &path)?;
     let mut problems = match lns_artifact::validate::validate(&json) {
         Ok(()) => Vec::new(),
         Err(problems) => problems,
@@ -137,13 +155,13 @@ pub fn validate<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32>
     if problems.is_empty()
         && let Ok(def) = lns_artifact::sandbox::parse(&json)
     {
-        problems.extend(super::fileset::path_fileset_problems(fs, cwd, &def));
+        problems.extend(super::fileset::path_fileset_problems(fs, project_dir, &def));
     }
     if problems.is_empty() {
-        writeln!(out, "{LNS_YAML} is valid.")?;
+        writeln!(out, "{name} is valid.")?;
         return Ok(0);
     }
-    writeln!(out, "{LNS_YAML} is not valid:")?;
+    writeln!(out, "{name} is not valid:")?;
     for problem in &problems {
         writeln!(out, "  - {problem}")?;
     }
@@ -254,7 +272,9 @@ mod tests {
     #[test]
     fn is_offline_matches_the_author_verbs_and_local_inspects_only() {
         assert!(is_offline(&SandboxCommand::Init));
-        assert!(is_offline(&SandboxCommand::Validate));
+        assert!(is_offline(&SandboxCommand::Validate(
+            crate::sandbox::SandboxValidateArgs { file: None }
+        )));
         assert!(is_offline(&inspect_cmd(None)));
         assert!(is_offline(&inspect_cmd(Some("."))));
         assert!(is_offline(&inspect_cmd(Some("lns.yaml"))));
@@ -303,16 +323,52 @@ mod tests {
     fn validate_passes_a_well_formed_definition() {
         let fs = fake("/work/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = validate(&fs, cwd(), &mut out).unwrap();
+        let code = validate(&fs, cwd(), None, &mut out).unwrap();
         assert_eq!(code, 0);
         assert!(String::from_utf8(out).unwrap().contains("is valid"));
+    }
+
+    #[test]
+    fn validate_file_selector_roots_filesets_at_the_files_directory_and_names_it() {
+        let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n";
+        let fs = MapFs::with(&[
+            ("/other/lns.dev.yaml", yaml),
+            ("/other/skills/prompts.md", "p"),
+        ]);
+        let mut out = Vec::new();
+        let code = validate(
+            &fs,
+            cwd(),
+            Some(Path::new("../other/lns.dev.yaml")),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("../other/lns.dev.yaml is valid."),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn validate_file_selector_reports_problems_under_the_selected_name() {
+        let fs = fake(
+            "/work/lns.dev.yaml",
+            "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev\nspec: {}\n",
+        );
+        let mut out = Vec::new();
+        let code = validate(&fs, cwd(), Some(Path::new("lns.dev.yaml")), &mut out).unwrap();
+        assert_eq!(code, 1);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("lns.dev.yaml is not valid:"), "got: {text}");
     }
 
     #[test]
     fn validate_surfaces_a_missing_file() {
         let fs = MapFs::default();
         let mut out = Vec::new();
-        let err = validate(&fs, cwd(), &mut out).unwrap_err();
+        let err = validate(&fs, cwd(), None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("lns init"));
     }
 
@@ -320,7 +376,7 @@ mod tests {
     fn validate_surfaces_malformed_yaml() {
         let fs = fake("/work/lns.yaml", "spec: [unterminated");
         let mut out = Vec::new();
-        let err = validate(&fs, cwd(), &mut out).unwrap_err();
+        let err = validate(&fs, cwd(), None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("parsing"));
     }
 
@@ -377,7 +433,7 @@ mod tests {
             "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n",
         );
         let mut out = Vec::new();
-        let code = validate(&fs, cwd(), &mut out).unwrap();
+        let code = validate(&fs, cwd(), None, &mut out).unwrap();
         assert_eq!(code, 1);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("fileset ./skills"), "got: {text}");

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -123,10 +123,6 @@ pub fn init<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32> {
     Ok(0)
 }
 
-pub fn load_definition_json<F: Fs>(fs: &F, cwd: &Path) -> Result<Vec<u8>> {
-    load_definition_json_at(fs, &yaml_path(cwd))
-}
-
 pub fn load_definition_json_at<F: Fs>(fs: &F, path: &Path) -> Result<Vec<u8>> {
     let yaml = fs
         .read_to_string(path)

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -126,9 +126,14 @@ pub fn init<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32> {
 }
 
 pub fn load_definition_json_at<F: Fs>(fs: &F, path: &Path) -> Result<Vec<u8>> {
+    let hint = if path.file_name() == Some(LNS_YAML.as_ref()) {
+        "; run `lns init` to scaffold one"
+    } else {
+        ""
+    };
     let yaml = fs
         .read_to_string(path)
-        .with_context(|| format!("reading {}; run `lns init` to scaffold one", path.display()))?;
+        .with_context(|| format!("reading {}{hint}", path.display()))?;
     let value: serde_json::Value =
         serde_yaml::from_str(&yaml).with_context(|| format!("parsing {}", path.display()))?;
     serde_json::to_vec(&value).context("normalizing the definition to json")
@@ -371,6 +376,19 @@ mod tests {
         let mut out = Vec::new();
         let err = validate(&fs, cwd(), None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("lns init"));
+    }
+
+    #[test]
+    fn a_missing_variant_file_does_not_hint_lns_init() {
+        let fs = MapFs::default();
+        let mut out = Vec::new();
+        let err = validate(&fs, cwd(), Some(Path::new("lns.dev.yaml")), &mut out).unwrap_err();
+        let text = format!("{err:#}");
+        assert!(text.contains("lns.dev.yaml"), "got: {text}");
+        assert!(
+            !text.contains("lns init"),
+            "`lns init` cannot scaffold a variant: {text}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -92,6 +92,13 @@ pub struct SandboxPushArgs {
         help = "Validate, pack, and build everything push would upload, print the digests, and upload nothing."
     )]
     pub dry_run: bool,
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        help = "Definition file to publish instead of ./lns.yaml; its directory roots the definition's relative filesets."
+    )]
+    pub file: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -1192,6 +1199,7 @@ mod tests {
         let cmd = SandboxCommand::Push(SandboxPushArgs {
             reference: "ghcr.io/team/hermes:1.4.0".into(),
             dry_run: false,
+            file: None,
         });
         let mut out = Vec::new();
         let mut stdout = Vec::new();

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -177,9 +177,18 @@ pub struct SandboxAttachArgs {
 pub struct SandboxInspectArgs {
     #[arg(
         value_name = "TARGET",
-        help = "A running run's id/name (live state), a cached sandbox reference (its definition), or a path to a local definition (., lns.yaml, ./dir — rendered offline). Omit to render ./lns.yaml."
+        help = "A running run's id/name (live state), a cached sandbox reference (its definition), or a path to a local definition (., lns.yaml, ./dir, ./lns.dev.yaml — rendered offline). Omit to render ./lns.yaml."
     )]
     pub run: Option<String>,
+
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        conflicts_with = "run",
+        help = "Definition file to render instead of ./lns.yaml, offline. Cannot be combined with TARGET."
+    )]
+    pub file: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -1174,7 +1183,10 @@ mod tests {
         for cmd in [
             SandboxCommand::Init,
             SandboxCommand::Validate(SandboxValidateArgs { file: None }),
-            SandboxCommand::Inspect(SandboxInspectArgs { run: None }),
+            SandboxCommand::Inspect(SandboxInspectArgs {
+                run: None,
+                file: None,
+            }),
         ] {
             let mut out = Vec::new();
             let mut stdout = Vec::new();

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -29,7 +29,7 @@ pub enum SandboxCommand {
     #[command(about = "Scaffold a default ./lns.yaml (kind: Sandbox) in this directory.")]
     Init,
     #[command(about = "Validate ./lns.yaml — schema, cross-field, and secret checks, offline.")]
-    Validate,
+    Validate(SandboxValidateArgs),
     #[command(
         about = "Build ./lns.yaml and upload it to a registry as a sandbox artifact, in one step."
     )]
@@ -67,6 +67,17 @@ pub enum SandboxCommand {
     Rm(SandboxRmArgs),
     #[command(about = "Remove every cached sandbox not held by a running one, reclaiming disk.")]
     Prune(SandboxPruneArgs),
+}
+
+#[derive(clap::Args)]
+pub struct SandboxValidateArgs {
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        help = "Definition file to validate instead of ./lns.yaml; its directory roots the definition's relative filesets."
+    )]
+    pub file: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -353,7 +364,7 @@ where
     E: AsyncWriteExt + Unpin,
 {
     match cmd {
-        SandboxCommand::Init | SandboxCommand::Validate => {
+        SandboxCommand::Init | SandboxCommand::Validate(_) => {
             bail!("author commands run offline, not through the service dispatch")
         }
         SandboxCommand::Push(_) => {
@@ -1155,7 +1166,7 @@ mod tests {
         let svc = CannedService::new(Response::Pong);
         for cmd in [
             SandboxCommand::Init,
-            SandboxCommand::Validate,
+            SandboxCommand::Validate(SandboxValidateArgs { file: None }),
             SandboxCommand::Inspect(SandboxInspectArgs { run: None }),
         ] {
             let mut out = Vec::new();

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -22,7 +22,8 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
         }
         if let super::SandboxCommand::Push(push_args) = &args.command {
             let reference = push_args.reference.clone();
-            return push_local(&reference, push_args.dry_run, ctx.cwd()?).await;
+            let file = push_args.file.clone();
+            return push_local(&reference, push_args.dry_run, file.as_deref(), ctx.cwd()?).await;
         }
         crate::service::require_running().await;
         dispatch(args).await
@@ -91,7 +92,13 @@ pub fn run_attach<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFut
 pub fn run_push<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = super::SandboxPushArgs::from_arg_matches(matches)?;
-        push_local(&args.reference, args.dry_run, ctx.cwd()?).await
+        push_local(
+            &args.reference,
+            args.dry_run,
+            args.file.as_deref(),
+            ctx.cwd()?,
+        )
+        .await
     })
 }
 
@@ -109,13 +116,28 @@ pub fn run_tag<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture
     })
 }
 
-async fn push_local(reference: &str, dry_run: bool, cwd: PathBuf) -> Result<i32> {
-    let doc = super::author::load_definition_json(&RealFs, &cwd)?;
+async fn push_local(
+    reference: &str,
+    dry_run: bool,
+    file: Option<&std::path::Path>,
+    cwd: PathBuf,
+) -> Result<i32> {
+    let path = super::author::selected_definition_path(file, &cwd);
+    let project_dir = path.parent().unwrap_or(&cwd).to_path_buf();
+    let doc = super::author::load_definition_json_at(&RealFs, &path)?;
     let mut out = std::io::stdout();
     if dry_run {
-        return super::distribute::push_dry_run(&RealFs, &cwd, &doc, reference, &mut out);
+        return super::distribute::push_dry_run(&RealFs, &project_dir, &doc, reference, &mut out);
     }
-    super::distribute::push(&RealFs, &cwd, &RealProducer, &doc, reference, &mut out).await
+    super::distribute::push(
+        &RealFs,
+        &project_dir,
+        &RealProducer,
+        &doc,
+        reference,
+        &mut out,
+    )
+    .await
 }
 
 struct RealProducer;

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -172,9 +172,13 @@ fn run_author(command: &super::SandboxCommand, ctx: RunCtx<'_>) -> Result<i32> {
         super::SandboxCommand::Validate(args) => {
             super::author::validate(&RealFs, &cwd, args.file.as_deref(), &mut out)
         }
-        super::SandboxCommand::Inspect(args) => {
-            super::author::inspect_local(&RealFs, &cwd, args.run.as_deref(), &mut out)
-        }
+        super::SandboxCommand::Inspect(args) => super::author::inspect_local(
+            &RealFs,
+            &cwd,
+            args.run.as_deref(),
+            args.file.as_deref(),
+            &mut out,
+        ),
         _ => unreachable!("run_author is only called for offline author verbs"),
     }
 }

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -147,7 +147,9 @@ fn run_author(command: &super::SandboxCommand, ctx: RunCtx<'_>) -> Result<i32> {
     let mut out = std::io::stdout();
     match command {
         super::SandboxCommand::Init => super::author::init(&RealFs, &cwd, &mut out),
-        super::SandboxCommand::Validate => super::author::validate(&RealFs, &cwd, &mut out),
+        super::SandboxCommand::Validate(args) => {
+            super::author::validate(&RealFs, &cwd, args.file.as_deref(), &mut out)
+        }
         super::SandboxCommand::Inspect(args) => {
             super::author::inspect_local(&RealFs, &cwd, args.run.as_deref(), &mut out)
         }

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -38,8 +38,12 @@ pub async fn launch_run(mut args: RunArgs, debug: bool) -> Result<i32> {
     let args = crate::config::apply_run_defaults(args, defaults);
     let cwd = std::env::current_dir().context("reading current directory")?;
     // Target resolution is offline; a missing or invalid definition fails fast, before the service gate.
-    let target =
-        crate::run::target::resolve(args.image.as_deref(), &crate::sandbox::real::RealFs, &cwd)?;
+    let target = crate::run::target::resolve(
+        args.image.as_deref(),
+        args.file.as_deref(),
+        &crate::sandbox::real::RealFs,
+        &cwd,
+    )?;
     require_running().await;
     run_image(args, target, cwd, debug).await
 }

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -17,14 +17,12 @@ Feature: selecting the sandbox definition file
     Then the exit code is 0
     And the service request roots the bind and fileset at "/other"
 
-  @todo
   Scenario: --file selects the definition for a reference-less run
     Given a sandbox definition file "lns.dev.yaml" in the current directory
     When the user runs "lns run --file lns.dev.yaml"
     Then the exit code is 0
     And the service request carries the definition from "lns.dev.yaml"
 
-  @todo
   Scenario: --file combined with a registry reference is refused
     Given a sandbox definition file "lns.dev.yaml" in the current directory
     When the user runs "lns run --file lns.dev.yaml ghcr.io/team/hermes:1.4.0"

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -43,7 +43,6 @@ Feature: selecting the sandbox definition file
     Then the exit code is 0
     And the pushed artifact carries the definition from "lns.dev.yaml"
 
-  @todo
   Scenario: inspect renders a named yaml file's definition offline
     Given a sandbox definition file "lns.dev.yaml" in the current directory
     When the user runs sandbox command "inspect ./lns.dev.yaml"

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -36,9 +36,9 @@ Feature: selecting the sandbox definition file
     And the output contains "valid"
     And the service received no request
 
-  @todo
   Scenario: push --file publishes the named definition
     Given a sandbox definition file "lns.dev.yaml" in the current directory
+    And the registry accepts the push
     When the user runs "lns push --file lns.dev.yaml ghcr.io/team/hermes:1.4.0"
     Then the exit code is 0
     And the pushed artifact carries the definition from "lns.dev.yaml"

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -1,0 +1,62 @@
+Feature: selecting the sandbox definition file
+  `./lns.yaml` is the sandbox — one directory is one sandbox. A path-shaped
+  reference naming a `.yaml` file, or the explicit `-f/--file` selector, is
+  the override that operates on a different definition file: the file's
+  directory roots its relative binds and filesets, compose-style, while the
+  policy still comes from where you run.
+
+  Scenario: a path-shaped reference naming a yaml file runs that file's definition
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs "lns run ./lns.dev.yaml"
+    Then the exit code is 0
+    And the service request carries the definition from "lns.dev.yaml"
+
+  Scenario: a yaml file reference in another directory roots relative sources at the file's directory
+    Given a sandbox definition file "/other/lns.dev.yaml" declaring a relative bind and fileset
+    When the user runs "lns run /other/lns.dev.yaml"
+    Then the exit code is 0
+    And the service request roots the bind and fileset at "/other"
+
+  @todo
+  Scenario: --file selects the definition for a reference-less run
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs "lns run --file lns.dev.yaml"
+    Then the exit code is 0
+    And the service request carries the definition from "lns.dev.yaml"
+
+  @todo
+  Scenario: --file combined with a registry reference is refused
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs "lns run --file lns.dev.yaml ghcr.io/team/hermes:1.4.0"
+    Then the exit code is 2
+    And the output contains "cannot be used with"
+
+  @todo
+  Scenario: validate --file validates the named definition
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs sandbox command "validate --file lns.dev.yaml"
+    Then the exit code is 0
+    And the output contains "valid"
+    And the service received no request
+
+  @todo
+  Scenario: push --file publishes the named definition
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs "lns push --file lns.dev.yaml ghcr.io/team/hermes:1.4.0"
+    Then the exit code is 0
+    And the pushed artifact carries the definition from "lns.dev.yaml"
+
+  @todo
+  Scenario: inspect renders a named yaml file's definition offline
+    Given a sandbox definition file "lns.dev.yaml" in the current directory
+    When the user runs sandbox command "inspect ./lns.dev.yaml"
+    Then the exit code is 0
+    And the output contains "image"
+    And the service received no request
+
+  Scenario: a named definition file that does not exist errors with its path
+    Given the current directory has no lns.yaml
+    When the user runs "lns run ./lns.dev.yaml"
+    Then the command fails with an exit code other than 0
+    And the output contains "no sandbox definition at"
+    And the output contains "lns.dev.yaml"

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -29,7 +29,6 @@ Feature: selecting the sandbox definition file
     Then the exit code is 2
     And the output contains "cannot be used with"
 
-  @todo
   Scenario: validate --file validates the named definition
     Given a sandbox definition file "lns.dev.yaml" in the current directory
     When the user runs sandbox command "validate --file lns.dev.yaml"

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -47,7 +47,7 @@ fn resolve_local(world: &BehaviourWorld) -> anyhow::Result<RunTarget> {
     let fs = StepFs {
         files: RefCell::new(world.author_files.clone()),
     };
-    resolve(None, &fs, Path::new("/work"))
+    resolve(None, None, &fs, Path::new("/work"))
 }
 
 #[when("the local sandbox run is prepared")]

--- a/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
+++ b/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+
+use cucumber::{given, then};
+use lns_cli::run::declarative::{Defaults, resolve};
+
+use crate::world::BehaviourWorld;
+
+const VARIANT_YAML: &str = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev-variant\nspec:\n  image: ghcr.io/team/dev-base:1\n";
+const DEFAULT_YAML: &str = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: sandbox\nspec:\n  image: ghcr.io/team/base:1\n";
+
+#[given(regex = r#"^a sandbox definition file "([^"]+)" in the current directory$"#)]
+fn variant_definition_in_cwd(w: &mut BehaviourWorld, name: String) {
+    w.author_files
+        .insert(PathBuf::from("/work/lns.yaml"), DEFAULT_YAML.to_string());
+    w.author_files
+        .insert(PathBuf::from("/work").join(name), VARIANT_YAML.to_string());
+}
+
+#[given(regex = r#"^a sandbox definition file "([^"]+)" declaring a relative bind and fileset$"#)]
+fn variant_definition_with_relative_sources(w: &mut BehaviourWorld, path: String) {
+    let path = PathBuf::from(path);
+    let dir = path
+        .parent()
+        .expect("the fixture path names a file in a directory")
+        .to_path_buf();
+    let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev-variant\nspec:\n  image: ghcr.io/team/dev-base:1\n  volumes:\n    - type: bind\n      source: .\n      target: /workspace\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n";
+    w.author_files.insert(path, yaml.to_string());
+    w.author_files
+        .insert(dir.join("skills/prompts.md"), "p".to_string());
+}
+
+fn wire_definition(w: &BehaviourWorld) -> Result<serde_json::Value, String> {
+    let json = w
+        .sandbox_run
+        .definition
+        .as_deref()
+        .ok_or("the run request carried no definition")?;
+    serde_json::from_str(json).map_err(|e| format!("definition was not json: {e}"))
+}
+
+#[then(regex = r#"^the service request carries the definition from "([^"]+)"$"#)]
+fn request_carries_variant_definition(w: &mut BehaviourWorld, _name: String) -> Result<(), String> {
+    let value = wire_definition(w)?;
+    if value["spec"]["image"] != "ghcr.io/team/dev-base:1" {
+        return Err(format!(
+            "expected the variant definition on the wire, got image {}",
+            value["spec"]["image"]
+        ));
+    }
+    Ok(())
+}
+
+#[then(regex = r#"^the service request roots the bind and fileset at "([^"]+)"$"#)]
+fn request_roots_sources_at(w: &mut BehaviourWorld, dir: String) -> Result<(), String> {
+    let value = wire_definition(w)?;
+    let fileset = value["spec"]["filesets"][0]["path"]
+        .as_str()
+        .unwrap_or_default();
+    if fileset != format!("{dir}/skills") {
+        return Err(format!(
+            "expected the fileset rooted at {dir}, got {fileset:?}"
+        ));
+    }
+    let json = w.sandbox_run.definition.as_deref().unwrap_or_default();
+    let def = lns_artifact::sandbox::parse(json.as_bytes())
+        .map_err(|e| format!("the wire definition did not parse: {e:#}"))?;
+    let project = w
+        .sandbox_run
+        .project_dir
+        .clone()
+        .ok_or("the run resolved no project directory")?;
+    let resolved = resolve(&Defaults::from_definition(&def), &project, None, Vec::new())
+        .map_err(|e| format!("declarative settings did not resolve: {e:#}"))?;
+    let (_, binds) = lns_cli::cli::split_mounts(&resolved.mounts);
+    let rendered: Vec<String> = binds
+        .iter()
+        .map(|b| format!("{} -> {}", b.host_source, b.target))
+        .collect();
+    if rendered != [format!("{dir} -> /workspace")] {
+        return Err(format!(
+            "expected the bind rooted at {dir}, got {rendered:?}"
+        ));
+    }
+    Ok(())
+}

--- a/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
+++ b/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
@@ -1,9 +1,28 @@
 use std::path::PathBuf;
 
-use cucumber::{given, then};
+use cucumber::{given, then, when};
 use lns_cli::run::declarative::{Defaults, resolve};
 
 use crate::world::BehaviourWorld;
+
+#[when(regex = r#"^the user runs "lns push(.*)"$"#)]
+async fn user_runs_lns_push(w: &mut BehaviourWorld, rest: String) {
+    super::sandbox_cli::drive_sandbox_command(w, &format!("push{rest}")).await;
+}
+
+#[then(regex = r#"^the pushed artifact carries the definition from "([^"]+)"$"#)]
+fn pushed_artifact_carries_variant(w: &mut BehaviourWorld, _name: String) -> Result<(), String> {
+    let doc = w.pushed_doc.as_ref().ok_or("no definition was pushed")?;
+    let value: serde_json::Value =
+        serde_json::from_slice(doc).map_err(|e| format!("pushed doc is not json: {e}"))?;
+    if value["spec"]["image"] != "ghcr.io/team/dev-base:1" {
+        return Err(format!(
+            "expected the variant definition to publish, got image {}",
+            value["spec"]["image"]
+        ));
+    }
+    Ok(())
+}
 
 const VARIANT_YAML: &str = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: dev-variant\nspec:\n  image: ghcr.io/team/dev-base:1\n";
 const DEFAULT_YAML: &str = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: sandbox\nspec:\n  image: ghcr.io/team/base:1\n";

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -3,6 +3,7 @@ pub mod config_cli;
 pub mod declarative_filesets;
 pub mod declarative_ports;
 pub mod declarative_run;
+pub mod definition_selection;
 pub mod env_file;
 pub mod host_bind;
 pub mod integration_cli;

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -304,6 +304,10 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &SandboxCommand) {
 
 #[when(regex = r#"^the user runs sandbox command "([^"]+)"$"#)]
 async fn run_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
+    drive_sandbox_command(w, &cmd).await;
+}
+
+pub(crate) async fn drive_sandbox_command(w: &mut BehaviourWorld, cmd: &str) {
     let mut argv: Vec<&str> = vec!["lns", "sandbox"];
     argv.extend(cmd.split_whitespace());
     let args: SandboxArgs = parse_args(&argv).expect("sandbox argv must parse");
@@ -325,18 +329,16 @@ async fn run_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
             filesets: RefCell::new(Vec::new()),
         };
         let mut out: Vec<u8> = Vec::new();
-        let result = match author::load_definition_json(&fs, Path::new("/work")) {
-            Ok(doc) if push_args.dry_run => distribute::push_dry_run(
-                &fs,
-                Path::new("/work"),
-                &doc,
-                &push_args.reference,
-                &mut out,
-            ),
+        let path = author::selected_definition_path(push_args.file.as_deref(), Path::new("/work"));
+        let project_dir = path.parent().unwrap_or(Path::new("/work")).to_path_buf();
+        let result = match author::load_definition_json_at(&fs, &path) {
+            Ok(doc) if push_args.dry_run => {
+                distribute::push_dry_run(&fs, &project_dir, &doc, &push_args.reference, &mut out)
+            }
             Ok(doc) => {
                 distribute::push(
                     &fs,
-                    Path::new("/work"),
+                    &project_dir,
                     &producer,
                     &doc,
                     &push_args.reference,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -281,7 +281,9 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &SandboxCommand) {
     let mut out: Vec<u8> = Vec::new();
     let result = match cmd {
         SandboxCommand::Init => author::init(&fs, cwd, &mut out),
-        SandboxCommand::Validate => author::validate(&fs, cwd, &mut out),
+        SandboxCommand::Validate(args) => {
+            author::validate(&fs, cwd, args.file.as_deref(), &mut out)
+        }
         SandboxCommand::Inspect(args) => {
             author::inspect_local(&fs, cwd, args.run.as_deref(), &mut out)
         }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -284,9 +284,13 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &SandboxCommand) {
         SandboxCommand::Validate(args) => {
             author::validate(&fs, cwd, args.file.as_deref(), &mut out)
         }
-        SandboxCommand::Inspect(args) => {
-            author::inspect_local(&fs, cwd, args.run.as_deref(), &mut out)
-        }
+        SandboxCommand::Inspect(args) => author::inspect_local(
+            &fs,
+            cwd,
+            args.run.as_deref(),
+            args.file.as_deref(),
+            &mut out,
+        ),
         _ => unreachable!("run_author_verb is only called for the offline author verbs"),
     };
     w.author_files = fs.files.into_inner();
@@ -436,6 +440,7 @@ async fn run_lns_inspect(w: &mut BehaviourWorld, reference: String) {
     let result = run_with_writers(
         &SandboxCommand::Inspect(lns_cli::sandbox::SandboxInspectArgs {
             run: Some(reference),
+            file: None,
         }),
         &svc,
         TermInfo::default(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -129,6 +129,7 @@ fn run_resolved(w: &mut BehaviourWorld, args: RunArgs, target: &RunTarget, cwd: 
     w.sandbox_run.request_image = Some(target.image());
     w.sandbox_run.verify_sandbox = Some(target.verify_sandbox());
     w.sandbox_run.definition = target.definition_json();
+    w.sandbox_run.project_dir = target.project_dir().map(Path::to_path_buf);
     if let Some(policy) = args.policy.as_deref() {
         w.summary_output = format_summary(
             &args,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -110,7 +110,7 @@ fn drive_run(w: &mut BehaviourWorld, argv: &[String]) {
     let fs = StepFs {
         files: RefCell::new(w.author_files.clone()),
     };
-    match resolve(args.image.as_deref(), &fs, cwd) {
+    match resolve(args.image.as_deref(), args.file.as_deref(), &fs, cwd) {
         Err(e) => {
             w.result = Some(CliRun {
                 exit_code: 1,

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -93,6 +93,7 @@ pub struct SandboxRunRig {
     pub request_image: Option<String>,
     pub verify_sandbox: Option<bool>,
     pub definition: Option<String>,
+    pub project_dir: Option<std::path::PathBuf>,
     pub refusal: Option<String>,
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -50,10 +50,12 @@ lns run [OPTIONS] [REF] [-- COMMAND...]
 ```
 
 `REF` is a **registry coordinate** (`ghcr.io/team/hermes:1.4.0`) or a **path to a
-local definition** — `.`, `lns.yaml`, `./lns.yaml`, or a relative/absolute path to
-a directory holding one; omit it to run the `./lns.yaml` in the current directory.
-A path-named definition's relative binds and filesets root at its own directory,
-compose-style; the policy still comes from where you run. A
+local definition** — `.`, `lns.yaml`, `./lns.yaml`, a relative/absolute path to
+a directory holding one, or a path-shaped `.yaml`/`.yml` file naming the
+definition itself (`./lns.dev.yaml`); omit it to run the `./lns.yaml` in the
+current directory, or select another file with `-f`/`--file` (exclusive with
+`REF`). A path-named definition's relative binds and filesets root at its own
+directory, compose-style; the policy still comes from where you run. A
 `COMMAND` after the reference overrides the sandbox base image's default command
 (`lns run ghcr.io/acme/agent:1 echo hi`) while keeping its `ENTRYPOINT`; an explicit `--`
 separator is still accepted. A command with no `REF` (`lns run -- echo hi`) runs
@@ -63,6 +65,7 @@ the `./lns.yaml` definition with its command overridden.
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
 | `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
 | `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; rounded up to a whole MiB); falls back to the `run.mem` config default. |
+| `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory roots the definition's relative binds and filesets. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `docker.io`      | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default. A fully-qualified reference is used as-is. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with `defaultVerdict: ask` if absent.         |
@@ -128,8 +131,8 @@ interchangeable everywhere a run is addressed.
 | Subcommand | Shortcut       | Meaning |
 | ---------- | -------------- | ------- |
 | `init`     | `lns init`     | Scaffold a default `./lns.yaml` (`kind: Sandbox`) in this directory. |
-| `validate` | —              | Validate `./lns.yaml` — schema, cross-field, and secret checks, offline. Exits non-zero and lists each problem when the definition is broken. |
-| `push`     | `lns push`     | Build `./lns.yaml` and upload it to a registry as a sandbox artifact, in one step. `<REF>` is the registry reference to publish at. Each `spec.filesets` `path` directory is packed into a FileSet artifact, pushed alongside, and pinned by digest in the published config. `--dry-run` validates, packs, and builds all of it offline, prints the digests that would publish, and uploads nothing. |
+| `validate` | —              | Validate `./lns.yaml` — schema, cross-field, and secret checks, offline. Exits non-zero and lists each problem when the definition is broken. `-f`/`--file` validates another definition file instead. |
+| `push`     | `lns push`     | Build `./lns.yaml` and upload it to a registry as a sandbox artifact, in one step. `<REF>` is the registry reference to publish at. Each `spec.filesets` `path` directory is packed into a FileSet artifact, pushed alongside, and pinned by digest in the published config. `--dry-run` validates, packs, and builds all of it offline, prints the digests that would publish, and uploads nothing. `-f`/`--file` publishes another definition file instead. |
 | `pull`     | `lns pull`     | Fetch a published sandbox and its base image into the local cache. |
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
@@ -139,7 +142,7 @@ interchangeable everywhere a run is addressed.
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |
 | `attach`   | `lns attach`   | Re-join a run's live output, most useful after `lns run -d`. The detach chord (`ctrl-p,ctrl-q` by default) leaves the run running and returns you to your shell (docker-attach style; no signal is sent). Stdin reaches the workload only if the run was started with stdin open. |
-| `inspect`  | `lns inspect`  | With no target or a path-shaped one (`.`, `lns.yaml`, `./dir`): render that local definition's effective form, offline. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `Sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <ref> -> <mountPath>`), integrations, and any over-broad-policy flag; or a plain `Image`. |
+| `inspect`  | `lns inspect`  | With no target, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: render that local definition's effective form, offline. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `Sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <ref> -> <mountPath>`), integrations, and any over-broad-policy flag; or a plain `Image`. |
 | `rm`       | `lns rm`       | Remove a cached sandbox and free its now-unreferenced layers; refuses a running one (a running id/name is rejected). |
 | `prune`    | —              | Remove every cached sandbox not held by a running one, reclaiming disk. Requires `-f`/`--force` — there is no interactive prompt. |
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -98,15 +98,18 @@ lns run [OPTIONS] [REF] [-- COMMAND...]
 
 `REF` is a sandbox reference: a **registry coordinate** (`ghcr.io/team/hermes:1.4.0`)
 or a **path to a local definition**. Omit it to run the `./lns.yaml` in the current
-directory; `.`, `lns.yaml`, and `./lns.yaml` mean the same thing, and a relative or
-absolute path runs another directory's definition (its relative binds and filesets
-root at that directory, compose-style, while the policy still comes from where you
-run):
+directory; `.`, `lns.yaml`, and `./lns.yaml` mean the same thing, a relative or
+absolute path runs another directory's definition, and a path-shaped `.yaml`/`.yml`
+file names the definition itself. Either way the definition's relative binds and
+filesets root at its own directory, compose-style, while the policy still comes
+from where you run:
 
 ```bash
 lns run                                  # run ./lns.yaml in this directory
 lns run .                                # same
 lns run ../other-project                 # run that directory's lns.yaml
+lns run ./docs/examples/claude-code      # same, no cd needed
+lns run ./lns.dev.yaml                   # run a definition file by name
 lns run ghcr.io/acme/agent:latest        # run a published sandbox by reference
 ```
 
@@ -136,6 +139,25 @@ lns run ghcr.io/acme/agent:latest
 
 The sandbox artifact and its base image are pulled and cached by the service, then
 its entrypoint starts inside the microVM.
+
+### Selecting a definition file
+
+`./lns.yaml` is the sandbox — one directory is one sandbox, and every verb
+defaults to it. When a project keeps a variant of its sandbox alongside the
+default (say `lns.dev.yaml` with looser resources), select it explicitly with
+`-f`/`--file` — the same escape hatch as `docker build -f`:
+
+```bash
+lns run -f lns.dev.yaml                  # run the variant
+lns sandbox validate -f lns.dev.yaml     # validate it, offline
+lns push -f lns.dev.yaml ghcr.io/acme/agent-dev:1.0.0
+lns inspect -f lns.dev.yaml              # render it, offline
+```
+
+The selected file's directory roots its relative binds and filesets, exactly as
+a path-shaped `REF` does, and the policy still comes from where you run. On
+`lns run` the selector is exclusive with `REF`; `lns run ./lns.dev.yaml` is the
+equivalent path spelling.
 
 ### Pinning a published sandbox by digest
 


### PR DESCRIPTION
## Summary

`lns run`, `sandbox validate`, and `push` could only operate on a definition named exactly `lns.yaml`. A project keeping a variant of its sandbox alongside the default (e.g. `lns.dev.yaml` with different policy or resources) had no way to run, validate, or push it — and pointing `lns run` at a `.yaml` file failed with a misleading `no lns.yaml in <your-file>` error, because the file path was treated as a directory.

This PR makes the definition file selectable, two ways, while keeping `./lns.yaml` the model and the default everywhere ("one directory is one sandbox" stands):

### 1. REF grammar: a path-shaped `.yaml`/`.yml` file names the definition itself

```bash
lns run ./lns.dev.yaml            # run a definition file by name
lns run /other/project/app.yml    # absolute file path
lns inspect ./lns.dev.yaml        # render it, offline
```

The file's directory roots the definition's relative binds and filesets, compose-style, exactly like directory-shaped REFs; the policy still comes from where you run. Registry-coordinate conservatism is untouched: `team/config.yaml` (no `./`) is still a registry reference, and the bare no-`./` privilege stays exact-name (`dir/lns.yaml`).

A path that names a missing file now errors with the file's path (`no sandbox definition at …/lns.dev.yaml`) instead of the old `no lns.yaml in <file-treated-as-directory>`, and the `run \`lns init\`` hint is only offered when the missing file is actually `lns.yaml` — init can't scaffold a variant.

### 2. A uniform `-f`/`--file` selector on the definition-reading verbs

```bash
lns run -f lns.dev.yaml
lns sandbox validate --file lns.dev.yaml
lns push --file lns.dev.yaml ghcr.io/acme/agent-dev:1.0.0
lns inspect -f lns.dev.yaml
```

`docker build -f`-style: the explicit override, defaulting to `./lns.yaml`. On `lns run` and `lns inspect` it is mutually exclusive with the positional target (clap `conflicts_with`). `validate` roots fileset checks and `push` packs path filesets at the selected file's directory. The run banner names the selected file (`lns.dev.yaml (resolving…)`), not `./lns.yaml`.

## Docs

`docs/running-workloads.md` gains a "Selecting a definition file" section presenting `-f` as the explicit override (the "One directory is one sandbox" model line is deliberately unchanged) and the REF paragraph covers `.yaml` file paths; `docs/cli-reference.md` gains the flag rows and updated REF/verb descriptions.

## Test instructions

1. In a directory with both `lns.yaml` and `lns.dev.yaml` (different `spec.image`): `lns run ./lns.dev.yaml` boots the variant's image; the run summary names the variant.
2. Same directory: `lns run -f lns.dev.yaml` behaves identically; `lns run -f lns.dev.yaml ghcr.io/acme/x` exits 2 with clap's "cannot be used with" refusal.
3. `lns sandbox validate --file lns.dev.yaml` prints `lns.dev.yaml is valid.` offline; with a relative fileset in the variant, the fileset directory is checked relative to the variant's directory.
4. `lns push --dry-run --file lns.dev.yaml ghcr.io/acme/dev:1` builds and prints the digest of the variant definition, uploading nothing.
5. `lns inspect ./lns.dev.yaml` (and `-f lns.dev.yaml`) renders the variant offline, no service running.
6. Error path: `lns run ./missing.yaml` exits 1 with `no sandbox definition at <abs>/missing.yaml` and no `lns init` hint; bare `lns run` with no `lns.yaml` still hints `lns init`.
7. Invariants: `lns run` with no REF runs `./lns.yaml`; `lns run team/config.yaml` is still treated as a registry reference.