### PR TITLE
fix(examples): declare the Claude subscription credential as a required slot

### DIFF
--- a/docs/examples/claude-code/README.md
+++ b/docs/examples/claude-code/README.md
@@ -8,8 +8,8 @@ hosts you allow.
 ## Files
 
 - **`lns.yaml`** — the sandbox definition: a `node:lts-alpine` base that installs
-  Claude Code on first boot, the network allowlist, and the
-  `claude-code-subscription` connector, and inline seed state mounted at the
+  Claude Code on first boot, the network allowlist, the required
+  `claude-code-subscription` credential, and inline seed state mounted at the
   workload's home (`/home/sandbox`). The inline `.claude.json` skips onboarding
   and pre-accepts the `/workspace` trust dialog. The inline
   `.claude/settings.json` runs Claude in `bypassPermissions` and turns **off
@@ -30,8 +30,19 @@ The first boot runs `npm install -g @anthropic-ai/claude-code`; the microVM is
 ephemeral, so each cold start reinstalls it (the `allowedRoutes` keep
 `registry.npmjs.org` open for that reason).
 
-On first run, an approval card asks for your Claude subscription token and shows
-how to mint it.
+The definition requires the `claude-code-subscription` credential, so on a
+machine with no bound value the first run refuses to boot and tells you how to
+bind one:
+
+```bash
+lns connector connect claude-code-subscription
+```
+
+An approval card opens: mint a long-lived subscription token with
+`claude setup-token`, then paste it (or accept the detected host value if
+`CLAUDE_CODE_OAUTH_TOKEN` is already set on your machine). The real token never
+enters the guest — the workload sees a placeholder and the boundary splices the
+value into requests to `api.anthropic.com`. Then `lns run` again.
 
 ## Publish and run from a registry
 

--- a/docs/examples/claude-code/lns.yaml
+++ b/docs/examples/claude-code/lns.yaml
@@ -29,8 +29,10 @@ spec:
         verdict: allow
       - match: downloads.claude.ai
         verdict: allow
-  connectors:
-    - claude-code-subscription
+  credentials:
+    - name: claude-code-subscription
+      env: CLAUDE_CODE_OAUTH_TOKEN
+      required: true
   volumes:
     - type: bind
       source: .

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -709,8 +709,8 @@ or `lns pull` simply fetches or rebuilds it again.
 
 [`examples/claude-code/`](examples/claude-code/) is a complete recipe that ties
 these pieces together: it runs Claude Code inside a sandbox using `spec.image`
-plus a first-boot install, `spec.env`, a tight `policy` allowlist, the
-`claude-code-subscription` connector, a `.` bind at `/workspace`, and a
+plus a first-boot install, `spec.env`, a tight `policy` allowlist, a required
+`claude-code-subscription` credential, a `.` bind at `/workspace`, and a
 self-contained inline fileset that seeds the agent's home. Copy its `lns.yaml`
 into your project and `lns run`.
 


### PR DESCRIPTION
Stage 1 of the plan on #167 (does not close it — the pre-boot card is stage 2).

## What

The claude-code example declared `claude-code-subscription` as a bare `spec.connectors` id. Since `219ac29c` (shipped in `lns-v0.16.0`) a bare id is disclosure only — never armed, never seeded — so the example boots to Claude Code's "Not logged in · Run /login" with no card and no way forward except a manual workaround.

This switches the example to the honest contract for a workload that gates on a locally-resolved token: a **required `spec.credentials` slot**.

```yaml
credentials:
  - name: claude-code-subscription
    env: CLAUDE_CODE_OAUTH_TOKEN
    required: true
```

## Behavior (all machinery already shipped in 0.16.0)

- **Unbound machine:** the launch is refused before any microVM boots, with the bind instruction — `lns connector connect claude-code-subscription` — which opens the approval-window value card (mint via `claude setup-token`, paste, or accept a detected host value). Run again and it boots logged in.
- **Bound machine:** the placeholder seeds at fork; the boundary splices the real value into requests to `api.anthropic.com`. The real token never enters the guest.

The README's stale first-run description ("an approval card asks…") is rewritten to match this flow, and the `running-workloads.md` cross-reference updated. Stage 2 on #167 (pre-boot setup-token card raised by `lns run` itself, per-workload grants) later collapses the refusal + connect + re-run round-trip into a single card.

## Testing

- `lns push --dry-run` against the installed release `lns 0.16.0` parses and validates the updated definition ("built and validated; nothing uploaded").
- Docs-only change; pre-push hook (lint:md, build, lint, test, complexity) green.
