### PR TITLE
feat(policy): per-binary scoping for network routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
 name = "lns-policy"
 version = "0.0.0"
 dependencies = [
+ "ipnet",
  "libc",
  "serde",
  "serde_json",
@@ -3428,6 +3429,7 @@ dependencies = [
  "async-trait",
  "lens-sandbox-core",
  "libc",
+ "lns-policy",
  "rustls",
  "serde_json",
  "serial_test",

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -190,6 +190,10 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
         .policy
         .validate_local_transport()
         .context("sandbox policy")?;
+    doc.spec
+        .policy
+        .validate_binary_scopes()
+        .context("sandbox policy")?;
     if let Some(workdir) = &doc.spec.workdir {
         spec::validate_mount_path(workdir).context("workdir")?;
     }
@@ -530,6 +534,42 @@ mod tests {
         assert!(
             format!("{err:#}").contains("upstream transport isn't supported in the local sandbox"),
             "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_relative_binary_scope() {
+        let err = parse(&def_json(
+            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["git"]}]}}}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("is not an absolute path"),
+            "a scope core would reject must fail here, not inside the guest: {err:#}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_empty_binary_scope() {
+        let err = parse(&def_json(
+            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":[]}]}}}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("matches no caller"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_an_absolute_binary_scope() {
+        let def = parse(&def_json(
+            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["/usr/bin/git"]}]}}}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            def.spec.policy.egress.http[0].binaries,
+            Some(vec!["/usr/bin/git".to_string()])
         );
     }
 

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -17,13 +17,26 @@ pub struct PolicyArgs {
 #[derive(clap::Subcommand)]
 pub enum PolicyCommand {
     #[command(about = "Add an allow rule for a destination pattern.")]
-    Allow(PolicyRuleArgs),
+    Allow(PolicyAllowArgs),
     #[command(about = "Add a deny rule for a destination pattern.")]
     Deny(PolicyRuleArgs),
     #[command(about = "List the rules in the policy file.")]
     List(PolicyScopeArgs),
-    #[command(about = "Remove the rule matching a destination pattern.")]
+    #[command(about = "Remove every rule matching a destination pattern.")]
     Remove(PolicyRemoveArgs),
+}
+
+/// Only `allow` takes `--binary`: on a deny the listed callers are blocked by verdict and the rest fail closed, so all the scoping buys is that a later rule scoped to one of those others can still let it through — a distinction too fine to hand a flag.
+#[derive(clap::Args)]
+pub struct PolicyAllowArgs {
+    #[command(flatten)]
+    pub rule: PolicyRuleArgs,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Restrict the rule to callers running this guest binary, given as an absolute path (e.g. /usr/bin/git); repeatable. Every other caller is denied the destination rather than asked."
+    )]
+    pub binary: Vec<String>,
 }
 
 #[derive(clap::Args)]
@@ -84,8 +97,10 @@ pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFut
 
 pub fn run(cmd: &PolicyCommand, cwd: &Path, writer: &mut impl Write) -> Result<i32> {
     match cmd {
-        PolicyCommand::Allow(args) => add_rule(args, Verdict::Allow, cwd, writer),
-        PolicyCommand::Deny(args) => add_rule(args, Verdict::Deny, cwd, writer),
+        PolicyCommand::Allow(args) => {
+            add_rule(&args.rule, Verdict::Allow, &args.binary, cwd, writer)
+        }
+        PolicyCommand::Deny(args) => add_rule(args, Verdict::Deny, &[], cwd, writer),
         PolicyCommand::List(args) => list_rules(args, cwd, writer),
         PolicyCommand::Remove(args) => remove_rule(args, cwd, writer),
     }
@@ -94,24 +109,45 @@ pub fn run(cmd: &PolicyCommand, cwd: &Path, writer: &mut impl Write) -> Result<i
 fn add_rule(
     args: &PolicyRuleArgs,
     verdict: Verdict,
+    binaries: &[String],
     cwd: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
+    let rule = build_rule(args, verdict, binaries)?;
     let path = policy_path(args.policy.as_deref(), cwd);
     let mut policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
-    policy.network.egress.http.push(RouteRule {
-        match_pattern: args.pattern.clone(),
-        verdict,
-        transport: Transport::Direct,
-        scheme: None,
-        description: args.description.clone(),
-        tls_terminate: false,
-        rules: Vec::new(),
-    });
+    let placement = place_rule(&mut policy, rule)?;
+    if let Placement::Redundant(reason) = &placement {
+        let message = match reason {
+            Redundant::AlreadyPresent => format!(
+                "That {} rule for {:?} is already in {}",
+                verdict_word(verdict),
+                args.pattern,
+                path.display()
+            ),
+            Redundant::DeniedBy(covering) => format!(
+                "The deny rule for {covering:?} in {} already blocks {:?}, so this deny adds nothing",
+                path.display(),
+                args.pattern
+            ),
+        };
+        writeln!(writer, "{message}")?;
+        return Ok(0);
+    }
     policy
         .save_atomic(&path)
         .with_context(|| format!("writing policy to {}", path.display()))?;
+    if matches!(placement, Placement::Described) {
+        writeln!(
+            writer,
+            "Updated the description of the {} rule for {:?} in {}",
+            verdict_word(verdict),
+            args.pattern,
+            path.display()
+        )?;
+        return Ok(0);
+    }
     writeln!(
         writer,
         "Added {} rule for {:?} to {}",
@@ -119,7 +155,191 @@ fn add_rule(
         args.pattern,
         path.display()
     )?;
+    if let Placement::Appended(Some(note)) | Placement::Inserted(note) = placement {
+        writeln!(writer, "{note}")?;
+    }
     Ok(0)
+}
+
+fn build_rule(args: &PolicyRuleArgs, verdict: Verdict, binaries: &[String]) -> Result<RouteRule> {
+    let rule = RouteRule {
+        match_pattern: args.pattern.clone(),
+        verdict,
+        transport: Transport::Direct,
+        scheme: None,
+        description: args.description.clone(),
+        tls_terminate: false,
+        rules: Vec::new(),
+        binaries: (!binaries.is_empty()).then(|| binaries.to_vec()),
+    };
+    rule.validate_binaries()?;
+    Ok(rule)
+}
+
+enum Placement {
+    Appended(Option<String>),
+    Inserted(String),
+    Described,
+    Redundant(Redundant),
+}
+
+enum Redundant {
+    AlreadyPresent,
+    DeniedBy(String),
+}
+
+/// The guest gate stops at the first matching rule, so a rule appended behind one that already covers it would never fire; put it in front of that rule instead and say so.
+fn place_rule(policy: &mut Policy, mut rule: RouteRule) -> Result<Placement> {
+    let shadowing = policy
+        .network
+        .first_shadowing_rule(&rule)
+        .map(|(index, shadowing)| (index, shadowing.clone()));
+    let Some((index, shadowing)) = shadowing else {
+        // The scoping is what fails the destination closed, so it is announced wherever the rule lands, not only where it had to displace another.
+        let note = rule
+            .binaries
+            .is_some()
+            .then(|| format!("{}.", fail_closed_note(&rule.match_pattern)));
+        policy.network.egress.http.push(rule);
+        return Ok(Placement::Appended(note));
+    };
+    let inherited = inherit_treatment(&mut rule, &shadowing);
+    // The rule the gate reaches first is the only one in force, so that is the one this grant can already be: a copy stranded behind it never fires, whether it is pre-empted by verdict, by scope, or by a request filter.
+    if grants_the_same(&shadowing, &rule) {
+        let held = &mut policy.network.egress.http[index];
+        return Ok(renote(held, rule.description));
+    }
+    if shadowing.verdict == Verdict::Deny {
+        return behind_a_deny(&shadowing, &rule);
+    }
+    if reopens_a_scoped_rule(&shadowing, &rule) {
+        return behind_a_scoped_rule(&shadowing, &rule);
+    }
+    if lifts_a_request_filter(&shadowing, &rule) {
+        return behind_a_request_filter(&shadowing, &rule);
+    }
+    Ok(Placement::Inserted(insert_ahead(
+        policy, index, rule, &shadowing, inherited,
+    )))
+}
+
+/// The rule going in front inherits the fronted rule's TLS termination: narrowing who may reach a destination is not a request to stop intercepting it, and a deny blocks the request before there is anything to intercept.
+fn inherit_treatment(rule: &mut RouteRule, shadowing: &RouteRule) -> bool {
+    let inherit = shadowing.tls_terminate && !rule.tls_terminate && rule.verdict != Verdict::Deny;
+    if inherit {
+        rule.tls_terminate = true;
+    }
+    inherit
+}
+
+/// Places the rule where it fires, taking over from any copy of the grant left stranded behind it — including the note that copy carried, which a command passing no `--description` is not asking to forget.
+fn insert_ahead(
+    policy: &mut Policy,
+    index: usize,
+    mut rule: RouteRule,
+    shadowing: &RouteRule,
+    inherited: bool,
+) -> String {
+    let mut note = placement_note(shadowing, &rule);
+    if inherited {
+        note.push_str(" It terminates TLS as that rule does.");
+    }
+    let rules = &mut policy.network.egress.http;
+    if rule.description.is_none() {
+        rule.description = rules
+            .iter()
+            .find(|held| grants_the_same(held, &rule))
+            .and_then(|stranded| stranded.description.clone());
+    }
+    rules.retain(|held| !grants_the_same(held, &rule));
+    rules.insert(index, rule);
+    note
+}
+
+/// Whether the file already holds this grant: the note is the one field neither the gate nor the developer's intent reads, so a rule differing only there is the same rule, not a second one to place in front of it.
+fn grants_the_same(held: &RouteRule, rule: &RouteRule) -> bool {
+    let renoted = RouteRule {
+        description: rule.description.clone(),
+        ..held.clone()
+    };
+    renoted == *rule
+}
+
+/// A `lns policy allow` with no `--description` is not a request to forget the note the rule already carries.
+fn renote(held: &mut RouteRule, description: Option<String>) -> Placement {
+    if description.is_none() || held.description == description {
+        return Placement::Redundant(Redundant::AlreadyPresent);
+    }
+    held.description = description;
+    Placement::Described
+}
+
+/// A deny already blocks every request the new rule could match: a deny asks for what the file delivers, while anything else would never fire and is refused rather than reordered ahead of a deny.
+fn behind_a_deny(shadowing: &RouteRule, rule: &RouteRule) -> Result<Placement> {
+    let pattern = &shadowing.match_pattern;
+    if rule.verdict == Verdict::Deny {
+        return Ok(Placement::Redundant(Redundant::DeniedBy(pattern.clone())));
+    }
+    bail!(
+        "the deny rule for {pattern:?} already blocks every request this rule could match, and the guest stops at the first matching rule, so this {} rule would never fire — narrow that deny to the destinations you still mean to block, or reorder the file by hand if this rule is meant to win",
+        verdict_word(rule.verdict)
+    )
+}
+
+/// The guest refuses to re-open a destination a binary-scoped rule claimed, so the only place this rule would reach the excluded callers is in front of that rule — a widening of the file's own grant, which is the developer's call to make, not ours.
+fn reopens_a_scoped_rule(shadowing: &RouteRule, rule: &RouteRule) -> bool {
+    shadowing.binaries.is_some() && rule.binaries.is_none() && rule.verdict != Verdict::Deny
+}
+
+fn behind_a_scoped_rule(shadowing: &RouteRule, rule: &RouteRule) -> Result<Placement> {
+    let pattern = &shadowing.match_pattern;
+    let scope = shadowing.binaries.as_deref().unwrap_or_default().join(", ");
+    let fix = if *pattern == rule.match_pattern {
+        format!("drop the scoped rule with `lns policy remove {pattern}`")
+    } else {
+        format!("narrow or remove the rule for {pattern:?}")
+    };
+    bail!(
+        "the rule for {pattern:?} is scoped to {scope}, and placing this {} rule in front of it would open the destination to every caller in the sandbox — {fix} first if that is what you mean",
+        verdict_word(rule.verdict)
+    )
+}
+
+/// A rule carrying an http `rules` list allows only the requests it names and denies the rest, so an unrestricted rule in front of it lifts that filter for every request it matches — everything but a deny, which blocks them all either way.
+fn lifts_a_request_filter(shadowing: &RouteRule, rule: &RouteRule) -> bool {
+    !shadowing.rules.is_empty() && rule.verdict != Verdict::Deny
+}
+
+fn behind_a_request_filter(shadowing: &RouteRule, rule: &RouteRule) -> Result<Placement> {
+    let pattern = &shadowing.match_pattern;
+    bail!(
+        "the rule for {pattern:?} allows only the requests its rules list names, and placing this {} rule in front of it would lift that restriction for every request it matches — narrow this rule's destination, or reorder the file by hand if that is what you mean",
+        verdict_word(rule.verdict)
+    )
+}
+
+fn fail_closed_note(pattern: &str) -> String {
+    format!("Every other caller is now denied {pattern:?} without being asked")
+}
+
+fn placement_note(shadowing: &RouteRule, rule: &RouteRule) -> String {
+    let pattern = &shadowing.match_pattern;
+    let placed = format!(
+        "Placed it before the existing rule for {pattern:?}, which covers the same destination and would otherwise pre-empt it."
+    );
+    match (&shadowing.binaries, &rule.binaries) {
+        (Some(binaries), None) => format!(
+            "{placed} That rule's scoping to {} no longer applies to {:?}.",
+            binaries.join(", "),
+            rule.match_pattern
+        ),
+        // The guest refuses to re-open a destination a scoped rule claimed, so the rule behind this one is now dead for everyone it excludes — silence there would leave the file reading as if it still served them.
+        (None, Some(_)) => format!(
+            "{placed} {}, and that rule no longer serves them.",
+            fail_closed_note(&rule.match_pattern)
+        ),
+        _ => placed,
+    }
 }
 
 fn list_rules(args: &PolicyScopeArgs, cwd: &Path, writer: &mut impl Write) -> Result<i32> {
@@ -143,6 +363,7 @@ fn list_rules(args: &PolicyScopeArgs, cwd: &Path, writer: &mut impl Write) -> Re
 struct RuleRow {
     verdict: &'static str,
     pattern: String,
+    binaries: Option<Vec<String>>,
     description: Option<String>,
 }
 
@@ -151,18 +372,23 @@ impl RuleRow {
         Self {
             verdict: verdict_word(rule.verdict),
             pattern: rule.match_pattern.clone(),
+            binaries: rule.binaries.clone(),
             description: rule.description.clone(),
         }
     }
 }
 
 impl crate::output::TableRow for RuleRow {
-    const HEADERS: &'static [&'static str] = &["VERDICT", "PATTERN", "DESCRIPTION"];
+    const HEADERS: &'static [&'static str] = &["VERDICT", "PATTERN", "BINARIES", "DESCRIPTION"];
 
     fn cells(&self) -> Vec<String> {
         vec![
             self.verdict.to_string(),
             self.pattern.clone(),
+            self.binaries
+                .as_ref()
+                .map(|b| b.join(","))
+                .unwrap_or_default(),
             self.description.clone().unwrap_or_default(),
         ]
     }
@@ -178,15 +404,18 @@ fn remove_rule(args: &PolicyRemoveArgs, cwd: &Path, writer: &mut impl Write) -> 
         .egress
         .http
         .retain(|rule| rule.match_pattern != args.pattern);
-    if policy.network.egress.http.len() == before {
+    let removed = before - policy.network.egress.http.len();
+    if removed == 0 {
         bail!("no rule matching {:?} in {}", args.pattern, path.display());
     }
     policy
         .save_atomic(&path)
         .with_context(|| format!("writing policy to {}", path.display()))?;
+    // Removal goes by pattern alone, so the count is the developer's only signal that a rule they didn't have in mind — a binary-scoped one — went with it.
     writeln!(
         writer,
-        "Removed rule for {:?} from {}",
+        "Removed {removed} {} for {:?} from {}",
+        if removed == 1 { "rule" } else { "rules" },
         args.pattern,
         path.display()
     )?;
@@ -230,11 +459,52 @@ mod tests {
     }
 
     #[test]
+    fn clap_collects_repeated_binary_flags_into_one_rule_scope() {
+        let matches = crate::command::build_cli()
+            .try_get_matches_from([
+                "lns",
+                "policy",
+                "allow",
+                "git.example.test",
+                "--binary",
+                "/usr/bin/git",
+                "--binary",
+                "/usr/bin/curl",
+            ])
+            .unwrap();
+        let (_, policy) = matches.subcommand().unwrap();
+        let (verb, allow) = policy.subcommand().unwrap();
+        assert_eq!(verb, "allow");
+        let args = PolicyAllowArgs::from_arg_matches(allow).unwrap();
+        assert_eq!(args.binary, ["/usr/bin/git", "/usr/bin/curl"]);
+    }
+
+    #[test]
+    fn re_adding_a_rule_with_the_note_it_already_carries_reports_it_as_already_present() {
+        let dir = TempDir::new().unwrap();
+        let mut args = rule_args("api.example.test", None);
+        args.description = Some("issue sync".into());
+        let mut out = Vec::new();
+        add_rule(&args, Verdict::Allow, &[], dir.path(), &mut out).unwrap();
+        out.clear();
+
+        add_rule(&args, Verdict::Allow, &[], dir.path(), &mut out).unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("is already in"),
+            "nothing about the rule changed, so reporting an edit would be a lie:\n{text}"
+        );
+        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        assert_eq!(policy.network.egress.http.len(), 1);
+    }
+
+    #[test]
     fn allow_writes_an_allow_rule_with_direct_transport() {
         let dir = TempDir::new().unwrap();
         let args = rule_args("api.acme.corp", None);
         let mut out = Vec::new();
-        let code = add_rule(&args, Verdict::Allow, dir.path(), &mut out).unwrap();
+        let code = add_rule(&args, Verdict::Allow, &[], dir.path(), &mut out).unwrap();
         assert_eq!(code, 0);
         let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
         assert_eq!(policy.network.egress.http.len(), 1);
@@ -304,6 +574,7 @@ mod tests {
             description: Some("undecided".into()),
             tls_terminate: false,
             rules: Vec::new(),
+            binaries: None,
         });
         policy.save_atomic(&path).unwrap();
         let mut out = Vec::new();
@@ -311,8 +582,8 @@ mod tests {
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("VERDICT  PATTERN"), "got: {text}");
         assert!(
-            text.contains("ask      ask.example  undecided"),
-            "got: {text}"
+            text.contains("ask      ask.example            undecided"),
+            "an unscoped rule leaves the BINARIES column blank and still lines up:\n{text}"
         );
     }
 
