### PR TITLE
refactor(policy)!: adopt egress.http as the canonical route table

### DIFF
--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -169,7 +169,7 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
     std::fs::write(root.join("lns.yaml"), definition).expect("write project lns.yaml");
     std::fs::write(
         root.join("lns-policy.yaml"),
-        "network:\n  allowedRoutes: []\n  defaultVerdict: ask\n  defaultTransport: direct\n",
+        "network:\n  egress:\n    http: []\n  defaultVerdict: ask\n  defaultTransport: direct\n",
     )
     .expect("write the project policy");
     root
@@ -1110,7 +1110,7 @@ fn output_lists_that_run(world: &mut E2eWorld) -> Result<(), String> {
 fn policy_ask_with_direct_route(world: &mut E2eWorld) {
     write_policy(
         world,
-        "network:\n  defaultVerdict: ask\n  defaultTransport: direct\n  allowedRoutes:\n    - match: api.example.test\n      verdict: allow\n      transport: direct\n",
+        "network:\n  defaultVerdict: ask\n  defaultTransport: direct\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n        transport: direct\n",
     );
 }
 

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -479,7 +479,7 @@ mod tests {
     #[test]
     fn parse_reads_the_whole_flat_definition() {
         let json = def_json(
-            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","workdir":"/workspace","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"policy":{"defaultVerdict":"deny","allowedRoutes":[{"match":"api.example.test","verdict":"allow"}]},"connectors":["some-provider"],"credentials":[{"name":"some-provider","env":"SOME_TOKEN"}],"volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"home","target":"/root/.home","readOnly":true}],"ports":[{"container":8080}]}"#,
+            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","workdir":"/workspace","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"policy":{"defaultVerdict":"deny","egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}},"connectors":["some-provider"],"credentials":[{"name":"some-provider","env":"SOME_TOKEN"}],"volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"home","target":"/root/.home","readOnly":true}],"ports":[{"container":8080}]}"#,
         );
         let def = parse(&json).unwrap();
         assert_eq!(def.metadata.name, "hermes");
@@ -491,7 +491,7 @@ mod tests {
             Some("research")
         );
         assert_eq!(def.spec.policy.default_verdict, Verdict::Deny);
-        assert_eq!(def.spec.policy.allowed_routes.len(), 1);
+        assert_eq!(def.spec.policy.egress.http.len(), 1);
         assert_eq!(def.spec.connectors, vec!["some-provider".to_string()]);
         assert_eq!(def.spec.credentials[0].env, "SOME_TOKEN");
         assert_eq!(def.spec.volumes[0].source(), ".");
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn parse_rejects_an_upstream_route_transport() {
         let err = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"allowedRoutes":[{"match":"api.example.test","verdict":"allow","transport":"upstream"}]}}"#,
