### PR TITLE
feat(service): raise the pre-boot value card for required credential slots

### DIFF
--- a/crates/lns-service/src/artifact/credential_boot.rs
+++ b/crates/lns-service/src/artifact/credential_boot.rs
@@ -1,11 +1,6 @@
 use lns_artifact::spec::CredentialSlot;
-use lns_policy::connectors::{AuthKind, Connector};
+use lns_policy::connectors::{AuthKind, Connector, TokenFallback};
 use lns_policy::credentials::{CredentialStateFile, has_armed_entry};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Binding {
-    pub placeholder: String,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectPrompt {
@@ -14,65 +9,76 @@ pub struct ConnectPrompt {
     pub required: bool,
 }
 
+/// The pre-boot value card for a required credential-kind slot with no bound value on this machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SlotPlan {
-    Armed { env: String, placeholder: String },
-    Connect(ConnectPrompt),
+pub struct ValuePrompt {
+    pub connector: String,
+    pub env: String,
+    pub token_fallback: Option<TokenFallback>,
+    pub injection_domains: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BootGate {
-    StartWorkload,
-    AwaitConnect,
+/// What the launch gate does for one required slot: boot silently, block on a card, or refuse outright.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlotGatePlan {
+    Armed { connector: String, env: String },
+    NeedsValue(ValuePrompt),
+    NeedsSignIn(ConnectPrompt),
+    Refused(RequiredSlotFailure),
 }
 
-pub fn plan_slot(slot: &CredentialSlot, binding: Option<Binding>) -> SlotPlan {
-    match binding {
-        Some(binding) => SlotPlan::Armed {
-            env: slot.env.clone(),
-            placeholder: binding.placeholder,
-        },
-        None => SlotPlan::Connect(ConnectPrompt {
-            connector: slot.name.clone(),
-            env: slot.env.clone(),
-            required: slot.required,
-        }),
-    }
-}
-
-/// Plan each launch-gated id (a definition's required credential slots): an `oauth` id with no armed machine grant blocks the boot on a required connect (the sign-in), while a credential id stays armed — its consent gate is the reactive per-machine value decision at first use. Ids the catalog lacks are the unknown-id refusal's job, not this gate's.
-pub fn plan_declared_connectors(
-    declared: &[String],
+/// Plan each required credential slot against this machine's store: a bound slot arms, an unbound oauth-kind slot blocks on the sign-in, an unbound credential-kind slot blocks on the value card, and a machine-denied or bindless one refuses. The slot's `env` (a remap of the catalog default) is carried into every prompt; ids the catalog lacks are the unknown-id refusal's job, and duplicate `(name, env)` slots plan once.
+pub fn plan_required_slots(
+    slots: &[CredentialSlot],
     catalog: &[Connector],
     state: &CredentialStateFile,
-) -> Vec<SlotPlan> {
-    declared
+) -> Vec<SlotGatePlan> {
+    let mut seen = std::collections::HashSet::new();
+    slots
         .iter()
-        .filter_map(|id| catalog.iter().find(|integ| &integ.id == id))
-        .map(|integ| {
-            let (env, placeholder) = match (&integ.oauth, &integ.credential) {
-                (Some(o), _) => (o.env_var.clone(), o.placeholder.clone()),
-                (None, Some(c)) => (c.env_var.clone(), c.placeholder.clone()),
-                (None, None) => (String::new(), String::new()),
-            };
-            if integ.auth_kind == AuthKind::Oauth && !has_armed_entry(state, &integ.id) {
-                SlotPlan::Connect(ConnectPrompt {
-                    connector: integ.id.clone(),
-                    env,
-                    required: true,
-                })
-            } else {
-                SlotPlan::Armed { env, placeholder }
-            }
+        .filter(|s| s.required)
+        .filter(|s| seen.insert((s.name.clone(), s.env.clone())))
+        .filter_map(|s| {
+            catalog
+                .iter()
+                .find(|integ| integ.id == s.name)
+                .map(|integ| plan_one(s, integ, state))
         })
         .collect()
 }
 
-pub fn boot_gate(plans: &[SlotPlan]) -> BootGate {
-    if plans.iter().all(|p| matches!(p, SlotPlan::Armed { .. })) {
-        BootGate::StartWorkload
-    } else {
-        BootGate::AwaitConnect
+fn plan_one(slot: &CredentialSlot, integ: &Connector, state: &CredentialStateFile) -> SlotGatePlan {
+    let armed = || SlotGatePlan::Armed {
+        connector: slot.name.clone(),
+        env: slot.env.clone(),
+    };
+    match integ.auth_kind {
+        AuthKind::Oauth if has_armed_entry(state, &integ.id) => armed(),
+        AuthKind::Oauth => SlotGatePlan::NeedsSignIn(ConnectPrompt {
+            connector: slot.name.clone(),
+            env: slot.env.clone(),
+            required: true,
+        }),
+        AuthKind::Credential if denied_on_machine(state, &integ.id) => {
+            SlotGatePlan::Refused(RequiredSlotFailure::Denied {
+                connector: slot.name.clone(),
+                env: slot.env.clone(),
+            })
+        }
+        AuthKind::Credential if binds_for_launch(state, &integ.id) => armed(),
+        AuthKind::Credential => match &integ.credential {
+            Some(cred) => SlotGatePlan::NeedsValue(ValuePrompt {
+                connector: slot.name.clone(),
+                env: slot.env.clone(),
+                token_fallback: integ.token_fallback.clone(),
+                injection_domains: cred.injections.iter().map(|i| i.domain.clone()).collect(),
+            }),
+            // A bindless entry has no value to collect, so a card could never unblock it.
+            None => SlotGatePlan::Refused(RequiredSlotFailure::Unbound {
+                connector: slot.name.clone(),
+                env: slot.env.clone(),
+            }),
+        },
     }
 }
 
@@ -103,17 +109,6 @@ pub fn resolve_connect(prompt: &ConnectPrompt, choice: ConnectChoice) -> SlotOut
     }
 }
 
-/// The ids the sign-in gate plans: only the definition's required credential slots, deduplicated in declaration order. A bare `spec.connectors` id is disclosure, not a launch contract — it is never force-armed and so never blocks the boot; its consent is the reactive connect offer on first use.
-pub fn sign_in_gate_ids(slots: &[CredentialSlot]) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    slots
-        .iter()
-        .filter(|s| s.required)
-        .map(|s| s.name.clone())
-        .filter(|id| seen.insert(id.clone()))
-        .collect()
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequiredSlotFailure {
     Unbound { connector: String, env: String },
@@ -137,6 +132,13 @@ impl RequiredSlotFailure {
     }
 }
 
+fn denied_on_machine(state: &CredentialStateFile, id: &str) -> bool {
+    matches!(
+        state.get(id),
+        Some(lns_policy::credentials::CredentialEntry::Deny)
+    )
+}
+
 /// True when a value decision arms the slot for a launch: a stored or oauth value, or host-detect (the decision exists; the value arms at the boundary at request time).
 fn binds_for_launch(state: &CredentialStateFile, id: &str) -> bool {
     matches!(
@@ -145,33 +147,23 @@ fn binds_for_launch(state: &CredentialStateFile, id: &str) -> bool {
     ) || has_armed_entry(state, id)
 }
 
-/// Fail a required credential-kind slot fast — before any microVM boots — when this machine has no armed value for it (or has denied it, a distinct refusal). Oauth-kind slots defer to the sign-in gate and ids the catalog lacks to the unknown-id refusal.
+/// The headless view of [`plan_required_slots`]: with no window to card, an unbound required credential-kind slot fails fast — before any microVM boots — exactly as a machine-denied or bindless one does.
 pub fn gate_required_slots(
     slots: &[CredentialSlot],
     catalog: &[Connector],
     state: &CredentialStateFile,
 ) -> Result<(), RequiredSlotFailure> {
-    for slot in slots.iter().filter(|s| s.required) {
-        let Some(integ) = catalog.iter().find(|i| i.id == slot.name) else {
-            continue;
-        };
-        if integ.auth_kind == AuthKind::Oauth {
-            continue;
+    for plan in plan_required_slots(slots, catalog, state) {
+        match plan {
+            SlotGatePlan::NeedsValue(prompt) => {
+                return Err(RequiredSlotFailure::Unbound {
+                    connector: prompt.connector,
+                    env: prompt.env,
+                });
+            }
+            SlotGatePlan::Refused(failure) => return Err(failure),
+            SlotGatePlan::Armed { .. } | SlotGatePlan::NeedsSignIn(_) => {}
         }
-        if binds_for_launch(state, &slot.name) {
-            continue;
-        }
-        let failure = match state.get(&slot.name) {
-            Some(lns_policy::credentials::CredentialEntry::Deny) => RequiredSlotFailure::Denied {
-                connector: slot.name.clone(),
-                env: slot.env.clone(),
-            },
-            _ => RequiredSlotFailure::Unbound {
-                connector: slot.name.clone(),
-                env: slot.env.clone(),
-            },
-        };
-        return Err(failure);
     }
     Ok(())
 }
@@ -222,34 +214,92 @@ mod tests {
             credential: Some(lns_policy::connectors::CredentialAuth {
                 env_var: env.into(),
                 placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-                injections: Vec::new(),
+                injections: vec![lns_policy::providers::InjectionDef {
+                    kind: lns_policy::providers::InjectionKind::BearerHeader,
+                    domain: "api.some-provider.example".into(),
+                    header: None,
+                }],
             }),
             oauth: None,
-            token_fallback: None,
+            token_fallback: Some(TokenFallback {
+                help: Some("https://docs.example.test/token".into()),
+                command: Some("some-cli setup-token".into()),
+            }),
+        }
+    }
+
+    fn required_slot(name: &str, env: &str) -> CredentialSlot {
+        CredentialSlot {
+            name: name.into(),
+            env: env.into(),
+            required: true,
+        }
+    }
+
+    fn stored(value: &str) -> lns_policy::credentials::CredentialEntry {
+        lns_policy::credentials::CredentialEntry::Stored {
+            value: value.into(),
+        }
+    }
+
+    fn value_env(plan: &SlotGatePlan) -> Option<&str> {
+        match plan {
+            SlotGatePlan::NeedsValue(prompt) => Some(&prompt.env),
+            _ => None,
         }
     }
 
     #[test]
-    fn a_declared_oauth_connector_without_a_grant_blocks_on_a_required_connect() {
+    fn an_unbound_required_credential_slot_plans_the_value_card() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let plans = plan_required_slots(&[slot(true)], &catalog, &CredentialStateFile::new());
+        assert_eq!(
+            plans,
+            vec![SlotGatePlan::NeedsValue(ValuePrompt {
+                connector: "some-provider".into(),
+                env: "SOME_TOKEN".into(),
+                token_fallback: Some(TokenFallback {
+                    help: Some("https://docs.example.test/token".into()),
+                    command: Some("some-cli setup-token".into()),
+                }),
+                injection_domains: vec!["api.some-provider.example".into()],
+            })],
+            "the card carries the mint instructions and the domains the value reaches"
+        );
+    }
+
+    #[test]
+    fn the_value_card_carries_the_slots_env_remap_not_the_catalog_default() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let plans = plan_required_slots(
+            &[required_slot("some-provider", "PROVIDER_KEY")],
+            &catalog,
+            &CredentialStateFile::new(),
+        );
+        let envs: Vec<&str> = plans.iter().filter_map(value_env).collect();
+        assert_eq!(envs, vec!["PROVIDER_KEY"], "got: {plans:?}");
+    }
+
+    #[test]
+    fn the_sign_in_prompt_carries_the_slots_env_remap_not_the_catalog_default() {
         let catalog = vec![oauth_connector("some-oauth", "SOME_OAUTH_TOKEN")];
-        let plans = plan_declared_connectors(
-            &["some-oauth".to_string()],
+        let plans = plan_required_slots(
+            &[required_slot("some-oauth", "OAUTH_KEY")],
             &catalog,
             &CredentialStateFile::new(),
         );
         assert_eq!(
             plans,
-            vec![SlotPlan::Connect(ConnectPrompt {
+            vec![SlotGatePlan::NeedsSignIn(ConnectPrompt {
                 connector: "some-oauth".into(),
-                env: "SOME_OAUTH_TOKEN".into(),
+                env: "OAUTH_KEY".into(),
                 required: true,
             })]
         );
-        assert_eq!(boot_gate(&plans), BootGate::AwaitConnect);
     }
 
     #[test]
-    fn a_declared_oauth_connector_with_a_machine_grant_is_armed() {
+    fn an_oauth_slot_with_a_machine_grant_arms_without_a_prompt() {
         let catalog = vec![oauth_connector("some-oauth", "SOME_OAUTH_TOKEN")];
         let mut state = CredentialStateFile::new();
         state.insert(
@@ -262,30 +312,79 @@ mod tests {
                 account: None,
             },
         );
-        let plans = plan_declared_connectors(&["some-oauth".to_string()], &catalog, &state);
-        assert_eq!(boot_gate(&plans), BootGate::StartWorkload);
-    }
-
-    #[test]
-    fn a_declared_credential_connector_never_blocks_the_boot() {
-        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
-        let plans = plan_declared_connectors(
-            &["some-provider".to_string()],
+        let plans = plan_required_slots(
+            &[required_slot("some-oauth", "SOME_OAUTH_TOKEN")],
             &catalog,
-            &CredentialStateFile::new(),
+            &state,
         );
         assert_eq!(
             plans,
-            vec![SlotPlan::Armed {
-                env: "SOME_TOKEN".into(),
-                placeholder: "some-provider-LNSPLACEHOLDER0000".into(),
-            }],
-            "a credential id's consent gate is the reactive value decision, not the boot"
+            vec![SlotGatePlan::Armed {
+                connector: "some-oauth".into(),
+                env: "SOME_OAUTH_TOKEN".into(),
+            }]
         );
     }
 
     #[test]
-    fn a_blockless_catalog_entry_arms_as_a_no_op_instead_of_blocking() {
+    fn a_bound_or_host_detect_credential_slot_arms_without_a_prompt() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let mut state = CredentialStateFile::new();
+        state.insert("some-provider".into(), stored("some-secret"));
+        let armed = vec![SlotGatePlan::Armed {
+            connector: "some-provider".into(),
+            env: "SOME_TOKEN".into(),
+        }];
+        assert_eq!(plan_required_slots(&[slot(true)], &catalog, &state), armed);
+        state.insert(
+            "some-provider".into(),
+            lns_policy::credentials::CredentialEntry::HostDetect,
+        );
+        let plans = plan_required_slots(&[slot(true)], &catalog, &state);
+        assert_eq!(
+            plans, armed,
+            "a host-detect decision exists; it arms at the boundary at request time"
+        );
+        assert_eq!(
+            plans.iter().filter_map(value_env).count(),
+            0,
+            "an armed plan raises no value card"
+        );
+    }
+
+    #[test]
+    fn an_empty_stored_value_still_plans_the_value_card() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let mut state = CredentialStateFile::new();
+        state.insert("some-provider".into(), stored(""));
+        let plans = plan_required_slots(&[slot(true)], &catalog, &state);
+        assert!(
+            matches!(plans.as_slice(), [SlotGatePlan::NeedsValue(_)]),
+            "an empty value cannot arm the boundary: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn a_machine_denied_credential_refuses_instead_of_carding() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let mut state = CredentialStateFile::new();
+        state.insert(
+            "some-provider".into(),
+            lns_policy::credentials::CredentialEntry::Deny,
+        );
+        let plans = plan_required_slots(&[slot(true)], &catalog, &state);
+        assert_eq!(
+            plans,
+            vec![SlotGatePlan::Refused(RequiredSlotFailure::Denied {
+                connector: "some-provider".into(),
+                env: "SOME_TOKEN".into(),
+            })],
+            "a machine-wide deny is an explicit standing decision, not a prompt to re-ask on every launch"
+        );
+    }
+
+    #[test]
+    fn a_bindless_catalog_entry_refuses_because_no_card_could_unblock_it() {
         let catalog = vec![Connector {
             id: "some-blockless".into(),
             name: None,
@@ -295,42 +394,53 @@ mod tests {
             oauth: None,
             token_fallback: None,
         }];
-        let plans = plan_declared_connectors(
-            &["some-blockless".to_string()],
+        let plans = plan_required_slots(
+            &[required_slot("some-blockless", "SOME_TOKEN")],
             &catalog,
             &CredentialStateFile::new(),
         );
         assert_eq!(
             plans,
-            vec![SlotPlan::Armed {
-                env: String::new(),
-                placeholder: String::new(),
-            }],
-            "an entry the catalog validator would refuse must never block a boot"
+            vec![SlotGatePlan::Refused(RequiredSlotFailure::Unbound {
+                connector: "some-blockless".into(),
+                env: "SOME_TOKEN".into(),
+            })]
         );
-        assert_eq!(boot_gate(&plans), BootGate::StartWorkload);
     }
 
     #[test]
-    fn an_id_the_catalog_lacks_is_skipped_by_the_gate() {
-        let plans = plan_declared_connectors(
-            &["some-unknown".to_string()],
-            &[],
+    fn an_optional_slot_never_plans_a_gate() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        assert!(
+            plan_required_slots(&[slot(false)], &catalog, &CredentialStateFile::new()).is_empty(),
+            "an unbound optional slot runs reactively"
+        );
+    }
+
+    #[test]
+    fn a_slot_the_catalog_lacks_is_skipped_as_the_unknown_id_refusals_job() {
+        let plans = plan_required_slots(&[slot(true)], &[], &CredentialStateFile::new());
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn duplicate_slots_plan_once_but_distinct_env_remaps_plan_separately() {
+        let catalog = vec![credential_connector("some-provider", "SOME_TOKEN")];
+        let plans = plan_required_slots(
+            &[
+                required_slot("some-provider", "SOME_TOKEN"),
+                required_slot("some-provider", "SOME_TOKEN"),
+                required_slot("some-provider", "PROVIDER_KEY"),
+            ],
+            &catalog,
             &CredentialStateFile::new(),
         );
-        assert!(plans.is_empty(), "unknown ids are the refusal's job");
-    }
-
-    #[test]
-    fn an_unbound_slot_forms_a_connect_prompt_that_discloses_its_target() {
-        let plan = plan_slot(&slot(true), None);
+        assert_eq!(plans.len(), 2, "got: {plans:?}");
+        let envs: Vec<&str> = plans.iter().filter_map(value_env).collect();
         assert_eq!(
-            plan,
-            SlotPlan::Connect(ConnectPrompt {
-                connector: "some-provider".into(),
-                env: "SOME_TOKEN".into(),
-                required: true,
-            })
+            envs,
+            vec!["SOME_TOKEN", "PROVIDER_KEY"],
+            "identical (name, env) slots coalesce; a distinct remap is its own capability"
         );
     }
 
@@ -344,27 +454,6 @@ mod tests {
         let outcome = resolve_connect(&prompt, ConnectChoice::Connect);
         assert_eq!(outcome, SlotOutcome::Connected);
         assert!(outcome.starts_workload());
-    }
-
-    #[test]
-    fn a_bound_slot_arms_under_its_env_without_a_prompt() {
-        let plan = plan_slot(
-            &slot(true),
-            Some(Binding {
-                placeholder: "some-provider-LNSPLACEHOLDER0000".into(),
-            }),
-        );
-        assert_eq!(
-            plan,
-            SlotPlan::Armed {
-                env: "SOME_TOKEN".into(),
-                placeholder: "some-provider-LNSPLACEHOLDER0000".into(),
-            }
-        );
-        assert_eq!(
-            boot_gate(std::slice::from_ref(&plan)),
-            BootGate::StartWorkload
-        );
     }
 
     #[test]
@@ -389,44 +478,6 @@ mod tests {
         let outcome = resolve_connect(&prompt, ConnectChoice::Decline);
         assert_eq!(outcome, SlotOutcome::LeftUnbound);
         assert!(outcome.starts_workload());
-    }
-
-    fn stored(value: &str) -> lns_policy::credentials::CredentialEntry {
-        lns_policy::credentials::CredentialEntry::Stored {
-            value: value.into(),
-        }
-    }
-
-    #[test]
-    fn sign_in_gate_ids_are_the_required_slots_only_once_each() {
-        let slots = vec![
-            CredentialSlot {
-                name: "some-oauth".into(),
-                env: "SOME_OAUTH_TOKEN".into(),
-                required: true,
-            },
-            CredentialSlot {
-                name: "some-oauth".into(),
-                env: "SOME_OAUTH_TOKEN".into(),
-                required: true,
-            },
-            CredentialSlot {
-                name: "other-provider".into(),
-                env: "OTHER_TOKEN".into(),
-                required: true,
-            },
-            CredentialSlot {
-                name: "optional-provider".into(),
-                env: "OPTIONAL_TOKEN".into(),
-                required: false,
-            },
-        ];
-        assert_eq!(
-            sign_in_gate_ids(&slots),
-            vec!["some-oauth".to_string(), "other-provider".to_string()],
-            "required slots join once; an optional slot never blocks a sign-in; a bare declared id never gates"
-        );
-        assert!(sign_in_gate_ids(&[]).is_empty());
     }
 
     #[test]
@@ -518,11 +569,7 @@ mod tests {
     #[test]
     fn a_required_oauth_slot_defers_to_the_sign_in_gate() {
         let catalog = vec![oauth_connector("some-oauth", "SOME_OAUTH_TOKEN")];
-        let slots = vec![CredentialSlot {
-            name: "some-oauth".into(),
-            env: "SOME_OAUTH_TOKEN".into(),
-            required: true,
-        }];
+        let slots = vec![required_slot("some-oauth", "SOME_OAUTH_TOKEN")];
         assert_eq!(
             gate_required_slots(&slots, &catalog, &CredentialStateFile::new()),
             Ok(()),
@@ -532,11 +579,7 @@ mod tests {
 
     #[test]
     fn a_slot_the_catalog_lacks_is_the_unknown_id_refusals_job() {
-        let slots = vec![CredentialSlot {
-            name: "some-unknown".into(),
-            env: "SOME_TOKEN".into(),
-            required: true,
-        }];
+        let slots = vec![required_slot("some-unknown", "SOME_TOKEN")];
         assert_eq!(
             gate_required_slots(&slots, &[], &CredentialStateFile::new()),
             Ok(()),

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -128,28 +128,88 @@ pub(crate) fn refuse_unknown_connectors(
     anyhow::bail!(crate::credential_flow::connectors::unknown_connectors_refusal(&unknown))
 }
 
-/// Refuse a launch whose definition requires a credential slot this machine has not bound (or has denied) — before any microVM boots.
-pub(crate) fn refuse_unbound_required_credentials(
+const LAUNCH_VALUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Gate a definition's required credential slots before any microVM boots: with the approval window present each unbound slot raises its value card; headless — or machine-denied — falls back to the fail-fast refusal.
+pub(crate) async fn gate_required_value_slots(
     credentials: &[lns_artifact::spec::CredentialSlot],
+    frame_tx: &tokio::sync::mpsc::Sender<lns_ipc::WireFrame>,
 ) -> Result<()> {
+    use crate::artifact::credential_boot::{
+        SlotGatePlan, ValuePrompt, gate_required_slots, plan_required_slots,
+    };
+    use crate::credential_flow::launch_gate::{ValueCardDeps, gate_value_prompts};
+    use crate::credential_flow::store::{
+        CredentialStore, JsonFileCredentialStore, default_credentials_path,
+    };
+
     if credentials.iter().all(|slot| !slot.required) {
         return Ok(());
     }
     let catalog = effective_machine_catalog();
-    let state = {
-        use crate::credential_flow::store::{
-            CredentialStore, JsonFileCredentialStore, default_credentials_path,
-        };
-        JsonFileCredentialStore::new(default_credentials_path())
-            .load()
-            .unwrap_or_default()
+    let store = JsonFileCredentialStore::new(default_credentials_path());
+    let state = store.load().unwrap_or_default();
+    let window = crate::tray::display_present()
+        .then(crate::approval_flow::window::get)
+        .flatten();
+    let Some(window) = window else {
+        if let Err(failure) = gate_required_slots(credentials, &catalog, &state) {
+            anyhow::bail!(failure.as_message());
+        }
+        return Ok(());
     };
-    if let Err(failure) =
-        crate::artifact::credential_boot::gate_required_slots(credentials, &catalog, &state)
-    {
-        anyhow::bail!(failure.as_message());
+    let mut prompts = Vec::new();
+    for plan in plan_required_slots(credentials, &catalog, &state) {
+        match plan {
+            SlotGatePlan::Refused(failure) => anyhow::bail!(failure.as_message()),
+            SlotGatePlan::NeedsValue(prompt) => prompts.push(prompt),
+            SlotGatePlan::Armed { .. } | SlotGatePlan::NeedsSignIn(_) => {}
+        }
     }
-    Ok(())
+    if prompts.is_empty() {
+        return Ok(());
+    }
+    let announce_tx = frame_tx.clone();
+    let deps = ValueCardDeps {
+        window: &window,
+        store: &store,
+        wait: LAUNCH_VALUE_TIMEOUT,
+        host_value_available: &|prompt: &ValuePrompt| host_value_available(&catalog, prompt),
+        announce: &move |msg: &str| {
+            let _ = announce_tx.try_send(lns_ipc::WireFrame::Json(lns_ipc::Response::RunLog {
+                level: lns_ipc::LogLevel::Info,
+                verb: None,
+                message: msg.to_string(),
+            }));
+        },
+        repaint: &|| {
+            if let Some(ctx) = crate::approval_flow::window::ctx() {
+                ctx.request_repaint();
+            }
+        },
+    };
+    gate_value_prompts(&prompts, &deps)
+        .await
+        .map_err(|reason| anyhow::anyhow!(reason))
+}
+
+fn host_value_available(
+    catalog: &[lns_policy::connectors::Connector],
+    prompt: &crate::artifact::credential_boot::ValuePrompt,
+) -> bool {
+    use crate::credential_flow::providers::{DefProvider, Provider};
+    catalog
+        .iter()
+        .find(|integ| integ.id == prompt.connector)
+        .and_then(|integ| integ.credential.as_ref())
+        .map(|cred| lns_policy::providers::ProviderDef {
+            id: prompt.connector.clone(),
+            env_var: prompt.env.clone(),
+            placeholder: cred.placeholder.clone(),
+            injections: cred.injections.clone(),
+        })
+        .and_then(|def| DefProvider::new(def).detector().detect())
+        .is_some()
 }
 
 fn effective_machine_catalog() -> Vec<lns_policy::connectors::Connector> {

--- a/crates/lns-service/src/credential_flow/launch_gate.rs
+++ b/crates/lns-service/src/credential_flow/launch_gate.rs
@@ -1,0 +1,526 @@
+//! The launch-triggered origin of the value card: unlike a request-triggered `CredentialPending`, there is no held request to release — the decision gates the boot itself.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::approval_flow::window::WindowState;
+use crate::artifact::credential_boot::ValuePrompt;
+use crate::credential_flow::session::{CredentialDecisionRequest, CredentialPendingPrompt};
+use lns_policy::credentials::{CredentialEntry, CredentialStore};
+
+pub fn launch_prompt(prompt: &ValuePrompt) -> CredentialPendingPrompt {
+    CredentialPendingPrompt {
+        id: format!("launch-{}-{}", prompt.connector, prompt.env),
+        credential_id: prompt.connector.clone(),
+        action: format!(
+            "provide the \"{}\" credential this sandbox requires",
+            prompt.connector
+        ),
+        oauth_display_name: None,
+        token_fallback: prompt.token_fallback.clone(),
+        env_var: Some(prompt.env.clone()),
+        injection_domains: prompt.injection_domains.clone(),
+        is_project_defined: true,
+    }
+}
+
+/// A saved value persists to the per-machine store and the boot proceeds; a decline or timeout aborts the launch and persists nothing — a launch-origin deny is never a machine-wide `Deny`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LaunchResolution {
+    Persist(CredentialEntry),
+    Abort(String),
+}
+
+pub fn resolve_launch_decision(
+    connector: &str,
+    request: CredentialDecisionRequest,
+) -> LaunchResolution {
+    match request {
+        CredentialDecisionRequest::Allow(CredentialEntry::Deny)
+        | CredentialDecisionRequest::Deny => LaunchResolution::Abort(format!(
+            "the \"{connector}\" credential this sandbox requires was declined; launch aborted"
+        )),
+        CredentialDecisionRequest::Allow(entry) => LaunchResolution::Persist(entry),
+        CredentialDecisionRequest::Timeout => LaunchResolution::Abort(format!(
+            "the \"{connector}\" value decision timed out; launch aborted"
+        )),
+    }
+}
+
+pub struct ValueCardDeps<'a> {
+    pub window: &'a WindowState,
+    pub store: &'a dyn CredentialStore,
+    pub wait: Duration,
+    pub host_value_available: &'a (dyn Fn(&ValuePrompt) -> bool + Sync),
+    pub announce: &'a (dyn Fn(&str) + Sync),
+    pub repaint: &'a (dyn Fn() + Sync),
+}
+
+/// Block the boot on each unbound required slot's value card in declaration order; the first decline, timeout, duplicate card, or store failure aborts the launch.
+pub async fn gate_value_prompts(
+    prompts: &[ValuePrompt],
+    deps: &ValueCardDeps<'_>,
+) -> Result<(), String> {
+    for prompt in prompts {
+        gate_one(prompt, deps).await?;
+    }
+    Ok(())
+}
+
+async fn gate_one(prompt: &ValuePrompt, deps: &ValueCardDeps<'_>) -> Result<(), String> {
+    let card = launch_prompt(prompt);
+    let card_id = card.id.clone();
+    let (decision_tx, mut decision_rx) = mpsc::unbounded_channel();
+    let inserted = deps.window.try_insert_credential_pending(
+        card,
+        (deps.host_value_available)(prompt),
+        decision_tx,
+    );
+    if !inserted {
+        return Err(format!(
+            "a value decision for \"{}\" is already pending in the approval window",
+            prompt.connector
+        ));
+    }
+    (deps.repaint)();
+    (deps.announce)(&format!(
+        "the \"{}\" credential is required before the workload starts — waiting for the value decision in the Lens Sandbox window",
+        prompt.connector
+    ));
+    let request = match tokio::time::timeout(deps.wait, decision_rx.recv()).await {
+        Ok(Some(delivery)) => delivery.request,
+        Ok(None) | Err(_) => {
+            deps.window.remove_credential_pending(&card_id);
+            CredentialDecisionRequest::Timeout
+        }
+    };
+    match resolve_launch_decision(&prompt.connector, request) {
+        LaunchResolution::Persist(entry) => persist(deps.store, &prompt.connector, entry),
+        LaunchResolution::Abort(reason) => Err(reason),
+    }
+}
+
+fn persist(store: &dyn CredentialStore, id: &str, entry: CredentialEntry) -> Result<(), String> {
+    let mut state = store
+        .load()
+        .map_err(|e| format!("reading the credential store failed: {e}"))?;
+    state.insert(id.to_string(), entry);
+    store
+        .save(&state)
+        .map_err(|e| format!("storing the value decision failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lns_policy::connectors::TokenFallback;
+    use lns_policy::credentials::CredentialStateFile;
+    use std::sync::Mutex;
+
+    fn value_prompt(connector: &str, env: &str) -> ValuePrompt {
+        ValuePrompt {
+            connector: connector.into(),
+            env: env.into(),
+            token_fallback: Some(TokenFallback {
+                help: Some("https://docs.example.test/token".into()),
+                command: Some("some-cli setup-token".into()),
+            }),
+            injection_domains: vec!["api.some-provider.example".into()],
+        }
+    }
+
+    #[derive(Default)]
+    struct MemStore {
+        state: Mutex<CredentialStateFile>,
+        fail_load: bool,
+        fail_save: bool,
+    }
+
+    impl CredentialStore for MemStore {
+        fn load(&self) -> std::io::Result<CredentialStateFile> {
+            if self.fail_load {
+                return Err(std::io::Error::other("store unreadable"));
+            }
+            Ok(self.state.lock().unwrap().clone())
+        }
+        fn save(&self, state: &CredentialStateFile) -> std::io::Result<()> {
+            if self.fail_save {
+                return Err(std::io::Error::other("disk full"));
+            }
+            *self.state.lock().unwrap() = state.clone();
+            Ok(())
+        }
+    }
+
+    struct Rig {
+        window: std::sync::Arc<WindowState>,
+        store: MemStore,
+        announced: Mutex<Vec<String>>,
+        repaints: Mutex<usize>,
+    }
+
+    impl Rig {
+        fn new() -> Self {
+            Self {
+                window: WindowState::new(),
+                store: MemStore::default(),
+                announced: Mutex::new(Vec::new()),
+                repaints: Mutex::new(0),
+            }
+        }
+
+        async fn run(
+            &self,
+            prompts: &[ValuePrompt],
+            decide: impl AsyncFn(&WindowState),
+        ) -> Result<(), String> {
+            let deps = ValueCardDeps {
+                window: &self.window,
+                store: &self.store,
+                wait: Duration::from_secs(5),
+                host_value_available: &|_| false,
+                announce: &|msg| self.announced.lock().unwrap().push(msg.to_string()),
+                repaint: &|| *self.repaints.lock().unwrap() += 1,
+            };
+            let gate = gate_value_prompts(prompts, &deps);
+            let (outcome, ()) = tokio::join!(gate, decide(&self.window));
+            outcome
+        }
+    }
+
+    async fn visible_card(
+        window: &WindowState,
+    ) -> crate::approval_flow::window::CredentialCardPrompt {
+        let mut card = None;
+        for _ in 0..1000 {
+            card = window.snapshot().pending_credentials.first().cloned();
+            if card.is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        card.expect("no value card became visible")
+    }
+
+    fn abort_reason(resolution: LaunchResolution) -> Option<String> {
+        match resolution {
+            LaunchResolution::Abort(reason) => Some(reason),
+            LaunchResolution::Persist(_) => None,
+        }
+    }
+
+    #[test]
+    fn the_launch_prompt_is_its_own_origin_not_a_synthetic_wire_event() {
+        let card = launch_prompt(&value_prompt("some-provider", "PROVIDER_KEY"));
+        assert_eq!(card.id, "launch-some-provider-PROVIDER_KEY");
+        assert_eq!(card.credential_id, "some-provider");
+        assert_eq!(
+            card.env_var.as_deref(),
+            Some("PROVIDER_KEY"),
+            "the card discloses the slot's env remap, not the catalog default"
+        );
+        assert!(
+            card.action.contains("this sandbox requires"),
+            "{}",
+            card.action
+        );
+        assert_eq!(card.oauth_display_name, None);
+        assert!(
+            card.is_project_defined,
+            "the requirement comes from the sandbox definition"
+        );
+        assert!(
+            card.token_fallback.is_some(),
+            "the card shows how to mint the value"
+        );
+        assert_eq!(
+            card.injection_domains,
+            vec!["api.some-provider.example".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_saved_value_resolves_to_persist() {
+        let entry = CredentialEntry::Stored {
+            value: "some-secret".into(),
+        };
+        let resolution = resolve_launch_decision(
+            "some-provider",
+            CredentialDecisionRequest::Allow(entry.clone()),
+        );
+        assert_eq!(resolution, LaunchResolution::Persist(entry));
+        assert_eq!(
+            abort_reason(resolution),
+            None,
+            "a saved value must not abort the launch"
+        );
+    }
+
+    #[test]
+    fn a_host_detect_choice_resolves_to_persist() {
+        assert_eq!(
+            resolve_launch_decision(
+                "some-provider",
+                CredentialDecisionRequest::Allow(CredentialEntry::HostDetect)
+            ),
+            LaunchResolution::Persist(CredentialEntry::HostDetect)
+        );
+    }
+
+    #[test]
+    fn a_decline_aborts_the_launch_naming_the_connector() {
+        let reason = abort_reason(resolve_launch_decision(
+            "some-provider",
+            CredentialDecisionRequest::Deny,
+        ))
+        .expect("a decline must abort");
+        assert!(reason.contains("\"some-provider\""), "{reason}");
+        assert!(reason.contains("launch aborted"), "{reason}");
+    }
+
+    #[test]
+    fn an_allow_carrying_a_deny_entry_still_aborts_instead_of_persisting_it() {
+        let resolution = resolve_launch_decision(
+            "some-provider",
+            CredentialDecisionRequest::Allow(CredentialEntry::Deny),
+        );
+        let aborts = matches!(resolution, LaunchResolution::Abort(_));
+        assert!(
+            aborts,
+            "a launch-origin decision must never write a machine-wide deny"
+        );
+    }
+
+    #[test]
+    fn a_timeout_aborts_the_launch_distinctly() {
+        let reason = abort_reason(resolve_launch_decision(
+            "some-provider",
+            CredentialDecisionRequest::Timeout,
+        ))
+        .expect("a timeout must abort");
+        assert!(reason.contains("timed out"), "{reason}");
+    }
+
+    #[tokio::test]
+    async fn saving_a_value_on_the_card_persists_it_and_lets_the_boot_proceed() {
+        let rig = Rig::new();
+        let outcome = rig
+            .run(&[value_prompt("some-provider", "SOME_TOKEN")], async |w| {
+                let card = visible_card(w).await;
+                assert!(!card.host_value_available);
+                w.decide_credential(
+                    &card.id,
+                    CredentialDecisionRequest::Allow(CredentialEntry::Stored {
+                        value: "some-secret".into(),
+                    }),
+                );
+            })
+            .await;
+        assert_eq!(outcome, Ok(()));
+        assert_eq!(
+            rig.store.state.lock().unwrap().get("some-provider"),
+            Some(&CredentialEntry::Stored {
+                value: "some-secret".into()
+            })
+        );
+        assert!(
+            rig.window.snapshot().pending_credentials.is_empty(),
+            "the decided card leaves the window"
+        );
+        assert_eq!(
+            *rig.repaints.lock().unwrap(),
+            1,
+            "the inserted card repaints the window"
+        );
+        let announced = rig.announced.lock().unwrap();
+        assert_eq!(announced.len(), 1);
+        let message = announced[0].clone();
+        assert!(message.contains("\"some-provider\""), "{message}");
+        assert!(message.contains("before the workload starts"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn declining_the_card_aborts_the_launch_without_a_machine_wide_deny() {
+        let rig = Rig::new();
+        let outcome = rig
+            .run(&[value_prompt("some-provider", "SOME_TOKEN")], async |w| {
+                let card = visible_card(w).await;
+                w.decide_credential(&card.id, CredentialDecisionRequest::Deny);
+            })
+            .await;
+        let reason = outcome.expect_err("a decline must abort the launch");
+        assert!(reason.contains("launch aborted"), "{reason}");
+        assert!(
+            !rig.store
+                .state
+                .lock()
+                .unwrap()
+                .contains_key("some-provider"),
+            "a launch-origin decline must not persist a machine-wide deny"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_undecided_card_times_out_aborting_the_launch_and_leaving_the_window_clean() {
+        let rig = Rig::new();
+        let deps = ValueCardDeps {
+            window: &rig.window,
+            store: &rig.store,
+            wait: Duration::from_millis(5),
+            host_value_available: &|_| false,
+            announce: &|_| {},
+            repaint: &|| {},
+        };
+        let reason = gate_value_prompts(&[value_prompt("some-provider", "SOME_TOKEN")], &deps)
+            .await
+            .expect_err("an undecided card must abort the launch");
+        assert!(reason.contains("timed out"), "{reason}");
+        assert!(
+            rig.window.snapshot().pending_credentials.is_empty(),
+            "the timed-out card is torn down"
+        );
+        assert!(rig.store.state.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_detected_host_value_is_offered_on_the_card() {
+        let rig = Rig::new();
+        let deps = ValueCardDeps {
+            window: &rig.window,
+            store: &rig.store,
+            wait: Duration::from_secs(5),
+            host_value_available: &|p| p.env == "SOME_TOKEN",
+            announce: &|_| {},
+            repaint: &|| {},
+        };
+        let prompts = [value_prompt("some-provider", "SOME_TOKEN")];
+        let gate = gate_value_prompts(&prompts, &deps);
+        let decide = async {
+            let card = visible_card(&rig.window).await;
+            assert!(
+                card.host_value_available,
+                "the card offers the detected host value"
+            );
+            rig.window.decide_credential(
+                &card.id,
+                CredentialDecisionRequest::Allow(CredentialEntry::HostDetect),
+            );
+        };
+        let (outcome, ()) = tokio::join!(gate, decide);
+        assert_eq!(outcome, Ok(()));
+        assert_eq!(
+            rig.store.state.lock().unwrap().get("some-provider"),
+            Some(&CredentialEntry::HostDetect)
+        );
+    }
+
+    #[tokio::test]
+    async fn each_prompt_cards_in_declaration_order_until_all_are_saved() {
+        let rig = Rig::new();
+        let prompts = vec![
+            value_prompt("some-provider", "SOME_TOKEN"),
+            value_prompt("other-provider", "OTHER_TOKEN"),
+        ];
+        let outcome = rig
+            .run(&prompts, async |w| {
+                for expected in ["some-provider", "other-provider"] {
+                    let card = visible_card(w).await;
+                    assert_eq!(card.credential_id, expected);
+                    w.decide_credential(
+                        &card.id,
+                        CredentialDecisionRequest::Allow(CredentialEntry::Stored {
+                            value: format!("{expected}-secret"),
+                        }),
+                    );
+                }
+            })
+            .await;
+        assert_eq!(outcome, Ok(()));
+        let state = rig.store.state.lock().unwrap();
+        assert!(state.contains_key("some-provider"));
+        assert!(state.contains_key("other-provider"));
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_pending_card_refuses_instead_of_coalescing() {
+        let rig = Rig::new();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        assert!(rig.window.try_insert_credential_pending(
+            launch_prompt(&value_prompt("some-provider", "SOME_TOKEN")),
+            false,
+            tx
+        ));
+        let outcome = rig
+            .run(&[value_prompt("some-provider", "SOME_TOKEN")], async |_| {})
+            .await;
+        let reason = outcome.expect_err("a duplicate card must refuse");
+        assert!(reason.contains("already pending"), "{reason}");
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_store_aborts_the_launch_after_a_save() {
+        let rig = Rig::new();
+        let deps = ValueCardDeps {
+            window: &rig.window,
+            store: &MemStore {
+                fail_load: true,
+                ..MemStore::default()
+            },
+            wait: Duration::from_secs(5),
+            host_value_available: &|_| false,
+            announce: &|_| {},
+            repaint: &|| {},
+        };
+        let prompts = [value_prompt("some-provider", "SOME_TOKEN")];
+        let gate = gate_value_prompts(&prompts, &deps);
+        let decide = async {
+            let card = visible_card(&rig.window).await;
+            rig.window.decide_credential(
+                &card.id,
+                CredentialDecisionRequest::Allow(CredentialEntry::Stored {
+                    value: "some-secret".into(),
+                }),
+            );
+        };
+        let (outcome, ()) = tokio::join!(gate, decide);
+        let reason = outcome.expect_err("an unreadable store must abort");
+        assert!(
+            reason.contains("reading the credential store failed"),
+            "{reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_store_that_cannot_persist_aborts_the_launch_after_a_save() {
+        let rig = Rig::new();
+        let deps = ValueCardDeps {
+            window: &rig.window,
+            store: &MemStore {
+                fail_save: true,
+                ..MemStore::default()
+            },
+            wait: Duration::from_secs(5),
+            host_value_available: &|_| false,
+            announce: &|_| {},
+            repaint: &|| {},
+        };
+        let prompts = [value_prompt("some-provider", "SOME_TOKEN")];
+        let gate = gate_value_prompts(&prompts, &deps);
+        let decide = async {
+            let card = visible_card(&rig.window).await;
+            rig.window.decide_credential(
+                &card.id,
+                CredentialDecisionRequest::Allow(CredentialEntry::Stored {
+                    value: "some-secret".into(),
+                }),
+            );
+        };
+        let (outcome, ()) = tokio::join!(gate, decide);
+        let reason = outcome.expect_err("an unpersistable store must abort");
+        assert!(
+            reason.contains("storing the value decision failed"),
+            "{reason}"
+        );
+    }
+}

--- a/crates/lns-service/src/credential_flow/mod.rs
+++ b/crates/lns-service/src/credential_flow/mod.rs
@@ -3,6 +3,7 @@
 pub mod bind;
 pub mod connectors;
 pub mod detection;
+pub mod launch_gate;
 pub mod notification;
 pub mod providers;
 pub mod registry;

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -90,7 +90,8 @@ async fn orchestrate(
             plan.workload.policy.as_ref(),
             &plan.workload.credentials,
         )?;
-        crate::artifact::real::refuse_unbound_required_credentials(&plan.workload.credentials)?;
+        crate::artifact::real::gate_required_value_slots(&plan.workload.credentials, &frame_tx)
+            .await?;
         gate_declared_sign_ins(&plan.workload.credentials, &frame_tx).await?;
     }
     let launch = sandbox_plan
@@ -443,16 +444,14 @@ async fn gate_declared_sign_ins(
     frame_tx: &Sender<WireFrame>,
 ) -> Result<()> {
     use crate::artifact::credential_boot::{
-        BootGate, ConnectChoice, SlotPlan, boot_gate, plan_declared_connectors, resolve_connect,
-        sign_in_gate_ids,
+        ConnectChoice, SlotGatePlan, plan_required_slots, resolve_connect,
     };
     use crate::credential_flow::store::{
         CredentialStore, JsonFileCredentialStore, default_credentials_path,
     };
     use lns_ipc::Response;
 
-    let declared = sign_in_gate_ids(credentials);
-    if declared.is_empty() {
+    if credentials.iter().all(|slot| !slot.required) {
         return Ok(());
     }
     let user = lns_policy::connectors::Catalog::load_or_default(
@@ -463,12 +462,8 @@ async fn gate_declared_sign_ins(
     let state = JsonFileCredentialStore::new(default_credentials_path())
         .load()
         .unwrap_or_default();
-    let plans = plan_declared_connectors(&declared, &catalog, &state);
-    if boot_gate(&plans) == BootGate::StartWorkload {
-        return Ok(());
-    }
-    for plan in plans {
-        let SlotPlan::Connect(prompt) = plan else {
+    for plan in plan_required_slots(credentials, &catalog, &state) {
+        let SlotGatePlan::NeedsSignIn(prompt) = plan else {
             continue;
         };
         let id = prompt.connector.clone();

--- a/crates/lns-service/tests/behaviours/credential_at_boot.feature
+++ b/crates/lns-service/tests/behaviours/credential_at_boot.feature
@@ -5,30 +5,95 @@ Feature: a sandbox definition's credential slots gate the launch
   resolves against this machine's per-machine credential store at launch:
   a bound slot arms silently under the slot's env name, an unbound optional
   slot runs reactively (the first placeholder use pauses for the value
-  decision, exactly as today), and an unbound required slot refuses the
-  launch before any microVM boots — naming the credential, its injection
-  target, and the `lns connector connect` fix. A credential denied on
-  this machine refuses a required slot distinctly: "you denied this" is
-  not "never bound". A required oauth-kind slot composes with the declared
+  decision, exactly as today), and an unbound required slot blocks the
+  launch before any microVM boots — raising its value card in the approval
+  window (disclosing the credential, its injection target, and how to mint
+  the value), or, headless, refusing with the `lns connector connect` fix.
+  Saving the value binds it on this machine and the boot proceeds; declining
+  aborts the launch without recording a machine-wide deny. A credential
+  denied on this machine refuses a required slot distinctly: "you denied
+  this" is not "never bound", and it is a standing decision — no card
+  re-asks it. A required oauth-kind slot composes with the declared
   sign-in gate instead of duplicating it. Real credential material never
   enters the artifact or the workload — only the boundary sees it.
 
   NOTE: this contract covers the flat sandbox definition's `spec.credentials`.
 
-  Scenario: A required slot with no bound value refuses the launch before boot
+  Scenario: A required slot with no bound value refuses a headless launch before boot
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
     And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
     And the per-machine credential store has no entry for "some-provider"
+    And no approval window is available on this machine
     When the sandbox is launched
     Then the launch is refused
     And the error names "some-provider"
     And the error names the injection target "SOME_TOKEN"
     And the error points at `lns connector connect some-provider`
 
+  Scenario: A required slot with no bound value raises the value card before boot
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" minted by "some-cli setup-token"
+    And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
+    And the per-machine credential store has no entry for "some-provider"
+    And the approval window is available on this machine
+    When the sandbox is launched
+    Then a value card for "some-provider" is shown before the workload starts
+    And the value card discloses the injection target "SOME_TOKEN"
+    And the value card shows how to mint the value with "some-cli setup-token"
+    And the workload does not start until the value is decided
+
+  Scenario: Saving a value on the pre-boot card boots the workload armed
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
+    And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
+    And the per-machine credential store has no entry for "some-provider"
+    And the approval window is available on this machine
+    When the sandbox is launched
+    And the developer saves value "some-secret" on the pre-boot value card
+    Then the workload starts
+    And the workload's environment contains the placeholder under "SOME_TOKEN"
+    And the per-machine credential store now binds "some-provider"
+
+  Scenario: Declining the pre-boot card aborts the launch without a machine-wide deny
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
+    And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
+    And the per-machine credential store has no entry for "some-provider"
+    And the approval window is available on this machine
+    When the sandbox is launched
+    And the developer declines the pre-boot value card
+    Then the launch is aborted
+    And the per-machine credential store keeps no entry for "some-provider"
+
+  Scenario: The pre-boot card honors the slot's env remap
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
+    And the sandbox definition requires a credential slot for "some-provider" injected as "PROVIDER_KEY"
+    And the per-machine credential store has no entry for "some-provider"
+    And the approval window is available on this machine
+    When the sandbox is launched
+    Then a value card for "some-provider" is shown before the workload starts
+    And the value card discloses the injection target "PROVIDER_KEY"
+
+  Scenario: Duplicate required slots coalesce into one value card
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
+    And the sandbox definition requires the credential slot for "some-provider" injected as "SOME_TOKEN" twice
+    And the per-machine credential store has no entry for "some-provider"
+    And the approval window is available on this machine
+    When the sandbox is launched
+    Then a value card for "some-provider" is shown before the workload starts
+    And only one value card is pending
+
   Scenario: A denied credential refuses a required slot distinctly
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
     And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
     And the per-machine credential store has a deny entry for "some-provider"
+    When the sandbox is launched
+    Then the launch is refused
+    And the error says the credential was denied on this machine
+    And the error points at `lns connector connect some-provider`
+
+  Scenario: A machine-denied credential refuses even when the approval window is available
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
+    And the sandbox definition requires a credential slot for "some-provider" injected as "SOME_TOKEN"
+    And the per-machine credential store has a deny entry for "some-provider"
+    And the approval window is available on this machine
     When the sandbox is launched
     Then the launch is refused
     And the error says the credential was denied on this machine

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -1,10 +1,13 @@
+use std::sync::{Arc, Mutex};
+
 use lns_policy::Policy;
 use lns_policy::connectors::Connector;
-use lns_policy::credentials::CredentialStateFile;
+use lns_policy::credentials::{CredentialStateFile, CredentialStore};
+use lns_service::approval_flow::window::WindowState;
 use lns_service::artifact::credential_boot::ConnectPrompt;
 
 /// Drives a sandbox definition through the launch path: catalog + definition + overlay + machine store in, armed providers (from the overlay's connected connectors and credential slots) + the ids offered for a reactive connect + running policy (or a blocked/refused launch) out.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct DeclaredRig {
     pub catalog: Vec<Connector>,
     pub definition: Option<String>,
@@ -20,4 +23,47 @@ pub struct DeclaredRig {
     pub error: Option<String>,
     /// The definition bytes as authored, for pinning that nothing writes back to it.
     pub definition_snapshot: Option<String>,
+    /// Some = the approval window is available; the launch gate cards instead of refusing.
+    pub window: Option<Arc<WindowState>>,
+    /// The store the in-flight value gate persists into, shared with the spawned gate task.
+    pub gate_store: Option<Arc<SharedStore>>,
+    pub value_gate: Option<tokio::task::JoinHandle<Result<(), String>>>,
+}
+
+impl std::fmt::Debug for DeclaredRig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeclaredRig")
+            .field("definition", &self.definition)
+            .field("providers", &self.providers)
+            .field("offered", &self.offered)
+            .field("pending", &self.pending)
+            .field("error", &self.error)
+            .field("window_present", &self.window.is_some())
+            .field("gate_running", &self.value_gate.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SharedStore(pub Mutex<CredentialStateFile>);
+
+impl SharedStore {
+    pub fn seeded(state: CredentialStateFile) -> Arc<Self> {
+        Arc::new(Self(Mutex::new(state)))
+    }
+
+    pub fn state(&self) -> CredentialStateFile {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+impl CredentialStore for SharedStore {
+    fn load(&self) -> std::io::Result<CredentialStateFile> {
+        Ok(self.state())
+    }
+
+    fn save(&self, state: &CredentialStateFile) -> std::io::Result<()> {
+        *self.0.lock().unwrap() = state.clone();
+        Ok(())
+    }
 }

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -5,7 +5,7 @@ use lns_policy::connectors::{
 use lns_policy::providers::{InjectionDef, InjectionKind};
 use lns_policy::{Policy, Verdict};
 use lns_service::artifact::credential_boot::{
-    BootGate, SlotPlan, boot_gate, gate_required_slots, plan_declared_connectors, sign_in_gate_ids,
+    SlotGatePlan, ValuePrompt, gate_required_slots, plan_required_slots,
 };
 use lns_service::artifact::policy::merge_effective;
 use lns_service::artifact::{plan_local_sandbox, resolved_from_sandbox};
@@ -13,6 +13,7 @@ use lns_service::credential_flow::connectors::{
     resolve_applied_with_slots, resolve_connectable_with_slots, unknown_connector_ids,
     unknown_connectors_refusal,
 };
+use lns_service::credential_flow::launch_gate::{ValueCardDeps, gate_value_prompts};
 use lns_service::credential_flow::providers::Provider;
 
 use crate::world::BehaviourWorld;
@@ -82,20 +83,54 @@ fn launch(
         rig.error = Some(unknown_connectors_refusal(&unknown));
         return;
     }
-    if let Err(failure) = gate_required_slots(&resolved.credentials, &rig.catalog, &rig.store) {
-        rig.error = Some(failure.as_message());
-        return;
+    let plans = plan_required_slots(&resolved.credentials, &rig.catalog, &rig.store);
+    match rig.window.clone() {
+        None => {
+            if let Err(failure) =
+                gate_required_slots(&resolved.credentials, &rig.catalog, &rig.store)
+            {
+                rig.error = Some(failure.as_message());
+                return;
+            }
+        }
+        Some(window) => {
+            if let Some(failure) = plans.iter().find_map(|plan| match plan {
+                SlotGatePlan::Refused(failure) => Some(failure.clone()),
+                _ => None,
+            }) {
+                rig.error = Some(failure.as_message());
+                return;
+            }
+            let prompts: Vec<ValuePrompt> = plans
+                .iter()
+                .filter_map(|plan| match plan {
+                    SlotGatePlan::NeedsValue(prompt) => Some(prompt.clone()),
+                    _ => None,
+                })
+                .collect();
+            if !prompts.is_empty() {
+                let store = crate::declared_rig::SharedStore::seeded(rig.store.clone());
+                rig.gate_store = Some(store.clone());
+                rig.value_gate = Some(tokio::spawn(async move {
+                    let deps = ValueCardDeps {
+                        window: &window,
+                        store: &*store,
+                        wait: std::time::Duration::from_secs(5),
+                        host_value_available: &|_| false,
+                        announce: &|_| {},
+                        repaint: &|| {},
+                    };
+                    gate_value_prompts(&prompts, &deps).await
+                }));
+                return;
+            }
+        }
     }
-    let plans = plan_declared_connectors(
-        &sign_in_gate_ids(&resolved.credentials),
-        &rig.catalog,
-        &rig.store,
-    );
-    if boot_gate(&plans) == BootGate::AwaitConnect {
-        rig.pending = plans.into_iter().find_map(|plan| match plan {
-            SlotPlan::Connect(prompt) => Some(prompt),
-            SlotPlan::Armed { .. } => None,
-        });
+    if let Some(prompt) = plans.into_iter().find_map(|plan| match plan {
+        SlotGatePlan::NeedsSignIn(prompt) => Some(prompt),
+        _ => None,
+    }) {
+        rig.pending = Some(prompt);
         return;
     }
     let mut policy = merge_effective(resolved.policy.as_ref(), &rig.overlay);
@@ -545,5 +580,228 @@ fn connector_is_not_offered(w: &mut BehaviourWorld, id: String) -> Result<(), St
         ))
     } else {
         Ok(())
+    }
+}
+
+#[given("the approval window is available on this machine")]
+fn window_available(w: &mut BehaviourWorld) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.window = Some(lns_service::approval_flow::window::WindowState::new());
+}
+
+#[given("no approval window is available on this machine")]
+fn window_absent(w: &mut BehaviourWorld) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    assert!(
+        rig.window.is_none(),
+        "the rig unexpectedly holds an approval window"
+    );
+}
+
+#[given(
+    regex = r#"^the machine catalog has a credential connector "([^"]+)" managing "([^"]+)" minted by "([^"]+)"$"#
+)]
+fn catalog_has_connector_with_mint(w: &mut BehaviourWorld, id: String, env: String, cmd: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    let mut connector = credential_connector(&id, &env, None);
+    connector.token_fallback = Some(lns_policy::connectors::TokenFallback {
+        help: None,
+        command: Some(cmd),
+    });
+    rig.catalog.push(connector);
+}
+
+#[given(
+    regex = r#"^the sandbox definition requires the credential slot for "([^"]+)" injected as "([^"]+)" twice$"#
+)]
+fn definition_requires_slot_twice(w: &mut BehaviourWorld, name: String, env: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    let slot = format!(r#"{{"name":"{name}","env":"{env}","required":true}}"#);
+    rig.definition = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","credentials":[{slot},{slot}]}}}}"#
+    ));
+}
+
+async fn pending_value_card(
+    w: &BehaviourWorld,
+) -> Result<lns_service::approval_flow::window::CredentialCardPrompt, String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if let Some(err) = &rig.error {
+        return Err(format!("the launch failed instead of carding: {err}"));
+    }
+    let window = rig
+        .window
+        .as_ref()
+        .ok_or("the scenario declared no approval window")?
+        .clone();
+    for _ in 0..1000 {
+        if let Some(card) = window.snapshot().pending_credentials.first() {
+            return Ok(card.clone());
+        }
+        tokio::task::yield_now().await;
+    }
+    Err("no value card became visible".to_string())
+}
+
+#[then(regex = r#"^a value card for "([^"]+)" is shown before the workload starts$"#)]
+async fn value_card_shown(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let card = pending_value_card(w).await?;
+    if card.credential_id != id {
+        return Err(format!(
+            "the pending value card is for {}, not {id}",
+            card.credential_id
+        ));
+    }
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if rig.running_policy.is_some() {
+        return Err("the workload started while the value was undecided".to_string());
+    }
+    Ok(())
+}
+
+#[then(regex = r#"^the value card discloses the injection target "([^"]+)"$"#)]
+async fn value_card_discloses_env(w: &mut BehaviourWorld, env: String) -> Result<(), String> {
+    let card = pending_value_card(w).await?;
+    if card.env_var.as_deref() == Some(env.as_str()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "the value card discloses {:?}, not {env}",
+            card.env_var
+        ))
+    }
+}
+
+#[then(regex = r#"^the value card shows how to mint the value with "([^"]+)"$"#)]
+async fn value_card_shows_mint(w: &mut BehaviourWorld, cmd: String) -> Result<(), String> {
+    let card = pending_value_card(w).await?;
+    let minted_by = card.token_fallback.as_ref().and_then(|t| t.command.clone());
+    if minted_by.as_deref() == Some(cmd.as_str()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "the value card offers {minted_by:?} as the mint command, not {cmd}"
+        ))
+    }
+}
+
+#[then("the workload does not start until the value is decided")]
+async fn workload_waits_for_value(w: &mut BehaviourWorld) -> Result<(), String> {
+    pending_value_card(w).await?;
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if rig.running_policy.is_some() {
+        return Err("the workload started while the value was undecided".to_string());
+    }
+    if rig.value_gate.is_none() {
+        return Err("no launch gate is holding the boot".to_string());
+    }
+    Ok(())
+}
+
+#[then("only one value card is pending")]
+async fn only_one_value_card(w: &mut BehaviourWorld) -> Result<(), String> {
+    let _ = pending_value_card(w).await?;
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    let window = rig.window.as_ref().ok_or("no approval window")?;
+    let cards = window.snapshot().pending_credentials;
+    if cards.len() == 1 {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected one coalesced value card, got {}: {cards:?}",
+            cards.len()
+        ))
+    }
+}
+
+async fn decide_pending_value_card(
+    w: &mut BehaviourWorld,
+    request: lns_service::credential_flow::session::CredentialDecisionRequest,
+) -> Result<(), String> {
+    let card = pending_value_card(w).await?;
+    let (window, gate) = {
+        let rig = w.declared.as_mut().ok_or("no launch happened")?;
+        let window = rig.window.clone().ok_or("no approval window")?;
+        let gate = rig.value_gate.take().ok_or("no launch gate is running")?;
+        (window, gate)
+    };
+    window.decide_credential(&card.id, request);
+    let outcome = gate
+        .await
+        .map_err(|e| format!("the gate task panicked: {e}"))?;
+    let rig = w.declared.as_mut().ok_or("no launch happened")?;
+    match outcome {
+        Ok(()) => {
+            rig.store = rig
+                .gate_store
+                .as_ref()
+                .ok_or("the gate ran without a store")?
+                .state();
+            relaunch(w);
+            Ok(())
+        }
+        Err(reason) => {
+            rig.error = Some(reason);
+            Ok(())
+        }
+    }
+}
+
+#[when(regex = r#"^the developer saves value "([^"]+)" on the pre-boot value card$"#)]
+async fn save_value_on_card(w: &mut BehaviourWorld, value: String) -> Result<(), String> {
+    use lns_policy::credentials::CredentialEntry;
+    use lns_service::credential_flow::session::CredentialDecisionRequest;
+    decide_pending_value_card(
+        w,
+        CredentialDecisionRequest::Allow(CredentialEntry::Stored { value }),
+    )
+    .await
+}
+
+#[when("the developer declines the pre-boot value card")]
+async fn decline_value_card(w: &mut BehaviourWorld) -> Result<(), String> {
+    use lns_service::credential_flow::session::CredentialDecisionRequest;
+    decide_pending_value_card(w, CredentialDecisionRequest::Deny).await
+}
+
+#[then("the launch is aborted")]
+fn launch_aborted(w: &mut BehaviourWorld) -> Result<(), String> {
+    let error = w
+        .declared
+        .as_ref()
+        .and_then(|r| r.error.as_ref())
+        .ok_or("no launch error was recorded")?;
+    if error.contains("launch aborted") {
+        Ok(())
+    } else {
+        Err(format!("expected an aborted launch, got: {error}"))
+    }
+}
+
+#[then(regex = r#"^the per-machine credential store keeps no entry for "([^"]+)"$"#)]
+fn store_keeps_no_entry(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    let gate_state = rig.gate_store.as_ref().map(|s| s.state());
+    let has_entry =
+        rig.store.contains_key(&id) || gate_state.is_some_and(|state| state.contains_key(&id));
+    if has_entry {
+        Err(format!(
+            "a launch-origin decline must not persist any entry for {id}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^the per-machine credential store now binds "([^"]+)"$"#)]
+fn store_now_binds(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if lns_policy::credentials::has_armed_entry(&rig.store, &id) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected the store to bind {id}, got {:?}",
+            rig.store.get(&id)
+        ))
     }
 }

--- a/docs/examples/claude-code/README.md
+++ b/docs/examples/claude-code/README.md
@@ -30,19 +30,16 @@ The first boot runs `npm install -g @anthropic-ai/claude-code`; the microVM is
 ephemeral, so each cold start reinstalls it (the `allowedRoutes` keep
 `registry.npmjs.org` open for that reason).
 
-The definition requires the `claude-code-subscription` credential, so on a
-machine with no bound value the first run refuses to boot and tells you how to
-bind one:
+The definition requires the `claude-code-subscription` credential. On a machine
+with no bound value, the first run raises an approval card before the workload
+starts: mint a long-lived subscription token with `claude setup-token`, then
+paste it (or accept the detected host value if `CLAUDE_CODE_OAUTH_TOKEN` is
+already set on your machine). Saving it boots the sandbox; declining aborts the
+launch. The real token never enters the guest — the workload sees a placeholder
+and the boundary splices the value into requests to `api.anthropic.com`.
 
-```bash
-lns connector connect claude-code-subscription
-```
-
-An approval card opens: mint a long-lived subscription token with
-`claude setup-token`, then paste it (or accept the detected host value if
-`CLAUDE_CODE_OAUTH_TOKEN` is already set on your machine). The real token never
-enters the guest — the workload sees a placeholder and the boundary splices the
-value into requests to `api.anthropic.com`. Then `lns run` again.
+Headless (no approval window available), the run refuses instead and tells you
+to bind the value first with `lns connector connect claude-code-subscription`.
 
 ## Publish and run from a registry
 

--- a/docs/examples/claude-code/README.md
+++ b/docs/examples/claude-code/README.md
@@ -8,8 +8,8 @@ hosts you allow.
 ## Files
 
 - **`lns.yaml`** — the sandbox definition: a `node:lts-alpine` base that installs
-  Claude Code on first boot, the network allowlist, and the
-  `claude-code-subscription` connector, and inline seed state mounted at the
+  Claude Code on first boot, the network allowlist, the required
+  `claude-code-subscription` credential, and inline seed state mounted at the
   workload's home (`/home/sandbox`). The inline `.claude.json` skips onboarding
   and pre-accepts the `/workspace` trust dialog. The inline
   `.claude/settings.json` runs Claude in `bypassPermissions` and turns **off
@@ -30,8 +30,19 @@ The first boot runs `npm install -g @anthropic-ai/claude-code`; the microVM is
 ephemeral, so each cold start reinstalls it (the `allowedRoutes` keep
 `registry.npmjs.org` open for that reason).
 
-On first run, an approval card asks for your Claude subscription token and shows
-how to mint it.
+The definition requires the `claude-code-subscription` credential, so on a
+machine with no bound value the first run refuses to boot and tells you how to
+bind one:
+
+```bash
+lns connector connect claude-code-subscription
+```
+
+An approval card opens: mint a long-lived subscription token with
+`claude setup-token`, then paste it (or accept the detected host value if
+`CLAUDE_CODE_OAUTH_TOKEN` is already set on your machine). The real token never
+enters the guest — the workload sees a placeholder and the boundary splices the
+value into requests to `api.anthropic.com`. Then `lns run` again.
 
 ## Publish and run from a registry
 

--- a/docs/examples/claude-code/lns.yaml
+++ b/docs/examples/claude-code/lns.yaml
@@ -29,8 +29,10 @@ spec:
         verdict: allow
       - match: downloads.claude.ai
         verdict: allow
-  connectors:
-    - claude-code-subscription
+  credentials:
+    - name: claude-code-subscription
+      env: CLAUDE_CODE_OAUTH_TOKEN
+      required: true
   volumes:
     - type: bind
       source: .

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -709,8 +709,8 @@ or `lns pull` simply fetches or rebuilds it again.
 
 [`examples/claude-code/`](examples/claude-code/) is a complete recipe that ties
 these pieces together: it runs Claude Code inside a sandbox using `spec.image`
-plus a first-boot install, `spec.env`, a tight `policy` allowlist, the
-`claude-code-subscription` connector, a `.` bind at `/workspace`, and a
+plus a first-boot install, `spec.env`, a tight `policy` allowlist, a required
+`claude-code-subscription` credential, a `.` bind at `/workspace`, and a
 self-contained inline fileset that seeds the agent's home. Copy its `lns.yaml`
 into your project and `lns run`.
 


### PR DESCRIPTION
Stage 2 of the plan on #167. **Draft** — stacked on #168 (stage 1, the example's required slot) and, per the shipping constraint recorded on #167, intended to merge **after** #166: pre-#166 the gate arms from any machine-global stored value, so a new workload with a stored value boots without a card. Steps 2 and 3 are development-separable but together form the trust-complete feature; #166's per-workload grant predicate and sidecar deny slot in behind the same gate.

## What

`lns run` itself now raises the setup-token value card **before the workload boots** when a definition's required credential-kind slot has no bound value on this machine — replacing the launch refusal (which remains the headless fallback). Saving the value persists it to the per-machine store and the boot proceeds with the placeholder seeded at fork; declining or timing out aborts the launch **without writing a machine-wide deny**. No more refusal → `lns connector connect` → re-run round-trip, and no reliance on the client emitting a request to trigger consent (the chicken-and-egg #167 documents).

## Design (the five tightenings from #167)

- **Plan actual slots, not deduplicated connector ids.** `plan_required_slots(slots, catalog, state)` replaces `sign_in_gate_ids` + `plan_declared_connectors` (+ `SlotPlan`/`boot_gate`/`plan_slot`, now retired). Each plan carries the slot's `env:` remap — previously lost, so a remapped slot would have carded the wrong variable. Duplicate `(name, env)` slots coalesce; a distinct remap plans separately.
- **Neutral prompt origin, no synthetic wire event.** The card is driven by `launch_gate::launch_prompt` (id `launch-<connector>-<env>`) through the same `CredentialPendingPrompt` presentation model the bind flow uses — a pre-boot requirement has no held request id, and none is fabricated.
- **Unified preflight ordering.** `gate_required_value_slots` (artifact/real.rs) replaces `refuse_unbound_required_credentials` in the orchestrator preflight: interactive card first, refusal text only when no display/window is present. A machine-wide `Deny` still refuses distinctly — it is a standing decision, not something to re-ask each launch.
- **Launch-origin decisions never write a machine-wide deny.** `resolve_launch_decision` maps decline/timeout (and a defensive `Allow(Deny)`) to launch-abort with nothing persisted; only a saved value/host-detect writes to the store. The per-workload sidecar deny arrives with #166.
- **Oauth-kind slots unchanged in behavior**, but `gate_declared_sign_ins` now consumes the same `NeedsSignIn` plans, so its prompts also honor the slot's env remap.

## Layers

- **Layer 3**: `credential_boot.rs` planner (21 tests) and the new `credential_flow/launch_gate.rs` (15 tests — save/decline/timeout/duplicate-card/store-failure/host-detect-offer, real headless `WindowState`, in-memory store; 100% from day one).
- **Layer 2**: `credential_at_boot.feature` evolves — the refusal scenario is now explicitly headless, and six new scenarios pin the card path (raised before boot with env remap + mint command, save boots armed, decline aborts with no machine deny, dedup, machine-denied refuses even with a window). 162/162 behaviours scenarios pass.
- The orchestrator/real.rs wiring stays Layer-1 territory (both files already in IGNORES).

## Docs

`docs/examples/claude-code/README.md` first-run section updated from the stage-1 interim flow (refusal + manual connect + re-run) to the card-first flow, with the headless refusal documented as the fallback.

## Testing

`make lint`, `make complexity`, `make coverage COVERAGE_CRATES="lns-service"` green; full behaviours suite 162/162. Live smoke (`lns run docs/examples/claude-code/lns.yaml` on a fresh credential store) pending — noted as a checklist item below.

- [ ] Live microVM smoke: fresh store → card at launch → paste `claude setup-token` output → Claude Code boots logged in
- [ ] Rebase once #168 merges; re-evaluate merge order against #166