@@ -362,8 +633,14 @@ mod tests {
         let path = dir.path().join("lns-policy.yaml");
         std::fs::write(&path, "network: not-a-map\n").unwrap();
         let mut out = Vec::new();
-        let err =
-            add_rule(&rule_args("x", None), Verdict::Allow, dir.path(), &mut out).unwrap_err();
+        let err = add_rule(
+            &rule_args("x", None),
+            Verdict::Allow,
+            &[],
+            dir.path(),
+            &mut out,
+        )
+        .unwrap_err();
         assert!(format!("{err:#}").contains("loading policy from"));
     }
 }

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -483,30 +483,6 @@ mod tests {
         );
     }
 
-    fn allow(host: &str) -> RouteRule {
-        RouteRule {
-            match_pattern: host.to_string(),
-            verdict: Verdict::Allow,
-            transport: Transport::Direct,
-            scheme: None,
-            description: None,
-            tls_terminate: false,
-            rules: Vec::new(),
-        }
-    }
-
-    fn deny(host: &str) -> RouteRule {
-        RouteRule {
-            match_pattern: host.to_string(),
-            verdict: Verdict::Deny,
-            transport: Transport::Direct,
-            scheme: None,
-            description: None,
-            tls_terminate: false,
-            rules: Vec::new(),
-        }
-    }
-
     #[test]
     fn summary_lists_image_resources_flags_and_policy_block() {
         let args = run_args(Some("ubuntu"));
@@ -775,6 +751,7 @@ mod tests {
             description: None,
             tls_terminate: false,
             rules: Vec::new(),
+            binaries: None,
         });
         let s = format_summary(
             &run_args(Some("ubuntu")),
@@ -803,10 +780,10 @@ mod tests {
     #[test]
     fn policy_block_shows_file_path_default_verdict_and_rule_summary() {
         let mut policy = Policy::default();
-        policy.add_rule(allow("api.linear.app"));
-        policy.add_rule(allow("api.example.com"));
-        policy.add_rule(allow("registry.npmjs.org"));
-        policy.add_rule(deny("evil.example"));
+        policy.add_rule(RouteRule::allow_host("api.linear.app"));
+        policy.add_rule(RouteRule::allow_host("api.example.com"));
+        policy.add_rule(RouteRule::allow_host("registry.npmjs.org"));
+        policy.add_rule(RouteRule::deny_host("evil.example"));
         let s = format_summary(
             &run_args(Some("ubuntu")),
             &policy,
@@ -835,8 +812,8 @@ mod tests {
     #[test]
     fn rules_line_uses_singular_counts_at_one() {
         let mut policy = Policy::default();
-        policy.add_rule(allow("api.linear.app"));
-        policy.add_rule(deny("evil.example"));
+        policy.add_rule(RouteRule::allow_host("api.linear.app"));
+        policy.add_rule(RouteRule::deny_host("evil.example"));
         let s = format_summary(
             &run_args(Some("ubuntu")),
             &policy,

--- a/crates/lns-cli/tests/behaviours/parse_errors.feature
+++ b/crates/lns-cli/tests/behaviours/parse_errors.feature
@@ -46,3 +46,8 @@ Feature: clap rejects bad input with exit code 2
     Then the exit code is 2
     And the output contains "invalid value"
     And the output contains "--format"
+
+  Scenario: lns policy deny does not take --binary, which only narrows an allow
+    When I run "lns policy deny evil.example.test --binary /usr/bin/git"
+    Then the exit code is 2
+    And the output contains "unexpected argument"

--- a/crates/lns-cli/tests/behaviours/policy_cli.feature
+++ b/crates/lns-cli/tests/behaviours/policy_cli.feature
@@ -39,6 +39,212 @@ Feature: shaping network rules from the CLI
     When the developer adds an allow rule for "api.linear.app" with description "Linear API for issue sync"
     Then "lns-policy.yaml" contains the allow rule with the description
 
+  # The note is not part of the grant, so annotating a rule the file already holds is an edit of that rule, not a second one to place in front of it.
+  Scenario: Annotating a rule the file already holds edits it in place
+    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" with description "issue sync"
+    Then "lns-policy.yaml" still holds 1 rule
+    And "lns-policy.yaml" contains the allow rule with the description
+    And the output says the description was updated
+
+  Scenario: Annotating a deny rule the file already holds edits it in place
+    Given "lns-policy.yaml" has a deny rule for "evil.example"
+    When the developer denies "evil.example" with description "phishing kit"
+    Then "lns-policy.yaml" still holds 1 rule
+    And the output says the description was updated
+
+  Scenario: Re-adding a rule without a description leaves the note it already carries
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" described as "issue sync"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then "lns-policy.yaml" still holds 1 rule
+    And "lns-policy.yaml" contains the allow rule with the description
+    And the output says the rule is already there
+
+  # A scoped rule claims the destination and fails closed, denying every caller off the list rather than falling through, which is why the flag exists only for allow.
+  Scenario: Scoping an allow rule to one binary records it in the policy file
+    When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Then "lns-policy.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git"
+
+  Scenario: Repeating the flag scopes one rule to several binaries
+    When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git" and "/usr/bin/curl"
+    Then "lns-policy.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git,/usr/bin/curl"
+
+  # The scoping is what denies without asking, not where the rule landed, so the one case a developer meets first — a fresh file with nothing to sit in front of — must say so too.
+  Scenario: Scoping a destination no other rule covers still says who it now denies
+    Given the developer is in a directory with no "lns-policy.yaml"
+    When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Then the output says every other caller is now denied "git.example.test"
+
+  Scenario: Adding an unscoped rule claims nothing about other callers
+    Given the developer is in a directory with no "lns-policy.yaml"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the output does not claim any caller is denied
+
+  Scenario: A relative binary path is refused before anything is written
+    Given the developer is in a directory with no "lns-policy.yaml"
+    When the developer adds an allow rule for "git.example.test" scoped to "git"
+    Then the command fails with an exit code other than 0
+    And the failure says a relative path can never match the kernel-resolved path
+    And "./lns-policy.yaml" is not created
+
+  Scenario: A binary path climbing through .. is refused before anything is written
+    Given the developer is in a directory with no "lns-policy.yaml"
+    When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/../bin/git"
+    Then the command fails with an exit code other than 0
+    And the failure says a .. segment can never match the kernel-resolved path
+    And "./lns-policy.yaml" is not created
+
+  # The gate stops at the first matching rule, so a narrowing rule written after an open one would never fire — the CLI puts it where it does what the developer asked and says so.
+  Scenario: Narrowing a destination an open rule already allows puts the scoped rule first
+    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
+    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "api.example.test"
+    And the output says it was placed before the rule for "api.example.test"
+    And the output says every other caller is now denied "api.example.test"
+
+  Scenario: A wildcard allow covering the destination is what the scoped rule goes in front of
+    Given "lns-policy.yaml" has an allow rule for "*.example.test"
+    When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
+    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "*.example.test"
+
+  Scenario: Scoping a whole suffix behind a catch-all allow puts the scoped rule first
+    Given "lns-policy.yaml" has an allow rule for "*"
+    When the developer adds an allow rule for "*.example.test" scoped to "/usr/bin/git"
+    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/git" before the rule for "*"
+    And the output says it was placed before the rule for "*"
+
+  # The only place an open rule reaches the callers a scoped rule excludes is in front of it, which opens the destination to everyone — the same widening the CLI refuses to perform behind a deny.
+  Scenario: Re-opening a destination a scoped rule claimed is refused rather than reordered
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    When the developer adds an allow rule for "git.example.test" without passing --policy
+    Then the command fails with an exit code other than 0
+    And the failure says the rule would open the destination to every caller
+    And the error names "/usr/bin/git"
+    And "lns-policy.yaml" still holds 1 rule
+
+  Scenario: The refusal names the covering rule when it is a wildcard the developer did not type
+    Given "lns-policy.yaml" has an allow rule for "*.example.test" scoped to "/usr/bin/git"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the command fails with an exit code other than 0
+    And the error names "*.example.test"
+    And "lns-policy.yaml" still holds 1 rule
+
+  # A narrowing rule is not a widening: the caller it names already reaches the destination through the rule it goes in front of.
+  Scenario: Narrowing a scoped rule to fewer of its binaries is placed in front of it
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" and "/usr/bin/curl"
+    When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/git" before the rule scoped to "/usr/bin/git,/usr/bin/curl"
+    And the output does not claim any scoping is spent
+
+  Scenario: Denying a destination a scoped allow claimed puts the deny in front of it
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    When the developer denies "git.example.test"
+    Then "lns-policy.yaml" lists the deny rule for "git.example.test" before the rule scoped to "/usr/bin/git"
+    And the output says the scoped rule for "git.example.test" no longer applies
+
+  # A narrowing of who may reach a destination is not a request to stop intercepting it, so the rule going in front carries the fronted rule's TLS termination with it.
+  Scenario: A rule placed in front of a TLS-terminating rule keeps terminating TLS
+    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
+    Then "lns-policy.yaml" terminates TLS on the rule scoped to "/usr/bin/curl"
+    And the output says the placed rule terminates TLS too
+
+  Scenario: A deny placed in front of a TLS-terminating rule does not take up terminating TLS
+    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test"
+    When the developer denies "api.example.test"
+    Then "lns-policy.yaml" does not terminate TLS on the deny rule for "api.example.test"
+
+  # Inheriting the termination makes the new rule the one the file already holds, so it is an annotation of that rule — not a second copy of it that drops its note.
+  Scenario: Re-adding a rule the file holds as a TLS-terminating one keeps its note
+    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test" described as "issue sync"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the output says the rule is already there
+    And "lns-policy.yaml" still holds 1 rule
+    And "lns-policy.yaml" describes the allow rule for "api.example.test" as "issue sync"
+
+  # A rule carrying an http `rules` list allows only the requests it names and denies the rest, so getting in front of it hands the new rule's callers every method and path.
+  Scenario: Fronting a rule that restricts which requests it allows is refused
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests
+    When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
+    Then the command fails with an exit code other than 0
+    And the failure says the rule would lift the request restriction
+    And "lns-policy.yaml" still holds 1 rule
+
+  Scenario: Denying a destination whose rule restricts requests is still placed in front of it
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests
+    When the developer denies "api.example.test"
+    Then "lns-policy.yaml" lists the deny rule for "api.example.test" before the rule restricted to GET requests
+
+  # Removing the deny would widen egress for every destination it covers, so the refusal must not send the developer there.
+  Scenario: A destination an earlier deny already blocks is refused rather than reordered
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" and a deny rule for "evil.example"
+    When the developer adds an allow rule for "evil.example" scoped to "/usr/bin/curl"
+    Then the command fails with an exit code other than 0
+    And the failure does not tell the developer to remove the deny
+    And the error names "evil.example"
+    And "lns-policy.yaml" still holds 2 rules
+
+  Scenario: Adding a rule the file already holds changes nothing
+    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the output says the rule is already there
+    And "lns-policy.yaml" still holds 1 rule
+
+  # The file holding a grant and the gate reaching it are different things: a copy stranded behind a rule that pre-empts it is not the rule to report as already in force.
+  Scenario: A grant the file holds but a deny pre-empts is refused, not reported as already there
+    Given "lns-policy.yaml" has a deny rule for "*.example.test" ahead of an allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the command fails with an exit code other than 0
+    And the error names "*.example.test"
+    And "lns-policy.yaml" still holds 2 rules
+
+  Scenario: A deny the file holds but an allow pre-empts is moved in front of that allow
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test"
+    When the developer denies "api.example.test"
+    Then "lns-policy.yaml" lists the deny rule for "api.example.test" before the allow rule for "api.example.test"
+    And "lns-policy.yaml" still holds 2 rules
+
+  Scenario: Moving a stranded rule into force keeps the note it was carrying
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test" described as "phishing kit"
+    When the developer denies "api.example.test"
+    Then "lns-policy.yaml" still holds 2 rules
+    And "lns-policy.yaml" describes the deny rule for "api.example.test" as "phishing kit"
+
+  # A same-verdict rule can pre-empt by scope or by request filter as surely as a deny pre-empts by verdict, and a copy stranded behind one of those is no more in force.
+  Scenario: A grant a binary-scoped rule pre-empts is refused, not reported as already there
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
+    When the developer adds an allow rule for "git.example.test" without passing --policy
+    Then the command fails with an exit code other than 0
+    And the failure says the rule would open the destination to every caller
+    And "lns-policy.yaml" still holds 2 rules
+
+  Scenario: A grant a request-filtered rule pre-empts is refused, not reported as already there
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests ahead of an unrestricted allow rule for "api.example.test"
+    When the developer adds an allow rule for "api.example.test" without passing --policy
+    Then the command fails with an exit code other than 0
+    And the failure says the rule would lift the request restriction
+    And "lns-policy.yaml" still holds 2 rules
+
+  # A deny behind a deny is the one shadowed rule that is not a mistake: the destination is already blocked, which is what the developer asked for.
+  Scenario: Denying a destination a broader deny already blocks succeeds and changes nothing
+    Given "lns-policy.yaml" has a deny rule for "*.example.test"
+    When the developer denies "api.example.test"
+    Then the command succeeds
+    And the output says the deny adds nothing
+    And "lns-policy.yaml" still holds 1 rule
+
+  # `lns policy remove` deletes every rule carrying the pattern, scoped or not, so the scoping has to be visible before removing anything.
+  Scenario: Listing shows which binaries a rule is scoped to
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    When the developer lists rules
+    Then the output shows the rule scoped to "/usr/bin/git"
+
+  Scenario: Listing as JSON tells a script which rules are binary-scoped
+    Given "lns-policy.yaml" has an allow rule for "api.example.test" and a scoped allow rule for "git.example.test"
+    When the developer lists rules as JSON
+    Then JSON row 0 has a null "binaries"
+    And JSON row 1 has "binaries" set to the list "/usr/bin/git"
+
   Scenario: Listing rules shows what is currently in the policy file
     Given "lns-policy.yaml" has an allow rule for "api.linear.app" and a deny rule for "evil.example"
     When the developer lists rules
@@ -54,6 +260,17 @@ Feature: shaping network rules from the CLI
     Given "lns-policy.yaml" has an allow rule for "api.linear.app"
     When the developer removes the rule matching "api.linear.app"
     Then "lns-policy.yaml" no longer contains a rule for "api.linear.app"
+
+  # Removal goes by pattern alone, so a scoped rule can go with the one the developer meant; the report has to name the count or a silent extra deletion reads as a single-rule removal.
+  Scenario: Removing a destination several rules carry says how many went
+    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
+    When the developer removes the rule matching "git.example.test"
+    Then the output says 2 rules were removed for "git.example.test"
+
+  Scenario: Removing a destination one rule carries reports it in the singular
+    Given "lns-policy.yaml" has an allow rule for "api.linear.app"
+    When the developer removes the rule matching "api.linear.app"
+    Then the output says 1 rule was removed for "api.linear.app"
 
   Scenario: Removing a rule that does not exist surfaces a clear error
     Given "lns-policy.yaml" has no rule for "ghost.example"

--- a/crates/lns-cli/tests/behaviours/steps/machine_output.rs
+++ b/crates/lns-cli/tests/behaviours/steps/machine_output.rs
@@ -96,6 +96,27 @@ fn json_row_number(
     }
 }
 
+#[then(regex = r#"^JSON row (\d+) has "([^"]+)" set to the list "([^"]*)"$"#)]
+fn json_row_list(
+    world: &mut BehaviourWorld,
+    index: usize,
+    key: String,
+    expected: String,
+) -> Result<(), String> {
+    let found = field(&row(world, index)?, &key)?;
+    let wanted: Vec<serde_json::Value> = expected
+        .split(',')
+        .map(|item| serde_json::Value::String(item.to_string()))
+        .collect();
+    if found == serde_json::Value::Array(wanted) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {key} to be the list {expected:?}, got {found}"
+        ))
+    }
+}
+
 #[then(regex = r#"^JSON row (\d+) has a non-empty "([^"]+)"$"#)]
 fn json_row_non_empty(world: &mut BehaviourWorld, index: usize, key: String) -> Result<(), String> {
     let found = field(&row(world, index)?, &key)?;

--- a/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
@@ -1,8 +1,10 @@
 use crate::runner::CliRun;
 use crate::world::BehaviourWorld;
 use cucumber::{given, then, when};
-use lns_cli::policy::{self, PolicyCommand, PolicyRemoveArgs, PolicyRuleArgs, PolicyScopeArgs};
-use lns_policy::{Policy, RouteRule, Verdict};
+use lns_cli::policy::{
+    self, PolicyAllowArgs, PolicyCommand, PolicyRemoveArgs, PolicyRuleArgs, PolicyScopeArgs,
+};
+use lns_policy::{HttpRule, Policy, RouteRule, Verdict};
 use std::path::{Path, PathBuf};
 
 fn cwd(world: &mut BehaviourWorld) -> PathBuf {
@@ -34,6 +36,24 @@ fn rule_args(world: &mut BehaviourWorld, pattern: &str, policy: Option<PathBuf>)
         pattern: pattern.to_string(),
         description: None,
         policy,
+    }
+}
+
+fn allow_args(
+    world: &mut BehaviourWorld,
+    pattern: &str,
+    policy: Option<PathBuf>,
+) -> PolicyAllowArgs {
+    PolicyAllowArgs {
+        rule: rule_args(world, pattern, policy),
+        binary: Vec::new(),
+    }
+}
+
+fn scoped_rule(pattern: &str, binaries: &[&str]) -> RouteRule {
+    RouteRule {
+        binaries: Some(binaries.iter().map(|b| (*b).to_string()).collect()),
+        ..RouteRule::allow_host(pattern)
     }
 }
 
@@ -87,6 +107,165 @@ fn policy_has_allow(world: &mut BehaviourWorld, file: String, pattern: String) {
     policy.save_atomic(&dir.join(file)).expect("seed policy");
 }
 
+#[given(regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" described as "([^"]+)"$"#)]
+fn policy_has_described_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    description: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule {
+        description: Some(description),
+        ..RouteRule::allow_host(pattern)
+    });
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(regex = r#"^"([^"]+)" has a deny rule for "([^"]+)"$"#)]
+fn policy_has_deny(world: &mut BehaviourWorld, file: String, pattern: String) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule::deny_host(pattern));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has a deny rule for "([^"]+)" ahead of an allow rule for "([^"]+)"$"#
+)]
+fn policy_has_deny_ahead_of_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    denied: String,
+    allowed: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule::deny_host(denied));
+    policy.add_rule(RouteRule::allow_host(allowed));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" ahead of a deny rule for "([^"]+)"$"#
+)]
+fn policy_has_allow_ahead_of_deny(
+    world: &mut BehaviourWorld,
+    file: String,
+    allowed: String,
+    denied: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule::allow_host(allowed));
+    policy.add_rule(RouteRule::deny_host(denied));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(regex = r#"^"([^"]+)" has a TLS-terminating allow rule for "([^"]+)"$"#)]
+fn policy_has_tls_terminating_allow(world: &mut BehaviourWorld, file: String, pattern: String) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule {
+        tls_terminate: true,
+        ..RouteRule::allow_host(pattern)
+    });
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has a TLS-terminating allow rule for "([^"]+)" described as "([^"]+)"$"#
+)]
+fn policy_has_described_tls_terminating_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    description: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule {
+        tls_terminate: true,
+        description: Some(description),
+        ..RouteRule::allow_host(pattern)
+    });
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" ahead of a deny rule for "([^"]+)" described as "([^"]+)"$"#
+)]
+fn policy_has_allow_ahead_of_described_deny(
+    world: &mut BehaviourWorld,
+    file: String,
+    allowed: String,
+    denied: String,
+    description: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule::allow_host(allowed));
+    policy.add_rule(RouteRule {
+        description: Some(description),
+        ..RouteRule::deny_host(denied)
+    });
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" scoped to "([^"]+)" ahead of an unscoped allow rule for "([^"]+)"$"#
+)]
+fn policy_has_scoped_ahead_of_unscoped_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    scoped: String,
+    binary: String,
+    unscoped: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(scoped_rule(&scoped, &[&binary]));
+    policy.add_rule(RouteRule::allow_host(unscoped));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" restricted to GET requests ahead of an unrestricted allow rule for "([^"]+)"$"#
+)]
+fn policy_has_restricted_ahead_of_unrestricted_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    restricted: String,
+    unrestricted: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule {
+        rules: vec![HttpRule {
+            method: Some("GET".into()),
+            path: None,
+        }],
+        ..RouteRule::allow_host(restricted)
+    });
+    policy.add_rule(RouteRule::allow_host(unrestricted));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" restricted to GET requests$"#)]
+fn policy_has_get_restricted_allow(world: &mut BehaviourWorld, file: String, pattern: String) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule {
+        rules: vec![HttpRule {
+            method: Some("GET".into()),
+            path: None,
+        }],
+        ..RouteRule::allow_host(pattern)
+    });
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
 #[given(regex = r#"^"([^"]+)" uses the removed allowedRoutes key for "([^"]+)"$"#)]
 fn policy_uses_the_removed_key(world: &mut BehaviourWorld, file: String, pattern: String) {
     let dir = cwd(world);
@@ -109,13 +288,13 @@ fn policy_has_no_rule(world: &mut BehaviourWorld, file: String, _pattern: String
 
 #[when(regex = r#"^the developer adds an allow rule for "([^"]+)" to "([^"]+)"$"#)]
 fn add_allow_to_file(world: &mut BehaviourWorld, pattern: String, file: String) {
-    let args = rule_args(world, &pattern, Some(PathBuf::from(file)));
+    let args = allow_args(world, &pattern, Some(PathBuf::from(file)));
     run_policy(world, PolicyCommand::Allow(args));
 }
 
 #[when(regex = r#"^the developer adds an allow rule for "([^"]+)" without passing --policy$"#)]
 fn add_allow_default_path(world: &mut BehaviourWorld, pattern: String) {
-    let args = rule_args(world, &pattern, None);
+    let args = allow_args(world, &pattern, None);
     run_policy(world, PolicyCommand::Allow(args));
 }
 
@@ -127,15 +306,92 @@ fn add_allow_explicit_path(world: &mut BehaviourWorld, pattern: String, path: St
         .file_name()
         .expect("explicit path has a file name");
     let explicit = cwd(world).join(basename);
-    let args = rule_args(world, &pattern, Some(explicit));
+    let args = allow_args(world, &pattern, Some(explicit));
     run_policy(world, PolicyCommand::Allow(args));
 }
 
 #[when(regex = r#"^the developer adds an allow rule for "([^"]+)" with description "([^"]+)"$"#)]
 fn add_allow_with_description(world: &mut BehaviourWorld, pattern: String, description: String) {
+    let mut args = allow_args(world, &pattern, None);
+    args.rule.description = Some(description);
+    run_policy(world, PolicyCommand::Allow(args));
+}
+
+#[given(regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" scoped to "([^"]+)"$"#)]
+fn policy_has_scoped_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    binary: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(scoped_rule(&pattern, &[&binary]));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" scoped to "([^"]+)" and "([^"]+)"$"#)]
+fn policy_has_multi_scoped_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    first: String,
+    second: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(scoped_rule(&pattern, &[&first, &second]));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[given(
+    regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" and a scoped allow rule for "([^"]+)"$"#
+)]
+fn policy_has_open_and_scoped_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    open: String,
+    scoped: String,
+) {
+    let dir = cwd(world);
+    let mut policy = Policy::default();
+    policy.add_rule(RouteRule::allow_host(open));
+    policy.add_rule(scoped_rule(&scoped, &["/usr/bin/git"]));
+    policy.save_atomic(&dir.join(file)).expect("seed policy");
+}
+
+#[when(regex = r#"^the developer adds an allow rule for "([^"]+)" scoped to "([^"]+)"$"#)]
+fn add_scoped_allow(world: &mut BehaviourWorld, pattern: String, binary: String) {
+    let mut args = allow_args(world, &pattern, None);
+    args.binary = vec![binary];
+    run_policy(world, PolicyCommand::Allow(args));
+}
+
+#[when(
+    regex = r#"^the developer adds an allow rule for "([^"]+)" scoped to "([^"]+)" and "([^"]+)"$"#
+)]
+fn add_multi_scoped_allow(
+    world: &mut BehaviourWorld,
+    pattern: String,
+    first: String,
+    second: String,
+) {
+    let mut args = allow_args(world, &pattern, None);
+    args.binary = vec![first, second];
+    run_policy(world, PolicyCommand::Allow(args));
+}
+
+#[when(regex = r#"^the developer denies "([^"]+)"$"#)]
+fn add_deny(world: &mut BehaviourWorld, pattern: String) {
+    let args = rule_args(world, &pattern, None);
+    run_policy(world, PolicyCommand::Deny(args));
+}
+
+#[when(regex = r#"^the developer denies "([^"]+)" with description "([^"]+)"$"#)]
+fn add_deny_with_description(world: &mut BehaviourWorld, pattern: String, description: String) {
     let mut args = rule_args(world, &pattern, None);
     args.description = Some(description);
-    run_policy(world, PolicyCommand::Allow(args));
+    run_policy(world, PolicyCommand::Deny(args));
 }
 
 #[when(regex = r"^the developer lists rules$")]
@@ -331,6 +587,462 @@ fn file_no_longer_contains(
     } else {
         Ok(())
     }
+}
+
+#[then(regex = r#"^"([^"]+)" scopes the allow rule for "([^"]+)" to "([^"]+)"$"#)]
+fn file_scopes_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    binaries: String,
+) -> Result<(), String> {
+    let expected: Vec<String> = binaries.split(',').map(str::to_string).collect();
+    let policy = load(world, &file);
+    let found = policy
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|r| r.match_pattern == pattern && r.verdict == Verdict::Allow)
+        .ok_or_else(|| format!("{file} has no allow rule for {pattern}"))?;
+    if found.binaries.as_deref() == Some(expected.as_slice()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {pattern} scoped to {expected:?}, got {:?}",
+            found.binaries
+        ))
+    }
+}
+
+#[then(regex = r"^the failure says a relative path can never match the kernel-resolved path$")]
+fn failure_explains_relative_path(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "is not an absolute path")?;
+    output_mentions(world, "kernel-resolved /proc/<pid>/exe")
+}
+
+#[then(regex = r"^the failure says a \.\. segment can never match the kernel-resolved path$")]
+fn failure_explains_parent_segment(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "climbs through a \"..\" segment")?;
+    output_mentions(world, "kernel-resolved /proc/<pid>/exe")
+}
+
+fn output_mentions(world: &BehaviourWorld, needle: &str) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    if out.contains(needle) {
+        Ok(())
+    } else {
+        Err(format!("failure output missing {needle:?}:\n{out}"))
+    }
+}
+
+#[then(regex = r#"^the output shows the rule scoped to "([^"]+)"$"#)]
+fn output_shows_scoping(world: &mut BehaviourWorld, binary: String) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    for needle in ["BINARIES", binary.as_str()] {
+        if !out.contains(needle) {
+            return Err(format!("list output missing {needle:?}:\n{out}"));
+        }
+    }
+    Ok(())
+}
+
+fn position_of(
+    world: &mut BehaviourWorld,
+    file: &str,
+    of: impl Fn(&RouteRule) -> bool,
+    what: &str,
+) -> Result<usize, String> {
+    load(world, file)
+        .network
+        .egress
+        .http
+        .iter()
+        .position(of)
+        .ok_or_else(|| format!("{file} has no {what}"))
+}
+
+fn scoped_to(binaries: String) -> impl Fn(&RouteRule) -> bool {
+    let binaries: Vec<String> = binaries.split(',').map(str::to_string).collect();
+    move |rule| rule.binaries.as_deref() == Some(binaries.as_slice())
+}
+
+fn open_rule_for(pattern: String) -> impl Fn(&RouteRule) -> bool {
+    move |rule| rule.match_pattern == pattern && rule.binaries.is_none()
+}
+
+fn deny_rule_for(pattern: String) -> impl Fn(&RouteRule) -> bool {
+    move |rule| rule.match_pattern == pattern && rule.verdict == Verdict::Deny
+}
+
+#[then(
+    regex = r#"^"([^"]+)" lists the deny rule for "([^"]+)" before the rule scoped to "([^"]+)"$"#
+)]
+fn deny_comes_first(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+    binary: String,
+) -> Result<(), String> {
+    let deny = position_of(
+        world,
+        &file,
+        deny_rule_for(pattern.clone()),
+        &format!("deny rule for {pattern}"),
+    )?;
+    let scoped = position_of(
+        world,
+        &file,
+        scoped_to(binary.clone()),
+        &format!("rule scoped to {binary}"),
+    )?;
+    if deny < scoped {
+        Ok(())
+    } else {
+        Err(format!(
+            "the scoped allow at {scoped} still serves its listed callers, so the deny at {deny} never blocks them"
+        ))
+    }
+}
+
+fn allow_rule_for(pattern: String) -> impl Fn(&RouteRule) -> bool {
+    move |rule| rule.match_pattern == pattern && rule.verdict == Verdict::Allow
+}
+
+#[then(
+    regex = r#"^"([^"]+)" lists the deny rule for "([^"]+)" before the allow rule for "([^"]+)"$"#
+)]
+fn deny_comes_before_the_allow(
+    world: &mut BehaviourWorld,
+    file: String,
+    denied: String,
+    allowed: String,
+) -> Result<(), String> {
+    let deny = position_of(
+        world,
+        &file,
+        deny_rule_for(denied.clone()),
+        &format!("deny rule for {denied}"),
+    )?;
+    let allow = position_of(
+        world,
+        &file,
+        allow_rule_for(allowed.clone()),
+        &format!("allow rule for {allowed}"),
+    )?;
+    if deny < allow {
+        Ok(())
+    } else {
+        Err(format!(
+            "the gate stops at the first match, so the allow at {allow} serves the destination and the deny at {deny} blocks nobody"
+        ))
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" terminates TLS on the rule scoped to "([^"]+)"$"#)]
+fn file_terminates_tls_on_the_scoped_rule(
+    world: &mut BehaviourWorld,
+    file: String,
+    binary: String,
+) -> Result<(), String> {
+    let scoped = scoped_to(binary.clone());
+    let found = load(world, &file)
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|rule| scoped(rule))
+        .cloned()
+        .ok_or_else(|| format!("{file} has no rule scoped to {binary}"))?;
+    if found.tls_terminate {
+        Ok(())
+    } else {
+        Err(format!(
+            "the rule it was placed in front of terminates TLS, so dropping it here stops intercepting the destination for {binary}: {found:?}"
+        ))
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" does not terminate TLS on the deny rule for "([^"]+)"$"#)]
+fn file_does_not_terminate_tls_on_the_deny(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+) -> Result<(), String> {
+    let deny = deny_rule_for(pattern.clone());
+    let found = load(world, &file)
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|rule| deny(rule))
+        .cloned()
+        .ok_or_else(|| format!("{file} has no deny rule for {pattern}"))?;
+    if found.tls_terminate {
+        Err(format!(
+            "a deny blocks the request before there is anything to intercept, so terminating TLS on it is noise in the file: {found:?}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" describes the (allow|deny) rule for "([^"]+)" as "([^"]+)"$"#)]
+fn file_describes_rule(
+    world: &mut BehaviourWorld,
+    file: String,
+    verdict: String,
+    pattern: String,
+    description: String,
+) -> Result<(), String> {
+    let wanted = match verdict.as_str() {
+        "allow" => Verdict::Allow,
+        _ => Verdict::Deny,
+    };
+    let found = load(world, &file)
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|rule| rule.match_pattern == pattern && rule.verdict == wanted)
+        .cloned()
+        .ok_or_else(|| format!("{file} has no {verdict} rule for {pattern}"))?;
+    if found.description.as_deref() == Some(description.as_str()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "a command passing no --description is not a request to forget the note the rule carries, got {:?}",
+            found.description
+        ))
+    }
+}
+
+#[then(regex = r"^the output says the placed rule terminates TLS too$")]
+fn output_reports_inherited_tls(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "terminates TLS as that rule does")
+}
+
+#[then(regex = r#"^"([^"]+)" lists the rule scoped to "([^"]+)" before the rule for "([^"]+)"$"#)]
+fn scoped_rule_comes_first(
+    world: &mut BehaviourWorld,
+    file: String,
+    binary: String,
+    pattern: String,
+) -> Result<(), String> {
+    let scoped = position_of(
+        world,
+        &file,
+        scoped_to(binary.clone()),
+        &format!("rule scoped to {binary}"),
+    )?;
+    let open = position_of(
+        world,
+        &file,
+        open_rule_for(pattern.clone()),
+        &format!("open rule for {pattern}"),
+    )?;
+    if scoped < open {
+        Ok(())
+    } else {
+        Err(format!(
+            "the gate stops at the first match, so the scoped rule at {scoped} never fires behind the open rule for {pattern} at {open}"
+        ))
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" still holds (\d+) rules?$"#)]
+fn file_still_holds(
+    world: &mut BehaviourWorld,
+    file: String,
+    expected: usize,
+) -> Result<(), String> {
+    let found = load(world, &file).network.egress.http.len();
+    if found == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {expected} rules in {file}, found {found}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the output says it was placed before the rule for "([^"]+)"$"#)]
+fn output_reports_placement(world: &mut BehaviourWorld, pattern: String) -> Result<(), String> {
+    output_mentions(world, &format!("before the existing rule for {pattern:?}"))
+}
+
+#[then(
+    regex = r#"^"([^"]+)" lists the rule scoped to "([^"]+)" before the rule scoped to "([^"]+)"$"#
+)]
+fn narrower_scope_comes_first(
+    world: &mut BehaviourWorld,
+    file: String,
+    narrower: String,
+    wider: String,
+) -> Result<(), String> {
+    let first = position_of(
+        world,
+        &file,
+        scoped_to(narrower.clone()),
+        &format!("rule scoped to {narrower}"),
+    )?;
+    let second = position_of(
+        world,
+        &file,
+        scoped_to(wider.clone()),
+        &format!("rule scoped to {wider}"),
+    )?;
+    if first < second {
+        Ok(())
+    } else {
+        Err(format!(
+            "the gate stops at the first match, so the rule at {first} narrows nothing behind the rule scoped to {wider} at {second}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the output says every other caller is now denied "([^"]+)"$"#)]
+fn output_reports_the_destination_is_claimed(
+    world: &mut BehaviourWorld,
+    pattern: String,
+) -> Result<(), String> {
+    output_mentions(
+        world,
+        &format!("Every other caller is now denied {pattern:?} without being asked"),
+    )
+}
+
+#[then(
+    regex = r#"^"([^"]+)" lists the deny rule for "([^"]+)" before the rule restricted to GET requests$"#
+)]
+fn deny_comes_before_the_restricted_rule(
+    world: &mut BehaviourWorld,
+    file: String,
+    pattern: String,
+) -> Result<(), String> {
+    let deny = position_of(
+        world,
+        &file,
+        deny_rule_for(pattern.clone()),
+        &format!("deny rule for {pattern}"),
+    )?;
+    let restricted = position_of(
+        world,
+        &file,
+        |rule| !rule.rules.is_empty(),
+        "rule restricted to GET requests",
+    )?;
+    if deny < restricted {
+        Ok(())
+    } else {
+        Err(format!(
+            "the restricted allow at {restricted} still serves the requests it names, so the deny at {deny} never blocks them"
+        ))
+    }
+}
+
+#[then(regex = r"^the failure says the rule would lift the request restriction$")]
+fn failure_reports_a_lifted_restriction(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "allows only the requests its rules list names")?;
+    output_mentions(world, "would lift that restriction")
+}
+
+#[then(regex = r"^the failure says the rule would open the destination to every caller$")]
+fn failure_reports_a_widening(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "open the destination to every caller")
+}
+
+#[then(regex = r"^the output does not claim any scoping is spent$")]
+fn output_does_not_claim_spent_scoping(world: &mut BehaviourWorld) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    if out.contains("no longer applies") {
+        return Err(format!(
+            "the rule it was placed in front of still serves the callers it lists, so nothing about its scoping is spent:\n{out}"
+        ));
+    }
+    Ok(())
+}
+
+#[then(regex = r#"^the output says the scoped rule for "([^"]+)" no longer applies$"#)]
+fn output_reports_spent_scoping(world: &mut BehaviourWorld, pattern: String) -> Result<(), String> {
+    output_mentions(world, &format!("no longer applies to {pattern:?}"))
+}
+
+#[then(regex = r"^the output does not claim any caller is denied$")]
+fn output_does_not_claim_a_denied_caller(world: &mut BehaviourWorld) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    if out.contains("is now denied") {
+        return Err(format!(
+            "an unscoped rule denies nobody, so claiming it does would send the developer looking for a filter that isn't there:\n{out}"
+        ));
+    }
+    Ok(())
+}
+
+#[then(regex = r#"^the output says (\d+) rules? (?:were|was) removed for "([^"]+)"$"#)]
+fn output_reports_the_removal_count(
+    world: &mut BehaviourWorld,
+    count: usize,
+    pattern: String,
+) -> Result<(), String> {
+    let noun = if count == 1 { "rule" } else { "rules" };
+    output_mentions(world, &format!("Removed {count} {noun} for {pattern:?}"))
+}
+
+#[then(regex = r"^the output says the description was updated$")]
+fn output_reports_a_described_rule(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "Updated the description of")
+}
+
+#[then(regex = r"^the output says the rule is already there$")]
+fn output_reports_already_present(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "is already in")
+}
+
+#[then(regex = r"^the command succeeds$")]
+fn command_succeeds(world: &mut BehaviourWorld) -> Result<(), String> {
+    match world.result.as_ref() {
+        Some(run) if run.exit_code == 0 => Ok(()),
+        Some(run) => Err(format!("exited {}:\n{}", run.exit_code, run.output)),
+        None => Err("the command did not run".to_string()),
+    }
+}
+
+#[then(regex = r"^the output says the deny adds nothing$")]
+fn output_reports_deny_adds_nothing(world: &mut BehaviourWorld) -> Result<(), String> {
+    output_mentions(world, "already blocks")?;
+    output_mentions(world, "adds nothing")
+}
+
+#[then(regex = r"^the failure does not tell the developer to remove the deny$")]
+fn failure_does_not_advise_removing_the_deny(world: &mut BehaviourWorld) -> Result<(), String> {
+    let out = world
+        .result
+        .as_ref()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+    if out.contains("policy remove") {
+        return Err(format!(
+            "removing the deny widens egress for every destination it covers, so the refusal must not propose it:\n{out}"
+        ));
+    }
+    Ok(())
 }
 
 #[then(regex = r"^the command fails with an exit code other than 0$")]

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -10,7 +10,7 @@ use lns_cli::service::{
 use lns_ipc::{
     LogLevel, Response, WireFrame, encode_frame, encode_wire_frame, read_frame_bytes_async,
 };
-use lns_policy::{Policy, RouteRule, Transport, Verdict};
+use lns_policy::{Policy, RouteRule, Verdict};
 use std::io::Write as _;
 use tokio::io::AsyncWriteExt;
 
@@ -173,26 +173,10 @@ fn that_policy_has(world: &mut BehaviourWorld, verdict: String, allows: usize, d
         other => panic!("unknown verdict {other:?}"),
     };
     for i in 0..allows {
-        policy.add_rule(RouteRule {
-            match_pattern: format!("allow-{i}.example"),
-            verdict: Verdict::Allow,
-            transport: Transport::Direct,
-            scheme: None,
-            description: None,
-            tls_terminate: false,
-            rules: Vec::new(),
-        });
+        policy.add_rule(RouteRule::allow_host(format!("allow-{i}.example")));
     }
     for i in 0..denies {
-        policy.add_rule(RouteRule {
-            match_pattern: format!("deny-{i}.example"),
-            verdict: Verdict::Deny,
-            transport: Transport::Direct,
-            scheme: None,
-            description: None,
-            tls_terminate: false,
-            rules: Vec::new(),
-        });
+        policy.add_rule(RouteRule::deny_host(format!("deny-{i}.example")));
     }
     policy
         .save_atomic(&cwd.join("lns-policy.yaml"))

--- a/crates/lns-policy/Cargo.toml
+++ b/crates/lns-policy/Cargo.toml
@@ -14,6 +14,7 @@ serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 libc       = "0.2"
+ipnet      = "2"
 
 [dev-dependencies]
 tempfile    = "3"

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -43,6 +43,7 @@ impl ConnectorRoute {
             description: None,
             tls_terminate: self.tls_terminate || !self.rules.is_empty(),
             rules: self.rules.clone(),
+            binaries: None,
         }
     }
 }

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +9,7 @@ pub mod credentials;
 mod env_subst;
 pub mod grants;
 pub mod host_bind_decisions;
+pub mod matching;
 pub mod providers;
 pub mod registry_auth;
 mod secure_file;
@@ -74,6 +75,13 @@ impl NetworkPolicy {
         }
         Ok(())
     }
+
+    pub fn validate_binary_scopes(&self) -> io::Result<()> {
+        self.egress
+            .http
+            .iter()
+            .try_for_each(RouteRule::validate_binaries)
+    }
 }
 
 pub(crate) fn is_false(b: &bool) -> bool {
@@ -97,6 +105,9 @@ pub struct RouteRule {
     pub tls_terminate: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules: Vec<HttpRule>,
+    /// Absolute guest binary paths this rule is scoped to; absent means any caller, and a listed rule denies every other caller rather than falling through.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binaries: Option<Vec<String>>,
 }
 
 /// HTTP method/path restriction within a route rule; wire-compatible with lens-sandbox-core's `HttpRule`.
@@ -139,6 +150,7 @@ impl Policy {
                 let policy: Self = serde_yaml::from_str(&text)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                 policy.network.validate_local_transport()?;
+                policy.network.validate_binary_scopes()?;
                 Ok(policy)
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
@@ -210,6 +222,7 @@ impl RouteRule {
             description: None,
             tls_terminate: false,
             rules: Vec::new(),
+            binaries: None,
         }
     }
 
@@ -222,8 +235,48 @@ impl RouteRule {
             description: None,
             tls_terminate: false,
             rules: Vec::new(),
+            binaries: None,
         }
     }
