### PR TITLE
fix(cli): default a bare registry reference to the Lens hub

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -54,7 +54,7 @@ pub struct RunArgs {
 
     #[arg(
         long,
-        help = "Registry to qualify a bare image reference (e.g. ghcr.io); falls back to the `run.registry` config default. A fully-qualified reference is used as-is."
+        help = "Registry to qualify a bare image reference (e.g. ghcr.io); falls back to the `run.registry` config default, else hub.lns.run. A fully-qualified reference is used as-is."
     )]
     pub registry: Option<String>,
 

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -353,11 +353,20 @@ fn legacy_entries(cfg: &ConfigFile) -> Vec<&'static str> {
     present
 }
 
+/// The registry a bare reference addresses when `run.registry` is unset — the Lens hub, so publishing a sandbox never silently targets Docker Hub.
+pub const DEFAULT_REGISTRY: &str = "hub.lns.run";
+
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct RunDefaults {
     pub cpus: Option<u8>,
     pub mem: Option<usize>,
     pub registry: Option<String>,
+}
+
+impl RunDefaults {
+    pub fn registry_or_default(&self) -> &str {
+        self.registry.as_deref().unwrap_or(DEFAULT_REGISTRY)
+    }
 }
 
 pub fn load_run_defaults(path: &Path) -> Result<RunDefaults> {
@@ -397,11 +406,9 @@ pub fn apply_run_defaults(mut args: RunArgs, defaults: RunDefaults) -> RunArgs {
     args
 }
 
-/// Qualifies a bare image reference with the configured default registry; a reference that already names a registry — or a docker.io default, which the parser already assumes — is left untouched so implicit `library/` namespacing is preserved.
+/// Qualifies a bare image reference with the configured default registry, falling back to [`DEFAULT_REGISTRY`]; a reference that already names a registry — or a docker.io default, which the parser already assumes — is left untouched so implicit `library/` namespacing is preserved.
 pub fn resolve_default_registry(image: &str, default_registry: Option<&str>) -> String {
-    let Some(registry) = default_registry else {
-        return image.to_string();
-    };
+    let registry = default_registry.unwrap_or(DEFAULT_REGISTRY);
     if lns_policy::registry_auth::canonical_registry(registry) == "docker.io"
         || image_has_registry(image)
     {
@@ -921,8 +928,25 @@ mod tests {
     }
 
     #[test]
-    fn resolve_default_registry_leaves_an_image_untouched_without_a_default() {
-        assert_eq!(resolve_default_registry("alpine", None), "alpine");
+    fn resolve_default_registry_falls_back_to_the_lens_hub_not_docker_hub() {
+        assert_eq!(
+            resolve_default_registry("hchen/claude-code", None),
+            "hub.lns.run/hchen/claude-code",
+            "an unconfigured bare reference must address the Lens hub; docker.io would push someone's sandbox to Docker Hub"
+        );
+    }
+
+    #[test]
+    fn run_defaults_report_the_lens_hub_when_no_registry_is_configured() {
+        assert_eq!(RunDefaults::default().registry_or_default(), "hub.lns.run");
+        assert_eq!(
+            RunDefaults {
+                registry: Some("ghcr.io".into()),
+                ..RunDefaults::default()
+            }
+            .registry_or_default(),
+            "ghcr.io"
+        );
     }
 
     #[test]
@@ -971,6 +995,12 @@ mod tests {
             },
         );
         assert_eq!(resolved.image.as_deref(), Some("ghcr.io/alpine"));
+    }
+
+    #[test]
+    fn apply_run_defaults_qualifies_a_bare_image_with_the_lens_hub_when_nothing_is_configured() {
+        let resolved = apply_run_defaults(bare_run_args(), RunDefaults::default());
+        assert_eq!(resolved.image.as_deref(), Some("hub.lns.run/alpine"));
     }
 
     #[test]

--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -17,7 +17,7 @@ pub use real::RealRegistryVerifier;
 #[derive(clap::Args)]
 pub struct LoginArgs {
     #[arg(
-        help = "Registry host to log in to (e.g. ghcr.io); defaults to the configured `run.registry`, else docker.io."
+        help = "Registry host to log in to (e.g. ghcr.io); defaults to the configured `run.registry`, else hub.lns.run."
     )]
     pub registry: Option<String>,
     #[arg(short = 'u', long, help = "Username for the registry.")]
@@ -45,7 +45,7 @@ pub struct LoginArgs {
 #[derive(clap::Args)]
 pub struct LogoutArgs {
     #[arg(
-        help = "Registry host to log out of; defaults to the configured `run.registry`, else docker.io."
+        help = "Registry host to log out of; defaults to the configured `run.registry`, else hub.lns.run."
     )]
     pub registry: Option<String>,
 }

