### PR TITLE
fix: confine a root run-as and every exec session to the workload's identity

### DIFF
--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -61,6 +61,15 @@ Feature: the workload runs unprivileged inside a locked-down guest
     Then the exit code is 0
     And the output contains "00000000000000fb"
 
+  Scenario: an exec does not inherit the supervisor's relay credentials
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox sleep 60'"
+    Then the exit code is 0
+    When the user execs "/bin/sh -c '/.lens/guest-tools/bin/busybox env'" in that run
+    Then the exit code is 0
+    And the output does not contain "LENS_SANDBOX_TOKEN"
+    And the output does not contain "LENS_SANDBOX_WS_URL"
+
   Scenario: /run is a fresh tmpfs, not the workload's persistent root
     Given the Lens Sandbox service is running
     When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox grep /run /proc/mounts'"
@@ -72,4 +81,5 @@ Feature: the workload runs unprivileged inside a locked-down guest
     When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox true && echo tooling-ok-$((7*6))'"
     Then the exit code is 0
     And the output contains "tooling-ok-42"
+
 

--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -22,9 +22,9 @@ Feature: the workload runs unprivileged inside a locked-down guest
 
   Scenario: a root run-as is honoured as an identity
     Given the Lens Sandbox service is running
-    When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox id -u'" as user "root"
+    When the user runs a microVM command "/bin/sh -c 'echo uid=$(/.lens/guest-tools/bin/busybox id -u)'" as user "root"
     Then the exit code is 0
-    And the output contains "0"
+    And the output contains "uid=0"
 
   Scenario: a root run-as keeps HOME and USER
     Given the Lens Sandbox service is running
@@ -56,3 +56,4 @@ Feature: the workload runs unprivileged inside a locked-down guest
     When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox true && echo tooling-ok-$((7*6))'"
     Then the exit code is 0
     And the output contains "tooling-ok-42"
+

--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -45,6 +45,22 @@ Feature: the workload runs unprivileged inside a locked-down guest
     Then the exit code is 0
     And the output contains "00000000000000fb"
 
+  Scenario: an exec lands on the workload's identity, not the broker's root
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox sleep 60'"
+    Then the exit code is 0
+    When the user execs "/bin/sh -c 'echo uid=$(/.lens/guest-tools/bin/busybox id -u)'" in that run
+    Then the exit code is 0
+    And the output contains "uid=65534"
+
+  Scenario: an exec into a root sandbox is capped like the workload it joins
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox sleep 60'" as user "root"
+    Then the exit code is 0
+    When the user execs "/bin/sh -c '/.lens/guest-tools/bin/busybox grep CapEff /proc/self/status'" in that run
+    Then the exit code is 0
+    And the output contains "00000000000000fb"
+
   Scenario: /run is a fresh tmpfs, not the workload's persistent root
     Given the Lens Sandbox service is running
     When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox grep /run /proc/mounts'"

--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -39,10 +39,11 @@ Feature: the workload runs unprivileged inside a locked-down guest
     Then the exit code is non-zero
     And the output contains "Operation not permitted"
 
-  Scenario: a root workload cannot read the supervisor's memory
+  Scenario: a root workload keeps only the identity-management capabilities
     Given the Lens Sandbox service is running
-    When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox cat /proc/1/mem'" as user "root"
-    Then the exit code is non-zero
+    When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox grep CapEff /proc/self/status'" as user "root"
+    Then the exit code is 0
+    And the output contains "00000000000000fb"
 
   Scenario: /run is a fresh tmpfs, not the workload's persistent root
     Given the Lens Sandbox service is running

--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -26,6 +26,13 @@ Feature: the workload runs unprivileged inside a locked-down guest
     Then the exit code is 0
     And the output contains "0"
 
+  Scenario: a root run-as keeps HOME and USER
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c 'echo home=[$HOME] user=[$USER]'" as user "root"
+    Then the exit code is 0
+    And the output does not contain "home=[]"
+    And the output does not contain "user=[]"
+
   Scenario: a root workload cannot tear down the network cage
     Given the Lens Sandbox service is running
     When the user runs a microVM command "/bin/sh -c '/.lens/nft flush ruleset'" as user "root"

--- a/crates/e2e-tests/features/microvm_privilege.feature
+++ b/crates/e2e-tests/features/microvm_privilege.feature
@@ -20,6 +20,23 @@ Feature: the workload runs unprivileged inside a locked-down guest
     Then the exit code is 0
     And the output contains "who=sandbox"
 
+  Scenario: a root run-as is honoured as an identity
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox id -u'" as user "root"
+    Then the exit code is 0
+    And the output contains "0"
+
+  Scenario: a root workload cannot tear down the network cage
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c '/.lens/nft flush ruleset'" as user "root"
+    Then the exit code is non-zero
+    And the output contains "Operation not permitted"
+
+  Scenario: a root workload cannot read the supervisor's memory
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox cat /proc/1/mem'" as user "root"
+    Then the exit code is non-zero
+
   Scenario: /run is a fresh tmpfs, not the workload's persistent root
     Given the Lens Sandbox service is running
     When the user runs a microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox grep /run /proc/mounts'"

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -849,6 +849,14 @@ fn start_detached(world: &mut E2eWorld, cmd_line: String) {
     }
 }
 
+#[when(regex = r#"^the user starts a detached microVM command "([^"]*)" as user "([^"]+)"$"#)]
+fn start_detached_as_user(world: &mut E2eWorld, cmd_line: String, user: String) {
+    run_microvm(world, vec!["-d".into(), "-u".into(), user], &cmd_line);
+    if let Some(id) = world.last_run_id.clone() {
+        world.detached_runs.push(id);
+    }
+}
+
 #[when(regex = r#"^the user starts a detached microVM command "([^"]*)" with auto-remove$"#)]
 fn start_detached_auto_remove(world: &mut E2eWorld, cmd_line: String) {
     run_microvm(world, vec!["-d".into(), "--rm".into()], &cmd_line);

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -481,6 +481,7 @@ pub(super) fn build_session_params(
         initial_winsize: args
             .initial_winsize
             .map(|(rows, cols)| lns_session::Winsize { rows, cols }),
+        confine: true,
     }
 }
 