+
+    pub fn validate_binaries(&self) -> io::Result<()> {
+        let Some(binaries) = self.binaries.as_deref() else {
+            return Ok(());
+        };
+        if binaries.is_empty() {
+            return Err(invalid_data(format!(
+                "the rule for {:?} has an empty binaries filter: it matches no caller, so it denies the host for everyone — omit binaries to let any caller through",
+                self.match_pattern
+            )));
+        }
+        binaries
+            .iter()
+            .try_for_each(|path| self.validate_binary(path))
+    }
+
+    fn validate_binary(&self, binary: &str) -> io::Result<()> {
+        let unmatchable = |why: &str| {
+            Err(invalid_data(format!(
+                "the rule for {:?} lists the binary {binary:?}, which {why}: binaries are matched against the kernel-resolved /proc/<pid>/exe, so it can never match",
+                self.match_pattern
+            )))
+        };
+        let path = Path::new(binary);
+        if !path.is_absolute() {
+            return unmatchable("is not an absolute path");
+        }
+        if path.components().any(|c| c == Component::ParentDir) {
+            return unmatchable("climbs through a \"..\" segment");
+        }
+        if path.file_name().is_none() {
+            return unmatchable("names no binary");
+        }
+        Ok(())
+    }
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
 }
 
 #[cfg(test)]