--- a/crates/lns-cli/src/login/real.rs
+++ b/crates/lns-cli/src/login/real.rs
@@ -44,7 +44,7 @@ pub fn run_logout<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutu
 fn configured_default_registry() -> Result<String> {
     let path = crate::config::default_config_path()?;
     let defaults = crate::config::load_run_defaults(&path)?;
-    Ok(defaults.registry.unwrap_or_else(|| "docker.io".to_string()))
+    Ok(defaults.registry_or_default().to_string())
 }
 
 pub struct RealRegistryVerifier {

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -96,7 +96,7 @@ pub struct SandboxValidateArgs {
 pub struct SandboxPushArgs {
     #[arg(
         value_name = "REF",
-        help = "Registry reference to publish the sandbox at, e.g. ghcr.io/team/hermes:1.4.0."
+        help = "Registry reference to publish the sandbox at, e.g. ghcr.io/team/hermes:1.4.0; a bare reference resolves against the `run.registry` default, else hub.lns.run."
     )]
     pub reference: String,
     #[arg(
@@ -117,7 +117,7 @@ pub struct SandboxPushArgs {
 pub struct SandboxPullArgs {
     #[arg(
         value_name = "REF",
-        help = "Published sandbox reference to fetch, e.g. ghcr.io/team/hermes:1.4.0."
+        help = "Published sandbox reference to fetch, e.g. ghcr.io/team/hermes:1.4.0; a bare reference resolves against the `run.registry` default, else hub.lns.run."
     )]
     pub reference: String,
 }
@@ -221,6 +221,16 @@ pub struct SandboxPruneArgs {
         help = "Required: confirm removing every cached sandbox not held by a running one."
     )]
     pub force: bool,
+}
+
+/// Qualifies the registry coordinate a distribution verb addresses with `registry`, or the built-in default when nothing is configured; the local-cache verbs take an id-or-ref the service resolves, so they are left alone.
+pub fn apply_registry_default(command: &mut SandboxCommand, registry: Option<&str>) {
+    let reference = match command {
+        SandboxCommand::Push(args) => &mut args.reference,
+        SandboxCommand::Pull(args) => &mut args.reference,
+        _ => return,
+    };
+    *reference = crate::config::resolve_default_registry(reference, registry);
 }
 
 pub fn augment(app: clap::Command) -> clap::Command {

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -13,7 +13,8 @@ use crate::service::client::BoxFuture;
 
 pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
-        let args = super::SandboxArgs::from_arg_matches(matches)?;
+        let mut args = super::SandboxArgs::from_arg_matches(matches)?;
+        qualify_references(&mut args.command)?;
         if let super::SandboxCommand::Run(run_args) = args.command {
             return crate::service::launch_run(*run_args, ctx.debug).await;
         }
@@ -28,6 +29,23 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
         crate::service::require_running().await;
         dispatch(args).await
     })
+}
+
+fn configured_registry() -> Result<Option<String>> {
+    let path = crate::config::default_config_path()?;
+    Ok(crate::config::load_run_defaults(&path)?.registry)
+}
+
+fn qualify_references(command: &mut super::SandboxCommand) -> Result<()> {
+    super::apply_registry_default(command, configured_registry()?.as_deref());
+    Ok(())
+}
+
+fn qualified_reference(reference: &str) -> Result<String> {
+    Ok(crate::config::resolve_default_registry(
+        reference,
+        configured_registry()?.as_deref(),
+    ))
 }
 
 pub fn run_init<'a>(_matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
@@ -96,7 +114,7 @@ pub fn run_push<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture
     Box::pin(async move {
         let args = super::SandboxPushArgs::from_arg_matches(matches)?;
         push_local(
-            &args.reference,
+            &qualified_reference(&args.reference)?,
             args.dry_run,
             args.file.as_deref(),
             ctx.cwd()?,
@@ -107,7 +125,8 @@ pub fn run_push<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture
 
 pub fn run_pull<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
-        let args = super::SandboxPullArgs::from_arg_matches(matches)?;
+        let mut args = super::SandboxPullArgs::from_arg_matches(matches)?;
+        args.reference = qualified_reference(&args.reference)?;
         dispatch_command(super::SandboxCommand::Pull(args)).await
     })
 }

--- a/crates/lns-cli/tests/behaviours/sandbox_distribute.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_distribute.feature
@@ -12,6 +12,26 @@ Feature: distributing a sandbox
     And the output contains "built"
     And the output contains "ghcr.io/team/hermes:1.4.0"
 