+            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","transport":"upstream"}]}}}"#,
         ))
         .unwrap_err();
         assert!(
@@ -1136,8 +1136,8 @@ mod tests {
             r#"{"image":"x:1","unexpected":true}"#,
             r#"{"image":"x:1","resources":{"cpu":1,"unexpected":true}}"#,
             r#"{"image":"x:1","policy":{"unexpected":true}}"#,
-            r#"{"image":"x:1","policy":{"allowedRoutes":[{"match":"api.example.test","verdict":"allow","unexpected":true}]}}"#,
-            r#"{"image":"x:1","policy":{"allowedRoutes":[{"match":"api.example.test","verdict":"allow","rules":[{"path":"/v1","unexpected":true}]}]}}"#,
+            r#"{"image":"x:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","unexpected":true}]}}}"#,
+            r#"{"image":"x:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","rules":[{"path":"/v1","unexpected":true}]}]}}}"#,
             r#"{"image":"x:1","credentials":[{"name":"some-provider","env":"SOME_TOKEN","requred":true}]}"#,
             r#"{"image":"x:1","volumes":[{"name":"data","target":"/data","readOlny":true}]}"#,
             r#"{"image":"x:1","filesets":[{"path":"./skills","mountPath":"/skills","unexpected":true}]}"#,

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -100,7 +100,7 @@ fn add_rule(
     let path = policy_path(args.policy.as_deref(), cwd);
     let mut policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
-    policy.network.allowed_routes.push(RouteRule {
+    policy.network.egress.http.push(RouteRule {
         match_pattern: args.pattern.clone(),
         verdict,
         transport: Transport::Direct,
@@ -128,7 +128,8 @@ fn list_rules(args: &PolicyScopeArgs, cwd: &Path, writer: &mut impl Write) -> Re
         .with_context(|| format!("loading policy from {}", path.display()))?;
     let rows: Vec<RuleRow> = policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .map(RuleRow::new)
         .collect();
@@ -171,12 +172,13 @@ fn remove_rule(args: &PolicyRemoveArgs, cwd: &Path, writer: &mut impl Write) -> 
     let path = policy_path(args.policy.as_deref(), cwd);
     let mut policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
-    let before = policy.network.allowed_routes.len();
+    let before = policy.network.egress.http.len();
     policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .retain(|rule| rule.match_pattern != args.pattern);
-    if policy.network.allowed_routes.len() == before {
+    if policy.network.egress.http.len() == before {
         bail!("no rule matching {:?} in {}", args.pattern, path.display());
     }
     policy
@@ -235,12 +237,9 @@ mod tests {
         let code = add_rule(&args, Verdict::Allow, dir.path(), &mut out).unwrap();
         assert_eq!(code, 0);
         let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
-        assert_eq!(policy.network.allowed_routes.len(), 1);
-        assert_eq!(policy.network.allowed_routes[0].verdict, Verdict::Allow);
-        assert_eq!(
-            policy.network.allowed_routes[0].transport,
-            Transport::Direct
-        );
+        assert_eq!(policy.network.egress.http.len(), 1);
+        assert_eq!(policy.network.egress.http[0].verdict, Verdict::Allow);
+        assert_eq!(policy.network.egress.http[0].transport, Transport::Direct);
     }
 
     #[test]
@@ -258,7 +257,8 @@ mod tests {
         assert!(
             policy
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|r| r.match_pattern == "evil.example" && r.verdict == Verdict::Deny)
         );
@@ -284,7 +284,8 @@ mod tests {
         assert!(
             policy
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|r| r.match_pattern == "api.acme.corp" && r.verdict == Verdict::Allow)
         );

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -17,7 +17,8 @@ pub enum PolicySource {
 const DEFAULT_POLICY_FILENAME: &str = "lns-policy.yaml";
 const DEFAULT_POLICY_YAML: &str = "\
 network:
-  allowedRoutes: []
+  egress:
+    http: []
   defaultVerdict: ask
 ";
 
@@ -268,7 +269,7 @@ fn verdict_word(v: Verdict) -> &'static str {
 }
 
 fn rules_line(policy: &Policy) -> String {
-    let routes = &policy.network.allowed_routes;
+    let routes = &policy.network.egress.http;
     if routes.is_empty() {
         return "none defined; anything else asks".to_string();
     }
@@ -918,7 +919,7 @@ mod tests {
         let preexisting = dir.path().join(DEFAULT_POLICY_FILENAME);
         std::fs::write(
             &preexisting,
-            "network:\n  allowedRoutes: []\n  defaultVerdict: ask\n",
+            "network:\n  egress:\n    http: []\n  defaultVerdict: ask\n",
         )
         .unwrap();
         let (resolved, source) = resolve_policy(None, dir.path()).unwrap();
@@ -934,6 +935,11 @@ mod tests {
         assert_eq!(source, PolicySource::AutoCreated);
         let body = std::fs::read_to_string(&resolved).unwrap();
         assert!(body.contains("defaultVerdict: ask"));
+        assert!(
+            body.contains("egress:") && body.contains("http: []"),
+            "the scaffold must name the table the guest reads, not the deprecated one:\n{body}"
+        );
+        assert!(!body.contains("allowedRoutes"), "got:\n{body}");
         assert!(!body.contains("defaultTransport"), "got:\n{body}");
         assert!(!body.contains("transport:"), "got:\n{body}");
     }

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -21,7 +21,8 @@ spec:
     memory: 512Mi
   policy:
     defaultVerdict: ask
-    allowedRoutes: []
+    egress:
+      http: []
   connectors: []
   credentials: []
   volumes:
@@ -230,7 +231,7 @@ fn render_effective<W: Write>(def: &lns_artifact::sandbox::Definition, out: &mut
         out,
         "  policy:       defaultVerdict={} ({} route(s))",
         verdict.trim_matches('"'),
-        def.spec.policy.allowed_routes.len()
+        def.spec.policy.egress.http.len()
     )?;
     if !def.spec.connectors.is_empty() {
         writeln!(out, "  connectors: {}", def.spec.connectors.join(", "))?;

--- a/crates/lns-cli/tests/behaviours/policy_cli.feature
+++ b/crates/lns-cli/tests/behaviours/policy_cli.feature
@@ -44,6 +44,12 @@ Feature: shaping network rules from the CLI
     When the developer lists rules
     Then the output shows both rules with their verdicts
 
+  Scenario: Listing rules from a policy file naming the removed allowedRoutes key fails loudly
+    Given "lns-policy.yaml" uses the removed allowedRoutes key for "api.linear.app"
+    When the developer lists rules
+    Then the command fails with an exit code other than 0
+    And the error names "allowedRoutes"
+
   Scenario: Removing a rule by pattern deletes it from the policy file
     Given "lns-policy.yaml" has an allow rule for "api.linear.app"
     When the developer removes the rule matching "api.linear.app"

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -15,7 +15,7 @@ Feature: authoring a sandbox
     And the file "lns.yaml" contains "env:"
     And the file "lns.yaml" contains "resources:"
     And the file "lns.yaml" contains "defaultVerdict: ask"
-    And the file "lns.yaml" contains "allowedRoutes:"
+    And the file "lns.yaml" contains "egress:"
     And the file "lns.yaml" contains "connectors:"
     And the file "lns.yaml" contains "credentials:"
     And the file "lns.yaml" contains "filesets:"

--- a/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
@@ -45,7 +45,8 @@ fn load(world: &mut BehaviourWorld, file: &str) -> Policy {
 fn has_rule(policy: &Policy, pattern: &str, verdict: Verdict) -> bool {
     policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.match_pattern == pattern && r.verdict == verdict)
 }
@@ -84,6 +85,18 @@ fn policy_has_allow(world: &mut BehaviourWorld, file: String, pattern: String) {
     let mut policy = Policy::default();
     policy.add_rule(RouteRule::allow_host(pattern));
     policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(regex = r#"^"([^"]+)" uses the removed allowedRoutes key for "([^"]+)"$"#)]
+fn policy_uses_the_removed_key(world: &mut BehaviourWorld, file: String, pattern: String) {
+    let dir = cwd(world);
+    std::fs::write(
+        dir.join(file),
+        format!(
+            "network:\n  allowedRoutes:\n    - match: {pattern}\n      verdict: allow\n  defaultVerdict: ask\n"
+        ),
+    )
+    .expect("seed a policy file in the pre-egress shape");
 }
 
 #[given(regex = r#"^"([^"]+)" has no rule for "([^"]+)"$"#)]
@@ -260,13 +273,28 @@ fn file_contains_described_rule(world: &mut BehaviourWorld, file: String) -> Res
     let policy = load(world, &file);
     let described = policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.verdict == Verdict::Allow && r.description.is_some());
     if described {
         Ok(())
     } else {
         Err(format!("{file} has no allow rule carrying a description"))
+    }
+}
+
+#[then(regex = r#"^the error names "([^"]+)"$"#)]
+fn error_names(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    if out.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!("error does not name {needle:?}:\n{out}"))
     }
 }
 
@@ -294,7 +322,8 @@ fn file_no_longer_contains(
     let policy = load(world, &file);
     if policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.match_pattern == pattern)
     {
@@ -315,7 +344,7 @@ fn command_fails(world: &mut BehaviourWorld) -> Result<(), String> {
 #[then(regex = r"^the policy file is unchanged$")]
 fn policy_file_unchanged(world: &mut BehaviourWorld) -> Result<(), String> {
     let policy = load(world, "lns-policy.yaml");
-    if policy.network.allowed_routes.is_empty() {
+    if policy.network.egress.http.is_empty() {
         Ok(())
     } else {
         Err("policy file was modified by a failed remove".to_string())

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -177,11 +177,15 @@ impl Catalog {
             i.validate()?;
         }
         NetworkPolicy {
-            allowed_routes: self
-                .connectors
-                .iter()
-                .flat_map(|connector| connector.routes.iter().map(ConnectorRoute::to_route_rule))
-                .collect(),
+            egress: crate::Egress {
+                http: self
+                    .connectors
+                    .iter()
+                    .flat_map(|connector| {
+                        connector.routes.iter().map(ConnectorRoute::to_route_rule)
+                    })
+                    .collect(),
+            },
             ..NetworkPolicy::default()
         }
         .validate_local_transport()

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -28,12 +28,20 @@ pub struct Policy {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NetworkPolicy {
     #[serde(default)]
-    pub allowed_routes: Vec<RouteRule>,
+    pub egress: Egress,
     #[serde(default = "default_ask")]
     pub default_verdict: Verdict,
     // Always serialized: sandbox-core's schema requires transport, and a missing one fail-closes a non-deny verdict to deny in the guest.
     #[serde(default)]
     pub default_transport: Transport,
+}
+
+/// The per-protocol egress tables lens-sandbox-core routes on.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Egress {
+    #[serde(default)]
+    pub http: Vec<RouteRule>,
 }
 
 fn default_ask() -> Verdict {
@@ -43,7 +51,7 @@ fn default_ask() -> Verdict {
 impl Default for NetworkPolicy {
     fn default() -> Self {
         Self {
-            allowed_routes: Vec::new(),
+            egress: Egress::default(),
             default_verdict: Verdict::Ask,
             default_transport: Transport::Direct,
         }
@@ -54,7 +62,8 @@ impl NetworkPolicy {
     pub fn validate_local_transport(&self) -> io::Result<()> {
         let uses_upstream = self.default_transport == Transport::Upstream
             || self
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|route| route.transport == Transport::Upstream);
         if uses_upstream {
@@ -152,8 +161,8 @@ impl Policy {
     }
 
     pub fn add_rule(&mut self, rule: RouteRule) {
-        if !self.network.allowed_routes.contains(&rule) {
-            self.network.allowed_routes.push(rule);
+        if !self.network.egress.http.contains(&rule) {
+            self.network.egress.http.push(rule);
         }
     }
 
@@ -227,12 +236,12 @@ mod tests {
         let p = Policy::default();
         assert_eq!(p.network.default_verdict, Verdict::Ask);
         assert_eq!(p.network.default_transport, Transport::Direct);
-        assert!(p.network.allowed_routes.is_empty());
+        assert!(p.network.egress.http.is_empty());
     }
 
     #[test]
     fn a_network_section_omitting_the_defaults_parses_to_ask_and_direct() {
-        let net: NetworkPolicy = serde_yaml::from_str("allowedRoutes: []\n").unwrap();
+        let net: NetworkPolicy = serde_yaml::from_str("egress:\n  http: []\n").unwrap();
         assert_eq!(net.default_verdict, Verdict::Ask);
         assert_eq!(net.default_transport, Transport::Direct);
     }
@@ -375,16 +384,67 @@ mod tests {
         let path = dir.path().join("lns-policy.yaml");
         let yaml = "\
 network:
+  egress:
+    http:
+      - match: api.linear.app
+        verdict: allow
+  defaultVerdict: ask
+";
+        fs::write(&path, yaml).unwrap();
+        let p = Policy::load_or_default(&path).unwrap();
+        assert_eq!(p.network.egress.http.len(), 1);
+        assert_eq!(p.network.egress.http[0].match_pattern, "api.linear.app");
+        assert_eq!(p.network.egress.http[0].verdict, Verdict::Allow);
+    }
+
+    #[test]
+    fn load_or_default_rejects_a_file_still_naming_the_removed_allowed_routes_key() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-policy.yaml");
+        let yaml = "\
+network:
   allowedRoutes:
     - match: api.linear.app
       verdict: allow
   defaultVerdict: ask
 ";
         fs::write(&path, yaml).unwrap();
-        let p = Policy::load_or_default(&path).unwrap();
-        assert_eq!(p.network.allowed_routes.len(), 1);
-        assert_eq!(p.network.allowed_routes[0].match_pattern, "api.linear.app");
-        assert_eq!(p.network.allowed_routes[0].verdict, Verdict::Allow);
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("allowedRoutes"),
+            "a stale key must name itself in the error, not load as a policy with zero rules: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_egress_table_is_a_parse_error_rather_than_an_empty_one() {
+        let err = serde_yaml::from_str::<NetworkPolicy>(
+            "egress:\n  tcp:\n    - match: db.example:5432\n",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("tcp"),
+            "an egress table this lns can't enforce must fail the load, not publish zero rules: {err}"
+        );
+    }
+
+    #[test]
+    fn saving_emits_the_egress_table_the_guest_routes_on() {
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("api.linear.app"));
+        let yaml = serde_yaml::to_string(&p).unwrap();
+        assert!(yaml.contains("egress:"), "got:\n{yaml}");
+        assert!(yaml.contains("http:"), "got:\n{yaml}");
+    }
+
+    #[test]
+    fn an_empty_policy_still_writes_the_http_table_the_guest_reads() {
+        let yaml = serde_yaml::to_string(&Policy::default()).unwrap();
+        assert!(
+            yaml.contains("http: []"),
+            "the guest reads egress.http; omitting it hands every destination to defaultVerdict:\n{yaml}"
+        );
     }
 
     #[test]
@@ -412,10 +472,11 @@ network:
         let path = dir.path().join("lns-policy.yaml");
         let yaml = "\
 network:
-  allowedRoutes:
-    - match: api.example.test
-      verdict: allow
-      transport: upstream
+  egress:
+    http:
+      - match: api.example.test
+        verdict: allow
+        transport: upstream
   defaultVerdict: ask
 ";
         fs::write(&path, yaml).unwrap();
@@ -502,15 +563,15 @@ network:
     }
 
     #[test]
-    fn add_rule_appends_to_allowed_routes_in_order() {
+    fn add_rule_appends_to_the_http_egress_table_in_order() {
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("a"));
         p.add_rule(RouteRule::deny_host("b"));
-        assert_eq!(p.network.allowed_routes.len(), 2);
-        assert_eq!(p.network.allowed_routes[0].match_pattern, "a");
-        assert_eq!(p.network.allowed_routes[0].verdict, Verdict::Allow);
-        assert_eq!(p.network.allowed_routes[1].match_pattern, "b");
-        assert_eq!(p.network.allowed_routes[1].verdict, Verdict::Deny);
+        assert_eq!(p.network.egress.http.len(), 2);
+        assert_eq!(p.network.egress.http[0].match_pattern, "a");
+        assert_eq!(p.network.egress.http[0].verdict, Verdict::Allow);
+        assert_eq!(p.network.egress.http[1].match_pattern, "b");
+        assert_eq!(p.network.egress.http[1].verdict, Verdict::Deny);
     }
 
     #[test]
@@ -518,7 +579,7 @@ network:
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("huggingface.co"));
         p.add_rule(RouteRule::allow_host("huggingface.co"));
-        assert_eq!(p.network.allowed_routes.len(), 1);
+        assert_eq!(p.network.egress.http.len(), 1);
     }
 
     #[test]
@@ -526,14 +587,15 @@ network:
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("example.com"));
         p.add_rule(RouteRule::deny_host("example.com"));
-        assert_eq!(p.network.allowed_routes.len(), 2);
+        assert_eq!(p.network.egress.http.len(), 2);
     }
 
     #[test]
     fn legacy_network_only_yaml_parses_with_empty_connectors() {
         let yaml = "\
 network:
-  allowedRoutes: []
+  egress:
+    http: []
   defaultVerdict: ask
   defaultTransport: direct
 ";
@@ -565,7 +627,8 @@ network:
     fn a_legacy_policy_carrying_the_removed_credentials_section_still_loads() {
         let yaml = "\
 network:
-  allowedRoutes: []
+  egress:
+    http: []
   defaultVerdict: ask
   defaultTransport: direct
 credentials:

--- a/crates/lns-service/src/approval_flow/protocol.rs
+++ b/crates/lns-service/src/approval_flow/protocol.rs
@@ -137,20 +137,42 @@ mod tests {
             v["network"]["defaultTransport"], "direct",
             "lens-sandbox-core fail-closes a non-deny verdict to deny when defaultTransport is missing"
         );
-        assert_eq!(v["network"]["allowedRoutes"], json!([]));
+        assert_eq!(v["network"]["egress"]["http"], json!([]));
+    }
+
+    #[test]
+    fn the_policy_frame_publishes_one_egress_table_and_not_the_deprecated_list() {
+        let frame = HostFrame::Policy(PolicyMessage {
+            network: Some(NetworkPolicy::default()),
+            credentials: None,
+        });
+        let v: serde_json::Value = serde_json::to_value(&frame).unwrap();
+        let network = v["network"].as_object().expect("network is an object");
+        assert!(
+            !network.contains_key("allowedRoutes"),
+            "an egress block supersedes allowedRoutes in the guest, so a route sent in both is a route sent in neither: {network:?}"
+        );
+        let egress = network["egress"]
+            .as_object()
+            .expect("a null or scalar egress makes the guest force-deny every destination");
+        assert_eq!(
+            egress.keys().collect::<Vec<_>>(),
+            ["http"],
+            "core denies unknown fields under egress, so one stray key fails the whole policy closed: {egress:?}"
+        );
     }
 
     #[test]
     fn every_route_in_the_frame_carries_its_transport_even_when_direct() {
         let mut net = NetworkPolicy::default();
-        net.allowed_routes.push(RouteRule::allow_host("10.0.0.0/8"));
+        net.egress.http.push(RouteRule::allow_host("10.0.0.0/8"));
         let frame = HostFrame::Policy(PolicyMessage {
             network: Some(net),
             credentials: None,
         });
         let v: serde_json::Value = serde_json::to_value(&frame).unwrap();
         assert_eq!(
-            v["network"]["allowedRoutes"][0]["transport"], "direct",
+            v["network"]["egress"]["http"][0]["transport"], "direct",
             "core's route schema has no transport default — one missing transport fails the whole route parse and clears every route"
         );
     }
@@ -158,7 +180,8 @@ mod tests {
     #[test]
     fn policy_frame_round_trips() {
         let mut net = NetworkPolicy::default();
-        net.allowed_routes
+        net.egress
+            .http
             .push(RouteRule::allow_host("api.linear.app"));
         let frame = HostFrame::Policy(PolicyMessage {
             network: Some(net),
@@ -245,7 +268,7 @@ mod tests {
     #[test]
     fn network_policy_in_frame_serializes_route_rule_with_match_key() {
         let mut net = NetworkPolicy::default();
-        net.allowed_routes.push(RouteRule {
+        net.egress.http.push(RouteRule {
             match_pattern: "api.linear.app".into(),
             verdict: Verdict::Allow,
             transport: Transport::Upstream,

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -459,7 +459,8 @@ impl ApprovalSession {
         if let Some(derive) = self.connector_routes.get() {
             new_policy
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .extend(derive(&new_policy.connectors));
         }
         if let Some(reconcile) = self.armed_reconciler.get() {
@@ -516,7 +517,7 @@ impl ApprovalSession {
             let mut policy = self.policy.lock().expect("policy mutex poisoned");
             policy.connect(id);
             let to_persist = policy.clone();
-            policy.network.allowed_routes.extend(routes);
+            policy.network.egress.http.extend(routes);
             (to_persist, policy.network.clone())
         };
         let credentials = self.current_credentials();
@@ -884,7 +885,7 @@ pub(crate) mod tests {
 
         s.record_decision("r1", Decision::AllowAlways);
 
-        let routes = s.current_policy().network.allowed_routes;
+        let routes = s.current_policy().network.egress.http;
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].match_pattern, "api.linear.app");
         assert_eq!(routes[0].verdict, Verdict::Allow);
@@ -892,14 +893,14 @@ pub(crate) mod tests {
         assert_eq!(decision_frame(&mut rx).decision, Decision::AllowAlways);
         let pushed = policy_frame(&mut rx);
         assert_eq!(
-            pushed.network.unwrap().allowed_routes[0].match_pattern,
+            pushed.network.unwrap().egress.http[0].match_pattern,
             "api.linear.app"
         );
 
         let saves = store.saves.lock().unwrap();
         assert_eq!(saves.len(), 1);
         assert_eq!(
-            saves[0].network.allowed_routes[0].match_pattern,
+            saves[0].network.egress.http[0].match_pattern,
             "api.linear.app"
         );
     }
@@ -911,14 +912,14 @@ pub(crate) mod tests {
 
         s.record_decision("r1", Decision::DenyAlways);
 
-        let routes = s.current_policy().network.allowed_routes;
+        let routes = s.current_policy().network.egress.http;
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].verdict, Verdict::Deny);
 
         assert_eq!(decision_frame(&mut rx).decision, Decision::DenyAlways);
         let pushed = policy_frame(&mut rx);
         assert_eq!(
-            pushed.network.unwrap().allowed_routes[0].verdict,
+            pushed.network.unwrap().egress.http[0].verdict,
             Verdict::Deny
         );
 
@@ -933,7 +934,7 @@ pub(crate) mod tests {
 
         s.record_decision("r1", Decision::AllowAlways);
 
-        let routes = s.current_policy().network.allowed_routes;
+        let routes = s.current_policy().network.egress.http;
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].verdict, Verdict::Allow);
 
@@ -1167,7 +1168,7 @@ pub(crate) mod tests {
         assert_eq!(s.current_policy(), updated);
         let pushed = policy_frame(&mut rx);
         assert_eq!(
-            pushed.network.unwrap().allowed_routes[0].match_pattern,
+            pushed.network.unwrap().egress.http[0].match_pattern,
             "api.linear.app"
         );
     }
@@ -1184,7 +1185,7 @@ pub(crate) mod tests {
         reloaded.add_rule(RouteRule::allow_host("api.example.test"));
         s.apply_external_policy(reloaded);
 
-        let routes = s.current_policy().network.allowed_routes;
+        let routes = s.current_policy().network.egress.http;
         let deny_idx = routes
             .iter()
             .position(|r| r.match_pattern == "api.example.test" && r.verdict == Verdict::Deny);
@@ -1243,7 +1244,7 @@ pub(crate) mod tests {
 
         s.apply_external_policy(reloaded);
 
-        let routes = s.current_policy().network.allowed_routes;
+        let routes = s.current_policy().network.egress.http;
         assert_eq!(
             routes.len(),
             1,
@@ -1251,7 +1252,7 @@ pub(crate) mod tests {
         );
         assert_eq!(routes[0].match_pattern, "api.some-oauth.example");
         assert_eq!(
-            policy_frame(&mut rx).network.unwrap().allowed_routes[0].match_pattern,
+            policy_frame(&mut rx).network.unwrap().egress.http[0].match_pattern,
             "api.some-oauth.example",
             "the hot-swap frame carries the re-derived route so the guest sees it"
         );
@@ -1363,7 +1364,8 @@ pub(crate) mod tests {
         assert!(
             !saves[0]
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|r| r.match_pattern == "gitlab.com"),
             "the route must not be baked into the file — boot re-derives it from the catalog, so persisting it would survive `disconnect`"
@@ -1372,7 +1374,7 @@ pub(crate) mod tests {
         let v = serde_json::to_value(rx.try_recv().expect("policy frame")).unwrap();
         assert_eq!(v["type"], "policy");
         assert_eq!(
-            v["network"]["allowedRoutes"][0]["match"], "gitlab.com",
+            v["network"]["egress"]["http"][0]["match"], "gitlab.com",
             "the live frame still carries the route so a held request can proceed"
         );
     }

--- a/crates/lns-service/src/approval_flow/watcher.rs
+++ b/crates/lns-service/src/approval_flow/watcher.rs
@@ -183,7 +183,7 @@ mod tests {
         let handler = event_handler(path.clone(), session.clone());
         handler(Ok(evt(EventKind::Modify(ModifyKind::Any), &path)));
 
-        assert_eq!(session.current_policy().network.allowed_routes.len(), 1);
+        assert_eq!(session.current_policy().network.egress.http.len(), 1);
         assert!(rx.try_recv().is_ok(), "expected a Policy hot-swap frame");
     }
 
@@ -204,7 +204,7 @@ mod tests {
         );
 
         let cur = session.current_policy();
-        assert_eq!(cur.network.allowed_routes.len(), 1);
+        assert_eq!(cur.network.egress.http.len(), 1);
         assert!(rx.try_recv().is_ok(), "expected a Policy hot-swap frame");
     }
 

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -49,7 +49,7 @@ pub fn guardrail_flags(policy: &Policy) -> Vec<GuardrailFlag> {
     if policy.network.default_verdict == Verdict::Allow {
         flags.push(GuardrailFlag::PermissiveDefaultVerdict);
     }
-    for rule in &policy.network.allowed_routes {
+    for rule in &policy.network.egress.http {
         if rule.verdict != Verdict::Allow {
             continue;
         }
@@ -74,15 +74,48 @@ pub fn run_summary(flags: &[GuardrailFlag]) -> String {
     summary
 }
 
-/// A deny-by-default layer permits only the routes it names, so an allow survives the merge only if every such ceiling layer carries it.
-fn allowed_by_every_ceiling(rule: &RouteRule, ceilings: &[&Policy]) -> bool {
-    ceilings
-        .iter()
-        .all(|ceiling| ceiling.network.allowed_routes.contains(rule))
+type TableOf<R> = fn(&Policy) -> &Vec<R>;
+
+fn push_unique<R: Clone + PartialEq>(merged: &mut Vec<R>, rule: &R) {
+    if !merged.contains(rule) {
+        merged.push(rule.clone());
+    }
+}
+
+/// A deny-by-default layer permits only the destinations it names, so an allow survives the merge only if every such ceiling layer carries it.
+fn allowed_by_every_ceiling<R: PartialEq>(
+    rule: &R,
+    ceilings: &[&Policy],
+    table: TableOf<R>,
+) -> bool {
+    ceilings.iter().all(|ceiling| table(ceiling).contains(rule))
+}
+
+/// Fold one egress table across `layers` into the merged table the guest gate installs, deny-first and clamped by the deny-by-default `ceilings`.
+// Deny-first ordering is load-bearing: lens-sandbox-core's rule lookup is first-match-wins, so a destination denied by any layer must have its deny rule appear before any allow.
+fn merge_rule_table<R: Clone + PartialEq>(
+    layers: &[&Policy],
+    ceilings: &[&Policy],
+    table: TableOf<R>,
+    is_deny: fn(&R) -> bool,
+) -> Vec<R> {
+    let mut merged: Vec<R> = Vec::new();
+    for layer in layers {
+        for rule in table(layer).iter().filter(|rule| is_deny(rule)) {
+            push_unique(&mut merged, rule);
+        }
+    }
+    for layer in layers {
+        for rule in table(layer).iter().filter(|rule| !is_deny(rule)) {
+            if allowed_by_every_ceiling(rule, ceilings, table) {
+                push_unique(&mut merged, rule);
+            }
+        }
+    }
+    merged
 }
 
 /// Merge a sandbox's shipped `baseline` policy under a local `overlay` into one effective policy for the guest gate: denies from every layer come first so a first-match gate stays deny-dominant, a `deny`-by-default layer is a ceiling an allow must clear in every such layer (so neither the artifact nor the user can widen the other's lockdown), `defaultVerdict` is backstopped to `ask` unless a layer denies, and only the user's overlay connectors are applied — an artifact-declared connector the user hasn't connected in this directory is never force-armed, so it stays connectable and is offered as a live connect on first use.
-// Deny-first ordering is load-bearing: lens-sandbox-core's `find_matching_route` is first-match-wins, so a host denied by any layer must have its deny rule appear before any allow.
 pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
     let layers: Vec<&Policy> = std::iter::once(overlay).chain(baseline).collect();
     let ceilings: Vec<&Policy> = layers
@@ -90,26 +123,12 @@ pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
         .copied()
         .filter(|policy| policy.network.default_verdict == Verdict::Deny)
         .collect();
-    let mut routes: Vec<RouteRule> = Vec::new();
-    let mut push_unique = |rule: &RouteRule| {
-        if !routes.contains(rule) {
-            routes.push(rule.clone());
-        }
-    };
-    for layer in &layers {
-        for rule in &layer.network.allowed_routes {
-            if rule.verdict == Verdict::Deny {
-                push_unique(rule);
-            }
-        }
-    }
-    for layer in &layers {
-        for rule in &layer.network.allowed_routes {
-            if rule.verdict != Verdict::Deny && allowed_by_every_ceiling(rule, &ceilings) {
-                push_unique(rule);
-            }
-        }
-    }
+    let http = merge_rule_table(
+        &layers,
+        &ceilings,
+        |policy| &policy.network.egress.http,
+        |rule: &RouteRule| rule.verdict == Verdict::Deny,
+    );
     let default_verdict = if layers
         .iter()
         .any(|l| l.network.default_verdict == Verdict::Deny)
@@ -120,7 +139,7 @@ pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
     };
     Policy {
         network: NetworkPolicy {
-            allowed_routes: routes,
+            egress: lns_policy::Egress { http },
             default_verdict,
             default_transport: overlay.network.default_transport,
         },
@@ -189,7 +208,7 @@ mod tests {
         let baseline = allow("api.example.test");
         let overlay = deny("api.example.test");
         let merged = merge_effective(Some(&baseline), &overlay);
-        let routes = &merged.network.allowed_routes;
+        let routes = &merged.network.egress.http;
         let deny_idx = routes.iter().position(|r| r.verdict == Verdict::Deny);
         let allow_idx = routes.iter().position(|r| r.verdict == Verdict::Allow);
         assert!(
@@ -243,12 +262,12 @@ mod tests {
         let merged = merge_effective(Some(&baseline), &overlay);
 
         assert!(
-            !merged.network.allowed_routes.iter().any(|rule| {
+            !merged.network.egress.http.iter().any(|rule| {
                 rule.match_pattern == "api.overlay-only.example" && rule.verdict == Verdict::Allow
             }),
             "a local overlay must not widen a sandbox's deny-by-default baseline: {merged:?}"
         );
-        assert!(merged.network.allowed_routes.iter().any(|rule| {
+        assert!(merged.network.egress.http.iter().any(|rule| {
             rule.match_pattern == "api.allowed.example" && rule.verdict == Verdict::Allow
         }));
         assert_eq!(merged.network.default_verdict, Verdict::Deny);
@@ -268,12 +287,12 @@ mod tests {
         let merged = merge_effective(Some(&baseline), &overlay);
 
         assert!(
-            !merged.network.allowed_routes.iter().any(|rule| {
+            !merged.network.egress.http.iter().any(|rule| {
                 rule.match_pattern == "attacker.example" && rule.verdict == Verdict::Allow
             }),
             "a pulled artifact's allow must not punch through the user's deny-by-default lockdown: {merged:?}"
         );
-        assert!(merged.network.allowed_routes.iter().any(|rule| {
+        assert!(merged.network.egress.http.iter().any(|rule| {
             rule.match_pattern == "api.trusted.example" && rule.verdict == Verdict::Allow
         }));
         assert_eq!(merged.network.default_verdict, Verdict::Deny);
@@ -287,7 +306,7 @@ mod tests {
         let merged = merge_effective(Some(&baseline), &overlay);
 
         assert!(
-            merged.network.allowed_routes.iter().any(|rule| {
+            merged.network.egress.http.iter().any(|rule| {
                 rule.match_pattern == "api.shared.example" && rule.verdict == Verdict::Allow
             }),
             "a host both the user and the artifact allow under deny-by-default is in the intersection and must survive: {merged:?}"
@@ -305,7 +324,8 @@ mod tests {
         assert!(
             !merged
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|rule| rule.verdict == Verdict::Allow),
             "two deny-by-default layers with disjoint allowlists intersect to nothing: {merged:?}"
@@ -320,7 +340,8 @@ mod tests {
         assert!(
             merged
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|r| r.match_pattern == "api.example.test")
         );

--- a/crates/lns-service/src/relay/mod.rs
+++ b/crates/lns-service/src/relay/mod.rs
@@ -596,7 +596,7 @@ mod tests {
         let json = serde_json::to_value(&frame).expect("serialise");
         assert_eq!(json["type"], "policy");
         assert_eq!(
-            json["network"]["allowedRoutes"][0]["match"],
+            json["network"]["egress"]["http"][0]["match"],
             "api.linear.app"
         );
     }

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -646,7 +646,7 @@ pub(super) async fn start(
         &declared_connectors,
         &catalog,
     );
-    policy.network.allowed_routes.extend(applied.routes);
+    policy.network.egress.http.extend(applied.routes);
     let offerable = build_offerable(&connectable, &catalog);
     let connectable_routes = Arc::new(connectable.routes);
     let run =
@@ -1557,7 +1557,7 @@ mod tests {
         let json = serde_json::to_value(&frame).expect("serialise");
         assert_eq!(json["type"], "policy");
         assert_eq!(
-            json["network"]["allowedRoutes"][0]["match"],
+            json["network"]["egress"]["http"][0]["match"],
             "api.linear.app"
         );
         let ids: Vec<&str> = json["credentials"]
@@ -1832,7 +1832,8 @@ mod tests {
             session
                 .current_policy()
                 .network
-                .allowed_routes
+                .egress
+                .http
                 .iter()
                 .any(|r| r.match_pattern == "gitlab.com"),
             "the connector's route is allowed live"

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -597,7 +597,7 @@ mod tests {
         let policy_path = dir.path().join("lns-policy.yaml");
         std::fs::write(
             &policy_path,
-            "network:\n  allowedRoutes: []\n  defaultVerdict: ask\n",
+            "network:\n  egress:\n    http: []\n  defaultVerdict: ask\n",
         )
         .expect("policy");
         lns_policy::connectors::Catalog {
@@ -734,7 +734,7 @@ mod tests {
         let policy_path = d.path().join("lns-policy.yaml");
         std::fs::write(
             &policy_path,
-            "network:\n  allowedRoutes: []\n  defaultVerdict: ask\n",
+            "network:\n  egress:\n    http: []\n  defaultVerdict: ask\n",
         )
         .expect("policy");
 
@@ -769,7 +769,7 @@ mod tests {
         let policy_path = d.path().join("lns-policy.yaml");
         std::fs::write(
             &policy_path,
-            "network:\n  allowedRoutes: []\n  defaultVerdict: ask\n  defaultTransport: direct\n",
+            "network:\n  egress:\n    http: []\n  defaultVerdict: ask\n  defaultTransport: direct\n",
         )
         .expect("policy");
         let mut sandbox_policy = lns_policy::Policy::default();

--- a/crates/lns-service/tests/behaviours/steps/approval_flow.rs
+++ b/crates/lns-service/tests/behaviours/steps/approval_flow.rs
@@ -80,7 +80,7 @@ fn given_launched_with_policy(world: &mut BehaviourWorld, _filename: String) {
 #[given(regex = r#"^the policy has no rule for "([^"]+)"$"#)]
 fn given_no_rule_for(world: &mut BehaviourWorld, host: String) {
     let rig = world.approval();
-    let routes = &rig.session.current_policy().network.allowed_routes;
+    let routes = &rig.session.current_policy().network.egress.http;
     assert!(
         !routes.iter().any(|r| r.match_pattern == host),
         "expected no rule for {host}, but found one"
@@ -357,10 +357,10 @@ fn then_request_failed_as_undecided(world: &mut BehaviourWorld) -> Result<(), St
 fn then_running_policy_unchanged(world: &mut BehaviourWorld) -> Result<(), String> {
     let rig = world.approval();
     let p = rig.session.current_policy();
-    if !p.network.allowed_routes.is_empty() {
+    if !p.network.egress.http.is_empty() {
         return Err(format!(
             "expected no rules in running policy, got {:?}",
-            p.network.allowed_routes
+            p.network.egress.http
         ));
     }
     Ok(())
@@ -373,10 +373,10 @@ fn then_policy_file_unchanged(world: &mut BehaviourWorld) -> Result<(), String> 
         return Ok(());
     }
     let on_disk = Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())?;
-    if !on_disk.network.allowed_routes.is_empty() {
+    if !on_disk.network.egress.http.is_empty() {
         return Err(format!(
             "policy file gained rules: {:?}",
-            on_disk.network.allowed_routes
+            on_disk.network.egress.http
         ));
     }
     Ok(())
@@ -436,7 +436,8 @@ fn assert_host_rule(
     let p = rig.session.current_policy();
     let matched = p
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .find(|r| r.match_pattern == host)
         .ok_or_else(|| format!("no rule for {host} in running policy"))?;
@@ -476,7 +477,8 @@ fn assert_file_rule(
     let on_disk = Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())?;
     let matched = on_disk
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .find(|r| r.match_pattern == host)
         .ok_or_else(|| format!("no rule for {host} in policy file"))?;
@@ -494,10 +496,10 @@ fn then_running_contains_same_rule(world: &mut BehaviourWorld) -> Result<(), Str
     let rig = world.approval();
     let on_disk = Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())?;
     let in_memory = rig.session.current_policy();
-    if on_disk.network.allowed_routes != in_memory.network.allowed_routes {
+    if on_disk.network.egress.http != in_memory.network.egress.http {
         return Err(format!(
             "running policy diverges from file:\n  file: {:?}\n  mem:  {:?}",
-            on_disk.network.allowed_routes, in_memory.network.allowed_routes
+            on_disk.network.egress.http, in_memory.network.egress.http
         ));
     }
     Ok(())
@@ -509,13 +511,14 @@ fn then_running_contains_new_allow_rule(world: &mut BehaviourWorld) -> Result<()
     let p = rig.session.current_policy();
     if !p
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.verdict == Verdict::Allow)
     {
         return Err(format!(
             "expected an allow rule in running policy, got {:?}",
-            p.network.allowed_routes
+            p.network.egress.http
         ));
     }
     Ok(())

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -105,7 +105,8 @@ fn launch(
     let applied = resolve_applied_with_slots(&policy, &resolved.credentials, &rig.catalog);
     policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .extend(applied.routes.iter().cloned());
     let declared_connectors = resolved
         .policy
@@ -197,7 +198,7 @@ fn published_declares_one(w: &mut BehaviourWorld, id: String) {
 fn definition_declares_with_allowed_route(w: &mut BehaviourWorld, id: String, host: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.definition = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","connectors":["{id}"],"policy":{{"defaultVerdict":"ask","allowedRoutes":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","connectors":["{id}"],"policy":{{"defaultVerdict":"ask","egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}}}"#
     ));
 }
 
@@ -490,7 +491,8 @@ fn request_denied_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(), 
     // The guest gate is first-match-wins; the merged policy must present the deny before the connector's allow.
     let verdict = policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .find(|r| r.match_pattern == host)
         .map(|r| r.verdict)
@@ -500,7 +502,7 @@ fn request_denied_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(), 
     } else {
         Err(format!(
             "expected {host} to be denied, first match gave {verdict:?}; routes: {:?}",
-            policy.network.allowed_routes
+            policy.network.egress.http
         ))
     }
 }
@@ -511,7 +513,8 @@ fn allow_rule_written_to_policy_file(w: &mut BehaviourWorld) -> Result<(), Strin
     let on_disk = Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())?;
     let has_allow = on_disk
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.verdict == Verdict::Allow);
     if has_allow {
@@ -520,7 +523,7 @@ fn allow_rule_written_to_policy_file(w: &mut BehaviourWorld) -> Result<(), Strin
         Err(format!(
             "no allow rule landed in {}: {:?}",
             rig.policy_path.display(),
-            on_disk.network.allowed_routes
+            on_disk.network.egress.http
         ))
     }
 }
@@ -607,7 +610,8 @@ fn running_policy_allows(w: &mut BehaviourWorld, host: String) -> Result<(), Str
         .ok_or("no running policy was produced")?;
     let allowed = policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .any(|r| r.match_pattern == host && r.verdict == Verdict::Allow);
     if allowed {
@@ -615,7 +619,7 @@ fn running_policy_allows(w: &mut BehaviourWorld, host: String) -> Result<(), Str
     } else {
         Err(format!(
             "expected an allow route for {host}, got: {:?}",
-            policy.network.allowed_routes
+            policy.network.egress.http
         ))
     }
 }
@@ -643,7 +647,8 @@ fn running_policy_does_not_allow(w: &mut BehaviourWorld, host: String) -> Result
         .ok_or("no running policy was produced")?;
     match policy
         .network
-        .allowed_routes
+        .egress
+        .http
         .iter()
         .find(|r| r.match_pattern == host && r.verdict == Verdict::Allow)
     {

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -94,7 +94,8 @@ resolves from the catalog at run time and the shareable policy stays small:
 
 ```yaml
 network:
-  allowedRoutes: []
+  egress:
+    http: []
   defaultVerdict: ask
 connectors:
   - gitlab

--- a/docs/examples/claude-code/README.md
+++ b/docs/examples/claude-code/README.md
@@ -27,7 +27,7 @@ lns run
 ```
 
 The first boot runs `npm install -g @anthropic-ai/claude-code`; the microVM is
-ephemeral, so each cold start reinstalls it (the `allowedRoutes` keep
+ephemeral, so each cold start reinstalls it (the `egress.http` rules keep
 `registry.npmjs.org` open for that reason).
 
 On first run, an approval card asks for your Claude subscription token and shows

--- a/docs/examples/claude-code/lns.yaml
+++ b/docs/examples/claude-code/lns.yaml
@@ -20,15 +20,16 @@ spec:
     memory: 6Gi
   policy:
     defaultVerdict: ask
-    allowedRoutes:
-      - match: registry.npmjs.org
-        verdict: allow
-      - match: api.anthropic.com
-        verdict: allow
-      - match: platform.claude.com
-        verdict: allow
-      - match: downloads.claude.ai
-        verdict: allow
+    egress:
+      http:
+        - match: registry.npmjs.org
+          verdict: allow
+        - match: api.anthropic.com
+          verdict: allow
+        - match: platform.claude.com
+          verdict: allow
+        - match: downloads.claude.ai
+          verdict: allow
   connectors:
     - claude-code-subscription
   volumes:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,8 @@ spec:
     memory: 512Mi
   policy:
     defaultVerdict: ask
-    allowedRoutes: []
+    egress:
+      http: []
   connectors: []
   credentials: []
   volumes:

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -13,7 +13,8 @@ it:
 
 ```yaml
 network:
-  allowedRoutes: []
+  egress:
+    http: []
   defaultVerdict: ask
 ```
 
@@ -29,7 +30,7 @@ lns run --policy ~/team/shared-policy.yaml ghcr.io/acme/agent
 
 ### Default verdict
 
-`defaultVerdict` decides what happens to a request that no rule in `allowedRoutes`
+`defaultVerdict` decides what happens to a request that no rule in `egress.http`
 matches:
 
 - `ask` (the default) — pause and prompt you.
@@ -41,19 +42,20 @@ does real work, and your decisions accumulate into a least-privilege rule set.
 
 ### Rules
 
-Each entry in `allowedRoutes` is a rule:
+Each entry in `egress.http` is a rule:
 
 ```yaml
 network:
   defaultVerdict: ask
-  allowedRoutes:
-    - match: api.github.com
-      verdict: allow
-      description: GitHub REST API
-    - match: "*.telemetry.example"
-      verdict: deny
-    - match: 10.0.0.0/8
-      verdict: allow
+  egress:
+    http:
+      - match: api.github.com
+        verdict: allow
+        description: GitHub REST API
+      - match: "*.telemetry.example"
+        verdict: deny
+      - match: 10.0.0.0/8
+        verdict: allow
 ```
 
 | Field         | Meaning                                                                 |
@@ -68,6 +70,10 @@ A `match` pattern can be:
 - a wildcard — `*.github.com`
 - a CIDR block — `10.0.0.0/8`
 - a host with a port — `registry.internal:5000`
+
+`egress.http` used to be a top-level `allowedRoutes:` list. That key is gone: a
+policy file still naming it is refused with an error rather than loaded as a
+policy with no rules. Move the list under `egress: http:`.
 
 ## Editing rules from the CLI
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -39,7 +39,8 @@ spec:
     memory: 512Mi
   policy:
     defaultVerdict: ask
-    allowedRoutes: []
+    egress:
+      http: []
   connectors: []
   credentials: []
   volumes:
@@ -62,7 +63,7 @@ The `spec` fields:
 | `command`      | Command to run in the workload, replacing the image's default command.       |
 | `workdir`      | Absolute guest working directory. It is created when missing.                 |
 | `env`          | Non-secret environment variables seeded into the workload.                   |
-| `policy`       | The network policy — `defaultVerdict` and `allowedRoutes` (see [Policy](policy.md)). |
+| `policy`       | The network policy — `defaultVerdict` and `egress.http` (see [Policy](policy.md)). |
 | `connectors` | Ids of the [connectors](connectors.md) the sandbox would like to use. Declaring seeds the connector's placeholder env var but is not a grant: a declared id is offered on first use (accept its connect card to arm it), never armed automatically — so an untrusted published sandbox can't open a route or spend a bound credential behind your back. An id the machine's catalog doesn't know refuses the launch. |
 | `credentials`  | Credential slots — the explicit way a sandbox insists on a credential: each names a connector (`name`), the env var it is injected as (`env`, remapping the catalog default), and optionally `required: true`. A slot arms when its value is bound on the machine; a **required** slot with no value bound refuses the launch before boot, pointing at `lns connector connect` (see [Credentials](credentials.md#value-decisions)). |
 | `resources`    | vCPUs and memory the sandbox boots with (`cpu`, `memory` with a unit suffix); per-run `--cpus` / `--mem` flags win. |


### PR DESCRIPTION
## What

Migrates our policy representation — in memory, on disk, and on the wire — from `network.allowedRoutes` to `network.egress.http`, which is what the newly-pinned `lens-sandbox-core` rev `4cb1d97` treats as canonical.

Zero new user-facing capability. This is the prerequisite for raw-TCP egress.

## Why

In core's `client.rs::handle_policy` → `parse_egress_tables`: **if `network.egress` is a JSON object, `allowedRoutes` is never read at all** — even when `egress.http` is absent. `allowedRoutes` is read only when there is no `egress` key. So a future `egress.tcp` cannot coexist with `allowedRoutes`; every HTTP route has to be in `egress.http` in the same frame.

Core parses `egress.http` and `allowedRoutes` with the *same* function (`parse_proxy_routes`), so this migration is behaviour-preserving for routing.

## How

- `lns_policy::NetworkPolicy` replaces `allowed_routes: Vec<RouteRule>` with a **non-optional** `egress: Egress`. Non-optional makes `egress: null` — which core reads as "no egress block", silently falling back to `allowedRoutes` — unrepresentable, and turns every touch point into a compile error rather than a silent write to a dead table.
- New `pub struct Egress { pub http: Vec<RouteRule> }`: camelCase, `deny_unknown_fields`, always serializes `http`. **No `tcp` field yet** — deliberate, so a hand-authored `egress.tcp:` is rejected for free until the real thing lands.
- Back-compat on load via `#[serde(try_from = "…")]`: `allowedRoutes` alone folds into `egress.http`; `egress` alone is used as-is; **both present is a hard error** (`policy sets both 'allowedRoutes' and 'egress'; keep one`). Core would silently ignore the `allowedRoutes` half here, and for a local user file silent rule-dropping is worse than an error. No existing file can have both — `egress:` was a `deny_unknown_fields` parse error until now — so the strict path breaks nobody.
- Serialization always emits `egress`, never `allowedRoutes`.
- The deny-first + ceiling merge in `artifact/policy.rs` is now a generic `merge_rule_table<R>`, so a second table can be folded the same way later. This PR still merges exactly one table and its behaviour is pinned unchanged — all 13 pre-existing merge/guardrail tests pass without modification.
- Scaffolds (`DEFAULT_POLICY_YAML`, `lns sandbox init`) emit `egress:\n  http: []`.

## Compatibility — one-way door

`allowedRoutes:` is accepted on load as a deprecated alias, so existing policy files keep working. But **the first save rewrites them**: an approval you accept, `lns policy allow`, or `lns connector connect` writes the file back in the `egress.http:` shape, which a *previous* lns release cannot parse (`deny_unknown_fields`).

This affects two cases:

- **Downgrades** — rolling back to an older lns after any policy write.
- **Team repos** sharing a committed `lns-policy.yaml` across mixed lns versions.

Accepted tradeoff: no dialect-preserving save path. Keeping one would mean two on-disk shapes and two wire shapes alive indefinitely, and the flip would still happen the moment a TCP rule landed — just at a more surprising time. Documented in `docs/policy.md`.

## Tests

- **Layer 3 (lns-policy)** — legacy `allowedRoutes:` loads into `egress.http`; new `egress: {http: [...]}` loads; both keys present errors with the exact message; round-trip save emits `egress` and no `allowedRoutes`; an empty policy still writes `http: []`; an unknown key under `egress` (`tcp:`) is a parse error.
- **Layer 3 (lns-service)** — the `PolicyMessage` wire JSON carries `egress` as an object whose only key is `http`, no `allowedRoutes`, and still `defaultTransport`.
- **Layer 2 (lns-cli Gherkin)** — `lns policy allow/deny/list/remove` behave identically against a new-shape file, plus a new scenario pinning that `lns policy list` still reads a legacy-shape one.

## Gate

`make lint`, `make complexity`, `make coverage` all green; no new entries in the `scripts/coverage-floor.sh` IGNORES table.