@@ -323,6 +376,7 @@ mod tests {
                 method: Some("GET".into()),
                 path: Some("/api/v4/**".into()),
             }],
+            binaries: None,
         };
         let yaml = serde_yaml::to_string(&rule).unwrap();
         assert!(yaml.contains("scheme: https"), "got:\n{yaml}");
@@ -330,6 +384,146 @@ mod tests {
         assert!(yaml.contains("path: /api/v4/**"), "got:\n{yaml}");
         let parsed: RouteRule = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, rule);
+    }
+
+    #[test]
+    fn a_binary_scoped_route_rule_round_trips_with_the_core_wire_name() {
+        let rule = RouteRule {
+            match_pattern: "git.example.test".into(),
+            verdict: Verdict::Allow,
+            transport: Transport::Direct,
+            scheme: None,
+            description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+            binaries: Some(vec!["/usr/bin/git".into()]),
+        };
+        let yaml = serde_yaml::to_string(&rule).unwrap();
+        assert!(yaml.contains("binaries:"), "got:\n{yaml}");
+        assert!(yaml.contains("- /usr/bin/git"), "got:\n{yaml}");
+        let parsed: RouteRule = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, rule);
+    }
+
+    #[test]
+    fn an_unscoped_route_rule_omits_the_binaries_key() {
+        let yaml = serde_yaml::to_string(&RouteRule::allow_host("api.example.test")).unwrap();
+        assert!(
+            !yaml.contains("binaries"),
+            "sandbox-core reads an empty binaries list as `matches no caller`, so a rule open to every caller must omit the key:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn load_or_default_accepts_a_rule_scoped_to_an_absolute_binary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-policy.yaml");
+        let yaml = "\
+network:
+  egress:
+    http:
+      - match: git.example.test
+        verdict: allow
+        binaries:
+          - /usr/bin/git
+  defaultVerdict: ask
+";
+        fs::write(&path, yaml).unwrap();
+        let p = Policy::load_or_default(&path).unwrap();
+        assert_eq!(
+            p.network.egress.http[0].binaries,
+            Some(vec!["/usr/bin/git".to_string()])
+        );
+    }
+
+    #[test]
+    fn load_or_default_rejects_an_empty_binaries_filter() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-policy.yaml");
+        let yaml = "\
+network:
+  egress:
+    http:
+      - match: git.example.test
+        verdict: allow
+        binaries: []
+  defaultVerdict: ask
+";
+        fs::write(&path, yaml).unwrap();
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("git.example.test")
+                && err.to_string().contains("matches no caller"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_or_default_rejects_a_relative_binary_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-policy.yaml");
+        let yaml = "\
+network:
+  egress:
+    http:
+      - match: git.example.test
+        verdict: allow
+        binaries:
+          - /usr/bin/git
+          - git
+  defaultVerdict: ask
+";
+        fs::write(&path, yaml).unwrap();
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("\"git\"")
+                && err.to_string().contains("is not an absolute path")
+                && err.to_string().contains("/proc/<pid>/exe"),
+            "got: {err}"
+        );
+    }
+
+    fn scoped_to(binary: &str) -> RouteRule {
+        RouteRule {
+            binaries: Some(vec![binary.to_string()]),
+            ..RouteRule::allow_host("git.example.test")
+        }
+    }
+
+    #[test]
+    fn validate_binaries_rejects_a_path_climbing_through_a_parent_segment() {
+        let err = scoped_to("/usr/bin/../bin/git")
+            .validate_binaries()
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("\"..\" segment"),
+            "core compares path components, so `..` survives and never equals a kernel-resolved exe path: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_binaries_rejects_a_path_naming_no_binary() {
+        let err = scoped_to("/").validate_binaries().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("names no binary"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_binaries_accepts_the_separators_a_kernel_path_compares_equal_to() {
+        for equivalent in [
+            "/usr/bin/git/",
+            "//usr/bin/git",
+            "/usr//bin/git",
+            "/usr/./bin/git",
+        ] {
+            assert!(
+                scoped_to(equivalent).validate_binaries().is_ok(),
+                "{equivalent} compares equal to /usr/bin/git as a Path, so refusing it would be a false error"
+            );
+        }
     }
 
     #[test]
@@ -588,6 +782,21 @@ network:
         p.add_rule(RouteRule::allow_host("example.com"));
         p.add_rule(RouteRule::deny_host("example.com"));
         assert_eq!(p.network.egress.http.len(), 2);
+    }
+
+    #[test]
+    fn add_rule_keeps_two_rules_that_differ_only_in_their_binaries() {
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("git.example.test"));
+        p.add_rule(RouteRule {
+            binaries: Some(vec!["/usr/bin/git".into()]),
+            ..RouteRule::allow_host("git.example.test")
+        });
+        assert_eq!(
+            p.network.egress.http.len(),
+            2,
+            "a binary-scoped grant is a different grant, not a duplicate of the open one"
+        );
     }
 
     #[test]