+  Scenario: a bare push reference publishes to the Lens hub
+    Given a valid lns.yaml in the current directory
+    And the registry accepts the push
+    When the user runs sandbox command "push hchen/claude-code"
+    Then the exit code is 0
+    And the output contains "hub.lns.run/hchen/claude-code"
+
+  Scenario: a bare pull reference fetches from the Lens hub
+    Given the registry serves the sandbox "hub.lns.run/hchen/claude-code"
+    When the user runs sandbox command "pull hchen/claude-code"
+    Then the exit code is 0
+    And the service received a request to pull "hub.lns.run/hchen/claude-code"
+
+  Scenario: a fully-qualified reference is published where it names
+    Given a valid lns.yaml in the current directory
+    And the registry accepts the push
+    When the user runs sandbox command "push ghcr.io/team/hermes:1.4.0"
+    Then the exit code is 0
+    And the output contains "ghcr.io/team/hermes:1.4.0"
+
   Scenario: there is no standalone build command
     When I run "lns build ."
     Then the exit code is 2

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -314,7 +314,8 @@ async fn run_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
 pub(crate) async fn drive_sandbox_command(w: &mut BehaviourWorld, cmd: &str) {
     let mut argv: Vec<&str> = vec!["lns", "sandbox"];
     argv.extend(cmd.split_whitespace());
-    let args: SandboxArgs = parse_args(&argv).expect("sandbox argv must parse");
+    let mut args: SandboxArgs = parse_args(&argv).expect("sandbox argv must parse");
+    lns_cli::sandbox::apply_registry_default(&mut args.command, None);
 
     if author::is_offline(&args.command) {
         run_author_verb(w, &args.command);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -99,7 +99,7 @@ the `./lns.yaml` definition with its command overridden.
 | `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; rounded up to a whole MiB); falls back to the `run.mem` config default. |
 | `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory roots the definition's relative binds and filesets. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
-| `--registry <HOST>`          | `docker.io`      | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default. A fully-qualified reference is used as-is. |
+| `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with `defaultVerdict: ask` if absent.         |
 | `-w`, `--workdir <DIR>`      | `spec.workdir`, then image `WORKDIR` | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
@@ -164,7 +164,7 @@ interchangeable everywhere a run is addressed.
 | ---------- | -------------- | ------- |
 | `init`     | `lns init`     | Scaffold a default `./lns.yaml` (`kind: Sandbox`) in this directory. |
 | `validate` | —              | Validate `./lns.yaml` — schema, cross-field, and secret checks, offline. Exits non-zero and lists each problem when the definition is broken. `-f`/`--file` validates another definition file instead. |
-| `push`     | `lns push`     | Build `./lns.yaml` and upload it to a registry as a sandbox artifact, in one step. `<REF>` is the registry reference to publish at. Each `spec.filesets` `path` directory is packed into a FileSet artifact, pushed alongside, and pinned by digest in the published config. `--dry-run` validates, packs, and builds all of it offline, prints the digests that would publish, and uploads nothing. `-f`/`--file` publishes another definition file instead. |
+| `push`     | `lns push`     | Build `./lns.yaml` and upload it to a registry as a sandbox artifact, in one step. `<REF>` is the registry reference to publish at; a bare one (`you/agent`) resolves against the `run.registry` default, else the Lens hub (`hub.lns.run`). Each `spec.filesets` `path` directory is packed into a FileSet artifact, pushed alongside, and pinned by digest in the published config. `--dry-run` validates, packs, and builds all of it offline, prints the digests that would publish, and uploads nothing. `-f`/`--file` publishes another definition file instead. |
 | `pull`     | `lns pull`     | Fetch a published sandbox and its base image into the local cache. |
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
@@ -218,12 +218,12 @@ lns logout <REGISTRY>
 
 | Form                                  | Meaning                                                                 |
 | ------------------------------------- | ----------------------------------------------------------------------- |
-| `lns login [REGISTRY]`                | Log in to `REGISTRY` (defaults to `run.registry`, else `docker.io`). Pass `-u`/`--username` and the secret via `--password-stdin` (recommended) or `-p`/`--password`. |
+| `lns login [REGISTRY]`                | Log in to `REGISTRY` (defaults to `run.registry`, else `hub.lns.run`). Pass `-u`/`--username` and the secret via `--password-stdin` (recommended) or `-p`/`--password`. |
 | `lns login --list`                    | List the registries you are logged in to, as `host  username` — never secrets. |
 | `lns logout [REGISTRY]`               | Remove the stored credential for `REGISTRY`.                            |
 
 The registry is matched by host: a bare published-sandbox reference uses the
-`run.registry` default (or Docker Hub), while a fully-qualified
+`run.registry` default (or the Lens hub), while a fully-qualified
 `lns run ghcr.io/org/app` always targets that registry and uses its stored login if present. Credentials live in
 a per-user file (`~/.lns-registry-auth.json`, `0600`; override with
 `LNS_REGISTRY_AUTH_PATH`), separate from any shareable policy.
@@ -385,7 +385,7 @@ lns config list
 | ------------- | ------------- | ---------------------------------------------------------- |
 | `run.cpus`    | `--cpus`      | Number of vCPUs.                                           |
 | `run.mem`     | `--mem`       | RAM in MiB.                                                |
-| `run.registry`| `--registry`  | Default registry host for bare published-sandbox references (e.g. `ghcr.io`). |
+| `run.registry`| `--registry`  | Default registry host for bare published-sandbox references (e.g. `ghcr.io`); unset means the Lens hub, `hub.lns.run`. |
 
 The settable defaults are `run.cpus`, `run.mem`, and `run.registry`. Environment
 variables, volumes, and ports are properties of a sandbox, not persistent config —

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -564,6 +564,14 @@ Publishing is one step. `lns push` (a shortcut for `lns sandbox push`) builds
 lns push ghcr.io/acme/reviewer:1.0.0
 ```
 
+A reference that names no registry (`lns push acme/reviewer:1.0.0`) resolves
+against the Lens hub, `hub.lns.run` — set `run.registry` (or pass `--registry`
+on `lns run`) to point bare references somewhere else:
+
+```bash
+lns config set run.registry ghcr.io
+```
+
 `lns push --dry-run` does everything short of uploading — validates the
 definition, packs the filesets, builds the artifact — and prints the digests
 that would publish (`npm publish --dry-run`-style), so you can preview a


### PR DESCRIPTION
## Problem

```
❯ bin/lns push hchen/claude-code -f docs/examples/claude-code/lns.yaml
Error: docker.io denied the push — no login is stored for it
```

A reference that names no registry never got qualified — it fell through to
`oci_client`'s own `docker.io` default. So `lns push hchen/claude-code` tried
to publish a Lens sandbox artifact to Docker Hub, then failed on a login
nobody would ever have stored there. `run.registry` existed as the knob, but
its *unset* value was Docker Hub, which is the wrong home for a sandbox.

## Fix

A bare reference resolves against `run.registry`, else the new
`config::DEFAULT_REGISTRY` = `hub.lns.run`. Fully-qualified references are
untouched, and an explicitly configured `docker.io` still short-circuits so
implicit `library/` namespacing keeps working.

Applied at every place a bare reference addresses a remote registry:

| Surface | Before | After |
| --- | --- | --- |
| `lns push you/agent` | `docker.io/you/agent` | `hub.lns.run/you/agent` |
| `lns pull you/agent` | `docker.io/you/agent` | `hub.lns.run/you/agent` |
| `lns run you/agent` | `docker.io/you/agent` | `hub.lns.run/you/agent` |
| `lns login` / `lns logout` (no host) | `docker.io` | `hub.lns.run` |

`push` and `pull` consulted no config at all before this; they now share one
seam, `sandbox::apply_registry_default`, with `lns run`'s existing
`config::resolve_default_registry`.

### Deliberately left alone

- **`spec.image`** — a base image is a plain OCI image and Docker Hub is its
  conventional default; the scaffold still ships
  `image: docker.io/library/alpine:3.20`, fully qualified.
- **`rm` / `inspect` / `tag`** — these take an id-*or*-ref the service
  resolves against the local cache, so qualifying would corrupt a run name.

## Tests

Red first, then green.

- Layer 2 (`sandbox_distribute.feature`): a bare push reference publishes to
  the Lens hub; a bare pull reference fetches from it; a fully-qualified
  reference is published where it names. The harness now mirrors
  `real::run`'s normalization step.
- Layer 3 (`config`): the unconfigured fallback is `hub.lns.run`, not
  `docker.io`; `RunDefaults::registry_or_default` reports the hub when
  nothing is configured. The old
  `resolve_default_registry_leaves_an_image_untouched_without_a_default` was
  the test that pinned the bug — it is replaced.

Verified both new Layer 3 tests fail against the old fallback before the fix.

## Verification

`make lint`, `make complexity`, and full-workspace `make coverage` are green
(332 scenarios, 0 coverage failures). Confirmed against the real binary:

```
❯ lns push --dry-run hchen/claude-code
would push hub.lns.run/hchen/claude-code@sha256:e157e22c… (387 bytes)

❯ lns logout
Error: not logged in to hub.lns.run
```