@@ -1882,6 +1883,15 @@ mod tests {
         );
         let ws = params.initial_winsize.expect("winsize should be mapped");
         assert_eq!((ws.rows, ws.cols), (24, 80));
+    }
+
+    #[test]
+    fn build_session_params_asks_the_broker_to_confine_the_exec() {
+        let params = build_session_params(exec_args(vec!["nft".into()], false, false));
+        assert!(
+            params.confine,
+            "an exec reaches the broker, not the supervisor, so the broker is the only place its identity and capabilities can be capped"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -395,7 +395,7 @@ async fn orchestrate(
         tty: args.tty,
         stdin: args.stdin,
         initial_winsize,
-        confine: false,
+        confine: session.is_none(),
     };
 
     let frame_tx_for_session = frame_tx.clone();

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -395,6 +395,7 @@ async fn orchestrate(
         tty: args.tty,
         stdin: args.stdin,
         initial_winsize,
+        confine: false,
     };
 
     let frame_tx_for_session = frame_tx.clone();

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -31,6 +31,8 @@ pub struct SessionParams {
     pub tty: bool,
     pub stdin: bool,
     pub initial_winsize: Option<Winsize>,
+    /// Ask the broker to drop to the guest run-as identity before exec; false for the primary session, whose workload is the supervisor.
+    pub confine: bool,
 }
 
 pub(super) fn input_to_frame(input: SessionInput) -> ClientFrame {

--- a/crates/lns-service/src/vm/session_client/real.rs
+++ b/crates/lns-service/src/vm/session_client/real.rs
@@ -51,6 +51,7 @@ async fn run_session(
         tty: params.tty,
         stdin: params.stdin,
         winsize: params.initial_winsize,
+        confine: params.confine,
     };
     send_client_frame(&writer, &open)
         .await
@@ -96,6 +97,7 @@ pub async fn capture_session_output(
         tty: false,
         stdin: false,
         initial_winsize: None,
+        confine: false,
     };
     let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(64);
     let (input_keepalive, input_rx) = mpsc::channel::<SessionInput>(1);

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -27,6 +27,27 @@ pub(crate) struct WorkloadSpec {
     pub(crate) env: Vec<String>,
     pub(crate) cwd: Option<String>,
     pub(crate) hostname: Option<String>,
+    pub(crate) confinement: Confinement,
+}
+
+const ROOT_UID: u32 = 0;
+
+/// What the broker owes a forked workload before `execvp`; `Inherit` keeps the broker's root and full capabilities.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Confinement {
+    Inherit,
+    CapsOnly,
+    Setuid { uid: u32, gid: u32 },
+}
+
+pub(crate) fn confinement(confine: bool, uid: Option<u32>, gid: Option<u32>) -> Confinement {
+    if !confine {
+        return Confinement::Inherit;
+    }
+    match (uid, gid) {
+        (Some(uid), Some(gid)) if uid != ROOT_UID => Confinement::Setuid { uid, gid },
+        _ => Confinement::CapsOnly,
+    }
 }
 
 #[derive(Debug)]
@@ -185,6 +206,7 @@ mod tests {
             tty: true,
             stdin: false,
             winsize: None,
+            confine: false,
         };
         assert!(validate_open_session(&frame).is_ok());
     }
@@ -199,6 +221,7 @@ mod tests {
             tty: false,
             stdin: false,
             winsize: None,
+            confine: false,
         };
         let err = validate_open_session(&frame).unwrap_err();
         assert!(matches!(&err, SessionError::Protocol(s) if s.contains("argv empty")));
@@ -233,6 +256,7 @@ mod tests {
             tty: false,
             stdin: false,
             winsize: None,
+            confine: false,
         };
         assert_eq!(dispatch_frame(opener), LoopAction::Stop);
     }
@@ -248,6 +272,43 @@ mod tests {
     fn signal_target_uses_foreground_pgrp_then_falls_back_to_child() {
         assert_eq!(signal_target(Some(7), 5, 9), Some((-7, 9)));
         assert_eq!(signal_target(None, 5, 9), Some((-5, 9)));
+    }
+
+    #[test]
+    fn an_unconfined_session_inherits_the_brokers_privileges() {
+        assert_eq!(
+            confinement(false, Some(65534), Some(65534)),
+            Confinement::Inherit,
+            "the primary session execs the supervisor, which needs root and CAP_NET_ADMIN to install the cage"
+        );
+    }
+
+    #[test]
+    fn a_confined_session_setuids_to_the_run_as_ids() {
+        assert_eq!(
+            confinement(true, Some(65534), Some(65534)),
+            Confinement::Setuid {
+                uid: 65534,
+                gid: 65534
+            },
+            "an exec must land on the same identity as the workload it joins, not the broker's root"
+        );
+    }
+
+    #[test]
+    fn a_confined_session_on_a_root_workload_drops_capabilities_instead() {
+        assert_eq!(
+            confinement(true, Some(ROOT_UID), Some(0)),
+            Confinement::CapsOnly,
+            "setuid(0) is a no-op that would leave CAP_NET_ADMIN in place, so a root workload's exec caps instead"
+        );
+    }
+
+    #[test]
+    fn a_confined_session_without_run_as_ids_still_drops_capabilities() {
+        assert_eq!(confinement(true, None, None), Confinement::CapsOnly);
+        assert_eq!(confinement(true, Some(1000), None), Confinement::CapsOnly);
+        assert_eq!(confinement(true, None, Some(1000)), Confinement::CapsOnly);
     }
 
     #[test]

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -28,6 +28,7 @@ pub(crate) struct WorkloadSpec {
     pub(crate) cwd: Option<String>,
     pub(crate) hostname: Option<String>,
     pub(crate) confinement: Confinement,
+    pub(crate) scrub: Vec<String>,
 }
 
 const ROOT_UID: u32 = 0;
@@ -48,6 +49,23 @@ pub(crate) fn confinement(confine: bool, uid: Option<u32>, gid: Option<u32>) -> 
         (Some(uid), Some(gid)) if uid != ROOT_UID => Confinement::Setuid { uid, gid },
         _ => Confinement::CapsOnly,
     }