--- a/crates/lns-policy/src/matching.rs
+++ b/crates/lns-policy/src/matching.rs
@@ -1,0 +1,598 @@
+use std::net::IpAddr;
+use std::path::Path;
+
+use ipnet::IpNet;
+
+use crate::{NetworkPolicy, RouteRule, Scheme};
+
+const CATCH_ALL: &str = "*";
+
+/// Ported from lens-sandbox-core's `domain_matches` so host coverage is decided the same way here as in the guest gate.
+pub fn domain_matches(pattern: &str, hostname: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    let hostname = hostname.to_ascii_lowercase();
+    if pattern == CATCH_ALL {
+        !hostname.is_empty()
+    } else if let Some(suffix) = pattern.strip_prefix("*.") {
+        hostname == suffix || hostname.ends_with(&format!(".{suffix}"))
+    } else if pattern.contains("*.") {
+        let (prefix, suffix) = pattern.split_once('*').unwrap_or((&pattern, ""));
+        hostname.starts_with(prefix)
+            && hostname[prefix.len()..].ends_with(suffix)
+            && hostname.len() > prefix.len() + suffix.len()
+    } else {
+        hostname == pattern
+    }
+}
+
+impl NetworkPolicy {
+    /// The first rule the guest gate's first-match scan would reach before `new`, for every request `new` could match — so a `new` appended after it could never fire.
+    pub fn first_shadowing_rule(&self, new: &RouteRule) -> Option<(usize, &RouteRule)> {
+        self.egress
+            .http
+            .iter()
+            .enumerate()
+            .find(|(_, existing)| shadows(existing, new))
+    }
+}
+
+fn shadows(existing: &RouteRule, new: &RouteRule) -> bool {
+    scheme_covers(existing.scheme, new.scheme)
+        && destination_covers(&existing.match_pattern, &new.match_pattern)
+        && caller_covers(existing, new)
+}
+
+fn scheme_covers(existing: Option<Scheme>, new: Option<Scheme>) -> bool {
+    existing.is_none() || existing == new
+}
+
+/// The destinations one `match` pattern names, read the way lens-sandbox-core's `parse_matcher` reads it: a set of hosts, open to every port or pinned to one.
+struct Destination<'a> {
+    hosts: Hosts<'a>,
+    port: PortScope,
+}
+
+enum Hosts<'a> {
+    Range(IpNet),
+    Pattern(&'a str),
+}
+
+#[derive(PartialEq)]
+enum PortScope {
+    Any,
+    Only(u16),
+}
+
+fn classify(pattern: &str) -> Destination<'_> {
+    if let Ok(range) = pattern.parse::<IpNet>() {
+        return Destination {
+            hosts: Hosts::Range(range),
+            port: PortScope::Any,
+        };
+    }
+    match split_port(pattern) {
+        Some((host, port)) => Destination {
+            hosts: hosts_of(host),
+            port: PortScope::Only(port),
+        },
+        None => Destination {
+            hosts: Hosts::Pattern(pattern),
+            port: PortScope::Any,
+        },
+    }
+}
+
+fn hosts_of(host: &str) -> Hosts<'_> {
+    match host.parse::<IpNet>() {
+        Ok(range) => Hosts::Range(range),
+        Err(_) => Hosts::Pattern(host),
+    }
+}
+
+fn split_port(pattern: &str) -> Option<(&str, u16)> {
+    if pattern.starts_with('[')
+        && let Some((bracketed, port)) = pattern.rsplit_once("]:")
+    {
+        return Some((bracketed.trim_start_matches('['), port.parse().ok()?));
+    }
+    // Several colons and no bracketed port means a bare IPv6 literal, not a host:port pair.
+    if pattern.matches(':').count() > 1 {
+        return None;
+    }
+    let (host, port) = pattern.rsplit_once(':')?;
+    Some((host, port.parse().ok()?))
+}
+
+fn destination_covers(existing: &str, new: &str) -> bool {
+    let (existing, new) = (classify(existing), classify(new));
+    port_covers(&existing.port, &new.port) && hosts_cover(&existing.hosts, &new.hosts)
+}
+
+/// A portless rule matches its hosts on every port, so it covers a rule pinned to one; a pinned rule covers only the same port.
+fn port_covers(existing: &PortScope, new: &PortScope) -> bool {
+    *existing == PortScope::Any || existing == new
+}
+
+fn hosts_cover(existing: &Hosts, new: &Hosts) -> bool {
+    match (existing, new) {
+        (Hosts::Range(existing), Hosts::Range(new)) => existing.contains(new),
+        (Hosts::Range(existing), Hosts::Pattern(new)) => new
+            .parse::<IpAddr>()
+            .is_ok_and(|ip| existing.contains(&ip.to_canonical())),
+        // Which addresses a name covers is DNS's answer, not ours, so only the catch-all is read as covering a range.
+        (Hosts::Pattern(existing), Hosts::Range(_)) => *existing == CATCH_ALL,
+        (Hosts::Pattern(existing), Hosts::Pattern(new)) => host_covers(existing, new),
+    }
+}
+
+/// Whether every host `new` matches is also matched by `existing`.
+fn host_covers(existing: &str, new: &str) -> bool {
+    if new.contains('*') {
+        wildcard_covers(existing, new)
+    } else {
+        domain_matches(existing, new)
+    }
+}
+
+/// Every host a wildcard names ends in the fixed part after its last `*` — plus, for a leading wildcard, the apex — so a suffix wildcard covering that tail covers the pattern. Whether one mid-segment wildcard subsumes another is guesswork, and guessing wrong would silently reorder the file, so those stay equality-only.
+fn wildcard_covers(existing: &str, new: &str) -> bool {
+    let (existing, new) = (existing.to_ascii_lowercase(), new.to_ascii_lowercase());
+    if existing == CATCH_ALL {
+        return true;
+    }
+    match existing.strip_prefix("*.") {
+        Some(suffix) => new
+            .rsplit_once('*')
+            .is_some_and(|(_, tail)| tail.ends_with(&format!(".{suffix}"))),
+        None => existing == new,
+    }
+}
+
+fn caller_covers(existing: &RouteRule, new: &RouteRule) -> bool {
+    match (existing.binaries.as_deref(), new.binaries.as_deref()) {
+        (None, _) => true,
+        // A scoped rule claims the destination: the gate stops there for the callers it lists, and suppresses a later unrestricted allow or ask rather than let it re-open the rest. A later unrestricted deny is still reached, but it only repeats the denial they already get, so it is dead either way.
+        (Some(_), None) => true,
+        (Some(existing), Some(new)) => new
+            .iter()
+            .all(|binary| existing.iter().any(|listed| same_path(listed, binary))),
+    }
+}
+
+fn same_path(one: &str, other: &str) -> bool {
+    Path::new(one) == Path::new(other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scoped(pattern: &str, binaries: &[&str]) -> RouteRule {
+        RouteRule {
+            binaries: Some(binaries.iter().map(|b| (*b).to_string()).collect()),
+            ..RouteRule::allow_host(pattern)
+        }
+    }
+
+    fn shadower_of(existing: Vec<RouteRule>, new: &RouteRule) -> Option<usize> {
+        let mut network = NetworkPolicy::default();
+        network.egress.http = existing;
+        network.first_shadowing_rule(new).map(|(index, _)| index)
+    }
+
+    #[test]
+    fn domain_matches_agrees_with_the_gate_on_every_pattern_shape() {
+        assert!(domain_matches("*", "api.example.test"));
+        assert!(!domain_matches("*", ""));
+        assert!(domain_matches("*.example.test", "api.example.test"));
+        assert!(
+            domain_matches("*.example.test", "example.test"),
+            "a leading wildcard covers the apex"
+        );
+        assert!(!domain_matches("*.example.test", "notexample.test"));
+        assert!(domain_matches("api.*.example.test", "api.eu.example.test"));
+        assert!(
+            !domain_matches("*.example.test", "us-east-1example.test"),
+            "the dot stays in the suffix, so a label boundary is required"
+        );
+        assert!(domain_matches("API.Example.Test", "api.example.test"));
+        assert!(!domain_matches("api.example.test", "other.example.test"));
+    }
+
+    #[test]
+    fn domain_matches_refuses_the_near_misses_a_wildcard_must_not_admit() {
+        assert!(
+            !domain_matches("*.example.test", "example.test.evil.test"),
+            "the pattern is a suffix, so a host merely starting with it is a different name"
+        );
+        assert!(
+            !domain_matches("api.*.example.test", "other.eu.example.test"),
+            "the fixed prefix has to match too"
+        );
+        assert!(
+            !domain_matches("api.*.example.test", "api.eu.example.test.evil.test"),
+            "the fixed suffix has to end the host"
+        );
+        assert!(
+            !domain_matches("api.*.example.test", "api.example.test"),
+            "the wildcard label cannot be empty"
+        );
+    }
+
+    #[test]
+    fn a_wildcard_allow_shadows_a_later_rule_for_a_host_it_covers() {
+        let existing = vec![RouteRule::allow_host("*.example.test")];
+        assert_eq!(
+            shadower_of(existing, &scoped("api.example.test", &["/usr/bin/curl"])),
+            Some(0),
+            "the gate stops at the wildcard, so narrowing api.example.test behind it would never fire"
+        );
+    }
+
+    #[test]
+    fn a_rule_for_one_host_does_not_shadow_a_wildcard_covering_more() {
+        let existing = vec![RouteRule::allow_host("api.example.test")];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::allow_host("*.example.test")),
+            None,
+            "the wildcard still fires for every other host under the suffix"
+        );
+    }
+
+    #[test]
+    fn an_identical_wildcard_shadows_a_later_one() {
+        let existing = vec![RouteRule::allow_host("*.EXAMPLE.test")];
+        assert_eq!(
+            shadower_of(existing, &scoped("*.example.test", &["/usr/bin/git"])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_portless_rule_shadows_a_host_port_rule_for_the_same_host() {
+        let existing = vec![RouteRule::allow_host("db.example.test")];
+        assert_eq!(
+            shadower_of(
+                existing,
+                &scoped("db.example.test:5432", &["/usr/bin/psql"])
+            ),
+            Some(0),
+            "a portless domain rule matches every port"
+        );
+    }
+
+    #[test]
+    fn a_host_port_rule_does_not_shadow_the_portless_rule_for_that_host() {
+        let existing = vec![RouteRule::allow_host("db.example.test:5432")];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::allow_host("db.example.test")),
+            None,
+            "the portless rule still fires on every other port"
+        );
+    }
+
+    #[test]
+    fn host_port_rules_for_different_ports_do_not_shadow_each_other() {
+        let existing = vec![RouteRule::allow_host("db.example.test:5432")];
+        assert_eq!(
+            shadower_of(
+                existing,
+                &scoped("db.example.test:6379", &["/usr/bin/redis-cli"])
+            ),
+            None
+        );
+    }
+
+    /// The gate refuses an unbracketed IPv6 pattern outright; all this pins is that we don't mis-split one into a host and a port and compare the wrong host.
+    #[test]
+    fn a_bare_ipv6_literal_is_not_read_as_a_host_and_port() {
+        let existing = vec![RouteRule::allow_host("2001:db8::1")];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::allow_host("2001:db8::1")),
+            Some(0)
+        );
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("2001:db8::9")],
+                &RouteRule::allow_host("2001:db8::1")
+            ),
+            None,
+            "dropping the last group would read both as the same host"
+        );
+    }
+
+    #[test]
+    fn a_bracketed_pattern_the_gate_reads_as_a_name_is_not_split_on_its_inner_colon() {
+        let existing = vec![RouteRule::allow_host("api.example.test")];
+        assert_eq!(
+            shadower_of(
+                existing,
+                &scoped("[api.example.test:443", &["/usr/bin/curl"])
+            ),
+            None,
+            "the bracket makes this one malformed name, not the host the existing rule covers"
+        );
+    }
+
+    #[test]
+    fn the_catch_all_shadows_a_wildcard_rule_written_behind_it() {
+        let existing = vec![RouteRule::allow_host("*")];
+        assert_eq!(
+            shadower_of(existing, &scoped("*.example.test", &["/usr/bin/git"])),
+            Some(0),
+            "the catch-all matches every host, so scoping a suffix behind it would restrict nobody"
+        );
+    }
+
+    #[test]
+    fn a_leading_wildcard_shadows_every_pattern_confined_to_its_suffix() {
+        let existing = vec![RouteRule::allow_host("*.example.test")];
+        assert_eq!(
+            shadower_of(
+                existing.clone(),
+                &scoped("*.eu.example.test", &["/usr/bin/git"])
+            ),
+            Some(0),
+            "every host under the narrower suffix is a host under the wider one"
+        );
+        assert_eq!(
+            shadower_of(existing, &scoped("api.*.example.test", &["/usr/bin/git"])),
+            Some(0),
+            "a mid-segment pattern ending in the same suffix names hosts the wildcard already covers"
+        );
+    }
+
+    #[test]
+    fn a_wildcard_does_not_shadow_one_reaching_outside_its_suffix() {
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("*.eu.example.test")],
+                &RouteRule::allow_host("*.example.test")
+            ),
+            None,
+            "the wider wildcard still fires for every host outside the narrower suffix"
+        );
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("*.example.test")],
+                &RouteRule::allow_host("*")
+            ),
+            None,
+            "a suffix rule leaves every other host to the catch-all"
+        );
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("api.*.example.test")],
+                &RouteRule::allow_host("*.example.test")
+            ),
+            None,
+            "whether a mid-segment wildcard subsumes another is guesswork, and guessing wrong would silently reorder the file"
+        );
+    }
+
+    #[test]
+    fn a_bracketed_ipv6_host_port_shadows_the_same_host_and_port() {
+        let existing = vec![RouteRule::allow_host("[2001:db8::1]:5432")];
+        assert_eq!(
+            shadower_of(existing, &scoped("[2001:db8::1]:5432", &["/usr/bin/psql"])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_cidr_shadows_the_identical_range_and_every_narrower_one_inside_it() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(existing.clone(), &scoped("10.0.0.0/8", &["/usr/bin/curl"])),
+            Some(0)
+        );
+        assert_eq!(
+            shadower_of(existing, &scoped("10.1.0.0/16", &["/usr/bin/curl"])),
+            Some(0),
+            "the gate matches an address against the whole range, so a rule for a subrange behind it never fires"
+        );
+    }
+
+    #[test]
+    fn a_narrower_range_does_not_shadow_the_range_containing_it() {
+        let existing = vec![RouteRule::allow_host("10.1.0.0/16")];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::allow_host("10.0.0.0/8")),
+            None,
+            "the wider rule still fires for every address outside the narrower one"
+        );
+    }
+
+    #[test]
+    fn a_cidr_shadows_a_later_rule_for_an_address_inside_it() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(existing.clone(), &scoped("10.1.2.3", &["/usr/bin/curl"])),
+            Some(0),
+            "the gate parses the request host as an address, so a bare literal inside the range is already claimed"
+        );
+        assert_eq!(
+            shadower_of(existing, &scoped("10.1.2.3:5432", &["/usr/bin/psql"])),
+            Some(0),
+            "a portless range covers that address on every port too"
+        );
+    }
+
+    #[test]
+    fn a_cidr_does_not_shadow_a_rule_for_an_address_outside_it() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(existing.clone(), &scoped("192.168.1.1", &["/usr/bin/curl"])),
+            None
+        );
+        assert_eq!(
+            shadower_of(existing, &scoped("[2001:db8::1]:443", &["/usr/bin/curl"])),
+            None,
+            "an IPv4 range holds no IPv6 address"
+        );
+    }
+
+    #[test]
+    fn a_cidr_reads_a_mapped_address_as_the_v4_address_it_names() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(
+                existing,
+                &scoped("[::ffff:10.1.2.3]:443", &["/usr/bin/curl"])
+            ),
+            Some(0),
+            "the gate canonicalizes the request address before the range test, so the mapped form is the same destination"
+        );
+    }
+
+    #[test]
+    fn a_portless_range_shadows_the_same_range_pinned_to_a_port() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(existing, &scoped("10.0.0.0/8:5432", &["/usr/bin/psql"])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_range_pinned_to_a_port_does_not_shadow_the_portless_range() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8:5432")];
+        assert_eq!(
+            shadower_of(existing.clone(), &RouteRule::allow_host("10.0.0.0/8")),
+            None,
+            "the portless rule still fires on every other port"
+        );
+        assert_eq!(
+            shadower_of(existing, &scoped("10.1.2.3:5432", &["/usr/bin/psql"])),
+            Some(0),
+            "on its own port it claims every address in the range"
+        );
+    }
+
+    #[test]
+    fn a_bracketed_ipv6_range_shadows_an_address_inside_it_on_the_same_port() {
+        let existing = vec![RouteRule::allow_host("[2001:db8::/32]:5432")];
+        assert_eq!(
+            shadower_of(existing, &scoped("[2001:db8::1]:5432", &["/usr/bin/psql"])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn the_catch_all_shadows_a_range_rule_but_a_name_pattern_does_not() {
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("*")],
+                &scoped("10.0.0.0/8", &["/usr/bin/curl"])
+            ),
+            Some(0),
+            "the catch-all matches an address literal too, so a range rule behind it never fires"
+        );
+        assert_eq!(
+            shadower_of(
+                vec![RouteRule::allow_host("*.example.test")],
+                &scoped("10.0.0.0/8", &["/usr/bin/curl"])
+            ),
+            None,
+            "which addresses a name covers is DNS's answer, so the range rule is left where the user put it"
+        );
+    }
+
+    #[test]
+    fn a_range_does_not_shadow_a_rule_for_a_name() {
+        let existing = vec![RouteRule::allow_host("10.0.0.0/8")];
+        assert_eq!(
+            shadower_of(existing, &scoped("api.example.test", &["/usr/bin/curl"])),
+            None,
+            "the name may resolve outside the range, so this is not ours to decide"
+        );
+    }
+
+    #[test]
+    fn a_pattern_whose_port_does_not_parse_is_read_as_a_name() {
+        let existing = vec![RouteRule::allow_host("api.example.test")];
+        assert_eq!(
+            shadower_of(
+                existing,
+                &scoped("api.example.test:oops", &["/usr/bin/curl"])
+            ),
+            None,
+            "the gate reads the whole thing as one name, which is not the host the existing rule covers"
+        );
+    }
+
+    #[test]
+    fn a_scoped_rule_shadows_a_later_unrestricted_allow_for_the_same_host() {
+        let existing = vec![scoped("git.example.test", &["/usr/bin/git"])];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::allow_host("git.example.test")),
+            Some(0),
+            "the gate serves the listed callers from the scoped rule and refuses to re-open the rest, so the later allow is dead"
+        );
+    }
+
+    #[test]
+    fn a_scoped_rule_shadows_a_later_deny_too() {
+        let existing = vec![scoped("git.example.test", &["/usr/bin/git"])];
+        assert_eq!(
+            shadower_of(existing, &RouteRule::deny_host("git.example.test")),
+            Some(0),
+            "the listed caller is served by the scoped allow before the deny is ever reached, and the rest were already failing closed, so the deny behind it blocks nobody"
+        );
+    }
+
+    #[test]
+    fn a_scoped_rule_shadows_a_later_rule_scoped_to_a_subset_of_its_binaries() {
+        let existing = vec![scoped(
+            "git.example.test",
+            &["/usr/bin/git", "/usr/bin/curl"],
+        )];
+        assert_eq!(
+            shadower_of(existing, &scoped("git.example.test", &["/usr/bin/git/"])),
+            Some(0),
+            "the guest compares path components, so a trailing separator is the same binary"
+        );
+    }
+
+    #[test]
+    fn a_scoped_rule_does_not_shadow_one_naming_a_binary_it_excludes() {
+        let existing = vec![scoped("git.example.test", &["/usr/bin/git"])];
+        assert_eq!(
+            shadower_of(existing, &scoped("git.example.test", &["/usr/bin/curl"])),
+            None,
+            "the excluded caller scans on and the second scoped rule admits it"
+        );
+    }
+
+    #[test]
+    fn a_rule_bound_to_one_scheme_does_not_shadow_the_other() {
+        let https = RouteRule {
+            scheme: Some(Scheme::Https),
+            ..RouteRule::allow_host("api.example.test")
+        };
+        let http = RouteRule {
+            scheme: Some(Scheme::Http),
+            ..scoped("api.example.test", &["/usr/bin/curl"])
+        };
+        assert_eq!(shadower_of(vec![https.clone()], &http), None);
+        assert_eq!(
+            shadower_of(vec![https], &scoped("api.example.test", &["/usr/bin/curl"])),
+            None,
+            "a scheme-bound rule leaves plain-http requests to later rules"
+        );
+    }
+
+    #[test]
+    fn the_first_shadowing_rule_is_the_one_reported() {
+        let existing = vec![
+            RouteRule::allow_host("other.example.test"),
+            RouteRule::allow_host("*.example.test"),
+            RouteRule::allow_host("api.example.test"),
+        ];
+        assert_eq!(
+            shadower_of(existing, &scoped("api.example.test", &["/usr/bin/curl"])),
+            Some(1),
+            "the gate stops at the first match, so that is the rule to sit in front of"
+        );
+    }
+}

