### PR TITLE
chore(deps): upgrade lens-sandbox-core to 4cb1d97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=08c588fcb8b5d68fe153c184c6cd7d3ce4f14f60#08c588fcb8b5d68fe153c184c6cd7d3ce4f14f60"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=4cb1d974da0409e605853bb0c3183e24e41e0786#4cb1d974da0409e605853bb0c3183e24e41e0786"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -7160,7 +7160,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -10,7 +10,7 @@ name = "lns-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "08c588fcb8b5d68fe153c184c6cd7d3ce4f14f60" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "4cb1d974da0409e605853bb0c3183e24e41e0786" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -61,7 +61,8 @@ impl AgentDispatcher {
         reaper: Arc<OrphanReaper>,
         runner: Arc<dyn AgentRunner>,
     ) -> Self {
-        let exec_manager = ExecManager::new(sandbox_creds.clone(), config.core.is_root);
+        let exec_manager =
+            ExecManager::new(sandbox_creds.clone(), config.core.is_root, reaper.guard());
         let activity = ActivityStream::new();
         spawn_activity_to_stdout(&activity);
         Self {


### PR DESCRIPTION
Bumps the git-pinned `lens-sandbox-core` from `08c588f` to `4cb1d97` — 31 upstream commits. Pure dependency upgrade; adopting the new core capabilities is deliberately out of scope and tracked separately.

## The only compile break

`ExecManager::new` gained a third parameter, `pid_guard: PidGuard` (core `49f0a56`, *shield exec child PIDs from the orphan reaper*). Previously the reaper protected only the single agent PID, so on `SIGCHLD` it could `waitpid()` an exec child before that child's own waiter — the wait then saw `ECHILD` and dropped the real exit code, surfacing as a flaky wrong `lns exec` exit status. The call site in `AgentDispatcher::with_runner` now passes `reaper.guard()`, so exec children are left to their own `Child::wait()`.

`OrphanReaper::guard()` exists on both the Linux and non-Linux `cfg` impls at this rev, so the macOS host build and the `aarch64-unknown-linux-musl` cross-build both compile unchanged.

## Compatibility checks

Everything else in the delta is additive or internal to the guest proxy. Verified explicitly:

- **`RequestPending` gained a required `treatment` field.** Our receiver (`lns-service/src/approval_flow/protocol.rs`) has no `deny_unknown_fields`, so the field is ignored rather than failing the frame. We simply don't surface it yet.
- **`NetworkPolicy.allowedRoutes` is now `Option<…>` and deprecated in favour of `egress.http`.** It remains an accepted back-compat alias, and we still emit it. The new `deny_unknown_fields` is scoped to the `egress` block only, which we never emit.
- **Audit actor records now carry `process.file.path`.** Our relay copies the `actor` key verbatim into the OCSF event, so the resolved exe path flows into the audit chain for free.

## Residual risk

`PidGuard::default()` in place of `reaper.guard()` would compile and pass every host-side test identically — `PidGuard::contains` is Linux-only and private, so there is no host seam that can distinguish "the reaper's guard" from "a fresh one". The wiring's correctness rests on review plus core's own Linux-side tests. Making it assertable needs an identity seam upstream in core; end-to-end confidence belongs on the existing `@microvm` track.

## Verification

- `make lint && make complexity && make coverage` — green (exit 0). `lns-supervisor/src/dispatcher/agent.rs` at 100.00% (428/428); no IGNORES added.
- `cargo clippy -p lns-supervisor --target aarch64-unknown-linux-musl --all-targets -- -D warnings` — clean (the host gate is blind to the guest crates' Linux `cfg` branches).