+}
+
+/// Supervisor-internal vars the guest inherits from the kernel cmdline; mirrors `INTERNAL_VAR_PREFIX` in lens-sandbox-core, which scrubs the same set before the supervisor spawns its agent.
+const INTERNAL_VAR_PREFIX: &str = "LENS_SANDBOX_";
+
+/// Inherited env keys a confined session must not carry: they hold the relay token and url, which authenticate the supervisor to the host.
+pub(crate) fn keys_to_scrub<'a>(
+    inherited: impl Iterator<Item = &'a str>,
+    confinement: &Confinement,
+) -> Vec<String> {
+    if matches!(confinement, Confinement::Inherit) {
+        return Vec::new();
+    }
+    inherited
+        .filter(|k| k.starts_with(INTERNAL_VAR_PREFIX))
+        .map(str::to_string)
+        .collect()
 }
 
 #[derive(Debug)]
@@ -309,6 +327,47 @@ mod tests {
         assert_eq!(confinement(true, None, None), Confinement::CapsOnly);
         assert_eq!(confinement(true, Some(1000), None), Confinement::CapsOnly);
         assert_eq!(confinement(true, None, Some(1000)), Confinement::CapsOnly);
+    }
+
+    #[test]
+    fn a_confined_session_scrubs_the_inherited_relay_credentials() {
+        let inherited = [
+            "LENS_SANDBOX_TOKEN",
+            "LENS_SANDBOX_WS_URL",
+            "PATH",
+            "HOME",
+            "LENS_RUN_UID",
+        ];
+        let scrubbed = keys_to_scrub(inherited.into_iter(), &Confinement::CapsOnly);
+        assert_eq!(
+            scrubbed,
+            vec![
+                "LENS_SANDBOX_TOKEN".to_string(),
+                "LENS_SANDBOX_WS_URL".to_string()
+            ],
+            "the relay token authenticates the supervisor to the host, so a confined session must not inherit it — /proc/cmdline is masked for the same reason"
+        );
+    }
+
+    #[test]
+    fn an_unconfined_session_keeps_the_relay_credentials() {
+        let scrubbed = keys_to_scrub(["LENS_SANDBOX_TOKEN"].into_iter(), &Confinement::Inherit);
+        assert!(
+            scrubbed.is_empty(),
+            "the primary session's workload is the supervisor, which needs the token to reach the relay at all"
+        );
+    }
+
+    #[test]
+    fn a_setuid_session_scrubs_them_too() {
+        let scrubbed = keys_to_scrub(
+            ["LENS_SANDBOX_TOKEN"].into_iter(),
+            &Confinement::Setuid {
+                uid: 65534,
+                gid: 65534,
+            },
+        );
+        assert_eq!(scrubbed, vec!["LENS_SANDBOX_TOKEN".to_string()]);
     }
 
     #[test]

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -582,6 +582,7 @@ mod tests {
             tty: false,
             stdin: false,
             winsize: None,
+            confine: false,
         };
         let bytes = encode_frame(&frame).expect("encode OpenSession");
         // SAFETY: bytes is borrowed for the duration of the call.

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -14,8 +14,9 @@ const PTY_DRAIN_GRACE: Duration = Duration::from_millis(500);
 const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
 use super::{
-    LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close, dispatch_frame,
-    read_client_frame, signal_target, validate_argv, validate_open_session,
+    Confinement, LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close,
+    confinement, dispatch_frame, read_client_frame, signal_target, validate_argv,
+    validate_open_session,
 };
 use crate::forker::{Fork, Forker};
 use crate::pty;
@@ -46,6 +47,95 @@ fn writeln_stderr(msg: &str) -> io::Result<()> {
     writeln!(std::io::stderr(), "lns-session-broker: {msg}")
 }
 