--- a/crates/lns-service/src/approval_flow/protocol.rs
+++ b/crates/lns-service/src/approval_flow/protocol.rs
@@ -276,6 +276,7 @@ mod tests {
             description: None,
             tls_terminate: false,
             rules: Vec::new(),
+            binaries: None,
         });
         let frame = HostFrame::Policy(PolicyMessage {
             network: Some(net),

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -11,6 +11,7 @@ use crate::approval_flow::protocol::{
 use crate::ledger::LedgerRecorder;
 use lns_ipc::{ApprovalKind, Decision as LedgerDecision, LedgerEvent};
 use lns_policy::connectors::TokenFallback;
+use lns_policy::matching::domain_matches;
 use lns_policy::{Policy, PolicyStore, RouteRule};
 
 pub type FrameSink = mpsc::UnboundedSender<HostFrame>;
@@ -167,7 +168,7 @@ impl ApprovalSession {
     fn offer_for_host(&self, host: &str) -> Option<&OfferableConnector> {
         self.offerable
             .iter()
-            .find(|i| i.patterns.iter().any(|p| host_matches_pattern(p, host)))
+            .find(|i| i.patterns.iter().any(|p| domain_matches(p, host)))
     }
 
     /// The (id, display name, token fallback) to offer for `host`, or `None` when nothing matches or the connector is already connected this run.
@@ -535,22 +536,6 @@ impl ApprovalSession {
             self.notifier.dismiss(&request_id);
             self.send_decision_frame(&request_id, Decision::AllowOnce);
         }
-    }
-}
-
-/// Matches a request host against a connector route pattern, case-insensitively as DNS names are: exact, a leading `*.suffix` wildcard covering the apex and any subdomain, or a mid-segment `prefix.*.suffix` wildcard covering one variable label.
-pub(crate) fn host_matches_pattern(pattern: &str, host: &str) -> bool {
-    let pattern = pattern.to_ascii_lowercase();
-    let host = host.to_ascii_lowercase();
-    let (pattern, host) = (pattern.as_str(), host.as_str());
-    if let Some(suffix) = pattern.strip_prefix("*.") {
-        host == suffix || host.ends_with(&format!(".{suffix}"))
-    } else if let Some((prefix, suffix)) = pattern.split_once('*') {
-        host.starts_with(prefix)
-            && host[prefix.len()..].ends_with(suffix)
-            && host.len() > prefix.len() + suffix.len()
-    } else {
-        pattern == host
     }
 }
 
@@ -1926,61 +1911,5 @@ pub(crate) mod tests {
             "once the connect ends the request can time out"
         );
         assert_eq!(decision_frame(&mut rx).decision, Decision::Timeout);
-    }
-
-    #[test]
-    fn host_matches_pattern_exact_matches_only_the_same_host() {
-        assert!(host_matches_pattern(
-            "api.some-oauth.example",
-            "api.some-oauth.example"
-        ));
-        assert!(!host_matches_pattern(
-            "api.some-oauth.example",
-            "some-oauth.example"
-        ));
-        assert!(!host_matches_pattern(
-            "api.some-oauth.example",
-            "evil-api.some-oauth.example"
-        ));
-    }
-
-    #[test]
-    fn host_matches_pattern_wildcard_covers_apex_and_subdomains_only() {
-        assert!(host_matches_pattern("*.huggingface.co", "huggingface.co"));
-        assert!(host_matches_pattern(
-            "*.huggingface.co",
-            "cdn.huggingface.co"
-        ));
-        assert!(!host_matches_pattern(
-            "*.huggingface.co",
-            "evilhuggingface.co"
-        ));
-        assert!(!host_matches_pattern(
-            "*.huggingface.co",
-            "huggingface.co.evil.com"
-        ));
-    }
-
-    #[test]
-    fn host_matches_pattern_is_case_insensitive_like_dns() {
-        assert!(host_matches_pattern("api.example.test", "API.Example.Test"));
-        assert!(host_matches_pattern("*.example.test", "CDN.Example.Test"));
-        assert!(host_matches_pattern("API.EXAMPLE.TEST", "api.example.test"));
-    }
-
-    #[test]
-    fn host_matches_pattern_mid_segment_wildcard_covers_a_variable_label() {
-        assert!(host_matches_pattern(
-            "bedrock-runtime.*.amazonaws.com",
-            "bedrock-runtime.us-east-1.amazonaws.com"
-        ));
-        assert!(!host_matches_pattern(
-            "bedrock-runtime.*.amazonaws.com",
-            "bedrock-runtime.us-east-1amazonaws.com"
-        ));
-        assert!(!host_matches_pattern(
-            "bedrock-runtime.*.amazonaws.com",
-            "bedrock.us-east-1.amazonaws.com"
-        ));
     }
 }

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use lns_policy::{NetworkPolicy, Policy, RouteRule, Verdict};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,13 +84,41 @@ fn push_unique<R: Clone + PartialEq>(merged: &mut Vec<R>, rule: &R) {
     }
 }
 
-/// A deny-by-default layer permits only the destinations it names, so an allow survives the merge only if every such ceiling layer carries it.
-fn allowed_by_every_ceiling<R: PartialEq>(
+/// A deny-by-default layer permits only the destinations it names, so an allow survives the merge only if every such ceiling layer carries a rule permitting it.
+fn allowed_by_every_ceiling<R>(
     rule: &R,
     ceilings: &[&Policy],
     table: TableOf<R>,
+    permits: fn(&R, &R) -> bool,
 ) -> bool {
-    ceilings.iter().all(|ceiling| table(ceiling).contains(rule))
+    ceilings.iter().all(|ceiling| {
+        table(ceiling)
+            .iter()
+            .any(|permitted| permits(permitted, rule))
+    })
+}
+
+/// Whether `permitted` covers `rule`: identical apart from binary scoping and the human-readable note neither layer grants anything by, and scoped no tighter than `rule` — a rule that only narrows a ceiling's grant to fewer callers grants nothing the ceiling didn't.
+fn permits(permitted: &RouteRule, rule: &RouteRule) -> bool {
+    let widened = RouteRule {
+        binaries: permitted.binaries.clone(),
+        description: permitted.description.clone(),
+        ..rule.clone()
+    };
+    widened == *permitted && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
+}
+
+fn scope_within(rule: Option<&[String]>, permitted: Option<&[String]>) -> bool {
+    match (rule, permitted) {
+        (_, None) => true,
+        (None, Some(_)) => false,
+        // Compared as paths, the way the guest compares them against /proc/<pid>/exe, so a redundant separator doesn't read as a different binary.
+        (Some(rule), Some(permitted)) => rule.iter().all(|binary| {
+            permitted
+                .iter()
+                .any(|listed| Path::new(listed) == Path::new(binary))
+        }),
+    }
 }
 
 /// Fold one egress table across `layers` into the merged table the guest gate installs, deny-first and clamped by the deny-by-default `ceilings`.
@@ -98,6 +128,7 @@ fn merge_rule_table<R: Clone + PartialEq>(
     ceilings: &[&Policy],
     table: TableOf<R>,
     is_deny: fn(&R) -> bool,
+    permits: fn(&R, &R) -> bool,
 ) -> Vec<R> {
     let mut merged: Vec<R> = Vec::new();
     for layer in layers {
@@ -107,7 +138,7 @@ fn merge_rule_table<R: Clone + PartialEq>(
     }
     for layer in layers {
         for rule in table(layer).iter().filter(|rule| !is_deny(rule)) {
-            if allowed_by_every_ceiling(rule, ceilings, table) {
+            if allowed_by_every_ceiling(rule, ceilings, table, permits) {
                 push_unique(&mut merged, rule);
             }
         }
@@ -128,6 +159,7 @@ pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
         &ceilings,
         |policy| &policy.network.egress.http,
         |rule: &RouteRule| rule.verdict == Verdict::Deny,
+        permits,
     );
     let default_verdict = if layers
         .iter()
@@ -296,6 +328,148 @@ mod tests {
             rule.match_pattern == "api.trusted.example" && rule.verdict == Verdict::Allow
         }));
         assert_eq!(merged.network.default_verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn merge_does_not_let_an_unscoped_allow_clear_a_binary_scoped_ceiling() {
+        let overlay = allow("git.example.test");
+        let mut baseline = deny_default_allowing("git.example.test");
+        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        assert!(
+            !merged.network.egress.http.iter().any(|rule| {
+                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
+            }),
+            "an artifact that only allows a host for one binary must not be widened to every caller by an unscoped overlay allow: {merged:?}"
+        );
+        assert!(
+            merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| { rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]) }),
+            "the scoped allow itself clears every ceiling and must survive, or the assertion above passes vacuously: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_keeps_a_scoped_allow_that_only_narrows_what_a_ceiling_already_permits() {
+        let mut overlay = allow("git.example.test");
+        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+        let baseline = deny_default_allowing("git.example.test");
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        let scoped = merged
+            .network
+            .egress
+            .http
+            .iter()
+            .position(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]));
+        let open =
+            merged.network.egress.http.iter().position(|rule| {
+                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
+            });
+        assert!(
+            scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
+            "narrowing a host the ceiling already allows to every caller must survive the merge, and a first-match gate must see the narrower rule before the ceiling's open allow or the narrowing is void: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_keeps_a_scoped_allow_whose_ceiling_rule_differs_only_in_its_description() {
+        let mut overlay = allow("git.example.test");
+        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+        let mut baseline = deny_default_allowing("git.example.test");
+        baseline.network.egress.http[0].description = Some("git over https".into());
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        let scoped = merged
+            .network
+            .egress
+            .http
+            .iter()
+            .position(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]));
+        let open =
+            merged.network.egress.http.iter().position(|rule| {
+                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
+            });
+        assert!(
+            scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
+            "a note on the ceiling's rule is not part of its grant, so it must not decide whether the user's narrowing survives — dropping it leaves the ceiling's own open allow in force: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_reads_a_redundant_separator_as_the_same_binary_the_ceiling_named() {
+        let mut overlay = allow("git.example.test");
+        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git/".into()]);
+        let mut baseline = deny_default_allowing("git.example.test");
+        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        assert!(
+            merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git/".to_string()])),
+            "the guest compares these as paths and admits the same caller, so the merge must not read them as different binaries and drop the overlay: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_drops_a_scoped_allow_for_a_binary_the_ceilings_own_scope_excludes() {
+        let mut overlay = allow("git.example.test");
+        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/curl".into()]);
+        let mut baseline = deny_default_allowing("git.example.test");
+        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        assert!(
+            !merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/curl".to_string()])),
+            "a ceiling that names one binary must not be widened to another by an overlay scoped to it: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_does_not_let_a_scoped_overlay_allow_punch_through_a_ceiling() {
+        let mut overlay = allow("git.example.test");
+        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
+        let baseline = deny_default_allowing("other.example.test");
+
+        let merged = merge_effective(Some(&baseline), &overlay);
+
+        assert!(
+            !merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.match_pattern == "git.example.test"),
+            "scoping an allow to one binary must not exempt it from an artifact's deny-by-default ceiling: {merged:?}"
+        );
+        assert!(
+            merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.match_pattern == "other.example.test"),
+            "the ceiling's own allow must survive, or the assertion above passes on an empty merge: {merged:?}"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -246,8 +246,8 @@ pub fn boot_sign_in_grants(
 
 /// Two route patterns collide if either matches the other as a host under the gate's own wildcard- and case-insensitive rule, so an applied domain suppresses a connectable that shares it even when the patterns aren't byte-identical.
 fn domains_overlap(a: &str, b: &str) -> bool {
-    use crate::approval_flow::session::host_matches_pattern;
-    host_matches_pattern(a, b) || host_matches_pattern(b, a)
+    use lns_policy::matching::domain_matches;
+    domain_matches(a, b) || domain_matches(b, a)
 }
 
 /// Every domain a connector claims: its route patterns plus the domains its credential/oauth injections actually write a token onto (a custom catalog may inject on a domain it doesn't route).

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -21,3 +21,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 
 [dev-dependencies]
 serial_test = "3"
+lns-policy = { path = "../lns-policy" }

--- a/crates/lns-supervisor/tests/matcher_parity.rs
+++ b/crates/lns-supervisor/tests/matcher_parity.rs
@@ -1,0 +1,36 @@
+//! Pins `lns-policy`'s host-side copy of the gate's matcher to the gate itself; this crate is the only one that depends on both.
+
+const CASES: &[(&str, &str)] = &[
+    ("*", "api.example.test"),
+    ("*", "1.2.3.4"),
+    ("*", ""),
+    ("*.example.test", "example.test"),
+    ("*.example.test", "api.example.test"),
+    ("*.example.test", "a.b.example.test"),
+    ("*.example.test", "notexample.test"),
+    ("*.example.test", "us-east-1example.test"),
+    ("*.example.test", "example.test.evil.test"),
+    ("api.*.example.test", "api.eu.example.test"),
+    ("api.*.example.test", "api.example.test"),
+    ("api.*.example.test", "other.eu.example.test"),
+    ("api.*.example.test", "api.eu.example.test.evil.test"),
+    ("api.*.example.test", "api.eu.exampleXtest"),
+    ("*-api.example.test", "eu-api.example.test"),
+    ("API.Example.Test", "api.example.test"),
+    ("api.example.test", "API.EXAMPLE.TEST"),
+    ("api.example.test", "other.example.test"),
+    ("api.example.test", "api.example.test"),
+    ("api.example.test", ""),
+    ("10.0.0.1", "10.0.0.1"),
+];
+
+#[test]
+fn the_ported_matcher_agrees_with_the_gate_it_was_ported_from() {
+    for (pattern, host) in CASES {
+        assert_eq!(
+            lns_policy::matching::domain_matches(pattern, host),
+            lens_sandbox_core::routing::domain_matches(pattern, host),
+            "the CLI decides rule placement with its own copy of this matcher, so a divergence on ({pattern:?}, {host:?}) means it reasons about an order the gate does not enforce"
+        );
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -296,9 +296,9 @@ Edit network rules in a policy file. All subcommands accept `--policy <PATH>`
 (default `lns-policy.yaml` in the current directory).
 
 ```bash
-lns policy allow  <PATTERN> [--description <TEXT>]
+lns policy allow  <PATTERN> [--description <TEXT>] [--binary <PATH>]…
 lns policy deny   <PATTERN> [--description <TEXT>]
-lns policy list
+lns policy list   [--format <table|json>]
 lns policy remove <PATTERN>
 ```
 
@@ -306,11 +306,23 @@ lns policy remove <PATTERN>
 | ---------- | ---------------------------------------------------------------- |
 | `allow`    | Add an allow rule for a destination pattern.                     |
 | `deny`     | Add a deny rule for a destination pattern.                       |
-| `list`     | List the rules in the policy file.                               |
-| `remove`   | Remove the rule matching a destination pattern.                  |
+| `list`     | List the rules in the policy file, including what each is scoped to. |
+| `remove`   | Remove every rule for a destination pattern, binary-scoped ones included. |
 
-`PATTERN` is a host, wildcard (`*.github.com`), CIDR, or `host:port`. See
-[Policy and approvals](policy.md).
+`PATTERN` is a host, wildcard (`*.github.com`), CIDR, or `host:port`.
+
+`--binary` restricts an allow rule to callers running that guest binary, named by
+absolute path and repeatable. The filter fails closed — once a scoped rule claims a
+destination, callers not on the list are denied it rather than asked. `deny` does not
+take the flag: it would block the listed callers by verdict and the rest by that same
+fail-closed filter, which is a plain deny by another name.
+
+Since the guest stops at the first matching rule, both `allow` and `deny` place the
+new rule ahead of any existing rule that covers the same destination and report where
+it landed. Where that placement would widen egress instead — an `allow` behind a
+`deny`, an unrestricted `allow` behind a binary-scoped rule, or an `allow` behind a
+rule that restricts which requests it permits — the command is refused and nothing is
+written. See [Policy and approvals](policy.md).
 
 ## `lns connector`
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -63,6 +63,8 @@ network:
 | `match`       | Destination pattern (see below).                                        |
 | `verdict`     | `allow`, `deny`, or `ask`.                                              |
 | `description` | Optional human-readable note kept alongside the rule.                   |
+| `binaries`    | Optional list of guest binaries the rule is scoped to (see below).      |
+| `rules`       | Optional `method` / `path` list; with it the rule permits only the requests it names and denies the rest. |
 
 A `match` pattern can be:
 
@@ -74,6 +76,57 @@ A `match` pattern can be:
 `egress.http` used to be a top-level `allowedRoutes:` list. That key is gone: a
 policy file still naming it is refused with an error rather than loaded as a
 policy with no rules. Move the list under `egress: http:`.
+
+### Scoping a rule to specific binaries
+
+`binaries` narrows a rule to the processes allowed to use it. Here only
+`/usr/bin/git` reaches `git.example.test`; every other process in the sandbox is
+denied that host:
+
+```yaml
+network:
+  defaultVerdict: ask
+  egress:
+    http:
+      - match: git.example.test
+        verdict: allow
+        binaries:
+          - /usr/bin/git
+```
+
+This is the one policy feature that denies without asking, so read the rest of this
+section before using it.
+
+- **The filter fails closed.** A caller that is not on the list does not fall
+  through to `defaultVerdict` — it is denied, and never prompted. Adding an
+  unrestricted `allow` or `ask` for the same destination later does *not* re-open it
+  for the excluded callers: the guest skips such a rule rather than let it undo the
+  scoping. What it does not skip is another *scoped* rule, so that is how you grant a
+  second binary — list them together in one rule, or add another scoped rule.
+- **Only meaningful on `allow`.** On a `deny` rule the listed binaries are blocked by
+  verdict and every other caller fails closed, so the only thing the scoping buys is
+  that a later rule scoped to one of those others can still let it through. That is
+  too fine a distinction to be worth the confusion, so `lns policy deny` has no
+  `--binary` flag; a hand-written scoped deny is honoured, but read it as a plain
+  deny with one narrow exception rather than as a per-binary block.
+- **Absolute, canonical paths only.** The path is compared against the kernel's view
+  of the running process (`/proc/<pid>/exe`), so name the real binary, not a symlink
+  or a `PATH` shim. Paths that could never equal such a target are rejected when the
+  policy loads: a relative path, one climbing through `..`, one naming no binary, and
+  an empty `binaries: []` list — the last would match no caller and deny the
+  destination outright.
+- **Ancestors count, up to eight deep.** A caller matches if its own executable path
+  or one of its first eight parents' is on the list, so a process that shells out
+  still matches a rule naming the binary that launched it. The walk stops at the
+  guest's init, at that eighth parent, or at the first parent whose executable it
+  cannot read — a caller further down a wrapper chain than that is denied like any
+  other unlisted one, without being asked.
+- **It gates DNS too**, not only the connection itself.
+- **Order matters.** Rules are read top to bottom and the first match wins, so a
+  scoped rule placed after an unrestricted rule for the same destination never fires.
+  `lns policy allow` handles this for you — it puts a new rule ahead of any existing
+  rule that would pre-empt it and prints where it landed — but when you hand-edit the
+  file, mind the order yourself.
 
 ## Editing rules from the CLI
 
@@ -89,19 +142,102 @@ lns policy allow "*.npmjs.org"
 lns policy deny metrics.vendor.example
 ```
 
+### Scope an allow rule to a binary
+
+`--binary` takes one absolute path and repeats:
+
+```bash
+lns policy allow git.example.test --binary /usr/bin/git
+lns policy allow api.example.test --binary /usr/bin/curl --binary /usr/bin/wget
+```
+
+`lns policy deny` does not take `--binary` — see
+[Scoping a rule to specific binaries](#scoping-a-rule-to-specific-binaries) for why.
+
+Because the guest stops at the first matching rule, a narrowing rule only has an
+effect ahead of the broader rule it narrows. `lns policy allow` places it there and
+says so:
+
+```
+Added allow rule for "api.example.test" to lns-policy.yaml
+Placed it before the existing rule for "*.example.test", which covers the same
+destination and would otherwise pre-empt it. Every other caller is now denied
+"api.example.test" without being asked, and that rule no longer serves them.
+```
+
+That second sentence is the fail-closed filter arriving: the rule the scoped one now
+sits in front of is still in the file, but it no longer admits anyone for that
+destination. A scoped rule for a destination no other rule covers has nothing to sit
+in front of, so it is appended — and still reports what it now denies:
+
+```
+Added allow rule for "git.example.test" to lns-policy.yaml
+Every other caller is now denied "git.example.test" without being asked.
+```
+
+A rule placed in front of another inherits its TLS termination, and says so. Sitting
+ahead of a rule the sandbox intercepts is a narrowing of *who* may reach the
+destination, not a request to stop intercepting it.
+
+What it will not do is widen egress to get a rule to fire. Three cases are refused
+outright, with nothing written:
+
+- An `allow` for a destination an earlier `deny` already blocks. Ahead of that deny
+  it would open every destination the deny covers, so narrowing the deny or
+  reordering the file is left to you.
+- An unrestricted `allow` for a destination an earlier binary-scoped rule already
+  claimed. Ahead of that rule it would open the destination to every caller in the
+  sandbox — the opposite of what the scoped rule says — so the error names the scoped
+  rule and, if you did mean to open it up, tells you to drop that rule first:
+
+  ```
+  error: the rule for "git.example.test" is scoped to /usr/bin/git, and placing
+  this allow rule in front of it would open the destination to every caller in the
+  sandbox — drop the scoped rule with `lns policy remove git.example.test` first if
+  that is what you mean
+  ```
+
+- An `allow` for a destination an earlier rule permits only *some requests* to (a
+  rule carrying a `rules:` list). Ahead of that rule it would hand its callers every
+  method and path the restriction was written to exclude.
+
+A `deny` behind a deny is not an error: the destination is already blocked, so the
+command says so and changes nothing. Adding a rule the file already holds is the
+same — it reports and leaves the file alone. What counts as already held is the rule
+the gate would actually reach, not any copy sitting somewhere in the file: a copy
+stranded behind a rule that pre-empts it — by verdict, by binary scope, or by a
+request filter — is not in force, so the command treats it as the placement or refusal
+it is rather than reporting a grant the sandbox does not honour. Where the stranded
+copy is the one that gets moved into force, it keeps the note it was carrying. The one
+exception is `--description`: the note is not part of the grant, so passing a new one
+for a rule the file already holds edits that rule in place instead of adding a second
+copy of it.
+
+One placement the CLI cannot make for you: a rule whose destination is an address
+range or IP literal is compared numerically, but whether a *hostname* rule resolves
+into a range is DNS's answer, not the file's. A scoped rule for a host behind a
+broad CIDR allow is left where you put it, so order those by hand.
+
 ### List rules
 
 ```bash
 lns policy list
 ```
 
+The `BINARIES` column shows what each rule is scoped to, and `--format json` reports
+the same under `binaries` (`null` for a rule open to every caller).
+
 ### Remove a rule
 
-Remove the rule matching a destination pattern:
+Remove every rule matching a destination pattern:
 
 ```bash
 lns policy remove api.github.com
 ```
+
+Removal goes by pattern alone, so it deletes *every* rule for that destination —
+binary-scoped ones included. The command reports how many rules went; run
+`lns policy list` first to see which ones they will be.
 
 ## The approval flow
 


### PR DESCRIPTION
## What

Exposes `binaries` on network route rules — scoping a rule to the specific guest executables allowed to use it.

```bash
lns policy allow git.example.test --binary /usr/bin/git --binary /usr/bin/ssh
```

```yaml
network:
  defaultVerdict: ask
  egress:
    http:
      - match: git.example.test
        verdict: allow
        binaries:
          - /usr/bin/git
```

## Why

The pinned `lens-sandbox-core` rev `4cb1d97` supports per-binary scoping, but we never emitted the field — and because our `RouteRule` carries `deny_unknown_fields`, a user who hand-wrote `binaries:` in `lns-policy.yaml` got a parse error rather than the feature.

## Semantics — this fails closed, and that is the point

Straight from core, and now documented in `docs/policy.md`:

- A caller matches if **its own executable path or any ancestor's, up to the guest's init**, is on the list. Paths are compared against the kernel-resolved `/proc/<pid>/exe`, so they must be absolute and canonical — not a symlink or a `PATH` shim.
- The filter scopes the whole rule **regardless of verdict** and **fails closed**: a rule whose host matches but whose binary filter excludes the caller **denies** that caller rather than falling through to the default verdict.
- Once a binary-scoped rule claims a host, a later **unrestricted** allow or ask for the same host does **not** re-open it for the excluded caller — the excluded caller is denied, not prompted.
- It gates DNS too, not just the connection.

This is the one policy feature that denies without asking, which is what drives the ordering and refusal behaviour below.

## Ordering — a rule that never fires is worse than no rule

The gate stops at the first matching rule, so a scoped rule appended behind a rule that already covers the destination does nothing at all: the developer reads their file as restricting egress to one binary while it stays open to every caller. `lns policy allow` and `lns policy deny` now place a new rule ahead of any existing rule that covers the same destination, and say where it landed.

Coverage is decided the way core decides it — `NetworkPolicy::first_shadowing_rule`, in a new `lns-policy::matching` module checked line-by-line against core's `routing.rs`:

- first-match order and the scheme filter;
- a portless rule covers the same hosts pinned to a port, not the reverse;
- address ranges compared numerically via `ipnet` (the crate and version core itself uses): range containment, `cidr:port`, bracketed IPv6, and `::ffff:` mapped literals canonicalized as core canonicalizes the request address;
- a wildcard covers every pattern confined to its suffix, so a scoped rule behind `*` or `*.example.test` is detected;
- caller coverage follows core's own no-reopen guard, including that a later rule scoped to a subset still matches and a later deny is never suppressed.

Where the answer belongs to DNS rather than to the file — a hostname rule against an address range, one mid-segment wildcard against another — the rule is left where the developer put it and `docs/policy.md` says so. Guessing there would silently reorder a file the developer wrote deliberately.

Two placements would widen egress rather than fix order, and both are refused with nothing written:

- an `allow` behind a covering `deny` — ahead of that deny it opens every destination the deny covers;
- an unrestricted `allow` behind a binary-scoped rule — ahead of that rule it opens the destination to every caller in the sandbox, the exact opposite of what the scoped rule says. The error names the covering rule and its binaries, and suggests `lns policy remove <pattern>` only when that command would not also delete the rule being added.

A `deny` behind a deny, or a rule the file already holds, reports and changes nothing.

## Design decisions

**`--binary` doesn't exist on `deny`.** Because the filter fails closed, every caller reaching the host is denied either way — the listed binaries by verdict, the rest by the filter — so a scoped deny is behaviourally identical to a plain deny. Rather than accept and ignore it, the flag is only defined on `allow`, so `lns policy deny host --binary /usr/bin/git` exits 2 with clap's unknown-argument error. A hand-written scoped deny still *loads* (core accepts it); we only refuse to author one.

**Validation rejects what the guest could never match.** Core hard-rejects an empty `binaries: []` (matches no caller, turning an allow into an unconditional deny for the host) and any relative path (can never equal an absolute `/proc/<pid>/exe`); both would fail the **entire policy** closed inside the guest, so we reject them at load and authoring time with a message that says why. On top of those we refuse two more shapes that can never equal a kernel-resolved path either — one climbing through `..`, and one naming no binary — while accepting the redundant separators that *do* compare equal as paths (`/usr/bin/git/`, `//usr/bin/git`, `/usr/./bin/git`), so validation never rejects a scope that would have worked.

**Absent is not empty.** Core reads `binaries: []` as "matches no caller", so a rule open to everyone omits the key entirely (`skip_serializing_if`), and there's a test pinning that.

**Approvals and connector routes stay unscoped.** `RouteRule::allow_host`/`deny_host` (the approval write-back) and `ConnectorRoute::to_route_rule` set `binaries: None`. Catalog routes are connector-scoped by design.

**One host matcher.** lns-service's private `host_matches_pattern` copy is gone; the offer card and the connector-overlap check now use the same port of core's `domain_matches` this scoping needs. The two had drifted on which pattern shapes count as wildcards, and a second matcher deciding host coverage next to a fail-closed filter is not something to keep.

## Artifact merge

An allow now clears a deny-by-default ceiling when some ceiling rule *permits* it, rather than only on exact equality. So an artifact's binary-scoped ceiling can no longer be widened to every caller by an unscoped overlay allow, while a user narrowing an open ceiling to fewer callers survives the merge — and lands ahead of the ceiling's own allow, without which a first-match gate would make the narrowing void.

## Visibility

`lns policy list` gains a `BINARIES` column, and `--format json` reports the same under `binaries` (`null` when unscoped). This is required rather than cosmetic: `lns policy remove <pattern>` deletes **every** rule carrying the pattern, scoped or not, so a developer has to be able to see the scoping before removing anything. The clap help and the docs now both say "every rule".

## Compatibility

A file using `binaries` needs an lns new enough to understand it. Releases since **0.16** refuse to load it rather than silently dropping the scoping; anything older ignores the key and strips the scoping the next time it writes the file — so don't edit a scoped policy with one. (Verified: `deny_unknown_fields` on `RouteRule` first shipped in `lns-v0.16.0`.)

## Tests

- **Layer 3 (lns-policy)** — a scoped rule round-trips through YAML under core's wire name; an unscoped rule omits the key; `binaries: []`, a relative path, a `..` segment and a path naming no binary are each refused with a message explaining why, while path-equal separators are accepted; two rules differing only in `binaries` are not deduped by `add_rule` (they are genuinely different grants).
- **Layer 3 (lns-policy::matching)** — the shadow model against every pattern shape the gate accepts: wildcard subsumption and its near misses, host/port coverage in both directions, bare vs bracketed IPv6, CIDR containment and `cidr:port`, mapped literals, scheme-bound rules, and caller coverage including the subset and no-reopen cases.
- **Layer 3 (lns-service)** — merge guards on the artifact-ceiling escalation surface: an unrestricted overlay allow cannot clear a ceiling whose only allow for that host is binary-scoped; a scoped overlay allow cannot punch through a ceiling that doesn't carry it; a narrowing that a ceiling already permits survives *and* lands ahead of it; a ceiling's description is not treated as part of its grant. Each carries a positive assertion so none can pass on an empty merge.
- **Layer 2 (lns-cli Gherkin)** — scoping an allow records it; repeating the flag records both; a relative path and a `..` path each error and write nothing; `--binary` on `deny` exits 2; `list` shows the scoping in both the table and `--format json`; and the placement behaviour end to end — narrowing behind an open rule, behind a wildcard, behind a catch-all, a deny placed ahead of a scoped allow, a narrowing that must not claim the rule it passed is spent, and the two refusals (behind a deny, and re-opening a scoped destination) each leaving the file untouched.

## Gate

`make lint` and `make complexity` green; every file this PR touches is at 100% under `make coverage`, with no new entries in the `scripts/coverage-floor.sh` IGNORES table.

## Follow-up

Not in this PR: `lns policy allow/deny` still accepts destination patterns core's `parse_matcher` rejects (an unbracketed IPv6 literal, a `host:443:extra` typo). Inside the guest one such rule answers with `force_deny()` over the whole table — fail-closed, but total and invisible from the host. Fixing it means validating pattern shape for every rule on both subcommands plus `Policy::load_or_default`, which is not specific to binary scoping.