+fn env_u32(key: &str) -> Option<u32> {
+    std::env::var(key).ok().and_then(|s| s.parse().ok())
+}
+
+/// Identity-management caps a confined root workload keeps; mirrors `KEEP_CAP_MASK` in lens-sandbox-core so an exec lands on the same set as the workload it joins.
+const KEEP_CAP_MASK: u64 =
+    (1 << 0) | (1 << 1) | (1 << 3) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7);
+
+const CAPSET_V3: u32 = 0x2008_0522;
+
+#[repr(C)]
+struct CapHeader {
+    version: u32,
+    pid: i32,
+}
+
+#[repr(C)]
+struct CapData {
+    effective: u32,
+    permitted: u32,
+    inheritable: u32,
+}
+
+fn no_new_privs() -> io::Result<()> {
+    // SAFETY: prctl with PR_SET_NO_NEW_PRIVS takes scalars only and cannot fail on a live process.
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn drop_capabilities() -> io::Result<()> {
+    no_new_privs()?;
+    // SAFETY: prctl with PR_CAP_AMBIENT_CLEAR_ALL takes scalars only.
+    if unsafe {
+        libc::prctl(
+            libc::PR_CAP_AMBIENT,
+            libc::PR_CAP_AMBIENT_CLEAR_ALL,
+            0,
+            0,
+            0,
+        )
+    } < 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let header = CapHeader {
+        version: CAPSET_V3,
+        pid: 0,
+    };
+    let lo = (KEEP_CAP_MASK & 0xFFFF_FFFF) as u32;
+    let hi = (KEEP_CAP_MASK >> 32) as u32;
+    let data = [
+        CapData {
+            effective: lo,
+            permitted: lo,
+            inheritable: 0,
+        },
+        CapData {
+            effective: hi,
+            permitted: hi,
+            inheritable: 0,
+        },
+    ];
+    // SAFETY: capset reads a v3 header plus the two 32-bit datums the version mandates; both live until the call returns.
+    if unsafe { libc::syscall(libc::SYS_capset, &header as *const _, data.as_ptr()) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn setuid_to(uid: u32, gid: u32) -> io::Result<()> {
+    // SAFETY: each call takes scalars; setgroups before setgid/setuid so the supplementary set is cleared while still privileged.
+    unsafe {
+        if libc::setgroups(0, ptr::null()) < 0 || libc::setgid(gid) < 0 || libc::setuid(uid) < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    no_new_privs()
+}
+
+fn apply_confinement(confinement: &Confinement) -> io::Result<()> {
+    match confinement {
+        Confinement::Inherit => Ok(()),
+        Confinement::CapsOnly => drop_capabilities(),
+        Confinement::Setuid { uid, gid } => setuid_to(*uid, *gid),
+    }
+}
+
 pub fn handle_session(
     conn: RawFd,
     pid_tx: Option<SyncSender<libc::pid_t>>,
@@ -70,6 +160,7 @@ pub fn handle_session(
         tty,
         stdin,
         winsize,
+        confine,
     } = opening
     else {
         unreachable!("validate_open_session guarantees OpenSession");
@@ -79,6 +170,7 @@ pub fn handle_session(
         env,
         cwd,
         hostname,
+        confinement: confinement(confine, env_u32("LENS_RUN_UID"), env_u32("LENS_RUN_GID")),
     };
     if tty {
         run_tty_session(conn, spec, winsize, stdin, pid_tx, forker)
@@ -411,6 +503,10 @@ fn exec_child(spec: &WorkloadSpec) -> ! {
             // SAFETY: putenv keeps the pointer; child execs imminently, so the leak ends with the process image.
             unsafe { libc::putenv(raw) };
         }
+    }
+    if let Err(e) = apply_confinement(&spec.confinement) {
+        let _ = writeln_stderr(&format!("confining the session: {e}"));
+        child_exit(126);
     }
     let Some(cargs) = validate_argv(&spec.argv) else {
         let _ = writeln_stderr("argv contained interior NUL");

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -15,7 +15,7 @@ const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
 use super::{
     Confinement, LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close,
-    confinement, dispatch_frame, read_client_frame, signal_target, validate_argv,
+    confinement, dispatch_frame, keys_to_scrub, read_client_frame, signal_target, validate_argv,
     validate_open_session,
 };
 use crate::forker::{Fork, Forker};
@@ -165,12 +165,15 @@ pub fn handle_session(
     else {
         unreachable!("validate_open_session guarantees OpenSession");
     };
+    let confinement = confinement(confine, env_u32("LENS_RUN_UID"), env_u32("LENS_RUN_GID"));
+    let inherited: Vec<String> = std::env::vars().map(|(k, _)| k).collect();
     let spec = WorkloadSpec {
         argv,
         env,
         cwd,
         hostname,
-        confinement: confinement(confine, env_u32("LENS_RUN_UID"), env_u32("LENS_RUN_GID")),
+        scrub: keys_to_scrub(inherited.iter().map(String::as_str), &confinement),
+        confinement,
     };
     if tty {
         run_tty_session(conn, spec, winsize, stdin, pid_tx, forker)
@@ -497,6 +500,12 @@ fn exec_child(spec: &WorkloadSpec) -> ! {
     };
     enter_workdir(spec.cwd.as_deref());
     set_guest_hostname(spec.hostname.as_deref());
+    for key in &spec.scrub {
+        if let Ok(c) = CString::new(key.as_str()) {
+            // SAFETY: unsetenv copies the name; the CString outlives the call.
+            unsafe { libc::unsetenv(c.as_ptr()) };
+        }
+    }
     for kv in &spec.env {
         if let Ok(c) = CString::new(kv.as_str()) {
             let raw = c.into_raw();

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -21,7 +21,7 @@ pub enum ClientFrame {
         tty: bool,
         stdin: bool,
         winsize: Option<Winsize>,
-        /// Drop to the guest's run-as identity (or cap a root one) before exec; the primary session leaves it false so the supervisor keeps the privileges the cage needs.
+        /// Drop to the guest's run-as identity (or cap a root one) and scrub the relay credentials before exec; only a supervised primary session leaves it false, because its workload is the supervisor.
         confine: bool,
     },
     StdinBytes(Vec<u8>),

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -21,6 +21,8 @@ pub enum ClientFrame {
         tty: bool,
         stdin: bool,
         winsize: Option<Winsize>,
+        /// Drop to the guest's run-as identity (or cap a root one) before exec; the primary session leaves it false so the supervisor keeps the privileges the cage needs.
+        confine: bool,
     },
     StdinBytes(Vec<u8>),
     Resize(Winsize),
@@ -127,6 +129,7 @@ mod tests {
             tty: true,
             stdin: true,
             winsize: Some(Winsize { rows: 24, cols: 80 }),
+            confine: true,
         };
         let bytes = encode_frame(&frame).expect("encode");
         let len = decode_length_prefix(&bytes[..4].try_into().unwrap()).expect("len");
@@ -145,6 +148,7 @@ mod tests {
             tty: false,
             stdin: false,
             winsize: None,
+            confine: false,
         };
         let bytes = encode_frame(&frame).expect("encode");
         let back: ClientFrame = decode_frame(&bytes[4..]).expect("decode");

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -61,8 +61,11 @@ impl AgentDispatcher {
         reaper: Arc<OrphanReaper>,
         runner: Arc<dyn AgentRunner>,
     ) -> Self {
-        let exec_manager =
-            ExecManager::new(sandbox_creds.clone(), config.core.is_root, reaper.guard());
+        let exec_manager = ExecManager::new(
+            crate::run_as::setuid_creds(sandbox_creds.as_ref()),
+            config.core.is_root,
+            reaper.guard(),
+        );
         let activity = ActivityStream::new();
         spawn_activity_to_stdout(&activity);
         Self {
@@ -237,7 +240,7 @@ pub(crate) fn agent_child_spec(
             creds.map(|c| c.home()),
         )),
         env: build_agent_env(config, creds, env),
-        creds: creds.cloned(),
+        creds: crate::run_as::setuid_creds(creds),
         is_root: config.core.is_root,
     }
 }
@@ -386,6 +389,42 @@ mod tests {
         let env = build_agent_env(&config, Some(&creds), &HashMap::new());
         assert_eq!(env.get("HOME").map(String::as_str), Some(creds.home()));
         assert_eq!(env.get("USER").map(String::as_str), Some(creds.user()));
+    }
+
+    #[test]
+    fn a_root_run_as_keeps_its_identity_but_not_its_setuid() {
+        let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
+        let mut config = make_agent_config();
+        config.workspace_path = None;
+
+        let spec = agent_child_spec(&config, Some(&creds), &HashMap::new());
+
+        assert!(
+            spec.creds.is_none(),
+            "a root run-as must reach child_spawner's cap-drop branch, which only runs when creds is None"
+        );
+        assert_eq!(
+            spec.env.get("HOME").map(String::as_str),
+            Some(creds.home()),
+            "dropping the setuid must not cost the workload its HOME — the flag exists so root-owned tooling works"
+        );
+        assert_eq!(spec.env.get("USER").map(String::as_str), Some(creds.user()));
+        assert_eq!(
+            spec.cwd.as_deref(),
+            Some(creds.home()),
+            "with no explicit workspace the agent still starts in the run-as user's home"
+        );
+    }
+
+    #[test]
+    fn a_non_root_run_as_still_setuids() {
+        let creds = SandboxCredentials::resolve_by_uid(65534, 65534).expect("uid resolves on host");
+        let config = make_agent_config();
+
+        let spec = agent_child_spec(&config, Some(&creds), &HashMap::new());
+
+        let (uid, gid) = spec.creds.expect("a non-root run-as setuids").uid_gid();
+        assert_eq!((uid.as_raw(), gid.as_raw()), (65534, 65534));
     }
 
     #[tokio::test]

--- a/crates/lns-supervisor/src/main.rs
+++ b/crates/lns-supervisor/src/main.rs
@@ -11,15 +11,13 @@ use lens_sandbox_core::network;
 use lens_sandbox_core::privilege;
 use lens_sandbox_core::proxy;
 
-/// Drop to the uid/gid lns-init resolved in the guest, or `None` so core's `apply_cap_drop` runs instead.
+/// The run-as identity lns-init resolved in the guest; whether it is also a setuid target is decided at spawn time by `run_as::setuid_creds`.
 fn resolve_agent_creds() -> Option<privilege::SandboxCredentials> {
     let uid = env_u32("LENS_RUN_UID");
     let gid = env_u32("LENS_RUN_GID");
-    let run_as::Plan::Setuid { uid, gid } = run_as::plan(uid, gid) else {
+    let (Some(uid), Some(gid)) = (uid, gid) else {
         tracing::info!(
-            ?uid,
-            ?gid,
-            "agent will run as root with capabilities dropped"
+            "no run-as uid/gid from lns-init — agent will run as root with capabilities dropped"
         );
         return None;
     };

--- a/crates/lns-supervisor/src/main.rs
+++ b/crates/lns-supervisor/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod dispatcher;
+mod run_as;
 
 use std::io::IsTerminal;
 use std::sync::Arc;
@@ -10,13 +11,15 @@ use lens_sandbox_core::network;
 use lens_sandbox_core::privilege;
 use lens_sandbox_core::proxy;
 
-/// Drop to the uid/gid lns-init resolved in the guest, or `None` to run the agent as root with capabilities dropped.
+/// Drop to the uid/gid lns-init resolved in the guest, or `None` so core's `apply_cap_drop` runs instead.
 fn resolve_agent_creds() -> Option<privilege::SandboxCredentials> {
     let uid = env_u32("LENS_RUN_UID");
     let gid = env_u32("LENS_RUN_GID");
-    let (Some(uid), Some(gid)) = (uid, gid) else {
+    let run_as::Plan::Setuid { uid, gid } = run_as::plan(uid, gid) else {
         tracing::info!(
-            "no run-as uid/gid from lns-init — agent will run as root with capabilities dropped"
+            ?uid,
+            ?gid,
+            "agent will run as root with capabilities dropped"
         );
         return None;
     };

--- a/crates/lns-supervisor/src/run_as.rs
+++ b/crates/lns-supervisor/src/run_as.rs
@@ -1,0 +1,65 @@
+/// How the supervisor should hand its privileges to the workload.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Plan {
+    RootWithCapsDropped,
+    Setuid { uid: u32, gid: u32 },
+}
+
+pub(crate) fn plan(uid: Option<u32>, gid: Option<u32>) -> Plan {
+    match (uid, gid) {
+        (Some(uid), Some(gid)) if uid != ROOT_UID => Plan::Setuid { uid, gid },
+        _ => Plan::RootWithCapsDropped,
+    }
+}
+
+const ROOT_UID: u32 = 0;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_root_run_as_keeps_root_but_drops_capabilities() {
+        assert_eq!(
+            plan(Some(0), Some(0)),
+            Plan::RootWithCapsDropped,
+            "setuid(0) is a no-op that leaves CAP_NET_ADMIN and CAP_SYS_PTRACE in place, so a root run-as must take the cap-drop path instead"
+        );
+    }
+
+    #[test]
+    fn a_root_uid_under_a_non_root_group_still_drops_capabilities() {
+        assert_eq!(
+            plan(Some(0), Some(20)),
+            Plan::RootWithCapsDropped,
+            "the kernel only zeroes the capability sets on setuid to a non-zero uid — the gid does not enter into it"
+        );
+    }
+
+    #[test]
+    fn a_non_root_run_as_setuids_to_the_resolved_ids() {
+        assert_eq!(
+            plan(Some(65534), Some(65534)),
+            Plan::Setuid {
+                uid: 65534,
+                gid: 65534
+            }
+        );
+    }
+
+    #[test]
+    fn a_non_root_uid_in_the_root_group_still_setuids() {
+        assert_eq!(
+            plan(Some(1000), Some(0)),
+            Plan::Setuid { uid: 1000, gid: 0 },
+            "setuid(1000) zeroes the capability sets even when the workload stays in group 0"
+        );
+    }
+
+    #[test]
+    fn ids_lns_init_could_not_resolve_keep_root_with_capabilities_dropped() {
+        assert_eq!(plan(None, None), Plan::RootWithCapsDropped);
+        assert_eq!(plan(Some(1000), None), Plan::RootWithCapsDropped);
+        assert_eq!(plan(None, Some(1000)), Plan::RootWithCapsDropped);
+    }
+}

--- a/crates/lns-supervisor/src/run_as.rs
+++ b/crates/lns-supervisor/src/run_as.rs
@@ -1,65 +1,56 @@
-/// How the supervisor should hand its privileges to the workload.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum Plan {
-    RootWithCapsDropped,
-    Setuid { uid: u32, gid: u32 },
-}
-
-pub(crate) fn plan(uid: Option<u32>, gid: Option<u32>) -> Plan {
-    match (uid, gid) {
-        (Some(uid), Some(gid)) if uid != ROOT_UID => Plan::Setuid { uid, gid },
-        _ => Plan::RootWithCapsDropped,
-    }
-}
+use lens_sandbox_core::privilege::SandboxCredentials;
 
 const ROOT_UID: u32 = 0;
+
+/// The identity to `setuid` into before exec; `None` keeps the supervisor's uid so the caller drops capabilities instead.
+pub(crate) fn setuid_creds(creds: Option<&SandboxCredentials>) -> Option<SandboxCredentials> {
+    creds
+        .filter(|c| c.uid_gid().0.as_raw() != ROOT_UID)
+        .cloned()
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn creds_for(uid: u32, gid: u32) -> SandboxCredentials {
+        SandboxCredentials::resolve_by_uid(uid, gid).expect("resolve_by_uid never fails on a host")
+    }
+
     #[test]
-    fn a_root_run_as_keeps_root_but_drops_capabilities() {
-        assert_eq!(
-            plan(Some(0), Some(0)),
-            Plan::RootWithCapsDropped,
-            "setuid(0) is a no-op that leaves CAP_NET_ADMIN and CAP_SYS_PTRACE in place, so a root run-as must take the cap-drop path instead"
+    fn a_root_run_as_is_not_a_setuid_target() {
+        assert!(
+            setuid_creds(Some(&creds_for(ROOT_UID, 0))).is_none(),
+            "setuid(0) is a no-op that leaves CAP_NET_ADMIN and CAP_SYS_PTRACE in place, so a root run-as must reach the cap-drop path instead"
         );
     }
 
     #[test]
-    fn a_root_uid_under_a_non_root_group_still_drops_capabilities() {
-        assert_eq!(
-            plan(Some(0), Some(20)),
-            Plan::RootWithCapsDropped,
+    fn a_root_uid_under_a_non_root_group_is_not_a_setuid_target() {
+        assert!(
+            setuid_creds(Some(&creds_for(ROOT_UID, 20))).is_none(),
             "the kernel only zeroes the capability sets on setuid to a non-zero uid — the gid does not enter into it"
         );
     }
 
     #[test]
     fn a_non_root_run_as_setuids_to_the_resolved_ids() {
-        assert_eq!(
-            plan(Some(65534), Some(65534)),
-            Plan::Setuid {
-                uid: 65534,
-                gid: 65534
-            }
-        );
+        let creds =
+            setuid_creds(Some(&creds_for(65534, 65534))).expect("a non-root run-as setuids");
+        let (uid, gid) = creds.uid_gid();
+        assert_eq!((uid.as_raw(), gid.as_raw()), (65534, 65534));
     }
 
     #[test]
     fn a_non_root_uid_in_the_root_group_still_setuids() {
-        assert_eq!(
-            plan(Some(1000), Some(0)),
-            Plan::Setuid { uid: 1000, gid: 0 },
-            "setuid(1000) zeroes the capability sets even when the workload stays in group 0"
-        );
+        let creds = setuid_creds(Some(&creds_for(1000, 0)))
+            .expect("setuid(1000) zeroes the capability sets even in group 0");
+        let (uid, gid) = creds.uid_gid();
+        assert_eq!((uid.as_raw(), gid.as_raw()), (1000, 0));
     }
 
     #[test]
-    fn ids_lns_init_could_not_resolve_keep_root_with_capabilities_dropped() {
-        assert_eq!(plan(None, None), Plan::RootWithCapsDropped);
-        assert_eq!(plan(Some(1000), None), Plan::RootWithCapsDropped);
-        assert_eq!(plan(None, Some(1000)), Plan::RootWithCapsDropped);
+    fn ids_lns_init_could_not_resolve_have_no_setuid_target() {
+        assert!(setuid_creds(None).is_none());
     }
 }


### PR DESCRIPTION
## Problem 1 — a root run-as keeps every capability

`lns run --sandbox-user root . -- sh -c '/.lens/nft flush ruleset'` succeeds. The workload tears down the nftables cage that redirects egress to the policy proxy, so network policy stops applying: no approval cards, no audit records, no gating.

The chain:

1. `resolve_run_as` (`crates/lns-service/src/vm/mod.rs:207`) accepts `root` verbatim — no uid-0 handling anywhere in lns-cli / lns-service / lns-init.
2. `lns-init` resolves the name against the image's `/etc/passwd` (`crates/lns-init/src/mount.rs:265`) and exports `LENS_RUN_UID=0` / `LENS_RUN_GID=0`.
3. `resolve_agent_creds` turns that into `Some(SandboxCredentials{uid:0,gid:0})`.
4. In lens-sandbox-core, `apply_privilege_drop` (`child_spawner.rs:85`) takes the `Some(creds)` arm and skips the `else if spec.is_root` cap drop:

```rust
if let Some(creds) = &spec.creds { creds.apply(cmd); }      // taken, uid 0
else if spec.is_root { privilege::apply_cap_drop(cmd); }    // the cap drop, skipped
```

`creds.apply` then runs `setgroups([]) + setgid(0) + setuid(0)` — all no-ops from root — followed only by `NO_NEW_PRIVS`. Its comment states the premise that breaks here: *"setuid(non-root) already zeroed effective/permitted/inheritable"*. That kernel side effect only fires for non-zero uids, so `CAP_NET_ADMIN` survives.

Two consequences, not one:

- **Network policy bypass** — `CAP_NET_ADMIN` in the guest's single netns flushes the cage.
- **Secret exposure** — `CAP_SYS_PTRACE` defeats `harden_supervisor`'s `PR_SET_DUMPABLE(0)` (non-dumpable blocks same-uid ptrace, not `CAP_SYS_PTRACE`), reaching the supervisor's relay token and MITM CA key. That is squarely against "real secrets stay outside the workload".

Same trigger without any flag: an image whose `USER` is `root` or `0` takes the identical path.

## Fix

Never hand core a uid-0 credential — but keep it for everything else. `crates/lns-supervisor/src/run_as.rs` decides the setuid target; the dispatcher keeps the full credentials for `HOME`/`USER` (`build_agent_env`) and the agent cwd (`resolve_cwd`), while only `ChildSpec.creds` and the exec manager get the filtered value. A root run-as therefore reaches core's `apply_cap_drop` while keeping the environment the flag exists to provide.

Deciding at the spawn boundary rather than at credential resolution covers both spawn paths — the piped one at `child_spawner.rs:88` and the hand-rolled PTY closure at `pty.rs:126`, so `-it` is fixed too — and `lns exec` sessions, which take the same credentials through `ExecManager`.

Net effect for a root workload: keeps uid 0, `HOME`, `USER`, cwd, and `KEEP_CAP_MASK` (`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `FSETID`, `KILL`, `SETUID`, `SETGID`) so package installs and chowns still work; loses `NET_ADMIN` and `SYS_PTRACE`. `NO_NEW_PRIVS` and pdeathsig are unchanged — `apply_cap_drop` installs both.

Guarding at the consumer keeps this to one repo: no core change and no pin bump, so core stays at `4cb1d974` from #178.

### One accepted behaviour change

`-u root:<group>` no longer honours the group. The caps-dropped path never calls `setgid`, so the workload inherits the supervisor's gid 0 where it previously got the requested gid. lns-init still resolves and exports it. Honouring a group without a setuid needs a core change; the combination looks rare enough to defer, and the alternative is leaving `NET_ADMIN` in place.


## Problem 2 — `lns exec` was never confined at all

Found while pinning the exec half of problem 1, and worse than it. `handle_exec` (`crates/lns-service/src/ipc/adapter.rs:621`) connects to `lns_session::BROKER_PORT`, so an exec is forked by the **session broker**, not the supervisor — it never met the privilege drop at all. `exec_child` (`crates/lns-session-broker/src/session/real.rs`) went from `close_range`/env straight to `execvp`.

Probed on `main`, exec'ing into a **default** sandbox with no `-u` anywhere:

```
Uid:      0  0  0  0            # the workload itself runs as 65534
CapEff:   000001ffffffffff
```

So `lns exec <run> -- /.lens/nft flush ruleset` took the cage down on any sandbox. Pre-existing and independent of problem 1 — the supervisor's `ExecManager` is simply not on this path.

## Fix 2 — carry the intent on the wire

`ClientFrame::OpenSession` gains `confine: bool`. When set, the broker applies the identity lns-init resolved (`LENS_RUN_UID`/`LENS_RUN_GID`): `setuid` for a non-root workload, `KEEP_CAP_MASK` for a root one, `NO_NEW_PRIVS` either way. `lns exec` sets it; the primary session leaves it false because its workload *is* the supervisor, which needs root and `CAP_NET_ADMIN` to install the cage in the first place.

Two design points worth stating:

- The decision resolves **before** the fork, so the post-fork child never takes the environment lock. It lives as a pure `confinement()` in `session.rs` (100% covered); only the syscalls sit in the platform leaf that is already in IGNORES.
- `KEEP_CAP_MASK` is duplicated in the broker rather than depending on lens-sandbox-core — the broker is a static-musl PID-1 sibling and pulling in core's async surface for one constant isn't worth it. The constant carries a comment naming core as the source of truth.

Not changed: the unsupervised primary session (no policy → no supervisor) still runs its workload unconfined, and the internal stats probe stays unconfined since its argv is service-controlled and unreachable from the workload. Both are noted as follow-ups rather than silently altered.


## Problem 3 — the relay token rode into every exec

`exec_child` applied the session env *on top of* the inherited environment, so `LENS_SANDBOX_TOKEN` and `LENS_SANDBOX_WS_URL` reached every exec'd command through its own `environ` — including the one fix 2 had just dropped to uid 65534 with no capabilities.

That token is the whole supervisor↔workload trust boundary inside the guest: vsock exposes no peer identity, so the host cannot tell the supervisor from the workload on port 1024, and the bearer token (per run, constant-time compared at `relay/mod.rs:306`) is the only discriminator. A workload holding it can approve its own egress, request credential injection, and write audit entries — defeating the policy engine without touching nftables. Removing `CAP_SYS_PTRACE` in fix 1 was done specifically to keep that token out of a workload's reach.

The cmdline leg was already closed: `lns-init` bind-mounts a sanitized `/.lens/.cmdline` over `/proc/cmdline` (`mount.rs:29,609-618`), verified in a booted guest. `environ` was the one remaining door.

## Fix 3 — scrub the inherited internal vars

A confined session unsets inherited `LENS_SANDBOX_*` before applying its own env, filtering on the same `INTERNAL_VAR_PREFIX` core scrubs before spawning the agent (`privilege.rs:11`). `clearenv()` would have taken `PATH`/`HOME` with it; `LENS_RUN_UID`/`GID` survive the prefix, matching what the agent already sees. Keys are selected before the fork, beside the confinement decision, so the child never walks the environment.

Gated on `Confinement` for the same reason as fix 2: `Inherit` keeps them, because a supervised primary session *is* the supervisor.

Also corrected here: `confine` for the primary session is now `session.is_none()` rather than a hardcoded `false`. With no resolved policy path `start_if_policy` returns `None` and the broker execs the *user's* command as the primary session, so the constant silently ignored `--sandbox-user` and dropped nothing. Deriving it from the value that already decides `argv` keeps the two from drifting. That path has no `@microvm` coverage — every e2e run resolves a policy — so it is structurally tied rather than test-pinned.

## Tests

Red first, at both seams. The capability decision:

```
a_root_run_as_is_not_a_setuid_target ... FAILED
  left: Setuid { uid: 0, gid: 0 }
 right: RootWithCapsDropped
```

Then the identity regression the first pass introduced:

```
a_root_run_as_keeps_its_identity_but_not_its_setuid ... FAILED
  at dispatcher/agent.rs:399: spec.creds.is_none()
```

**Layer 3** — `run_as.rs` (100%): root uid is not a setuid target regardless of gid; non-root uid is, even in group 0; unresolvable ids have no target. `dispatcher/agent.rs` (100%): a root run-as yields no `ChildSpec.creds` but keeps `HOME`, `USER` and a home cwd; a non-root run-as still setuids.

**Layer 1** — `microvm_privilege.feature` (`@microvm`): a root run-as is honoured as an identity; it keeps `HOME`/`USER`; it cannot flush the ruleset; and its `CapEff` is `00000000000000fb`. Verified on a real guest, 8 scenarios / 34 steps green via `LNS_E2E_FEATURE=unprivileged make e2e-microvm`.

The capability assertion replaced an earlier `cat /proc/1/mem` probe that could not fail: the read returns `EIO` from the unmapped offset 0 regardless of capabilities, and PID 1 is the session broker rather than the supervisor holding the placeholder map. Reading `CapEff` pins the real invariant — `0xfb` is `KEEP_CAP_MASK` exactly, so `NET_ADMIN` (bit 12) and `SYS_PTRACE` (bit 19) are both provably absent where the pre-fix workload carried the full `000001ffffffffff`.

Observed in the guest under `--sandbox-user root`, for the record:

```
Uid:         0
CapPrm:      00000000000000fb
CapEff:      00000000000000fb
CapBnd:      000001ffffffffff
CapAmb:      0000000000000000
NoNewPrivs:  1
```

### Why the existing suite did not catch this

Worth recording, because the first pass shipped a regression past a green gate:

- `resolve_agent_creds` lives in `main.rs`, which is in the coverage IGNORES as a guest-only bootstrap. The function whose semantics changed had no test at any layer.
- The gate measures lines, not behaviour. `build_agent_env`'s `if let Some(creds)` arms were already covered from both directions by existing tests, so changing which arm production takes at runtime moved no hit count. Coverage stayed at 100% while the behaviour broke.
- The tests that would have caught it are `@microvm`, which the required suite does not run.

The new Layer 3 tests close the first two by asserting across the seam instead of on either side of it.

### Fix 2's tests

**Layer 3** — `confinement()`: an unconfined session inherits, a confined non-root session setuids, a confined root session caps instead, and missing ids still cap. `build_session_params_asks_the_broker_to_confine_the_exec` pins the service side. `OpenSession` round-trips the flag.

**Layer 1** — two `@microvm` scenarios through a new `-u`-carrying detached-start step: an exec into a default sandbox reports `uid=65534`, and an exec into a root sandbox reports `CapEff: …fb`.

**Mutation-checked.** Flipping `confine` back to `false` fails exactly those two scenarios and nothing else.

### Fix 3's tests

**Layer 3** — `keys_to_scrub()`: a confined session scrubs exactly the two relay vars while keeping `PATH`/`HOME`/`LENS_RUN_UID`, a setuid session scrubs them too, an unconfined session keeps them.

**Layer 1** — `an exec does not inherit the supervisor's relay credentials` asserts an exec's own `env` carries neither var.

**Mutation-checked.** Disabling the prefix filter fails exactly that scenario.

### Verification

Full `@microvm` suite: **70/73**. The 3 failures are pre-existing and unrelated — 2 stale credential specs (#181, broken on `main` since #170) and a local-registry `503`. All pre-existing exec scenarios in `microvm_streaming.feature` still pass, so confining an exec to uid 65534 broke nothing.

## Follow-up, not in this PR

- `CapBnd` stays at the full `000001ffffffffff` because `KEEP_CAP_MASK` excludes `CAP_SETPCAP`, so the bounding set cannot be narrowed from the child. Not exploitable on its own — `CapInh` and `CapAmb` are zero and `NoNewPrivs` is 1, so nothing can promote a bounding-set bit into permitted — but it is the same gap as the item below.
- The unsupervised primary session is now confined, but nothing in the harness can boot a run without a resolved policy, so that path stays unverified end to end.
- The core restructure — registering `apply_cap_drop` *before* `creds.apply` — additionally drops the **bounding set** on non-root runs, which `creds.apply` admits it cannot do today (`privilege.rs:294`, `CAP_SETPCAP` is already gone by then). Worth a `lens-sandbox-core` PR so every consumer gets it instead of each one guarding uid 0.
- `host_known_workload_gid` (`vm/mod.rs:260`) returns `Some` only for the exact default `sandbox`/65534, so any `-u` override serves Linux binds 1:1 with no virtiofsd `--uid-map` (`orchestrate.rs:58`). Separate bug.
