### PR TITLE
fix: offer a connector on first use, whatever the policy allows

### DIFF
--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -277,7 +277,7 @@ fn home_catalog_declares(world: &mut E2eWorld, id: String, env: String) {
         .as_ref()
         .expect("Given a clean lns cache home before writing a catalog");
     let catalog = format!(
-        "connectors:\n  - id: {id}\n    authKind: credential\n    routes:\n      - match: api.{id}.example\n    credential:\n      envVar: {env}\n      placeholder: {id}-LNSPLACEHOLDER0000000000\n      injections:\n        - kind: bearer_header\n          domain: api.{id}.example\n"
+        "connectors:\n  - id: {id}\n    routes:\n      - match: api.{id}.example\n    methods:\n      - id: token\n        kind: credential\n        credential:\n          envVar: {env}\n          placeholder: {id}-LNSPLACEHOLDER0000000000\n          injections:\n            - kind: bearer_header\n              domain: api.{id}.example\n"
     );
     std::fs::write(home.path().join(".lns-connectors.yaml"), catalog)
         .expect("write the user connector catalog");
@@ -317,7 +317,7 @@ fn home_catalog_declares_oauth(world: &mut E2eWorld, id: String, endpoint: Strin
         .as_ref()
         .expect("Given a clean lns cache home before writing a catalog");
     let catalog = format!(
-        "connectors:\n  - id: {id}\n    authKind: oauth\n    oauth:\n      clientId: some-client\n      deviceAuthorizationEndpoint: {endpoint}/device\n      tokenEndpoint: {endpoint}/token\n      envVar: SOME_OAUTH_TOKEN\n      placeholder: {id}-LNSPLACEHOLDER0000000000\n"
+        "connectors:\n  - id: {id}\n    methods:\n      - id: device\n        kind: oauth\n        oauth:\n          clientId: some-client\n          deviceAuthorizationEndpoint: {endpoint}/device\n          tokenEndpoint: {endpoint}/token\n          envVar: SOME_OAUTH_TOKEN\n          placeholder: {id}-LNSPLACEHOLDER0000000000\n"
     );
     std::fs::write(home.path().join(".lns-connectors.yaml"), catalog)
         .expect("write the user connector catalog");

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use lns_policy::Policy;
 use lns_policy::connectors::{
-    AuthKind, Catalog, Connector, ConnectorRoute, CredentialAuth, bundled_connectors,
+    AuthKind, Catalog, Connector, ConnectorRoute, CredentialAuth, SignInMethod, bundled_connectors,
     effective_connectors,
 };
 use lns_policy::grants::{GrantRecord, GrantStore, GrantVerdict, JsonFileGrantStore, project_key};
@@ -270,15 +270,15 @@ fn add(args: &ConnectorAddArgs, catalog_path: &Path, writer: &mut impl Write) ->
     catalog.connectors.push(Connector {
         id: args.id.clone(),
         name: None,
-        auth_kind: AuthKind::Credential,
         routes,
-        credential: Some(CredentialAuth {
-            env_var: args.env_var.clone(),
-            placeholder,
-            injections: args.inject.clone(),
-        }),
-        oauth: None,
-        token_fallback: None,
+        methods: vec![SignInMethod::credential(
+            "token",
+            CredentialAuth {
+                env_var: args.env_var.clone(),
+                placeholder,
+                injections: args.inject.clone(),
+            },
+        )],
     });
     catalog
         .save_atomic(catalog_path)
@@ -322,7 +322,10 @@ impl ConnectorRow {
         Self {
             id: connector.id.clone(),
             source,
-            auth_kind: kind_word(connector.auth_kind),
+            auth_kind: connector
+                .sole_method()
+                .map(|m| kind_word(m.kind))
+                .unwrap_or("multiple"),
         }
     }
 }
@@ -370,7 +373,10 @@ pub async fn connect(
         bail!("unknown connector {:?}; see `lns connector list`", args.id);
     };
     // An oauth connector authenticates by an interactive sign-in; a credential connector binds its per-machine value decision through the approval-window card. Either way the id is recorded only on success.
-    let closing = if integ.auth_kind == AuthKind::Oauth {
+    let signs_in_interactively = integ
+        .sole_method()
+        .is_some_and(|m| m.kind == AuthKind::Oauth);
+    let closing = if signs_in_interactively {
         match signin.sign_in(&args.id, writer).await? {
             SignInOutcome::ServiceUnavailable => bail!(
                 "the background service must be running to sign in to {:?}; start it with `lns service start`",
@@ -714,7 +720,6 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.somesaas.com".into(),
                 transport: None,
@@ -722,28 +727,29 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                flow: OauthFlow::Device,
-                client_id: Some("Iv1.somesaas".into()),
-                client_secret: None,
-                scopes: vec!["repo".into()],
-                device_authorization_endpoint: Some(
-                    "https://api.somesaas.com/login/device/code".into(),
-                ),
-                authorization_endpoint: None,
-                token_endpoint: "https://api.somesaas.com/login/oauth/access_token".into(),
-                userinfo_endpoint: None,
-                account_field: None,
-                env_var: "SOMESAAS_TOKEN".into(),
-                placeholder: "lns-somesaas-placeholder".into(),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: "api.somesaas.com".into(),
-                    header: None,
-                }],
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                OauthAuth {
+                    flow: OauthFlow::Device,
+                    client_id: Some("Iv1.somesaas".into()),
+                    client_secret: None,
+                    scopes: vec!["repo".into()],
+                    device_authorization_endpoint: Some(
+                        "https://api.somesaas.com/login/device/code".into(),
+                    ),
+                    authorization_endpoint: None,
+                    token_endpoint: "https://api.somesaas.com/login/oauth/access_token".into(),
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    env_var: "SOMESAAS_TOKEN".into(),
+                    placeholder: "lns-somesaas-placeholder".into(),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: "api.somesaas.com".into(),
+                        header: None,
+                    }],
+                },
+            )],
         }
     }
 
@@ -757,9 +763,9 @@ mod tests {
         assert_eq!(catalog.connectors.len(), 1);
         let acme = &catalog.connectors[0];
         assert_eq!(acme.id, "acme");
-        assert_eq!(acme.auth_kind, AuthKind::Credential);
+        assert_eq!(acme.methods[0].kind, AuthKind::Credential);
         assert_eq!(acme.routes[0].match_pattern, "api.acme.corp");
-        let cred = acme.credential.as_ref().unwrap();
+        let cred = acme.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "ACME_API_KEY");
         assert!(is_self_identifying(&cred.placeholder));
     }
@@ -772,7 +778,7 @@ mod tests {
         args.placeholder = Some("acme_LNSPLACEHOLDER".into());
         add(&args, &path, &mut Vec::new()).unwrap();
         assert_eq!(
-            load(&path).connectors[0]
+            load(&path).connectors[0].methods[0]
                 .credential
                 .as_ref()
                 .unwrap()
@@ -852,15 +858,15 @@ mod tests {
             vec![Connector {
                 id: "gitlab".into(),
                 name: None,
-                auth_kind: AuthKind::Credential,
                 routes: Vec::new(),
-                credential: Some(CredentialAuth {
-                    env_var: "EVIL".into(),
-                    placeholder: "lns-evil".into(),
-                    injections: Vec::new(),
-                }),
-                oauth: None,
-                token_fallback: None,
+                methods: vec![SignInMethod::credential(
+                    "token",
+                    CredentialAuth {
+                        env_var: "EVIL".into(),
+                        placeholder: "lns-evil".into(),
+                        injections: Vec::new(),
+                    },
+                )],
             }],
         );
         let mut out = Vec::new();

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -105,7 +105,7 @@ async fn run_connector(world: &mut BehaviourWorld, tail: &[&str]) {
 #[given(regex = r#"^a user catalog declares the "([^"]+)" oauth connector$"#)]
 fn given_user_oauth_connector(world: &mut BehaviourWorld, id: String) {
     use lns_policy::connectors::{
-        AuthKind, Catalog, Connector, ConnectorRoute, OauthAuth, OauthFlow,
+        Catalog, Connector, ConnectorRoute, OauthAuth, OauthFlow, SignInMethod,
     };
     use lns_policy::providers::{InjectionDef, InjectionKind};
     let dir = cwd(world);
@@ -113,7 +113,6 @@ fn given_user_oauth_connector(world: &mut BehaviourWorld, id: String) {
         connectors: vec![Connector {
             id,
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.some-oauth.example".into(),
                 transport: None,
@@ -121,26 +120,27 @@ fn given_user_oauth_connector(world: &mut BehaviourWorld, id: String) {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                flow: OauthFlow::Device,
-                client_id: Some("Iv1.some-oauth".into()),
-                client_secret: None,
-                scopes: vec!["repo".into()],
-                device_authorization_endpoint: Some("https://example.com/device/code".into()),
-                authorization_endpoint: None,
-                token_endpoint: "https://example.com/oauth/token".into(),
-                userinfo_endpoint: None,
-                account_field: None,
-                env_var: "SOME_OAUTH_TOKEN".into(),
-                placeholder: "some-oauth-placeholder-0000000000000000".into(),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: "api.some-oauth.example".into(),
-                    header: None,
-                }],
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                OauthAuth {
+                    flow: OauthFlow::Device,
+                    client_id: Some("Iv1.some-oauth".into()),
+                    client_secret: None,
+                    scopes: vec!["repo".into()],
+                    device_authorization_endpoint: Some("https://example.com/device/code".into()),
+                    authorization_endpoint: None,
+                    token_endpoint: "https://example.com/oauth/token".into(),
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    env_var: "SOME_OAUTH_TOKEN".into(),
+                    placeholder: "some-oauth-placeholder-0000000000000000".into(),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: "api.some-oauth.example".into(),
+                        header: None,
+                    }],
+                },
+            )],
         }],
     }
     .save_atomic(&dir.join(".lns-connectors.yaml"))
@@ -150,7 +150,7 @@ fn given_user_oauth_connector(world: &mut BehaviourWorld, id: String) {
 #[given(regex = r#"^a user catalog declares the "([^"]+)" pkce connector$"#)]
 fn given_user_pkce_connector(world: &mut BehaviourWorld, id: String) {
     use lns_policy::connectors::{
-        AuthKind, Catalog, Connector, ConnectorRoute, OauthAuth, OauthFlow,
+        Catalog, Connector, ConnectorRoute, OauthAuth, OauthFlow, SignInMethod,
     };
     use lns_policy::providers::{InjectionDef, InjectionKind};
     world.signin_is_pkce = true;
@@ -159,7 +159,6 @@ fn given_user_pkce_connector(world: &mut BehaviourWorld, id: String) {
         connectors: vec![Connector {
             id,
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.some-pkce.example".into(),
                 transport: None,
@@ -167,26 +166,27 @@ fn given_user_pkce_connector(world: &mut BehaviourWorld, id: String) {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                flow: OauthFlow::Pkce,
-                client_id: None,
-                client_secret: None,
-                scopes: Vec::new(),
-                device_authorization_endpoint: None,
-                authorization_endpoint: Some("https://api.some-pkce.example/auth".into()),
-                token_endpoint: "https://api.some-pkce.example/api/v1/auth/keys".into(),
-                userinfo_endpoint: None,
-                account_field: None,
-                env_var: "SOME_PKCE_TOKEN".into(),
-                placeholder: "some-pkce-LNSPLACEHOLDER0000000000000000".into(),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: "api.some-pkce.example".into(),
-                    header: None,
-                }],
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                OauthAuth {
+                    flow: OauthFlow::Pkce,
+                    client_id: None,
+                    client_secret: None,
+                    scopes: Vec::new(),
+                    device_authorization_endpoint: None,
+                    authorization_endpoint: Some("https://api.some-pkce.example/auth".into()),
+                    token_endpoint: "https://api.some-pkce.example/api/v1/auth/keys".into(),
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    env_var: "SOME_PKCE_TOKEN".into(),
+                    placeholder: "some-pkce-LNSPLACEHOLDER0000000000000000".into(),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: "api.some-pkce.example".into(),
+                        header: None,
+                    }],
+                },
+            )],
         }],
     }
     .save_atomic(&dir.join(".lns-connectors.yaml"))
@@ -194,14 +194,15 @@ fn given_user_pkce_connector(world: &mut BehaviourWorld, id: String) {
 }
 
 fn write_credential_catalog(world: &mut BehaviourWorld, id: String) {
-    use lns_policy::connectors::{AuthKind, Catalog, Connector, ConnectorRoute, CredentialAuth};
+    use lns_policy::connectors::{
+        Catalog, Connector, ConnectorRoute, CredentialAuth, SignInMethod,
+    };
     use lns_policy::providers::{InjectionDef, InjectionKind};
     let dir = cwd(world);
     Catalog {
         connectors: vec![Connector {
             id: id.clone(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: vec![ConnectorRoute {
                 match_pattern: format!("api.{id}.example"),
                 transport: None,
@@ -209,17 +210,18 @@ fn write_credential_catalog(world: &mut BehaviourWorld, id: String) {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: Some(CredentialAuth {
-                env_var: "SOME_TOKEN".into(),
-                placeholder: format!("{id}-LNSPLACEHOLDER0000000000"),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: format!("api.{id}.example"),
-                    header: None,
-                }],
-            }),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "token",
+                CredentialAuth {
+                    env_var: "SOME_TOKEN".into(),
+                    placeholder: format!("{id}-LNSPLACEHOLDER0000000000"),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: format!("api.{id}.example"),
+                        header: None,
+                    }],
+                },
+            )],
         }],
     }
     .save_atomic(&dir.join(".lns-connectors.yaml"))

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -153,6 +153,11 @@ impl SignInMethod {
         self
     }
 
+    /// The user-facing label for the button that picks this sign-in; falls back to the id.
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.id)
+    }
+
     pub fn env_var(&self) -> &str {
         match self.kind {
             AuthKind::Credential => self.credential.as_ref().map(|c| c.env_var.as_str()),
@@ -235,9 +240,12 @@ impl Connector {
         }
     }
 
-    /// The method to act on where no choice has been made — the first listed. A connector orders its methods most-expected first.
-    pub fn default_method(&self) -> Option<&SignInMethod> {
-        self.methods.first()
+    /// The per-machine store key a sign-in method binds under: the bare connector id when it is the only way in, so every value and grant already bound keeps working.
+    pub fn provider_id_of(&self, method: &SignInMethod) -> String {
+        match self.methods.as_slice() {
+            [_only] => self.id.clone(),
+            _ => format!("{}:{}", self.id, method.id),
+        }
     }
 
     /// A connector needs at least one way in, every method must be well-formed, and no two methods may write one env var — a tool reading that variable could not tell which sign-in it got.
@@ -754,6 +762,51 @@ connectors:
         );
         i.name = Some("Acme Corp".into());
         assert_eq!(i.display_name(), "Acme Corp");
+    }
+
+    #[test]
+    fn a_method_display_name_prefers_an_explicit_name_and_falls_back_to_its_id() {
+        let mut m = SignInMethod::credential(
+            "api-key",
+            credential("ACME_API_KEY", "acme_LNSPLACEHOLDER0000", "api.acme.corp"),
+        );
+        assert_eq!(m.display_name(), "api-key");
+        m.name = Some("API key".into());
+        assert_eq!(m.display_name(), "API key");
+    }
+
+    #[test]
+    fn a_sole_method_keys_under_the_bare_connector_id() {
+        let connector = sample_connector();
+        let method = connector.sole_method().expect("one method");
+        assert_eq!(
+            connector.provider_id_of(method),
+            "acme",
+            "every value and grant already bound under the bare id must keep working, so a connector with one way in must not gain a suffix"
+        );
+    }
+
+    #[test]
+    fn each_of_several_methods_keys_under_its_own_suffixed_id() {
+        let mut connector = sample_connector();
+        connector.methods.push(SignInMethod::credential(
+            "other",
+            credential(
+                "ACME_OTHER_TOKEN",
+                "acme_LNSPLACEHOLDER0001",
+                "api.acme.corp",
+            ),
+        ));
+        let keys: Vec<String> = connector
+            .methods
+            .iter()
+            .map(|m| connector.provider_id_of(m))
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["acme:api-key".to_string(), "acme:other".to_string()],
+            "the method must be part of the machine store key, or the two sign-ins would overwrite each other's value"
+        );
     }
 
     #[test]

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -109,15 +109,14 @@ pub struct TokenFallback {
     pub command: Option<String>,
 }
 
+/// One way to sign in to a connector. A connector owns a domain; its methods are the alternative ways to obtain a credential for it, each with its own env var because that is what a tool branches on to decide it is signed in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Connector {
+pub struct SignInMethod {
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    pub auth_kind: AuthKind,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub routes: Vec<ConnectorRoute>,
+    pub kind: AuthKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential: Option<CredentialAuth>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -126,42 +125,143 @@ pub struct Connector {
     pub token_fallback: Option<TokenFallback>,
 }
 
+impl SignInMethod {
+    pub fn credential(id: impl Into<String>, credential: CredentialAuth) -> Self {
+        Self {
+            id: id.into(),
+            name: None,
+            kind: AuthKind::Credential,
+            credential: Some(credential),
+            oauth: None,
+            token_fallback: None,
+        }
+    }
+
+    pub fn oauth(id: impl Into<String>, oauth: OauthAuth) -> Self {
+        Self {
+            id: id.into(),
+            name: None,
+            kind: AuthKind::Oauth,
+            credential: None,
+            oauth: Some(oauth),
+            token_fallback: None,
+        }
+    }
+
+    pub fn with_token_fallback(mut self, fallback: TokenFallback) -> Self {
+        self.token_fallback = Some(fallback);
+        self
+    }
+
+    pub fn env_var(&self) -> &str {
+        match self.kind {
+            AuthKind::Credential => self.credential.as_ref().map(|c| c.env_var.as_str()),
+            AuthKind::Oauth => self.oauth.as_ref().map(|o| o.env_var.as_str()),
+        }
+        .unwrap_or_default()
+    }
+
+    pub fn placeholder(&self) -> &str {
+        match self.kind {
+            AuthKind::Credential => self.credential.as_ref().map(|c| c.placeholder.as_str()),
+            AuthKind::Oauth => self.oauth.as_ref().map(|o| o.placeholder.as_str()),
+        }
+        .unwrap_or_default()
+    }
+
+    pub fn injections(&self) -> &[InjectionDef] {
+        match self.kind {
+            AuthKind::Credential => self.credential.as_ref().map(|c| c.injections.as_slice()),
+            AuthKind::Oauth => self.oauth.as_ref().map(|o| o.injections.as_slice()),
+        }
+        .unwrap_or_default()
+    }
+
+    /// Each kind must carry its matching block, and an oauth block must carry the endpoint its `flow` needs.
+    fn validate(&self, connector_id: &str) -> Result<(), String> {
+        match self.kind {
+            AuthKind::Credential if self.credential.is_none() => Err(format!(
+                "connector {connector_id:?} method {:?} is kind credential but has no `credential:` block",
+                self.id
+            )),
+            AuthKind::Oauth => self.validate_oauth(connector_id),
+            _ => Ok(()),
+        }
+    }
+
+    fn validate_oauth(&self, connector_id: &str) -> Result<(), String> {
+        let Some(oauth) = self.oauth.as_ref() else {
+            return Err(format!(
+                "connector {connector_id:?} method {:?} is kind oauth but has no `oauth:` block",
+                self.id
+            ));
+        };
+        match oauth.flow {
+            OauthFlow::Device if oauth.device_authorization_endpoint.is_none() => Err(format!(
+                "connector {connector_id:?} method {:?} uses the oauth device flow but has no `deviceAuthorizationEndpoint`",
+                self.id
+            )),
+            OauthFlow::Pkce if oauth.authorization_endpoint.is_none() => Err(format!(
+                "connector {connector_id:?} method {:?} uses the oauth pkce flow but has no `authorizationEndpoint`",
+                self.id
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Connector {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<ConnectorRoute>,
+    pub methods: Vec<SignInMethod>,
+}
+
 impl Connector {
     /// The user-facing label for cards and prompts; falls back to the id when no `name` is set.
     pub fn display_name(&self) -> &str {
         self.name.as_deref().unwrap_or(&self.id)
     }
 
-    /// Each authKind must carry its matching block, and an oauth block must carry the endpoint its `flow` needs.
-    pub fn validate(&self) -> Result<(), String> {
-        match self.auth_kind {
-            AuthKind::Credential if self.credential.is_none() => Err(format!(
-                "connector {:?} declares authKind credential but has no `credential:` block",
-                self.id
-            )),
-            AuthKind::Oauth => self.validate_oauth(),
-            _ => Ok(()),
+    /// The method a single-method connector signs in with; `None` once the user must choose between several.
+    pub fn sole_method(&self) -> Option<&SignInMethod> {
+        match self.methods.as_slice() {
+            [only] => Some(only),
+            _ => None,
         }
     }
 
-    fn validate_oauth(&self) -> Result<(), String> {
-        let Some(oauth) = self.oauth.as_ref() else {
+    /// The method to act on where no choice has been made — the first listed. A connector orders its methods most-expected first.
+    pub fn default_method(&self) -> Option<&SignInMethod> {
+        self.methods.first()
+    }
+
+    /// A connector needs at least one way in, every method must be well-formed, and no two methods may write one env var — a tool reading that variable could not tell which sign-in it got.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.methods.is_empty() {
             return Err(format!(
-                "connector {:?} declares authKind oauth but has no `oauth:` block",
+                "connector {:?} declares no sign-in method, so it could never be connected",
                 self.id
             ));
-        };
-        match oauth.flow {
-            OauthFlow::Device if oauth.device_authorization_endpoint.is_none() => Err(format!(
-                "connector {:?} uses the oauth device flow but has no `deviceAuthorizationEndpoint`",
-                self.id
-            )),
-            OauthFlow::Pkce if oauth.authorization_endpoint.is_none() => Err(format!(
-                "connector {:?} uses the oauth pkce flow but has no `authorizationEndpoint`",
-                self.id
-            )),
-            _ => Ok(()),
         }
+        for method in &self.methods {
+            method.validate(&self.id)?;
+        }
+        let mut seen: HashSet<&str> = HashSet::new();
+        for method in &self.methods {
+            if !seen.insert(method.env_var()) {
+                return Err(format!(
+                    "connector {:?} has two sign-in methods writing {:?}, which a workload could not tell apart",
+                    self.id,
+                    method.env_var()
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -356,15 +456,15 @@ mod tests {
         Connector {
             id: "examplepkce".into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![route("api.examplepkce.com")],
-            credential: None,
-            oauth: Some(pkce_oauth_auth(
-                "EXAMPLEPKCE_TOKEN",
-                "examplepkce_LNSPLACEHOLDER0000",
-                "api.examplepkce.com",
-            )),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "pkce",
+                pkce_oauth_auth(
+                    "EXAMPLEPKCE_TOKEN",
+                    "examplepkce_LNSPLACEHOLDER0000",
+                    "api.examplepkce.com",
+                ),
+            )],
         }
     }
 
@@ -378,19 +478,108 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_connector_may_carry_several_sign_in_methods() {
+        let yaml = r#"
+connectors:
+  - id: some-multi
+    name: Some Multi
+    routes:
+      - match: api.some-multi.example
+    methods:
+      - id: api-key
+        name: API key
+        kind: credential
+        credential:
+          envVar: SOME_TOKEN
+          placeholder: some-LNSPLACEHOLDER0000
+          injections:
+            - kind: bearer_header
+              domain: api.some-multi.example
+      - id: subscription
+        name: Subscription
+        kind: credential
+        credential:
+          envVar: SOME_OTHER_TOKEN
+          placeholder: some-other-LNSPLACEHOLDER0000
+          injections:
+            - kind: bearer_header
+              domain: api.some-multi.example
+"#;
+        let catalog: Catalog = serde_yaml::from_str(yaml).expect("a methods list parses");
+        catalog.validate().expect("two methods is consistent");
+        let methods = &catalog.connectors[0].methods;
+        assert_eq!(
+            methods.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            ["api-key", "subscription"],
+            "one connector owns the domain and offers the ways to sign in to it"
+        );
+        assert_eq!(
+            methods.iter().map(|m| m.env_var()).collect::<Vec<_>>(),
+            ["SOME_TOKEN", "SOME_OTHER_TOKEN"],
+            "each method carries its own env var, which is what a tool branches on"
+        );
+    }
+
+    #[test]
+    fn a_connector_with_no_sign_in_method_is_rejected() {
+        let yaml = r#"
+connectors:
+  - id: some-empty
+    routes:
+      - match: api.some-empty.example
+    methods: []
+"#;
+        let catalog: Catalog = serde_yaml::from_str(yaml).expect("an empty methods list parses");
+        let err = catalog
+            .validate()
+            .expect_err("a connector with no way to sign in can never be connected");
+        assert!(
+            err.contains("some-empty"),
+            "the refusal must name the connector: {err}"
+        );
+    }
+
+    #[test]
+    fn two_methods_sharing_one_env_var_are_rejected() {
+        let yaml = r#"
+connectors:
+  - id: some-clash
+    routes:
+      - match: api.some-clash.example
+    methods:
+      - id: first
+        kind: credential
+        credential:
+          envVar: SOME_TOKEN
+          placeholder: first-LNSPLACEHOLDER0000
+          injections: []
+      - id: second
+        kind: credential
+        credential:
+          envVar: SOME_TOKEN
+          placeholder: second-LNSPLACEHOLDER0000
+          injections: []
+"#;
+        let catalog: Catalog = serde_yaml::from_str(yaml).expect("the clash parses");
+        let err = catalog
+            .validate()
+            .expect_err("two methods writing one env var could never be told apart");
+        assert!(
+            err.contains("SOME_TOKEN"),
+            "the refusal must name the variable: {err}"
+        );
+    }
+
     fn sample_connector() -> Connector {
         Connector {
             id: "acme".into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: vec![route("api.acme.corp")],
-            credential: Some(credential(
-                "ACME_API_KEY",
-                "acme_LNSPLACEHOLDER0000",
-                "api.acme.corp",
-            )),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "api-key",
+                credential("ACME_API_KEY", "acme_LNSPLACEHOLDER0000", "api.acme.corp"),
+            )],
         }
     }
 
@@ -398,15 +587,15 @@ mod tests {
         Connector {
             id: "examplehub".into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![route("api.examplehub.com")],
-            credential: None,
-            oauth: Some(oauth_auth(
-                "EXAMPLEHUB_TOKEN",
-                "examplehub_LNSPLACEHOLDER0000",
-                "api.examplehub.com",
-            )),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                oauth_auth(
+                    "EXAMPLEHUB_TOKEN",
+                    "examplehub_LNSPLACEHOLDER0000",
+                    "api.examplehub.com",
+                ),
+            )],
         }
     }
 
@@ -510,7 +699,7 @@ mod tests {
     fn credential_connector_round_trips_with_a_named_credential_block() {
         let i = sample_connector();
         let yaml = serde_yaml::to_string(&i).unwrap();
-        assert!(yaml.contains("authKind: credential"), "got: {yaml}");
+        assert!(yaml.contains("kind: credential"), "got: {yaml}");
         assert!(yaml.contains("credential:"), "got: {yaml}");
         assert!(yaml.contains("envVar: ACME_API_KEY"), "got: {yaml}");
         let parsed: Connector = serde_yaml::from_str(&yaml).unwrap();
@@ -521,7 +710,7 @@ mod tests {
     fn an_oauth_connector_round_trips_with_an_oauth_block_and_no_credential_block() {
         let i = oauth_connector();
         let yaml = serde_yaml::to_string(&i).unwrap();
-        assert!(yaml.contains("authKind: oauth"), "got: {yaml}");
+        assert!(yaml.contains("kind: oauth"), "got: {yaml}");
         assert!(yaml.contains("oauth:"), "got: {yaml}");
         assert!(yaml.contains("clientId:"), "got: {yaml}");
         assert!(yaml.contains("deviceAuthorizationEndpoint:"), "got: {yaml}");
@@ -536,7 +725,7 @@ mod tests {
     #[test]
     fn an_oauth_connector_round_trips_an_optional_client_secret() {
         let mut i = oauth_connector();
-        i.oauth.as_mut().unwrap().client_secret = Some("some-client-secret".into());
+        i.methods[0].oauth.as_mut().unwrap().client_secret = Some("some-client-secret".into());
         let yaml = serde_yaml::to_string(&i).unwrap();
         assert!(
             yaml.contains("clientSecret: some-client-secret"),
@@ -589,7 +778,7 @@ mod tests {
     #[test]
     fn an_connector_round_trips_its_optional_token_fallback_with_a_help_url() {
         let mut i = oauth_connector();
-        i.token_fallback = Some(TokenFallback {
+        i.methods[0].token_fallback = Some(TokenFallback {
             help: Some("https://example.com/tokens/new".into()),
             command: None,
         });
@@ -606,7 +795,7 @@ mod tests {
     #[test]
     fn a_token_fallback_round_trips_with_no_help() {
         let mut i = oauth_connector();
-        i.token_fallback = Some(TokenFallback {
+        i.methods[0].token_fallback = Some(TokenFallback {
             help: None,
             command: None,
         });
@@ -634,11 +823,15 @@ mod tests {
         let bad = Connector {
             id: "x".into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: Vec::new(),
-            credential: None,
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod {
+                id: "api-key".into(),
+                name: None,
+                kind: AuthKind::Credential,
+                credential: None,
+                oauth: None,
+                token_fallback: None,
+            }],
         };
         let err = bad.validate().unwrap_err();
         assert!(err.contains("credential"), "got: {err}");
@@ -654,11 +847,15 @@ mod tests {
         let bad = Connector {
             id: "x".into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: Vec::new(),
-            credential: None,
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod {
+                id: "device".into(),
+                name: None,
+                kind: AuthKind::Oauth,
+                credential: None,
+                oauth: None,
+                token_fallback: None,
+            }],
         };
         let err = bad.validate().unwrap_err();
         assert!(err.contains("oauth"), "got: {err}");
@@ -677,7 +874,10 @@ mod tests {
             "the default device flow must not serialize: {yaml}"
         );
         let parsed: Connector = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(parsed.oauth.unwrap().flow, OauthFlow::Device);
+        assert_eq!(
+            parsed.methods[0].oauth.as_ref().unwrap().flow,
+            OauthFlow::Device
+        );
     }
 
     #[test]
@@ -710,7 +910,7 @@ mod tests {
     #[test]
     fn validate_rejects_a_pkce_oauth_connector_missing_its_authorization_endpoint() {
         let mut i = pkce_connector();
-        i.oauth.as_mut().unwrap().authorization_endpoint = None;
+        i.methods[0].oauth.as_mut().unwrap().authorization_endpoint = None;
         let err = i.validate().unwrap_err();
         assert!(err.contains("authorizationEndpoint"), "got: {err}");
     }
@@ -718,7 +918,11 @@ mod tests {
     #[test]
     fn validate_rejects_a_device_oauth_connector_missing_its_device_authorization_endpoint() {
         let mut i = oauth_connector();
-        i.oauth.as_mut().unwrap().device_authorization_endpoint = None;
+        i.methods[0]
+            .oauth
+            .as_mut()
+            .unwrap()
+            .device_authorization_endpoint = None;
         let err = i.validate().unwrap_err();
         assert!(err.contains("deviceAuthorizationEndpoint"), "got: {err}");
     }
@@ -749,7 +953,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "openai")
             .expect("openai is bundled");
-        let cred = openai.credential.as_ref().unwrap();
+        let cred = openai.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "OPENAI_API_KEY");
         assert!(
             cred.injections
@@ -766,7 +970,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "anthropic")
             .expect("anthropic is bundled");
-        let cred = anthropic.credential.as_ref().unwrap();
+        let cred = anthropic.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "ANTHROPIC_API_KEY");
         assert!(
             cred.injections
@@ -787,13 +991,18 @@ mod tests {
     }
 
     #[test]
-    fn bundled_claude_code_subscription_bearer_injects_an_oat01_token_on_the_anthropic_api() {
+    fn bundled_anthropic_offers_a_subscription_method_injecting_an_oat01_token() {
         let integ = bundled_connectors()
             .iter()
-            .find(|i| i.id == "claude-code-subscription")
-            .expect("claude-code-subscription is bundled");
-        assert_eq!(integ.auth_kind, AuthKind::Credential);
-        let cred = integ.credential.as_ref().unwrap();
+            .find(|i| i.id == "anthropic")
+            .expect("anthropic is bundled");
+        let method = integ
+            .methods
+            .iter()
+            .find(|m| m.id == "claude-code-subscription")
+            .expect("the subscription is a sign-in method of anthropic, not its own connector");
+        assert_eq!(method.kind, AuthKind::Credential);
+        let cred = method.credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "CLAUDE_CODE_OAUTH_TOKEN");
         assert!(
             cred.placeholder.starts_with("sk-ant-oat01-"),
@@ -808,7 +1017,7 @@ mod tests {
             cred.injections
         );
         assert_eq!(
-            integ
+            method
                 .token_fallback
                 .as_ref()
                 .and_then(|f| f.command.as_deref()),
@@ -823,8 +1032,8 @@ mod tests {
             .iter()
             .find(|i| i.id == "bedrock")
             .expect("bedrock is bundled");
-        assert_eq!(bedrock.auth_kind, AuthKind::Credential);
-        let cred = bedrock.credential.as_ref().unwrap();
+        assert_eq!(bedrock.methods[0].kind, AuthKind::Credential);
+        let cred = bedrock.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "AWS_BEARER_TOKEN_BEDROCK");
         for domain in ["bedrock-runtime.*.amazonaws.com", "bedrock.*.amazonaws.com"] {
             assert!(
@@ -843,7 +1052,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "linear")
             .expect("linear is bundled");
-        let cred = linear.credential.as_ref().unwrap();
+        let cred = linear.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "LINEAR_API_KEY");
         assert!(
             cred.injections
@@ -860,7 +1069,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "telegram")
             .expect("telegram is bundled");
-        let cred = telegram.credential.as_ref().unwrap();
+        let cred = telegram.methods[0].credential.as_ref().unwrap();
         assert_eq!(cred.env_var, "TELEGRAM_BOT_TOKEN");
         assert!(
             cred.injections
@@ -884,7 +1093,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "gitlab")
             .expect("gitlab is bundled");
-        let injections = &gitlab.credential.as_ref().unwrap().injections;
+        let injections = &gitlab.methods[0].credential.as_ref().unwrap().injections;
         assert!(
             injections
                 .iter()
@@ -905,20 +1114,15 @@ mod tests {
     fn every_bundled_connector_is_valid_with_a_self_identifying_placeholder_and_routes() {
         for i in bundled_connectors() {
             assert!(i.validate().is_ok(), "{} is inconsistent", i.id);
-            let placeholder = match i.auth_kind {
-                AuthKind::Credential => {
-                    &i.credential
-                        .as_ref()
-                        .expect("credential block present")
-                        .placeholder
-                }
-                AuthKind::Oauth => &i.oauth.as_ref().expect("oauth block present").placeholder,
-            };
-            assert!(
-                crate::providers::is_self_identifying(placeholder),
-                "{} placeholder must self-identify: {placeholder}",
-                i.id,
-            );
+            for method in &i.methods {
+                let placeholder = method.placeholder();
+                assert!(
+                    crate::providers::is_self_identifying(placeholder),
+                    "{} method {} placeholder must self-identify: {placeholder}",
+                    i.id,
+                    method.id,
+                );
+            }
             assert!(
                 !i.routes.is_empty(),
                 "{} must declare the routes it needs",
@@ -933,8 +1137,8 @@ mod tests {
             .iter()
             .find(|i| i.id == "github")
             .expect("github is bundled");
-        assert_eq!(gh.auth_kind, AuthKind::Oauth);
-        let oauth = gh.oauth.as_ref().expect("oauth block present");
+        assert_eq!(gh.methods[0].kind, AuthKind::Oauth);
+        let oauth = gh.methods[0].oauth.as_ref().expect("oauth block present");
         assert_eq!(oauth.env_var, "GH_TOKEN");
         assert!(
             oauth
@@ -960,7 +1164,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "github")
             .expect("github is bundled");
-        let oauth = gh.oauth.as_ref().expect("oauth block present");
+        let oauth = gh.methods[0].oauth.as_ref().expect("oauth block present");
         assert_eq!(
             oauth.userinfo_endpoint.as_deref(),
             Some("https://api.github.com/user")
@@ -978,7 +1182,7 @@ mod tests {
             .iter()
             .find(|i| i.id == "github")
             .expect("github is bundled");
-        let fallback = gh
+        let fallback = gh.methods[0]
             .token_fallback
             .as_ref()
             .expect("github must offer a token fallback for SSO/approval-gated orgs");
@@ -998,8 +1202,8 @@ mod tests {
             .iter()
             .find(|i| i.id == "openrouter")
             .expect("openrouter is bundled");
-        assert_eq!(or.auth_kind, AuthKind::Oauth);
-        let oauth = or.oauth.as_ref().expect("oauth block present");
+        assert_eq!(or.methods[0].kind, AuthKind::Oauth);
+        let oauth = or.methods[0].oauth.as_ref().expect("oauth block present");
         assert_eq!(
             oauth.flow,
             OauthFlow::Pkce,
@@ -1035,8 +1239,11 @@ mod tests {
             .iter()
             .find(|i| i.id == "google")
             .expect("google is bundled");
-        assert_eq!(google.auth_kind, AuthKind::Oauth);
-        let oauth = google.oauth.as_ref().expect("oauth block present");
+        assert_eq!(google.methods[0].kind, AuthKind::Oauth);
+        let oauth = google.methods[0]
+            .oauth
+            .as_ref()
+            .expect("oauth block present");
         assert_eq!(oauth.flow, OauthFlow::Device);
         assert_eq!(oauth.env_var, "GOOGLE_OAUTH_ACCESS_TOKEN");
         assert_eq!(
@@ -1056,14 +1263,12 @@ mod tests {
             "Google APIs take Authorization: Bearer, got: {:?}",
             oauth.injections
         );
+        let fallback = google.methods[0].token_fallback.as_ref();
         assert!(
-            google
-                .token_fallback
-                .as_ref()
+            fallback
                 .and_then(|f| f.help.as_deref())
                 .is_some_and(|h| h.starts_with("https://")),
-            "an unconfigured build must let the user pivot to a pasted token, got: {:?}",
-            google.token_fallback
+            "an unconfigured build must let the user pivot to a pasted token, got: {fallback:?}"
         );
     }
 
@@ -1113,7 +1318,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "bundled connector catalog must be internally consistent")]
     fn parse_catalog_panics_on_a_credential_entry_missing_its_block() {
-        parse_catalog("connectors:\n  - id: x\n    authKind: credential\n");
+        parse_catalog(
+            "connectors:\n  - id: x\n    methods:\n      - id: api-key\n        kind: credential\n",
+        );
     }
 
     #[test]
@@ -1250,7 +1457,10 @@ mod tests {
     fn effective_connectors_drops_a_user_entry_that_shadows_a_bundled_id() {
         let mut shadow = sample_connector();
         shadow.id = "gitlab".into();
-        shadow.credential = Some(credential("EVIL", "lns-evil", "gitlab.com"));
+        shadow.methods = vec![SignInMethod::credential(
+            "api-key",
+            credential("EVIL", "lns-evil", "gitlab.com"),
+        )];
         let user = Catalog {
             connectors: vec![shadow],
         };
@@ -1262,7 +1472,7 @@ mod tests {
         );
         let gitlab = eff.iter().find(|i| i.id == "gitlab").unwrap();
         assert_ne!(
-            gitlab.credential.as_ref().unwrap().env_var,
+            gitlab.methods[0].credential.as_ref().unwrap().env_var,
             "EVIL",
             "the bundled gitlab definition must win over a user shadow"
         );

--- a/crates/lns-policy/src/connectors.yaml
+++ b/crates/lns-policy/src/connectors.yaml
@@ -1,157 +1,180 @@
 connectors:
   - id: gitlab
-    authKind: credential
     routes:
       - match: gitlab.com
-    credential:
-      envVar: GITLAB_TOKEN
-      placeholder: glpat-LNSPLACEHOLDER0000000000000000
-      injections:
-        - kind: api_key_header
-          domain: gitlab.com
-          header: PRIVATE-TOKEN
-        - kind: bearer_header
-          domain: gitlab.com
+    methods:
+      - id: token
+        kind: credential
+        credential:
+          envVar: GITLAB_TOKEN
+          placeholder: glpat-LNSPLACEHOLDER0000000000000000
+          injections:
+            - kind: api_key_header
+              domain: gitlab.com
+              header: PRIVATE-TOKEN
+            - kind: bearer_header
+              domain: gitlab.com
   - id: huggingface
-    authKind: credential
     routes:
       - match: huggingface.co
       - match: "*.huggingface.co"
-    credential:
-      envVar: HF_TOKEN
-      placeholder: hf_LNSPLACEHOLDER0000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: huggingface.co
+    methods:
+      - id: token
+        kind: credential
+        credential:
+          envVar: HF_TOKEN
+          placeholder: hf_LNSPLACEHOLDER0000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: huggingface.co
   - id: github
     name: GitHub
-    authKind: oauth
     routes:
       - match: api.github.com
       - match: github.com
-    oauth:
-      clientId: "${LNS_OAUTH_CLIENT_ID_GITHUB}"
-      scopes:
-        - repo
-        - read:org
-      deviceAuthorizationEndpoint: https://github.com/login/device/code
-      tokenEndpoint: https://github.com/login/oauth/access_token
-      userinfoEndpoint: https://api.github.com/user
-      accountField: login
-      envVar: GH_TOKEN
-      placeholder: gho_LNSPLACEHOLDER0000000000000000000000
-      injections:
-        - kind: token_header
-          domain: api.github.com
-        - kind: basic_x_access_token
-          domain: github.com
-    tokenFallback:
-      help: https://github.com/settings/personal-access-tokens/new
+    methods:
+      - id: device
+        name: Sign in with GitHub
+        kind: oauth
+        oauth:
+          clientId: "${LNS_OAUTH_CLIENT_ID_GITHUB}"
+          scopes:
+            - repo
+            - read:org
+          deviceAuthorizationEndpoint: https://github.com/login/device/code
+          tokenEndpoint: https://github.com/login/oauth/access_token
+          userinfoEndpoint: https://api.github.com/user
+          accountField: login
+          envVar: GH_TOKEN
+          placeholder: gho_LNSPLACEHOLDER0000000000000000000000
+          injections:
+            - kind: token_header
+              domain: api.github.com
+            - kind: basic_x_access_token
+              domain: github.com
+        tokenFallback:
+          help: https://github.com/settings/personal-access-tokens/new
   - id: google
     name: Google
-    authKind: oauth
     routes:
       - match: www.googleapis.com
-    oauth:
-      clientId: "${LNS_OAUTH_CLIENT_ID_GOOGLE}"
-      clientSecret: "${LNS_OAUTH_CLIENT_SECRET_GOOGLE}"
-      scopes:
-        - openid
-        - email
-        - profile
-      deviceAuthorizationEndpoint: https://oauth2.googleapis.com/device/code
-      tokenEndpoint: https://oauth2.googleapis.com/token
-      userinfoEndpoint: https://openidconnect.googleapis.com/v1/userinfo
-      accountField: email
-      envVar: GOOGLE_OAUTH_ACCESS_TOKEN
-      placeholder: ya29.LNSPLACEHOLDER000000000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: www.googleapis.com
-    tokenFallback:
-      help: https://developers.google.com/oauthplayground
+    methods:
+      - id: device
+        name: Sign in with Google
+        kind: oauth
+        oauth:
+          clientId: "${LNS_OAUTH_CLIENT_ID_GOOGLE}"
+          clientSecret: "${LNS_OAUTH_CLIENT_SECRET_GOOGLE}"
+          scopes:
+            - openid
+            - email
+            - profile
+          deviceAuthorizationEndpoint: https://oauth2.googleapis.com/device/code
+          tokenEndpoint: https://oauth2.googleapis.com/token
+          userinfoEndpoint: https://openidconnect.googleapis.com/v1/userinfo
+          accountField: email
+          envVar: GOOGLE_OAUTH_ACCESS_TOKEN
+          placeholder: ya29.LNSPLACEHOLDER000000000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: www.googleapis.com
+        tokenFallback:
+          help: https://developers.google.com/oauthplayground
   - id: openai
-    authKind: credential
     routes:
       - match: api.openai.com
-    credential:
-      envVar: OPENAI_API_KEY
-      placeholder: sk-LNSPLACEHOLDER0000000000000000000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: api.openai.com
+    methods:
+      - id: api-key
+        kind: credential
+        credential:
+          envVar: OPENAI_API_KEY
+          placeholder: sk-LNSPLACEHOLDER0000000000000000000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: api.openai.com
   - id: anthropic
-    authKind: credential
+    name: Anthropic
     routes:
       - match: api.anthropic.com
-    credential:
-      envVar: ANTHROPIC_API_KEY
-      placeholder: sk-ant-LNSPLACEHOLDER00000000000000000000000000000000000000000000000000000000000000000000000000
-      injections:
-        - kind: api_key_header
-          domain: api.anthropic.com
-          header: x-api-key
-        - kind: bearer_header
-          domain: api.anthropic.com
-  - id: claude-code-subscription
-    name: Claude Code (subscription)
-    authKind: credential
-    routes:
-      - match: api.anthropic.com
-    credential:
-      envVar: CLAUDE_CODE_OAUTH_TOKEN
-      placeholder: sk-ant-oat01-LNSPLACEHOLDER0000000000000000000000000000000000000000000000000000000000AA
-      injections:
-        - kind: bearer_header
-          domain: api.anthropic.com
-    tokenFallback:
-      command: claude setup-token
-      help: https://docs.claude.com/en/docs/claude-code/setup#long-lived-authentication-token
+    methods:
+      - id: api-key
+        name: API key
+        kind: credential
+        credential:
+          envVar: ANTHROPIC_API_KEY
+          placeholder: sk-ant-LNSPLACEHOLDER00000000000000000000000000000000000000000000000000000000000000000000000000
+          injections:
+            - kind: api_key_header
+              domain: api.anthropic.com
+              header: x-api-key
+            - kind: bearer_header
+              domain: api.anthropic.com
+      - id: claude-code-subscription
+        name: Claude Code (subscription)
+        kind: credential
+        credential:
+          envVar: CLAUDE_CODE_OAUTH_TOKEN
+          placeholder: sk-ant-oat01-LNSPLACEHOLDER0000000000000000000000000000000000000000000000000000000000AA
+          injections:
+            - kind: bearer_header
+              domain: api.anthropic.com
+        tokenFallback:
+          command: claude setup-token
+          help: https://docs.claude.com/en/docs/claude-code/setup#long-lived-authentication-token
   - id: bedrock
     name: Amazon Bedrock
-    authKind: credential
     routes:
       - match: bedrock-runtime.*.amazonaws.com
       - match: bedrock.*.amazonaws.com
-    credential:
-      envVar: AWS_BEARER_TOKEN_BEDROCK
-      placeholder: ABSKLNSPLACEHOLDER000000000000000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: bedrock-runtime.*.amazonaws.com
-        - kind: bearer_header
-          domain: bedrock.*.amazonaws.com
+    methods:
+      - id: bearer-token
+        kind: credential
+        credential:
+          envVar: AWS_BEARER_TOKEN_BEDROCK
+          placeholder: ABSKLNSPLACEHOLDER000000000000000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: bedrock-runtime.*.amazonaws.com
+            - kind: bearer_header
+              domain: bedrock.*.amazonaws.com
   - id: linear
-    authKind: credential
     routes:
       - match: api.linear.app
-    credential:
-      envVar: LINEAR_API_KEY
-      placeholder: lin_api_LNSPLACEHOLDER0000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: api.linear.app
+    methods:
+      - id: api-key
+        kind: credential
+        credential:
+          envVar: LINEAR_API_KEY
+          placeholder: lin_api_LNSPLACEHOLDER0000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: api.linear.app
   - id: telegram
-    authKind: credential
     routes:
       - match: api.telegram.org
-    credential:
-      envVar: TELEGRAM_BOT_TOKEN
-      placeholder: "0000000000:LNSPLACEHOLDER000000000000000000000"
-      injections:
-        - kind: uri_placeholder
-          domain: api.telegram.org
+    methods:
+      - id: bot-token
+        kind: credential
+        credential:
+          envVar: TELEGRAM_BOT_TOKEN
+          placeholder: "0000000000:LNSPLACEHOLDER000000000000000000000"
+          injections:
+            - kind: uri_placeholder
+              domain: api.telegram.org
   - id: openrouter
     name: OpenRouter
-    authKind: oauth
     routes:
       - match: openrouter.ai
-    oauth:
-      flow: pkce
-      authorizationEndpoint: https://openrouter.ai/auth
-      tokenEndpoint: https://openrouter.ai/api/v1/auth/keys
-      envVar: OPENROUTER_API_KEY
-      placeholder: sk-or-v1-LNSPLACEHOLDER0000000000000000000000000000000000000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: openrouter.ai
+    methods:
+      - id: pkce
+        name: Sign in with OpenRouter
+        kind: oauth
+        oauth:
+          flow: pkce
+          authorizationEndpoint: https://openrouter.ai/auth
+          tokenEndpoint: https://openrouter.ai/api/v1/auth/keys
+          envVar: OPENROUTER_API_KEY
+          placeholder: sk-or-v1-LNSPLACEHOLDER0000000000000000000000000000000000000000000000000000
+          injections:
+            - kind: bearer_header
+              domain: openrouter.ai

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -169,11 +169,14 @@ impl WorkloadGrantFile {
         before != self.grants.len()
     }
 
-    /// Forgets a project's grants for one connector and counts the forget, so a grant decided before it — by a run that is still deciding when the forget lands — can be recognized as stale and dropped instead of resurrecting what was just forgotten.
+    /// Forgets a project's grants for one connector — including those its individual sign-in methods hold — and counts the forget, so a grant decided before it — by a run that is still deciding when the forget lands — can be recognized as stale and dropped instead of resurrecting what was just forgotten.
     pub fn revoke_project_connector(&mut self, project: &str, connector: &str) -> usize {
         let before = self.grants.len();
-        self.grants
-            .retain(|g| !(g.project == project && g.connector == connector));
+        let method_prefix = format!("{connector}:");
+        self.grants.retain(|g| {
+            !(g.project == project
+                && (g.connector == connector || g.connector.starts_with(&method_prefix)))
+        });
         match self
             .revocations
             .iter_mut()
@@ -684,6 +687,36 @@ mod tests {
         assert!(
             file.lookup("/other", &def("/other"), "some-provider")
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn revoking_a_connector_also_drops_the_grants_its_sign_in_methods_hold() {
+        let mut file = WorkloadGrantFile::default();
+        file.upsert(GrantRecord::allow(
+            "/proj",
+            &def("/proj"),
+            "some-provider:api-key",
+            "SOME_TOKEN",
+            vec![],
+        ));
+        file.upsert(GrantRecord::allow(
+            "/proj",
+            &def("/proj"),
+            "some-provider-elsewhere",
+            "SOME_OTHER_TOKEN",
+            vec![],
+        ));
+
+        let removed = file.revoke_project_connector("/proj", "some-provider");
+        assert_eq!(
+            removed, 1,
+            "a method's grant is a grant for the connector, so revoking the connector must forget it too"
+        );
+        assert!(
+            file.lookup("/proj", &def("/proj"), "some-provider-elsewhere")
+                .is_some(),
+            "the prefix sweep must stop at the method separator, or it would forget an unrelated connector whose id merely starts the same"
         );
     }
 

--- a/crates/lns-service/examples/approval_preview.rs
+++ b/crates/lns-service/examples/approval_preview.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use eframe::egui;
 use lns_policy::connectors::TokenFallback;
 use lns_service::approval_flow::protocol::Treatment;
-use lns_service::approval_flow::session::PendingPrompt;
+use lns_service::approval_flow::session::{OfferMethodPrompt, OfferPrompt, PendingPrompt};
 use lns_service::approval_flow::window::{
     CredentialCardPrompt, SignInCard, Snapshot, StackItem, install_icon_font, install_system_fonts,
     lds_visuals, quiet_debug_overlays,
@@ -98,7 +98,7 @@ fn dismiss_card(snapshot: &mut Snapshot, action: &CardAction) {
     }
     let item = match action {
         CardAction::Decide { id, .. }
-        | CardAction::ConnectOffer { id }
+        | CardAction::ConnectOffer { id, .. }
         | CardAction::DeclineOffer { id }
         | CardAction::UseOfferToken { id, .. } => snapshot
             .pending
@@ -149,7 +149,6 @@ fn seed_one() -> Snapshot {
             host: "pypi.org".into(),
             action: "CONNECT pypi.org:443".into(),
             offer: None,
-            token_fallback: None,
             treatment: Treatment::Inspected,
         }],
         pending_credentials: vec![],
@@ -168,15 +167,21 @@ fn seed_all() -> Snapshot {
                 host: "pypi.org".into(),
                 action: "CONNECT pypi.org:443".into(),
                 offer: None,
-                token_fallback: None,
                 treatment: Treatment::Inspected,
             },
             PendingPrompt {
                 id: "net-offer".into(),
                 host: "openrouter.ai".into(),
                 action: "CONNECT openrouter.ai:443".into(),
-                offer: Some("OpenRouter".into()),
-                token_fallback: None,
+                offer: Some(OfferPrompt {
+                    connector_id: "openrouter".into(),
+                    display_name: "OpenRouter".into(),
+                    methods: vec![OfferMethodPrompt {
+                        id: "pkce".into(),
+                        display_name: "pkce".into(),
+                        token_fallback: None,
+                    }],
+                }),
                 treatment: Treatment::Inspected,
             },
         ],

--- a/crates/lns-service/src/approval_flow/notification.rs
+++ b/crates/lns-service/src/approval_flow/notification.rs
@@ -85,7 +85,6 @@ pub(crate) mod tests {
             host: host.into(),
             action: format!("CONNECT {host}:443"),
             offer: None,
-            token_fallback: None,
             treatment: Treatment::Inspected,
         }
     }
@@ -184,9 +183,13 @@ pub(crate) mod tests {
     fn connect_finished_clears_the_connecting_placeholder() {
         let (n, state, _rx) = fixture(false);
         let mut offer = prompt("r1", "api.some-oauth.example");
-        offer.offer = Some("GitHub".into());
+        offer.offer = Some(crate::approval_flow::session::OfferPrompt {
+            connector_id: "some-oauth".into(),
+            display_name: "GitHub".into(),
+            methods: Vec::new(),
+        });
         n.present(&offer);
-        state.connect_offer("r1");
+        state.connect_offer("r1", None);
         assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
         n.connect_finished("GitHub");
         assert!(
@@ -199,9 +202,13 @@ pub(crate) mod tests {
     fn clear_all_connecting_drops_every_placeholder() {
         let (n, state, _rx) = fixture(false);
         let mut offer = prompt("r1", "api.some-oauth.example");
-        offer.offer = Some("GitHub".into());
+        offer.offer = Some(crate::approval_flow::session::OfferPrompt {
+            connector_id: "some-oauth".into(),
+            display_name: "GitHub".into(),
+            methods: Vec::new(),
+        });
         n.present(&offer);
-        state.connect_offer("r1");
+        state.connect_offer("r1", None);
         assert_eq!(state.snapshot().connecting, vec!["GitHub".to_string()]);
         n.clear_all_connecting();
         assert!(state.snapshot().connecting.is_empty());

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -29,6 +29,9 @@ pub type ArmedReconciler = Box<dyn Fn(&[String]) + Send + Sync>;
 /// Strips the allows that belong to a connector this workload has not decided yet, so a reload can't hand back what the launch withheld.
 pub type PolicyWithholder = Box<dyn Fn(&Policy) -> Policy + Send + Sync>;
 
+/// The connected connectors this machine holds no sign-in for, so being listed in `connectors:` does not suppress their offer card.
+pub type UnchosenConnectors = Box<dyn Fn(&Policy) -> HashSet<String> + Send + Sync>;
+
 /// One way to sign in to an offered connector, paired with the per-machine store id that sign-in binds under.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OfferMethod {
@@ -187,6 +190,7 @@ pub struct ApprovalSession {
     /// Connectors this run has a standing no for, so a second request to the same domain is not offered again.
     declined: Mutex<HashSet<String>>,
     policy_withholder: OnceLock<PolicyWithholder>,
+    unchosen_connectors: OnceLock<UnchosenConnectors>,
     armed_reconciler: OnceLock<ArmedReconciler>,
     offerable: Vec<OfferableConnector>,
     connector: OnceLock<Arc<dyn ConnectPort>>,
@@ -220,6 +224,7 @@ impl ApprovalSession {
             connector_routes: OnceLock::new(),
             declined: Mutex::new(HashSet::new()),
             policy_withholder: OnceLock::new(),
+            unchosen_connectors: OnceLock::new(),
             armed_reconciler: OnceLock::new(),
             offerable: Vec::new(),
             connector: OnceLock::new(),
@@ -243,6 +248,11 @@ impl ApprovalSession {
     /// Installs the armed-reconciler once at boot so a watcher reload revokes a disconnected connector's arming; idempotent, the first wins.
     pub fn set_armed_reconciler(&self, reconciler: ArmedReconciler) {
         let _ = self.armed_reconciler.set(reconciler);
+    }
+
+    /// Installs the unchosen-connector lookup once at boot, so a connector connected mid-run with no sign-in held is still offered rather than silently allowed; idempotent, the first wins.
+    pub fn set_unchosen_connectors(&self, unchosen: UnchosenConnectors) {
+        let _ = self.unchosen_connectors.set(unchosen);
     }
 
     /// Installs the launch's withholder once at boot so every later reload re-applies it; idempotent, the first wins.
@@ -278,13 +288,15 @@ impl ApprovalSession {
     /// The offer to raise for `host`, or `None` when nothing matches or the connector is already connected — or declined — this run.
     fn offer_for(&self, host: &str) -> Option<OfferRef> {
         let integ = self.offer_for_host(host)?;
-        let already_connected = self
-            .policy
-            .lock()
-            .expect("policy mutex poisoned")
-            .connectors
-            .iter()
-            .any(|i| i == &integ.id);
+        let already_connected = {
+            let policy = self.policy.lock().expect("policy mutex poisoned");
+            policy.connectors.iter().any(|i| i == &integ.id)
+                // A connector no sign-in is held for cannot authenticate, so listing it must not suppress the card that asks which sign-in to use.
+                && !self
+                    .unchosen_connectors
+                    .get()
+                    .is_some_and(|unchosen| unchosen(&policy).contains(&integ.id))
+        };
         let already_declined = self
             .declined
             .lock()
@@ -2727,6 +2739,38 @@ pub(crate) mod tests {
             notifier.presented.lock().unwrap()[0].offer,
             None,
             "a connected connector is not re-offered"
+        );
+    }
+
+    #[test]
+    fn a_connected_connector_no_sign_in_is_held_for_is_still_offered() {
+        let mut policy = Policy::default();
+        policy.connect("some-provider");
+        let notifier = Arc::new(RecordingNotifier::default());
+        let store = Arc::new(CapturingStore::default());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let s = ApprovalSession::new(policy, notifier.clone(), store, tx, TEST_TIMEOUT)
+            .with_offers(vec![offerable_two_ways(
+                "some-provider",
+                "Some Provider",
+                "api.some-provider.example",
+            )]);
+        // A policy write connected it mid-run; no sign-in is held, so nothing seeds and no value card can fire.
+        s.set_unchosen_connectors(Box::new(|_policy| {
+            HashSet::from(["some-provider".to_string()])
+        }));
+
+        s.submit_pending(pending("r1", "api.some-provider.example"), Instant::now());
+
+        let presented = notifier.presented.lock().unwrap();
+        let offer = presented[0]
+            .offer
+            .as_ref()
+            .expect("a connector that cannot authenticate must still be offered");
+        assert_eq!(
+            offer.methods.len(),
+            2,
+            "the card must still ask which sign-in, or the user gets a plain destination prompt for a credential decision"
         );
     }
 

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -26,6 +26,9 @@ pub type ConnectorRouteDeriver = Box<dyn Fn(&[String]) -> Vec<RouteRule> + Send 
 /// Invoked on a policy reload with the reloaded connected-connector ids so the credential subsystem can revoke a disconnected connector's arming.
 pub type ArmedReconciler = Box<dyn Fn(&[String]) + Send + Sync>;
 
+/// Strips the allows that belong to a connector this workload has not decided yet, so a reload can't hand back what the launch withheld.
+pub type PolicyWithholder = Box<dyn Fn(&Policy) -> Policy + Send + Sync>;
+
 /// A connectable connector whose routes aren't allowed yet, so a held request to one of its `patterns` offers to connect it before the plain allow/deny.
 pub struct OfferableConnector {
     pub id: String,
@@ -42,6 +45,8 @@ pub trait ConnectPort: Send + Sync {
         id: &'a str,
         value: String,
     ) -> futures_util::future::BoxFuture<'a, bool>;
+    /// Remembers that this workload answered the connector's offer without taking it, so the next run stops asking.
+    fn decline(&self, id: &str);
 }
 
 pub trait Notifier: Send + Sync {
@@ -140,6 +145,9 @@ pub struct ApprovalSession {
     timeout: Duration,
     credentials_provider: OnceLock<CredentialsProvider>,
     connector_routes: OnceLock<ConnectorRouteDeriver>,
+    /// Connectors this run has a standing no for, so a second request to the same domain is not offered again.
+    declined: Mutex<HashSet<String>>,
+    policy_withholder: OnceLock<PolicyWithholder>,
     armed_reconciler: OnceLock<ArmedReconciler>,
     offerable: Vec<OfferableConnector>,
     connector: OnceLock<Arc<dyn ConnectPort>>,
@@ -171,6 +179,8 @@ impl ApprovalSession {
             timeout,
             credentials_provider: OnceLock::new(),
             connector_routes: OnceLock::new(),
+            declined: Mutex::new(HashSet::new()),
+            policy_withholder: OnceLock::new(),
             armed_reconciler: OnceLock::new(),
             offerable: Vec::new(),
             connector: OnceLock::new(),
@@ -194,6 +204,11 @@ impl ApprovalSession {
     /// Installs the armed-reconciler once at boot so a watcher reload revokes a disconnected connector's arming; idempotent, the first wins.
     pub fn set_armed_reconciler(&self, reconciler: ArmedReconciler) {
         let _ = self.armed_reconciler.set(reconciler);
+    }
+
+    /// Installs the launch's withholder once at boot so every later reload re-applies it; idempotent, the first wins.
+    pub fn set_policy_withholder(&self, withholder: PolicyWithholder) {
+        let _ = self.policy_withholder.set(withholder);
     }
 
     /// Installs the connector-route deriver once at boot so a watcher reload re-applies a connected connector's routes instead of dropping them; idempotent, the first wins.
@@ -221,7 +236,7 @@ impl ApprovalSession {
             .find(|i| i.patterns.iter().any(|p| domain_matches(p, host)))
     }
 
-    /// The (id, display name, token fallback) to offer for `host`, or `None` when nothing matches or the connector is already connected this run.
+    /// The (id, display name, token fallback) to offer for `host`, or `None` when nothing matches or the connector is already connected — or declined — this run.
     fn offer_id_and_name_for(&self, host: &str) -> Option<(String, String, Option<TokenFallback>)> {
         let integ = self.offer_for_host(host)?;
         let already_connected = self
@@ -231,7 +246,12 @@ impl ApprovalSession {
             .connectors
             .iter()
             .any(|i| i == &integ.id);
-        (!already_connected).then(|| {
+        let already_declined = self
+            .declined
+            .lock()
+            .expect("declined mutex poisoned")
+            .contains(&integ.id);
+        (!already_connected && !already_declined).then(|| {
             (
                 integ.id.clone(),
                 integ.display_name.clone(),
@@ -309,7 +329,23 @@ impl ApprovalSession {
         self.send_decision_frame(id, decision);
         self.persist_always_decision(&entry, decision);
         self.record_approval(&entry, decision);
+        self.decline_unanswered_offer(&entry, decision);
         DecisionOutcome::Resolved
+    }
+
+    /// An offer answered as a plain network decision is a no to the connector, so it becomes this workload's standing no rather than a question every run re-asks.
+    fn decline_unanswered_offer(&self, entry: &PendingEntry, decision: Decision) {
+        if decision == Decision::Timeout {
+            return;
+        }
+        let (Some(offer), Some(connector)) = (entry.offer.as_ref(), self.connector.get()) else {
+            return;
+        };
+        self.declined
+            .lock()
+            .expect("declined mutex poisoned")
+            .insert(offer.connector_id.clone());
+        connector.decline(&offer.connector_id);
     }
 
     /// Fails a held request because its card was closed: no rule, no audit line, and `Timeout` on the wire because a dismissal is the absence of a decision rather than a deny the developer picked.
@@ -540,6 +576,9 @@ impl ApprovalSession {
                 &mut new_policy.network.egress.http,
                 routes,
             );
+        }
+        if let Some(withhold) = self.policy_withholder.get() {
+            new_policy = withhold(&new_policy);
         }
         if let Some(reconcile) = self.armed_reconciler.get() {
             reconcile(&new_policy.connectors);
@@ -1697,6 +1736,37 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn apply_external_policy_still_withholds_an_undecided_connectors_allow() {
+        let (s, _n, _store, mut rx) = fixture();
+        s.set_policy_withholder(Box::new(|policy| {
+            let mut out = policy.clone();
+            out.network
+                .egress
+                .http
+                .retain(|r| r.match_pattern != "api.some-provider.example");
+            out
+        }));
+        let mut reloaded = Policy::default();
+        reloaded.add_rule(RouteRule::allow_host("api.some-provider.example"));
+
+        s.apply_external_policy(reloaded);
+
+        assert!(
+            s.current_policy().network.egress.http.is_empty(),
+            "a reload must not hand back the allow the launch withheld, or the offer is lost mid-run"
+        );
+        assert!(
+            policy_frame(&mut rx)
+                .network
+                .unwrap()
+                .egress
+                .http
+                .is_empty(),
+            "the guest must see the withheld policy too, not just the host copy"
+        );
+    }
+
+    #[test]
     fn apply_external_policy_re_derives_a_connected_connectors_routes() {
         let (s, _n, _store, mut rx) = fixture();
         s.set_connector_route_deriver(Box::new(|ids| {
@@ -1859,6 +1929,7 @@ pub(crate) mod tests {
         result: bool,
         connected: StdMutex<Vec<String>>,
         connected_with_token: StdMutex<Vec<(String, String)>>,
+        declined: StdMutex<Vec<String>>,
     }
 
     impl FakeConnector {
@@ -1867,6 +1938,7 @@ pub(crate) mod tests {
                 result,
                 connected: StdMutex::new(Vec::new()),
                 connected_with_token: StdMutex::new(Vec::new()),
+                declined: StdMutex::new(Vec::new()),
             }
         }
     }
@@ -1890,6 +1962,9 @@ pub(crate) mod tests {
                     .push((id.to_string(), value));
                 self.result
             })
+        }
+        fn decline(&self, id: &str) {
+            self.declined.lock().unwrap().push(id.to_string());
         }
     }
 
@@ -1943,6 +2018,81 @@ pub(crate) mod tests {
             n.presented.lock().unwrap()[0].offer.as_deref(),
             Some("GitHub"),
             "a held request to a connector domain offers to connect it"
+        );
+    }
+
+    #[test]
+    fn answering_an_offer_card_as_a_plain_network_decision_declines_the_connector() {
+        let connector = Arc::new(FakeConnector::new(false));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+        let id = n.presented.lock().unwrap()[0].id.clone();
+
+        s.record_decision(&id, Decision::AllowOnce);
+
+        assert_eq!(
+            connector.declined.lock().unwrap().as_slice(),
+            ["some-oauth"],
+            "letting the request through without taking the offer is a no to the connector, so the next run must not re-ask"
+        );
+    }
+
+    #[test]
+    fn a_declined_connector_is_not_offered_again_in_the_same_run() {
+        let connector = Arc::new(FakeConnector::new(false));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+        let first = n.presented.lock().unwrap()[0].id.clone();
+        s.record_decision(&first, Decision::AllowOnce);
+
+        s.submit_pending(pending("r2", "api.some-oauth.example"), Instant::now());
+
+        assert_eq!(
+            n.presented.lock().unwrap()[1].offer,
+            None,
+            "a standing no must silence the offer for the rest of the run, not re-ask on every request"
+        );
+    }
+
+    #[test]
+    fn closing_an_offer_card_declines_nothing() {
+        let connector = Arc::new(FakeConnector::new(false));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
+        let id = n.presented.lock().unwrap()[0].id.clone();
+
+        s.dismiss_request(&id);
+
+        assert!(
+            connector.declined.lock().unwrap().is_empty(),
+            "closing a card decides nothing, so it must not leave a standing no the developer never gave"
+        );
+    }
+
+    #[test]
+    fn a_decision_on_a_card_carrying_no_offer_declines_nothing() {
+        let connector = Arc::new(FakeConnector::new(false));
+        let (s, n, _rx) = offer_session(
+            vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.elsewhere.example"), Instant::now());
+        let id = n.presented.lock().unwrap()[0].id.clone();
+
+        s.record_decision(&id, Decision::AllowAlways);
+
+        assert!(
+            connector.declined.lock().unwrap().is_empty(),
+            "a plain destination card names no connector, so answering it must not decline one"
         );
     }
 

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -29,24 +29,33 @@ pub type ArmedReconciler = Box<dyn Fn(&[String]) + Send + Sync>;
 /// Strips the allows that belong to a connector this workload has not decided yet, so a reload can't hand back what the launch withheld.
 pub type PolicyWithholder = Box<dyn Fn(&Policy) -> Policy + Send + Sync>;
 
+/// One way to sign in to an offered connector, paired with the per-machine store id that sign-in binds under.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfferMethod {
+    pub method_id: String,
+    pub provider_id: String,
+    pub display_name: String,
+    pub token_fallback: Option<TokenFallback>,
+}
+
 /// A connectable connector whose routes aren't allowed yet, so a held request to one of its `patterns` offers to connect it before the plain allow/deny.
 pub struct OfferableConnector {
     pub id: String,
     pub display_name: String,
     pub patterns: Vec<String>,
-    pub token_fallback: Option<TokenFallback>,
+    pub methods: Vec<OfferMethod>,
 }
 
 /// Connects a connector interactively and reports whether it is now connected; injected so the approval flow can offer a connect without owning the credential machinery. `connect_with_token` arms a pasted token instead of running the interactive sign-in.
 pub trait ConnectPort: Send + Sync {
-    fn connect<'a>(&'a self, id: &'a str) -> futures_util::future::BoxFuture<'a, bool>;
+    fn connect<'a>(&'a self, provider: &'a str) -> futures_util::future::BoxFuture<'a, bool>;
     fn connect_with_token<'a>(
         &'a self,
-        id: &'a str,
+        provider: &'a str,
         value: String,
     ) -> futures_util::future::BoxFuture<'a, bool>;
     /// Remembers that this workload answered the connector's offer without taking it, so the next run stops asking.
-    fn decline(&self, id: &str);
+    fn decline(&self, connector: &str);
 }
 
 pub trait Notifier: Send + Sync {
@@ -62,15 +71,30 @@ pub trait Notifier: Send + Sync {
     fn clear_all_connecting(&self) {}
 }
 
+/// One sign-in the offer card can pick, named as the user sees it. The card never learns the store id behind it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfferMethodPrompt {
+    pub id: String,
+    pub display_name: String,
+    /// Some when this sign-in declares a token fallback, so the card can also reveal "use a token instead".
+    pub token_fallback: Option<TokenFallback>,
+}
+
+/// The connect offer a held request carries: which connector claims the host, and the ways in the user can pick between.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfferPrompt {
+    pub connector_id: String,
+    pub display_name: String,
+    pub methods: Vec<OfferMethodPrompt>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingPrompt {
     pub id: String,
     pub host: String,
     pub action: String,
-    /// Some(display name) when `host` matches a connectable connector, so the card offers to connect it before the plain allow/deny.
-    pub offer: Option<String>,
-    /// Some when the offered connector declares a token fallback, so the offer card can also reveal "use a token instead".
-    pub token_fallback: Option<TokenFallback>,
+    /// Some when `host` matches a connectable connector, so the card offers to connect it before the plain allow/deny.
+    pub offer: Option<OfferPrompt>,
     /// `Raw` when approving splices the connection through unread, which the card has to say out loud.
     pub treatment: Treatment,
 }
@@ -134,6 +158,21 @@ impl PendingEntry {
 struct OfferRef {
     connector_id: String,
     display_name: String,
+    methods: Vec<OfferMethod>,
+}
+
+impl OfferRef {
+    /// The store id the chosen sign-in binds under: the named method, or the only one when the card had no choice to present.
+    fn provider_for(&self, method: Option<&str>) -> Option<&str> {
+        match method {
+            Some(id) => self.methods.iter().find(|m| m.method_id == id),
+            None => match self.methods.as_slice() {
+                [only] => Some(only),
+                _ => None,
+            },
+        }
+        .map(|m| m.provider_id.as_str())
+    }
 }
 
 pub struct ApprovalSession {
@@ -236,8 +275,8 @@ impl ApprovalSession {
             .find(|i| i.patterns.iter().any(|p| domain_matches(p, host)))
     }
 
-    /// The (id, display name, token fallback) to offer for `host`, or `None` when nothing matches or the connector is already connected — or declined — this run.
-    fn offer_id_and_name_for(&self, host: &str) -> Option<(String, String, Option<TokenFallback>)> {
+    /// The offer to raise for `host`, or `None` when nothing matches or the connector is already connected — or declined — this run.
+    fn offer_for(&self, host: &str) -> Option<OfferRef> {
         let integ = self.offer_for_host(host)?;
         let already_connected = self
             .policy
@@ -251,12 +290,10 @@ impl ApprovalSession {
             .lock()
             .expect("declined mutex poisoned")
             .contains(&integ.id);
-        (!already_connected && !already_declined).then(|| {
-            (
-                integ.id.clone(),
-                integ.display_name.clone(),
-                integ.token_fallback.clone(),
-            )
+        (!already_connected && !already_declined).then(|| OfferRef {
+            connector_id: integ.id.clone(),
+            display_name: integ.display_name.clone(),
+            methods: integ.methods.clone(),
         })
     }
 
@@ -277,13 +314,9 @@ impl ApprovalSession {
 
     pub fn submit_pending(&self, req: RequestPending, now: Instant) {
         // Connecting a connector arms credential injection, which an opaque splice can never carry — and the offer card has no room for the RAW disclosure.
-        let matched = (req.treatment == Treatment::Inspected)
-            .then(|| self.offer_id_and_name_for(&req.host))
+        let offer_ref = (req.treatment == Treatment::Inspected)
+            .then(|| self.offer_for(&req.host))
             .flatten();
-        let offer_ref = matched.as_ref().map(|(id, name, _)| OfferRef {
-            connector_id: id.clone(),
-            display_name: name.clone(),
-        });
         // While a connect for this connector is in flight, hold the request silently and let that connect's batch release it — a fresh offer card would only cover the sign-in card.
         let coalesced = offer_ref
             .as_ref()
@@ -299,7 +332,7 @@ impl ApprovalSession {
                 action: req.action.clone(),
                 treatment: req.treatment,
                 deadline: now + self.timeout,
-                offer: offer_ref,
+                offer: offer_ref.clone(),
                 reason: req.reason.clone(),
             },
         );
@@ -307,16 +340,12 @@ impl ApprovalSession {
         if coalesced {
             return;
         }
-        let (offer, token_fallback) = match matched {
-            Some((_, name, fallback)) => (Some(name), fallback),
-            None => (None, None),
-        };
+        let offer = offer_ref;
         self.notifier.present(&PendingPrompt {
             id: req.id,
             host: req.host,
             action: req.action,
-            offer,
-            token_fallback,
+            offer: offer.map(offer_prompt),
             treatment: req.treatment,
         });
     }
@@ -432,18 +461,32 @@ impl ApprovalSession {
     }
 
     /// Accepts a held request's connector offer via the interactive connect (oauth sign-in or a straight credential connect). See [`Self::connect_offer_with`].
-    pub async fn connect_offer(&self, id: &str) -> DecisionOutcome {
-        self.connect_offer_with(id, None).await
+    pub async fn connect_offer(&self, id: &str, method: Option<&str>) -> DecisionOutcome {
+        self.connect_offer_with(id, method, None).await
     }
 
     /// Accepts a held request's connector offer by arming a pasted token instead of the interactive connect. See [`Self::connect_offer_with`].
-    pub async fn connect_offer_with_token(&self, id: &str, value: String) -> DecisionOutcome {
-        self.connect_offer_with(id, Some(value)).await
+    pub async fn connect_offer_with_token(
+        &self,
+        id: &str,
+        method: Option<&str>,
+        value: String,
+    ) -> DecisionOutcome {
+        self.connect_offer_with(id, method, Some(value)).await
     }
 
     /// Drives one connect for the offered connector and releases **every** held request for it — allow-once on success, deny-once closed on failure or a missing connector. A second card for the same connector coalesces onto the in-flight connect instead of starting another. `token` selects the pasted-token connect over the interactive one.
-    async fn connect_offer_with(&self, id: &str, token: Option<String>) -> DecisionOutcome {
+    async fn connect_offer_with(
+        &self,
+        id: &str,
+        method: Option<&str>,
+        token: Option<String>,
+    ) -> DecisionOutcome {
         let Some(offer) = self.offer_of(id) else {
+            return DecisionOutcome::UnknownId;
+        };
+        // A card that presented a choice must name one; without a provider there is nothing to bind, and guessing would pick a sign-in the user does not hold.
+        let Some(provider) = offer.provider_for(method).map(str::to_string) else {
             return DecisionOutcome::UnknownId;
         };
         if !self.begin_connecting(&offer.connector_id) {
@@ -457,12 +500,8 @@ impl ApprovalSession {
         }
         let connected = match self.connector.get() {
             Some(connector) => match token {
-                Some(value) => {
-                    connector
-                        .connect_with_token(&offer.connector_id, value)
-                        .await
-                }
-                None => connector.connect(&offer.connector_id).await,
+                Some(value) => connector.connect_with_token(&provider, value).await,
+                None => connector.connect(&provider).await,
             },
             None => false,
         };
@@ -711,6 +750,23 @@ impl ApprovalSession {
             self.notifier.dismiss(&request_id);
             self.send_decision_frame(&request_id, Decision::AllowOnce);
         }
+    }
+}
+
+/// The card's view of an offer: the sign-ins by the names the user reads, with the store ids left behind.
+fn offer_prompt(offer: OfferRef) -> OfferPrompt {
+    OfferPrompt {
+        connector_id: offer.connector_id,
+        display_name: offer.display_name,
+        methods: offer
+            .methods
+            .into_iter()
+            .map(|m| OfferMethodPrompt {
+                id: m.method_id,
+                display_name: m.display_name,
+                token_fallback: m.token_fallback,
+            })
+            .collect(),
     }
 }
 
@@ -1890,6 +1946,94 @@ pub(crate) mod tests {
         assert_eq!(deny.verdict, Verdict::Deny);
     }
 
+    #[tokio::test]
+    async fn an_offer_for_a_connector_reachable_two_ways_asks_which_sign_in() {
+        let (s, n, _rx) = offer_session(
+            vec![offerable_two_ways(
+                "some-provider",
+                "Some Provider",
+                "api.some-provider.example",
+            )],
+            None,
+        );
+        s.submit_pending(pending("r1", "api.some-provider.example"), Instant::now());
+
+        let presented = n.presented.lock().unwrap();
+        let offer = presented[0].offer.as_ref().expect("an offer");
+        assert_eq!(
+            offer
+                .methods
+                .iter()
+                .map(|m| m.display_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["API key", "Subscription"],
+            "the card must name every way in, or it would pick a sign-in the user may not hold"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepting_a_named_sign_in_connects_that_sign_ins_own_binding() {
+        let connector = Arc::new(FakeConnector::new(true));
+        let (s, _n, _rx) = offer_session(
+            vec![offerable_two_ways(
+                "some-provider",
+                "Some Provider",
+                "api.some-provider.example",
+            )],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-provider.example"), Instant::now());
+
+        s.connect_offer("r1", Some("subscription")).await;
+
+        assert_eq!(
+            connector.connected.lock().unwrap().as_slice(),
+            &["some-provider:subscription".to_string()],
+            "the sign-in the user picked is what binds, so the connect must name its own key rather than the connector's"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepting_an_offer_that_presented_a_choice_without_naming_one_binds_nothing() {
+        let connector = Arc::new(FakeConnector::new(true));
+        let (s, _n, _rx) = offer_session(
+            vec![offerable_two_ways(
+                "some-provider",
+                "Some Provider",
+                "api.some-provider.example",
+            )],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-provider.example"), Instant::now());
+
+        assert_eq!(
+            s.connect_offer("r1", None).await,
+            DecisionOutcome::UnknownId,
+            "guessing a sign-in would bind a credential the user never chose"
+        );
+        assert!(connector.connected.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn accepting_an_offer_naming_a_sign_in_the_catalog_dropped_binds_nothing() {
+        let connector = Arc::new(FakeConnector::new(true));
+        let (s, _n, _rx) = offer_session(
+            vec![offerable_two_ways(
+                "some-provider",
+                "Some Provider",
+                "api.some-provider.example",
+            )],
+            Some(connector.clone()),
+        );
+        s.submit_pending(pending("r1", "api.some-provider.example"), Instant::now());
+
+        assert_eq!(
+            s.connect_offer("r1", Some("no-longer-offered")).await,
+            DecisionOutcome::UnknownId
+        );
+        assert!(connector.connected.lock().unwrap().is_empty());
+    }
+
     #[test]
     fn connect_connector_persists_only_the_id_but_emits_the_route_live() {
         let (s, _n, store, mut rx) = fixture();
@@ -1973,18 +2117,42 @@ pub(crate) mod tests {
             id: id.into(),
             display_name: name.into(),
             patterns: vec![pattern.into()],
-            token_fallback: None,
+            methods: vec![OfferMethod {
+                method_id: "token".into(),
+                provider_id: id.into(),
+                display_name: "token".into(),
+                token_fallback: None,
+            }],
         }
     }
 
     fn offerable_with_fallback(id: &str, name: &str, pattern: &str) -> OfferableConnector {
-        OfferableConnector {
-            token_fallback: Some(TokenFallback {
-                help: Some("https://example.com/pat".into()),
-                command: None,
-            }),
-            ..offerable(id, name, pattern)
-        }
+        let mut out = offerable(id, name, pattern);
+        out.methods[0].token_fallback = Some(TokenFallback {
+            help: Some("https://example.com/pat".into()),
+            command: None,
+        });
+        out
+    }
+
+    /// A connector reachable two ways, so the card must ask which sign-in the user holds.
+    fn offerable_two_ways(id: &str, name: &str, pattern: &str) -> OfferableConnector {
+        let mut out = offerable(id, name, pattern);
+        out.methods = vec![
+            OfferMethod {
+                method_id: "api-key".into(),
+                provider_id: format!("{id}:api-key"),
+                display_name: "API key".into(),
+                token_fallback: None,
+            },
+            OfferMethod {
+                method_id: "subscription".into(),
+                provider_id: format!("{id}:subscription"),
+                display_name: "Subscription".into(),
+                token_fallback: None,
+            },
+        ];
+        out
     }
 
     fn offer_session(
@@ -2015,7 +2183,10 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
         assert_eq!(
-            n.presented.lock().unwrap()[0].offer.as_deref(),
+            n.presented.lock().unwrap()[0]
+                .offer
+                .as_ref()
+                .map(|o| o.display_name.as_str()),
             Some("GitHub"),
             "a held request to a connector domain offers to connect it"
         );
@@ -2169,9 +2340,15 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
         let presented = n.presented.lock().unwrap();
-        assert_eq!(presented[0].offer.as_deref(), Some("GitHub"));
         assert_eq!(
-            presented[0].token_fallback,
+            presented[0].offer.as_ref().map(|o| o.display_name.as_str()),
+            Some("GitHub")
+        );
+        assert_eq!(
+            presented[0]
+                .offer
+                .as_ref()
+                .and_then(|o| o.methods[0].token_fallback.clone()),
             Some(TokenFallback {
                 help: Some("https://example.com/pat".into()),
                 command: None,
@@ -2187,7 +2364,13 @@ pub(crate) mod tests {
             None,
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
-        assert_eq!(n.presented.lock().unwrap()[0].token_fallback, None);
+        assert_eq!(
+            n.presented.lock().unwrap()[0]
+                .offer
+                .as_ref()
+                .and_then(|o| o.methods[0].token_fallback.clone()),
+            None
+        );
     }
 
     #[tokio::test]
@@ -2205,7 +2388,7 @@ pub(crate) mod tests {
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
         let outcome = s
-            .connect_offer_with_token("r1", "some-pasted-token".into())
+            .connect_offer_with_token("r1", None, "some-pasted-token".into())
             .await;
 
         assert_eq!(outcome, DecisionOutcome::Resolved);
@@ -2228,7 +2411,7 @@ pub(crate) mod tests {
         let (s, _n, _rx) = offer_session(vec![], Some(connector.clone()));
         s.submit_pending(pending("r1", "example.com"), Instant::now());
         assert_eq!(
-            s.connect_offer_with_token("r1", "some-pasted-token".into())
+            s.connect_offer_with_token("r1", None, "some-pasted-token".into())
                 .await,
             DecisionOutcome::UnknownId
         );
@@ -2244,7 +2427,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        let outcome = s.connect_offer("r1").await;
+        let outcome = s.connect_offer("r1", None).await;
 
         assert_eq!(outcome, DecisionOutcome::Resolved);
         assert_eq!(
@@ -2265,7 +2448,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(
             decision_frame(&mut rx).decision,
@@ -2282,7 +2465,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(decision_frame(&mut rx).decision, Decision::DenyOnce);
     }
@@ -2298,7 +2481,7 @@ pub(crate) mod tests {
         s.set_ledger_recorder(recorder.clone());
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         let events = recorder.events.lock().unwrap();
         assert_eq!(
@@ -2324,7 +2507,7 @@ pub(crate) mod tests {
         s.set_ledger_recorder(recorder.clone());
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         let events = recorder.events.lock().unwrap();
         assert_eq!(
@@ -2345,7 +2528,10 @@ pub(crate) mod tests {
         let (s, _n, mut rx) = offer_session(vec![], Some(connector.clone()));
         s.submit_pending(pending("r1", "example.com"), Instant::now());
 
-        assert_eq!(s.connect_offer("r1").await, DecisionOutcome::UnknownId);
+        assert_eq!(
+            s.connect_offer("r1", None).await,
+            DecisionOutcome::UnknownId
+        );
         assert!(
             connector.connected.lock().unwrap().is_empty(),
             "a plain network request must not be treated as an offer"
@@ -2362,7 +2548,10 @@ pub(crate) mod tests {
             vec![offerable("some-oauth", "GitHub", "api.some-oauth.example")],
             None,
         );
-        assert_eq!(s.connect_offer("never").await, DecisionOutcome::UnknownId);
+        assert_eq!(
+            s.connect_offer("never", None).await,
+            DecisionOutcome::UnknownId
+        );
     }
 
     #[tokio::test]
@@ -2375,7 +2564,7 @@ pub(crate) mod tests {
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
         s.submit_pending(pending("r2", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(
             connector.connected.lock().unwrap().as_slice(),
@@ -2406,7 +2595,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(
             n.connects_finished.lock().unwrap().as_slice(),
@@ -2424,7 +2613,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(
             n.connects_finished.lock().unwrap().as_slice(),
@@ -2441,7 +2630,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer("r1").await;
+        s.connect_offer("r1", None).await;
 
         assert_eq!(
             n.connects_finished.lock().unwrap().as_slice(),
@@ -2462,7 +2651,7 @@ pub(crate) mod tests {
         );
         s.submit_pending(pending("r1", "api.some-oauth.example"), Instant::now());
 
-        s.connect_offer_with_token("r1", "some-pasted-token".into())
+        s.connect_offer_with_token("r1", None, "some-pasted-token".into())
             .await;
 
         assert_eq!(
@@ -2500,7 +2689,7 @@ pub(crate) mod tests {
         s.begin_connecting("some-oauth");
         s.submit_pending(pending("r2", "api.some-oauth.example"), Instant::now());
 
-        let outcome = s.connect_offer("r2").await;
+        let outcome = s.connect_offer("r2", None).await;
 
         assert_eq!(outcome, DecisionOutcome::Resolved);
         assert!(

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -621,16 +621,23 @@ impl ApprovalSession {
         if let Some(floor) = self.policy_floor.get() {
             new_policy = crate::artifact::policy::merge_effective(Some(floor), &new_policy);
         }
-        if let Some(derive) = self.connector_routes.get() {
-            let routes = derive(&new_policy.connectors);
-            crate::artifact::policy::splice_connector_routes(
-                &mut new_policy.network.egress.http,
-                routes,
-            );
-        }
-        if let Some(withhold) = self.policy_withholder.get() {
-            new_policy = withhold(&new_policy);
-        }
+        let routes = self
+            .connector_routes
+            .get()
+            .map(|derive| derive(&new_policy.connectors))
+            .unwrap_or_default();
+        new_policy = match self.policy_withholder.get() {
+            Some(withhold) => {
+                crate::artifact::policy::compose_running_policy(&new_policy, routes, withhold)
+            }
+            None => {
+                crate::artifact::policy::splice_connector_routes(
+                    &mut new_policy.network.egress.http,
+                    routes,
+                );
+                new_policy
+            }
+        };
         if let Some(reconcile) = self.armed_reconciler.get() {
             reconcile(&new_policy.connectors);
         }

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -24,8 +24,12 @@ pub enum RequestAction {
     Decide(Decision),
     /// A closed card: fail the held request, but record nothing — the developer made no decision.
     Dismiss,
-    ConnectConnector,
+    /// `method` names the sign-in the user picked; `None` where the connector had only one to offer.
+    ConnectConnector {
+        method: Option<String>,
+    },
     UseToken {
+        method: Option<String>,
         value: String,
     },
 }
@@ -342,13 +346,13 @@ impl WindowState {
     }
 
     /// Accepts the connector offer via its interactive connect (browser sign-in or straight credential connect). See [`Self::route_offer`].
-    pub fn connect_offer(&self, id: &str) -> bool {
-        self.route_offer(id, RequestAction::ConnectConnector)
+    pub fn connect_offer(&self, id: &str, method: Option<String>) -> bool {
+        self.route_offer(id, RequestAction::ConnectConnector { method })
     }
 
     /// Accepts the connector offer by connecting it with a pasted token. See [`Self::route_offer`].
-    pub fn use_offer_token(&self, id: &str, value: String) -> bool {
-        self.route_offer(id, RequestAction::UseToken { value })
+    pub fn use_offer_token(&self, id: &str, method: Option<String>, value: String) -> bool {
+        self.route_offer(id, RequestAction::UseToken { method, value })
     }
 
     /// Routes one connect action for the clicked request and immediately drops every other offer card for the same connector, so no sibling card flashes up before the in-flight connect releases them all. The clicked card's slot is kept by a connecting placeholder until the connect resolves.
@@ -363,11 +367,13 @@ impl WindowState {
             id: id.to_string(),
             action,
         });
-        if let Some(name) = offer {
-            g.pending
-                .retain(|e| e.prompt.offer.as_deref() != Some(name.as_str()));
+        if let Some(offer) = offer {
+            g.pending.retain(|e| {
+                e.prompt.offer.as_ref().map(|o| o.connector_id.as_str())
+                    != Some(offer.connector_id.as_str())
+            });
             g.connecting.push(ConnectingEntry {
-                display_name: name,
+                display_name: offer.display_name,
                 seq: entry.seq,
             });
         }
@@ -390,19 +396,21 @@ impl WindowState {
     /// Declines the connector offer: clears the offer on every held request for that connector so each falls back to the plain allow/deny (rather than re-offering via a sibling card) without resolving them; returns whether an offer was present to clear.
     pub fn decline_offer(&self, id: &str) -> bool {
         let mut g = self.lock();
-        let Some(name) = g
+        let Some(connector_id) = g
             .pending
             .iter()
             .find(|e| e.prompt.id == id)
-            .and_then(|e| e.prompt.offer.clone())
+            .and_then(|e| e.prompt.offer.as_ref())
+            .map(|o| o.connector_id.clone())
         else {
             return false;
         };
-        for entry in g
-            .pending
-            .iter_mut()
-            .filter(|e| e.prompt.offer.as_deref() == Some(name.as_str()))
-        {
+        for entry in g.pending.iter_mut().filter(|e| {
+            e.prompt
+                .offer
+                .as_ref()
+                .is_some_and(|o| o.connector_id == connector_id)
+        }) {
             entry.prompt.offer = None;
         }
         true
@@ -642,18 +650,17 @@ mod tests {
             host: host.into(),
             action: format!("CONNECT {host}:443"),
             offer: None,
-            token_fallback: None,
             treatment: Treatment::Inspected,
         }
     }
 
     fn cred_prompt(id: &str, credential_id: &str) -> CredentialPendingPrompt {
         CredentialPendingPrompt {
+            token_fallback: None,
             id: id.into(),
             credential_id: credential_id.into(),
             action: format!("use of {credential_id} placeholder"),
             oauth_display_name: None,
-            token_fallback: None,
             env_var: None,
             injection_domains: vec![],
             is_project_defined: false,
@@ -817,8 +824,11 @@ mod tests {
             id: id.into(),
             host: host.into(),
             action: format!("CONNECT {host}:443"),
-            offer: Some(name.into()),
-            token_fallback: None,
+            offer: Some(crate::approval_flow::session::OfferPrompt {
+                connector_id: name.into(),
+                display_name: name.into(),
+                methods: Vec::new(),
+            }),
             treatment: Treatment::Inspected,
         }
     }
@@ -828,11 +838,11 @@ mod tests {
         let s = WindowState::new();
         let (tx, mut rx) = unbounded_channel();
         s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
-        assert!(s.connect_offer("r1"));
+        assert!(s.connect_offer("r1", None));
         assert_eq!(s.pending_count(), 0, "accepting the offer clears the card");
         let got = rx.try_recv().expect("delivery");
         assert_eq!(got.id, "r1");
-        assert_eq!(got.action, RequestAction::ConnectConnector);
+        assert_eq!(got.action, RequestAction::ConnectConnector { method: None });
     }
 
     #[test]
@@ -844,7 +854,7 @@ mod tests {
             tx.clone(),
         );
         s.insert_pending(offer_prompt("r2", "api.some-oauth.example", "GitHub"), tx);
-        assert!(s.connect_offer("r1"));
+        assert!(s.connect_offer("r1", None));
         assert_eq!(
             s.pending_count(),
             0,
@@ -852,7 +862,7 @@ mod tests {
         );
         let got = rx.try_recv().expect("delivery");
         assert_eq!(got.id, "r1");
-        assert_eq!(got.action, RequestAction::ConnectConnector);
+        assert_eq!(got.action, RequestAction::ConnectConnector { method: None });
         assert!(
             rx.try_recv().is_err(),
             "only one connect is routed; the in-flight connect releases the siblings"
@@ -868,7 +878,7 @@ mod tests {
             tx.clone(),
         );
         s.insert_pending(prompt("r2", "example.com"), tx);
-        assert!(s.connect_offer("r1"));
+        assert!(s.connect_offer("r1", None));
         let snap = s.snapshot();
         assert_eq!(snap.pending.len(), 1);
         assert_eq!(
@@ -882,7 +892,7 @@ mod tests {
         let s = WindowState::new();
         let (tx, mut rx) = unbounded_channel();
         s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
-        assert!(!s.connect_offer("nope"));
+        assert!(!s.connect_offer("nope", None));
         assert!(rx.try_recv().is_err());
     }
 
@@ -895,7 +905,7 @@ mod tests {
             tx.clone(),
         );
         s.insert_pending(offer_prompt("r2", "api.some-oauth.example", "GitHub"), tx);
-        assert!(s.use_offer_token("r1", "some-pasted-token".into()));
+        assert!(s.use_offer_token("r1", None, "some-pasted-token".into()));
         assert_eq!(
             s.pending_count(),
             0,
@@ -906,6 +916,7 @@ mod tests {
         assert_eq!(
             got.action,
             RequestAction::UseToken {
+                method: None,
                 value: "some-pasted-token".into()
             }
         );
@@ -917,7 +928,7 @@ mod tests {
         let s = WindowState::new();
         let (tx, mut rx) = unbounded_channel();
         s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
-        assert!(!s.use_offer_token("nope", "some-pasted-token".into()));
+        assert!(!s.use_offer_token("nope", None, "some-pasted-token".into()));
         assert!(rx.try_recv().is_err());
     }
 
@@ -1134,11 +1145,11 @@ mod tests {
 
     fn sign_in_card(credential_id: &str) -> SignInCard {
         SignInCard {
+            token_fallback: None,
             credential_id: credential_id.into(),
             display_name: "GitHub".into(),
             user_code: Some("WXYZ-1234".into()),
             verification_uri: "https://some-oauth.example/login/device".into(),
-            token_fallback: None,
             env_var: None,
             injection_domains: vec![],
             is_project_defined: false,
@@ -1245,7 +1256,7 @@ mod tests {
             tx.clone(),
         );
         s.insert_pending(prompt("r2", "example.com"), tx);
-        assert!(s.connect_offer("r1"));
+        assert!(s.connect_offer("r1", None));
         let snap = s.snapshot();
         assert_eq!(snap.connecting, vec!["GitHub".to_string()]);
         assert_eq!(
@@ -1260,7 +1271,7 @@ mod tests {
         let s = WindowState::new();
         let (tx, _rx) = unbounded_channel();
         s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
-        assert!(s.use_offer_token("r1", "some-pasted-token".into()));
+        assert!(s.use_offer_token("r1", None, "some-pasted-token".into()));
         assert_eq!(s.snapshot().connecting, vec!["GitHub".to_string()]);
     }
 
@@ -1282,7 +1293,7 @@ mod tests {
             tx.clone(),
         );
         s.insert_pending(prompt("r2", "example.com"), tx);
-        s.connect_offer("r1");
+        s.connect_offer("r1", None);
         let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
         s.insert_sign_in(sign_in_card("some-oauth"), cancel_tx);
         let snap = s.snapshot();
@@ -1322,8 +1333,8 @@ mod tests {
             offer_prompt("r2", "api.other-oauth.example", "Other Service"),
             tx,
         );
-        s.connect_offer("r1");
-        s.connect_offer("r2");
+        s.connect_offer("r1", None);
+        s.connect_offer("r2", None);
         s.clear_connecting("GitHub");
         assert_eq!(s.snapshot().connecting, vec!["Other Service".to_string()]);
     }
@@ -1333,7 +1344,7 @@ mod tests {
         let s = WindowState::new();
         let (tx, _rx) = unbounded_channel();
         s.insert_pending(offer_prompt("r1", "api.some-oauth.example", "GitHub"), tx);
-        s.connect_offer("r1");
+        s.connect_offer("r1", None);
         s.clear_connecting("Other Service");
         assert_eq!(s.snapshot().connecting, vec!["GitHub".to_string()]);
     }
@@ -1350,8 +1361,8 @@ mod tests {
             offer_prompt("r2", "api.other-oauth.example", "Other Service"),
             tx,
         );
-        s.connect_offer("r1");
-        s.connect_offer("r2");
+        s.connect_offer("r1", None);
+        s.connect_offer("r2", None);
         s.clear_all_connecting();
         assert!(
             s.snapshot().connecting.is_empty(),
@@ -1361,11 +1372,11 @@ mod tests {
 
     fn oauth_cred_prompt(id: &str, name: &str) -> CredentialPendingPrompt {
         CredentialPendingPrompt {
+            token_fallback: None,
             id: id.into(),
             credential_id: "some-oauth".into(),
             action: "use of some-oauth placeholder".into(),
             oauth_display_name: Some(name.into()),
-            token_fallback: None,
             env_var: None,
             injection_domains: vec![],
             is_project_defined: false,

--- a/crates/lns-service/src/artifact/credential_boot.rs
+++ b/crates/lns-service/src/artifact/credential_boot.rs
@@ -50,12 +50,13 @@ pub fn plan_declared_connectors(
         .iter()
         .filter_map(|id| catalog.iter().find(|integ| &integ.id == id))
         .map(|integ| {
-            let (env, placeholder) = match (&integ.oauth, &integ.credential) {
-                (Some(o), _) => (o.env_var.clone(), o.placeholder.clone()),
-                (None, Some(c)) => (c.env_var.clone(), c.placeholder.clone()),
-                (None, None) => (String::new(), String::new()),
-            };
-            if integ.auth_kind == AuthKind::Oauth && !has_armed_entry(state, &integ.id) {
+            let method = integ.default_method();
+            let env = method.map(|m| m.env_var().to_string()).unwrap_or_default();
+            let placeholder = method
+                .map(|m| m.placeholder().to_string())
+                .unwrap_or_default();
+            let signs_in = method.is_some_and(|m| m.kind == AuthKind::Oauth);
+            if signs_in && !has_armed_entry(state, &integ.id) {
                 SlotPlan::Connect(ConnectPrompt {
                     connector: integ.id.clone(),
                     env,
@@ -155,7 +156,10 @@ pub fn gate_required_slots(
         let Some(integ) = catalog.iter().find(|i| i.id == slot.name) else {
             continue;
         };
-        if integ.auth_kind == AuthKind::Oauth {
+        if integ
+            .default_method()
+            .is_some_and(|m| m.kind == AuthKind::Oauth)
+        {
             continue;
         }
         if binds_for_launch(state, &slot.name) {
@@ -179,6 +183,7 @@ pub fn gate_required_slots(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lns_policy::connectors::SignInMethod;
 
     fn slot(required: bool) -> CredentialSlot {
         CredentialSlot {
@@ -192,24 +197,26 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: Vec::new(),
-            credential: None,
-            oauth: Some(lns_policy::connectors::OauthAuth {
-                flow: lns_policy::connectors::OauthFlow::Device,
-                client_id: Some("some-client".into()),
-                client_secret: None,
-                scopes: Vec::new(),
-                device_authorization_endpoint: Some("https://api.some-oauth.example/device".into()),
-                authorization_endpoint: None,
-                token_endpoint: "https://api.some-oauth.example/token".into(),
-                userinfo_endpoint: None,
-                account_field: None,
-                env_var: env.into(),
-                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-                injections: Vec::new(),
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                lns_policy::connectors::OauthAuth {
+                    flow: lns_policy::connectors::OauthFlow::Device,
+                    client_id: Some("some-client".into()),
+                    client_secret: None,
+                    scopes: Vec::new(),
+                    device_authorization_endpoint: Some(
+                        "https://api.some-oauth.example/device".into(),
+                    ),
+                    authorization_endpoint: None,
+                    token_endpoint: "https://api.some-oauth.example/token".into(),
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    env_var: env.into(),
+                    placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                    injections: Vec::new(),
+                },
+            )],
         }
     }
 
@@ -217,15 +224,15 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: Vec::new(),
-            credential: Some(lns_policy::connectors::CredentialAuth {
-                env_var: env.into(),
-                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-                injections: Vec::new(),
-            }),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "token",
+                lns_policy::connectors::CredentialAuth {
+                    env_var: env.into(),
+                    placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                    injections: Vec::new(),
+                },
+            )],
         }
     }
 
@@ -289,11 +296,15 @@ mod tests {
         let catalog = vec![Connector {
             id: "some-blockless".into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: Vec::new(),
-            credential: None,
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod {
+                id: "token".into(),
+                name: None,
+                kind: AuthKind::Credential,
+                credential: None,
+                oauth: None,
+                token_fallback: None,
+            }],
         }];
         let plans = plan_declared_connectors(
             &["some-blockless".to_string()],

--- a/crates/lns-service/src/artifact/credential_boot.rs
+++ b/crates/lns-service/src/artifact/credential_boot.rs
@@ -2,6 +2,8 @@ use lns_artifact::spec::CredentialSlot;
 use lns_policy::connectors::{AuthKind, Connector};
 use lns_policy::credentials::{CredentialStateFile, has_armed_entry};
 
+use crate::credential_flow::connectors::held_method;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
     pub placeholder: String,
@@ -40,6 +42,15 @@ pub fn plan_slot(slot: &CredentialSlot, binding: Option<Binding>) -> SlotPlan {
     }
 }
 
+/// A sign-in counts as held here only when a value is actually bound on this machine, because a required slot demands a value rather than a permission.
+fn bound_value(state: &CredentialStateFile) -> impl Fn(&str) -> bool + '_ {
+    move |provider| {
+        state
+            .get(provider)
+            .is_some_and(|entry| !matches!(entry, lns_policy::credentials::CredentialEntry::Deny))
+    }
+}
+
 /// Plan each launch-gated id (a definition's required credential slots): an `oauth` id with no armed machine grant blocks the boot on a required connect (the sign-in), while a credential id stays armed — its consent gate is the reactive per-machine value decision at first use. Ids the catalog lacks are the unknown-id refusal's job, not this gate's.
 pub fn plan_declared_connectors(
     declared: &[String],
@@ -49,14 +60,13 @@ pub fn plan_declared_connectors(
     declared
         .iter()
         .filter_map(|id| catalog.iter().find(|integ| &integ.id == id))
-        .map(|integ| {
-            let method = integ.default_method();
-            let env = method.map(|m| m.env_var().to_string()).unwrap_or_default();
-            let placeholder = method
-                .map(|m| m.placeholder().to_string())
-                .unwrap_or_default();
-            let signs_in = method.is_some_and(|m| m.kind == AuthKind::Oauth);
-            if signs_in && !has_armed_entry(state, &integ.id) {
+        // A connector the machine holds no sign-in for wires no provider, so it must be reported neither armed nor connectable — certifying it would start a workload whose credential is inert.
+        .filter_map(|integ| held_method(integ, &bound_value(state)).map(|h| (integ, h)))
+        .map(|(integ, held)| {
+            let env = held.method.env_var().to_string();
+            let placeholder = held.method.placeholder().to_string();
+            let signs_in = held.method.kind == AuthKind::Oauth;
+            if signs_in && !has_armed_entry(state, &held.provider_id) {
                 SlotPlan::Connect(ConnectPrompt {
                     connector: integ.id.clone(),
                     env,
@@ -117,8 +127,19 @@ pub fn sign_in_gate_ids(slots: &[CredentialSlot]) -> Vec<String> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequiredSlotFailure {
-    Unbound { connector: String, env: String },
-    Denied { connector: String, env: String },
+    Unbound {
+        connector: String,
+        env: String,
+    },
+    Denied {
+        connector: String,
+        env: String,
+    },
+    /// A connector reachable several ways, none of them held: `lns connector connect` refuses it, so the only recovery is the first-use card.
+    NoSignInHeld {
+        connector: String,
+        env: String,
+    },
 }
 
 impl RequiredSlotFailure {
@@ -133,6 +154,11 @@ impl RequiredSlotFailure {
                 "this sandbox requires the \"{connector}\" credential, injected as {env}, \
                  and you have denied it on this machine; change the decision with \
                  `lns connector connect {connector}`, then run again"
+            ),
+            RequiredSlotFailure::NoSignInHeld { connector, env } => format!(
+                "this sandbox requires the \"{connector}\" credential, injected as {env}, \
+                 and this machine holds no sign-in for it; \"{connector}\" is reachable several ways, \
+                 so connect it from the offer card, which asks which sign-in to use"
             ),
         }
     }
@@ -156,14 +182,24 @@ pub fn gate_required_slots(
         let Some(integ) = catalog.iter().find(|i| i.id == slot.name) else {
             continue;
         };
-        if integ
-            .default_method()
-            .is_some_and(|m| m.kind == AuthKind::Oauth)
+        let held = held_method(integ, &bound_value(state));
+        if held
+            .as_ref()
+            .is_some_and(|h| h.method.kind == AuthKind::Oauth)
         {
             continue;
         }
-        if binds_for_launch(state, &slot.name) {
+        if held
+            .as_ref()
+            .is_some_and(|h| binds_for_launch(state, &h.provider_id))
+        {
             continue;
+        }
+        if held.is_none() {
+            return Err(RequiredSlotFailure::NoSignInHeld {
+                connector: slot.name.clone(),
+                env: slot.env.clone(),
+            });
         }
         let failure = match state.get(&slot.name) {
             Some(lns_policy::credentials::CredentialEntry::Deny) => RequiredSlotFailure::Denied {
@@ -218,6 +254,81 @@ mod tests {
                 },
             )],
         }
+    }
+
+    /// A connector reachable two ways, so the machine must hold one of them before a slot can be filled.
+    fn two_method_connector(id: &str) -> Connector {
+        let mut out = credential_connector(id, "SOME_TOKEN");
+        out.methods[0].id = "api-key".into();
+        out.methods.push(SignInMethod::credential(
+            "subscription",
+            lns_policy::connectors::CredentialAuth {
+                env_var: "SOME_SUBSCRIPTION_TOKEN".into(),
+                placeholder: format!("{id}-subscription-LNSPLACEHOLDER"),
+                injections: Vec::new(),
+            },
+        ));
+        out
+    }
+
+    #[test]
+    fn a_required_slot_on_a_connector_reachable_two_ways_with_no_bound_value_fails_the_launch() {
+        let failure = gate_required_slots(
+            &[slot(true)],
+            &[two_method_connector("some-provider")],
+            &CredentialStateFile::new(),
+        )
+        .expect_err("a required slot with no value must refuse the launch");
+        assert_eq!(
+            failure,
+            RequiredSlotFailure::NoSignInHeld {
+                connector: "some-provider".into(),
+                env: "SOME_TOKEN".into(),
+            },
+            "no sign-in is held, so the workload must never start believing its required credential will arrive"
+        );
+        let message = failure.as_message();
+        assert!(
+            !message.contains("lns connector connect"),
+            "that command refuses a connector reachable several ways, so naming it would send the user to a dead end: {message}"
+        );
+        assert!(
+            message.contains("offer card"),
+            "the refusal must name the one recovery that works: {message}"
+        );
+    }
+
+    #[test]
+    fn a_required_slot_is_satisfied_by_a_value_bound_under_the_held_methods_own_key() {
+        let mut state = CredentialStateFile::new();
+        state.insert(
+            "some-provider:subscription".into(),
+            lns_policy::credentials::CredentialEntry::Stored {
+                value: "some-secret".into(),
+            },
+        );
+        assert!(
+            gate_required_slots(
+                &[slot(true)],
+                &[two_method_connector("some-provider")],
+                &state
+            )
+            .is_ok(),
+            "the value is bound under the sign-in that holds it, so the launch must proceed"
+        );
+    }
+
+    #[test]
+    fn no_armed_plan_is_reported_for_a_connector_the_machine_holds_no_sign_in_for() {
+        let plans = plan_declared_connectors(
+            &["some-provider".to_string()],
+            &[two_method_connector("some-provider")],
+            &CredentialStateFile::new(),
+        );
+        assert!(
+            plans.is_empty(),
+            "nothing was wired, so certifying it armed would start a workload whose credential is inert: {plans:?}"
+        );
     }
 
     fn credential_connector(id: &str, env: &str) -> Connector {

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -186,6 +186,17 @@ fn merge_rule_table<R: Clone + PartialEq>(
     merged
 }
 
+/// One function, because a boot that composed this differently from a reload once handed back an allow the launch had withheld.
+pub fn compose_running_policy(
+    base: &Policy,
+    connector_routes: Vec<RouteRule>,
+    withhold: &dyn Fn(&Policy) -> Policy,
+) -> Policy {
+    let mut spliced = base.clone();
+    splice_connector_routes(&mut spliced.network.egress.http, connector_routes);
+    withhold(&spliced)
+}
+
 /// Adds a connector's derived rules ahead of any catch-all, since appended behind one they would never fire and a closed policy raises no card to say why.
 pub fn splice_connector_routes(
     table: &mut Vec<RouteRule>,
@@ -245,6 +256,37 @@ mod tests {
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host(host));
         p
+    }
+
+    #[test]
+    fn compose_running_policy_withholds_from_the_spliced_policy_not_the_bare_base() {
+        let base = Policy::default();
+        let routes = vec![RouteRule::allow_host("api.some-provider.example")];
+        let seen = std::sync::Mutex::new(Vec::new());
+
+        let composed = compose_running_policy(&base, routes, &|policy| {
+            seen.lock().expect("seen mutex poisoned").extend(
+                policy
+                    .network
+                    .egress
+                    .http
+                    .iter()
+                    .map(|r| r.match_pattern.clone()),
+            );
+            let mut out = policy.clone();
+            out.network.egress.http.clear();
+            out
+        });
+
+        assert_eq!(
+            seen.into_inner().expect("seen mutex poisoned"),
+            vec!["api.some-provider.example".to_string()],
+            "the withholder must receive the spliced policy, not the bare base"
+        );
+        assert!(
+            composed.network.egress.http.is_empty(),
+            "the withholder's verdict is what the run enforces"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -156,6 +156,46 @@ pub(crate) fn refuse_unbound_required_credentials(
     Ok(())
 }
 
+/// Refuse a launch whose directory has connected a connector reachable several ways that this machine holds no sign-in for — nothing would authenticate its requests and no card could ask, so fail before any microVM boots. Directory state, so it applies to a plain `lns run` too.
+pub(crate) fn refuse_unchosen_connected_connectors(
+    policy_path: Option<&std::path::Path>,
+    workload: &lns_policy::grants::WorkloadIdentity,
+) -> Result<()> {
+    let Some(policy_path) = policy_path else {
+        return Ok(());
+    };
+    let policy = lns_policy::Policy::load_or_default(policy_path).unwrap_or_default();
+    if policy.connectors.is_empty() {
+        return Ok(());
+    }
+    let catalog = effective_machine_catalog();
+    let state = {
+        use crate::credential_flow::store::{
+            CredentialStore, JsonFileCredentialStore, default_credentials_path,
+        };
+        JsonFileCredentialStore::new(default_credentials_path())
+            .load()
+            .unwrap_or_default()
+    };
+    let grants = {
+        use lns_policy::grants::{GrantStore, JsonFileGrantStore, default_workload_grants_path};
+        JsonFileGrantStore::new(default_workload_grants_path())
+            .load()
+            .unwrap_or_default()
+    };
+    let project = lns_policy::grants::project_key(policy_path);
+    let chosen = crate::credential_flow::connectors::machine_holds_sign_in(
+        &state, &grants, &project, workload,
+    );
+    let unchosen = crate::credential_flow::connectors::unchosen_connected_connectors(
+        &policy, &catalog, &chosen,
+    );
+    if unchosen.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(crate::credential_flow::connectors::unchosen_connectors_refusal(&unchosen))
+}
+
 fn effective_machine_catalog() -> Vec<lns_policy::connectors::Connector> {
     let user = lns_policy::connectors::Catalog::load_or_default(
         &lns_policy::connectors::default_connectors_path(),

--- a/crates/lns-service/src/credential_flow/bind.rs
+++ b/crates/lns-service/src/credential_flow/bind.rs
@@ -8,9 +8,9 @@ use crate::credential_flow::session::{
 };
 use crate::credential_flow::store::CredentialEntry;
 
-/// The connect-time value-decision card for a credential connector; an oauth id signs in instead, and a blockless entry has nothing to bind.
+/// The connect-time value-decision card for a credential connector; an oauth id signs in instead, a blockless entry has nothing to bind, and a connector reachable several ways has no one value to bind until the sign-in is picked.
 pub fn bind_prompt(integ: &Connector) -> Option<CredentialPendingPrompt> {
-    let method = integ.default_method()?;
+    let method = integ.sole_method()?;
     if method.kind != AuthKind::Credential {
         return None;
     }
@@ -34,7 +34,7 @@ pub fn bind_prompt(integ: &Connector) -> Option<CredentialPendingPrompt> {
 /// The provider the bind card detects a host value through — the same wiring a run would seed.
 pub fn bind_provider(integ: &Connector) -> Option<DefProvider> {
     let method = integ
-        .default_method()
+        .sole_method()
         .filter(|m| m.kind == AuthKind::Credential)?;
     Some(DefProvider::new(ProviderDef {
         id: integ.id.clone(),
@@ -144,6 +144,25 @@ mod tests {
         let mut blockless = credential_connector("some-blockless", "SOME_TOKEN");
         blockless.methods[0].credential = None;
         assert_eq!(bind_prompt(&blockless), None);
+    }
+
+    #[test]
+    fn binding_a_connector_reachable_two_ways_is_refused_rather_than_bound_under_a_dead_key() {
+        let mut two_ways = credential_connector("some-provider", "SOME_TOKEN");
+        two_ways.methods.push(SignInMethod::credential(
+            "subscription",
+            CredentialAuth {
+                env_var: "SOME_SUBSCRIPTION_TOKEN".into(),
+                placeholder: "some-provider-subscription-LNSPLACEHOLDER".into(),
+                injections: Vec::new(),
+            },
+        ));
+        assert_eq!(
+            bind_prompt(&two_ways),
+            None,
+            "each sign-in binds under its own key, so binding the bare connector id would store a value nothing ever reads"
+        );
+        assert!(bind_provider(&two_ways).is_none());
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/bind.rs
+++ b/crates/lns-service/src/credential_flow/bind.rs
@@ -10,16 +10,17 @@ use crate::credential_flow::store::CredentialEntry;
 
 /// The connect-time value-decision card for a credential connector; an oauth id signs in instead, and a blockless entry has nothing to bind.
 pub fn bind_prompt(integ: &Connector) -> Option<CredentialPendingPrompt> {
-    if integ.auth_kind != AuthKind::Credential {
+    let method = integ.default_method()?;
+    if method.kind != AuthKind::Credential {
         return None;
     }
-    let cred = integ.credential.as_ref()?;
+    let cred = method.credential.as_ref()?;
     Some(CredentialPendingPrompt {
         id: format!("bind-{}", integ.id),
         credential_id: integ.id.clone(),
         action: format!("bind a value for \"{}\" on this machine", integ.id),
         oauth_display_name: None,
-        token_fallback: integ.token_fallback.clone(),
+        token_fallback: method.token_fallback.clone(),
         env_var: Some(cred.env_var.clone()),
         injection_domains: cred.injections.iter().map(|i| i.domain.clone()).collect(),
         is_project_defined: false,
@@ -32,12 +33,14 @@ pub fn bind_prompt(integ: &Connector) -> Option<CredentialPendingPrompt> {
 
 /// The provider the bind card detects a host value through — the same wiring a run would seed.
 pub fn bind_provider(integ: &Connector) -> Option<DefProvider> {
-    let cred = integ.credential.as_ref()?;
+    let method = integ
+        .default_method()
+        .filter(|m| m.kind == AuthKind::Credential)?;
     Some(DefProvider::new(ProviderDef {
         id: integ.id.clone(),
-        env_var: cred.env_var.clone(),
-        placeholder: cred.placeholder.clone(),
-        injections: cred.injections.clone(),
+        env_var: method.env_var().to_string(),
+        placeholder: method.placeholder().to_string(),
+        injections: method.injections().to_vec(),
     }))
 }
 
@@ -83,26 +86,26 @@ pub fn resolve_bind_decision(request: CredentialDecisionRequest) -> BindResoluti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lns_policy::connectors::CredentialAuth;
+    use lns_policy::connectors::{CredentialAuth, SignInMethod};
     use lns_policy::providers::{InjectionDef, InjectionKind};
 
     fn credential_connector(id: &str, env: &str) -> Connector {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: Vec::new(),
-            credential: Some(CredentialAuth {
-                env_var: env.into(),
-                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: "api.example.test".into(),
-                    header: None,
-                }],
-            }),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "token",
+                CredentialAuth {
+                    env_var: env.into(),
+                    placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: "api.example.test".into(),
+                        header: None,
+                    }],
+                },
+            )],
         }
     }
 
@@ -110,11 +113,15 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: Vec::new(),
-            credential: None,
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod {
+                id: "device".into(),
+                name: None,
+                kind: AuthKind::Oauth,
+                credential: None,
+                oauth: None,
+                token_fallback: None,
+            }],
         }
     }
 
@@ -134,10 +141,8 @@ mod tests {
     #[test]
     fn bind_prompt_refuses_an_oauth_or_blockless_connector() {
         assert_eq!(bind_prompt(&oauth_connector("some-oauth")), None);
-        let blockless = Connector {
-            credential: None,
-            ..credential_connector("some-blockless", "SOME_TOKEN")
-        };
+        let mut blockless = credential_connector("some-blockless", "SOME_TOKEN");
+        blockless.methods[0].credential = None;
         assert_eq!(bind_prompt(&blockless), None);
     }
 

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use lns_policy::connectors::{AuthKind, Connector, OauthAuth, OauthFlow};
+use lns_policy::connectors::{Connector, OauthAuth, OauthFlow};
 use lns_policy::grants::{GrantRecord, GrantVerdict, WorkloadGrantFile, WorkloadIdentity};
 use lns_policy::providers::ProviderDef;
 use lns_policy::{Policy, RouteRule};
@@ -27,21 +27,12 @@ pub struct ConnectableConnectors {
 
 /// The env/placeholder/injection wiring a connector seeds, taken from whichever block its authKind carries.
 fn wire_provider_def(integ: &Connector) -> Option<ProviderDef> {
-    let (env_var, placeholder, injections) = match integ.auth_kind {
-        AuthKind::Credential => {
-            let c = integ.credential.as_ref()?;
-            (&c.env_var, &c.placeholder, &c.injections)
-        }
-        AuthKind::Oauth => {
-            let o = integ.oauth.as_ref()?;
-            (&o.env_var, &o.placeholder, &o.injections)
-        }
-    };
+    let method = integ.default_method()?;
     Some(ProviderDef {
         id: integ.id.clone(),
-        env_var: env_var.clone(),
-        placeholder: placeholder.clone(),
-        injections: injections.clone(),
+        env_var: method.env_var().to_string(),
+        placeholder: method.placeholder().to_string(),
+        injections: method.injections().to_vec(),
     })
 }
 
@@ -51,7 +42,7 @@ fn wire_provider(integ: &Connector) -> Option<DefProvider> {
 
 /// The oauth block usable for a device sign-in: the device flow with a client_id baked in (community builds ship none, so they fall back to the token paste).
 fn signin_oauth(integ: &Connector) -> Option<&OauthAuth> {
-    integ.oauth.as_ref().filter(|o| {
+    integ.default_method()?.oauth.as_ref().filter(|o| {
         o.flow == OauthFlow::Device && o.client_id.as_deref().is_some_and(|c| !c.is_empty())
     })
 }
@@ -59,6 +50,7 @@ fn signin_oauth(integ: &Connector) -> Option<&OauthAuth> {
 /// The oauth block usable for a pkce browser sign-in: the pkce flow with an authorization endpoint to redirect through.
 fn signin_pkce(integ: &Connector) -> Option<&OauthAuth> {
     integ
+        .default_method()?
         .oauth
         .as_ref()
         .filter(|o| o.flow == OauthFlow::Pkce && o.authorization_endpoint.is_some())
@@ -126,7 +118,9 @@ pub fn offerable_connectors(
                     .map(|i| i.display_name().to_string())
                     .unwrap_or_else(|| id.clone()),
                 patterns: routes.iter().map(|r| r.match_pattern.clone()).collect(),
-                token_fallback: entry.and_then(|i| i.token_fallback.clone()),
+                token_fallback: entry
+                    .and_then(|i| i.default_method())
+                    .and_then(|m| m.token_fallback.clone()),
             }
         })
         .collect()
@@ -318,24 +312,14 @@ fn domains_overlap(a: &str, b: &str) -> bool {
     domain_matches(a, b) || domain_matches(b, a)
 }
 
-/// Every domain a connector claims: its route patterns plus the domains its credential/oauth injections actually write a token onto (a custom catalog may inject on a domain it doesn't route).
+/// Every domain a connector claims: its route patterns plus the domains any of its sign-in methods actually write a token onto (a custom catalog may inject on a domain it doesn't route).
 fn claimed_domains(integ: &Connector) -> impl Iterator<Item = &str> {
-    integ
-        .routes
-        .iter()
-        .map(|r| r.match_pattern.as_str())
-        .chain(
-            integ
-                .credential
-                .iter()
-                .flat_map(|c| c.injections.iter().map(|i| i.domain.as_str())),
-        )
-        .chain(
-            integ
-                .oauth
-                .iter()
-                .flat_map(|o| o.injections.iter().map(|i| i.domain.as_str())),
-        )
+    integ.routes.iter().map(|r| r.match_pattern.as_str()).chain(
+        integ
+            .methods
+            .iter()
+            .flat_map(|m| m.injections().iter().map(|i| i.domain.as_str())),
+    )
 }
 
 /// The catalog connectors a run can offer to connect: every entry (credential or oauth) not already applied and not colliding with an applied connector's domain.
@@ -346,7 +330,7 @@ pub fn resolve_connectable_connectors(
     resolve_connectable_with_declared(policy, &[], catalog)
 }
 
-/// Connectables minus any colliding with a domain already spoken for — by an applied credential (`policy.connectors`) or by an artifact-declared, offered-not-armed connector (`declared`) — so a colliding entry's machine-global stored value can never inject over the credential that owns that domain (e.g. a leftover `anthropic` value clobbering a declared `claude-code-subscription` on api.anthropic.com, even when that domain is an injection target rather than a declared route).
+/// Connectables minus any colliding with a domain already spoken for — by an applied credential (`policy.connectors`) or by an artifact-declared, offered-not-armed connector (`declared`) — so a colliding entry's machine-global stored value can never inject over the credential that owns that domain, even where that domain is an injection target rather than a declared route. Two *bundled* entries can no longer collide (one connector owns a domain, its alternatives are its sign-in methods); this still guards a user catalog entry that claims a bundled connector's domain.
 fn resolve_connectable_with_declared(
     policy: &Policy,
     declared: &[String],
@@ -400,7 +384,9 @@ fn resolve_connectable_with_declared(
 mod tests {
     use super::*;
     use crate::credential_flow::providers::Provider;
-    use lns_policy::connectors::{ConnectorRoute, CredentialAuth, OauthAuth, OauthFlow};
+    use lns_policy::connectors::{
+        ConnectorRoute, CredentialAuth, OauthAuth, OauthFlow, SignInMethod,
+    };
     use lns_policy::grants::GrantRecord;
     use lns_policy::providers::{InjectionDef, InjectionKind};
 
@@ -408,7 +394,6 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: vec![ConnectorRoute {
                 match_pattern: domain.into(),
                 transport: None,
@@ -416,17 +401,18 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: Some(CredentialAuth {
-                env_var: env_var.into(),
-                placeholder: format!("lns-{id}-placeholder"),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: domain.into(),
-                    header: None,
-                }],
-            }),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "token",
+                CredentialAuth {
+                    env_var: env_var.into(),
+                    placeholder: format!("lns-{id}-placeholder"),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: domain.into(),
+                        header: None,
+                    }],
+                },
+            )],
         }
     }
 
@@ -780,7 +766,6 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: domain.into(),
                 transport: None,
@@ -788,26 +773,29 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                userinfo_endpoint: None,
-                account_field: None,
-                flow: OauthFlow::Device,
-                client_id: Some(format!("Iv1.{id}")),
-                client_secret: None,
-                scopes: vec!["repo".into()],
-                device_authorization_endpoint: Some(format!("https://{domain}/login/device/code")),
-                authorization_endpoint: None,
-                token_endpoint: format!("https://{domain}/login/oauth/access_token"),
-                env_var: env_var.into(),
-                placeholder: format!("lns-{id}-placeholder"),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: domain.into(),
-                    header: None,
-                }],
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                OauthAuth {
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    flow: OauthFlow::Device,
+                    client_id: Some(format!("Iv1.{id}")),
+                    client_secret: None,
+                    scopes: vec!["repo".into()],
+                    device_authorization_endpoint: Some(format!(
+                        "https://{domain}/login/device/code"
+                    )),
+                    authorization_endpoint: None,
+                    token_endpoint: format!("https://{domain}/login/oauth/access_token"),
+                    env_var: env_var.into(),
+                    placeholder: format!("lns-{id}-placeholder"),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: domain.into(),
+                        header: None,
+                    }],
+                },
+            )],
         }
     }
 
@@ -815,7 +803,6 @@ mod tests {
         Connector {
             id: id.into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: domain.into(),
                 transport: None,
@@ -823,26 +810,27 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                userinfo_endpoint: None,
-                account_field: None,
-                flow: OauthFlow::Pkce,
-                client_id: None,
-                client_secret: None,
-                scopes: Vec::new(),
-                device_authorization_endpoint: None,
-                authorization_endpoint: Some(format!("https://{domain}/auth")),
-                token_endpoint: format!("https://{domain}/api/v1/auth/keys"),
-                env_var: env_var.into(),
-                placeholder: format!("lns-{id}-placeholder"),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: domain.into(),
-                    header: None,
-                }],
-            }),
-            token_fallback: None,
+            methods: vec![SignInMethod::oauth(
+                "device",
+                OauthAuth {
+                    userinfo_endpoint: None,
+                    account_field: None,
+                    flow: OauthFlow::Pkce,
+                    client_id: None,
+                    client_secret: None,
+                    scopes: Vec::new(),
+                    device_authorization_endpoint: None,
+                    authorization_endpoint: Some(format!("https://{domain}/auth")),
+                    token_endpoint: format!("https://{domain}/api/v1/auth/keys"),
+                    env_var: env_var.into(),
+                    placeholder: format!("lns-{id}-placeholder"),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: domain.into(),
+                        header: None,
+                    }],
+                },
+            )],
         }
     }
 
@@ -1011,7 +999,7 @@ mod tests {
             "PRIMARY_TOKEN",
             "login.some-primary.example",
         );
-        applied.credential.as_mut().unwrap().injections[0].domain =
+        applied.methods[0].credential.as_mut().unwrap().injections[0].domain =
             "api.some-provider.example".into();
         let catalog = vec![
             applied,
@@ -1143,7 +1131,7 @@ mod tests {
 
     fn oauth_connector_without_client_id(id: &str, env_var: &str, domain: &str) -> Connector {
         let mut i = oauth_connector(id, env_var, domain);
-        i.oauth.as_mut().unwrap().client_id = None;
+        i.methods[0].oauth.as_mut().unwrap().client_id = None;
         i
     }
 

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -208,6 +208,15 @@ fn is_decided(
             .is_some_and(|(env_var, domains)| grant.matches_disclosure(&env_var, &domains))
 }
 
+/// A connector the policy connects and this machine holds a sign-in for keeps its routes: its value card still carries the decision, and a hand edit writes no grant to prove one with. A connector no sign-in is held for can never authenticate, so its routes wait for the card instead. `held_method` is unconditionally `Some` for a single-method connector, so one can never be withheld here whatever the store says.
+fn is_connected_with_a_sign_in(
+    integ: &Connector,
+    policy: &Policy,
+    chosen: MethodChosen<'_>,
+) -> bool {
+    policy.connectors.iter().any(|id| id == &integ.id) && held_method(integ, chosen).is_some()
+}
+
 /// The policy a launch actually runs: the user's own rules minus the allows that would let a request past a connector nobody has decided yet, so the first request to a claimed domain is held and the connect offer gets its chance. Once the connector is connected or decided either way, the withheld rule applies as written. Only an `offerable` connector can withhold anything — a connector with no path to a card could never release the rule again.
 pub fn withhold_undecided_connector_allows(
     policy: &Policy,
@@ -216,12 +225,12 @@ pub fn withhold_undecided_connector_allows(
     project: &str,
     workload: &WorkloadIdentity,
     grants: &WorkloadGrantFile,
+    chosen: MethodChosen<'_>,
 ) -> Policy {
     let undecided: Vec<&str> = catalog
         .iter()
         .filter(|integ| offerable.contains(&integ.id))
-        // `offerable` is a launch-time snapshot, so a connector connected since — by a policy edit, which writes no grant — is still in it.
-        .filter(|integ| !policy.connectors.iter().any(|id| id == &integ.id))
+        .filter(|integ| !is_connected_with_a_sign_in(integ, policy, chosen))
         .filter(|integ| !is_decided(integ, project, workload, grants))
         .flat_map(claimed_domains)
         .collect();
@@ -632,6 +641,7 @@ mod tests {
             "proj",
             &workload,
             &WorkloadGrantFile::default(),
+            &nothing_chosen,
         );
 
         assert_eq!(
@@ -1043,6 +1053,7 @@ mod tests {
             "/proj",
             &workload,
             &grants,
+            &nothing_chosen,
         );
         assert_eq!(
             out.network.egress.http.len(),
@@ -1113,6 +1124,64 @@ mod tests {
             "a refusal is not a sign-in the machine holds"
         );
         assert!(!chosen("some-provider:never-touched"));
+    }
+
+    #[test]
+    fn a_connected_connector_no_sign_in_is_held_for_still_withholds_its_route() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        // A policy write mid-run connects it; nothing seeds, so no value card can ever fire for it.
+        let mut policy = policy_applying(&["some-provider"]);
+        policy.add_rule(RouteRule::allow_host("api.some-provider.example"));
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+
+        let out = withhold_undecided_connector_allows(
+            &policy,
+            &catalog,
+            &HashSet::from(["some-provider".to_string()]),
+            "/proj",
+            &workload,
+            &WorkloadGrantFile::default(),
+            &nothing_chosen,
+        );
+
+        assert!(
+            out.network.egress.http.is_empty(),
+            "the connector can never authenticate, so its route must wait for the card rather than letting requests leave unauthenticated"
+        );
+    }
+
+    #[test]
+    fn a_connected_connector_whose_sign_in_is_held_keeps_its_routes() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let mut policy = policy_applying(&["some-provider"]);
+        policy.add_rule(RouteRule::allow_host("api.some-provider.example"));
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+
+        let out = withhold_undecided_connector_allows(
+            &policy,
+            &catalog,
+            &HashSet::from(["some-provider".to_string()]),
+            "/proj",
+            &workload,
+            &WorkloadGrantFile::default(),
+            &|provider| provider == "some-provider:api-key",
+        );
+
+        assert_eq!(
+            out.network.egress.http.len(),
+            1,
+            "the sign-in is held, so its value card carries the decision and withholding the route would only strand a working connector"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use lns_policy::connectors::{Connector, OauthAuth, OauthFlow};
+use lns_policy::connectors::{Connector, OauthAuth, OauthFlow, SignInMethod};
 use lns_policy::grants::{GrantRecord, GrantVerdict, WorkloadGrantFile, WorkloadIdentity};
 use lns_policy::providers::ProviderDef;
 use lns_policy::{Policy, RouteRule};
@@ -14,6 +14,8 @@ pub struct AppliedConnectors {
     pub routes: Vec<RouteRule>,
     pub oauth_configs: HashMap<String, OauthAuth>,
     pub pkce_configs: HashMap<String, OauthAuth>,
+    /// Which connector each provider id belongs to, so a connect persists the connector rather than the sign-in method the user picked.
+    pub owner: HashMap<String, String>,
 }
 
 /// Catalog connectors that aren't yet connected, with their routes held ready to allow live on connect, and device-flow / pkce configs for a sign-in dance on connect; a definition-declared entry seeds its placeholder env so the workload attempts its first request, while the rest stay detect-only.
@@ -23,45 +25,175 @@ pub struct ConnectableConnectors {
     pub routes: HashMap<String, Vec<RouteRule>>,
     pub oauth_configs: HashMap<String, OauthAuth>,
     pub pkce_configs: HashMap<String, OauthAuth>,
+    /// Which connector each provider id belongs to, so a connect persists the connector rather than the sign-in method the user picked.
+    pub owner: HashMap<String, String>,
 }
 
-/// The env/placeholder/injection wiring a connector seeds, taken from whichever block its authKind carries.
-fn wire_provider_def(integ: &Connector) -> Option<ProviderDef> {
-    let method = integ.default_method()?;
-    Some(ProviderDef {
-        id: integ.id.clone(),
+/// The env/placeholder/injection wiring one sign-in method seeds, keyed by the store id that method binds under.
+fn method_provider_def(integ: &Connector, method: &SignInMethod) -> ProviderDef {
+    ProviderDef {
+        id: integ.provider_id_of(method),
         env_var: method.env_var().to_string(),
         placeholder: method.placeholder().to_string(),
         injections: method.injections().to_vec(),
-    })
+    }
+}
+
+/// The wiring a connector seeds where no choice has been made — its only method. A connector reachable several ways has no single answer, so nothing seeds until the user picks one.
+fn wire_provider_def(integ: &Connector) -> Option<ProviderDef> {
+    integ
+        .sole_method()
+        .map(|method| method_provider_def(integ, method))
 }
 
 fn wire_provider(integ: &Connector) -> Option<DefProvider> {
     wire_provider_def(integ).map(DefProvider::new)
 }
 
+/// One wire provider per sign-in method. `seeds` reaches the workload env only for a connector with a single way in; a method the user has not chosen stays detect-only, so its placeholder is recognized on the wire but never seeded.
+fn wire_providers(integ: &Connector, seeds: bool) -> Vec<DefProvider> {
+    let sole = integ.sole_method().is_some();
+    integ
+        .methods
+        .iter()
+        .map(|method| {
+            let provider = DefProvider::new(method_provider_def(integ, method));
+            if seeds && sole {
+                provider
+            } else {
+                provider.detect_only()
+            }
+        })
+        .collect()
+}
+
+/// True when the machine (or this workload) holds a sign-in bound under this provider id — a stored value, an oauth token, or a host-detect choice, but never a refusal. A method picked on the offer card records only a grant, because nothing was seeded for a value card to answer.
+pub fn machine_holds_sign_in<'a>(
+    state: &'a lns_policy::credentials::CredentialStateFile,
+    grants: &'a WorkloadGrantFile,
+    project: &'a str,
+    workload: &'a WorkloadIdentity,
+) -> impl Fn(&str) -> bool + 'a {
+    move |provider| {
+        state
+            .get(provider)
+            .is_some_and(|entry| !matches!(entry, lns_policy::credentials::CredentialEntry::Deny))
+            || grants
+                .lookup(project, workload, provider)
+                .is_some_and(|g| g.verdict == GrantVerdict::Allow)
+    }
+}
+
+/// A sign-in this machine holds, paired with the key its value and grant actually sit under.
+pub(crate) struct HeldSignIn<'a> {
+    pub method: &'a SignInMethod,
+    /// The bare connector id for a binding made before the connector grew a second way in, so the value and grant already stored keep resolving.
+    pub provider_id: String,
+}
+
+/// The sign-in this machine actually holds: the only way in, the one whose provider id is chosen, or — for a binding made before the connector grew a second way in, which sits under the bare connector id — the one the catalog still lists first.
+pub(crate) fn held_method<'a>(
+    integ: &'a Connector,
+    chosen: MethodChosen<'_>,
+) -> Option<HeldSignIn<'a>> {
+    if let Some(method) = integ.sole_method() {
+        return Some(HeldSignIn {
+            method,
+            provider_id: integ.provider_id_of(method),
+        });
+    }
+    if let Some(method) = integ
+        .methods
+        .iter()
+        .find(|m| chosen(&integ.provider_id_of(m)))
+    {
+        return Some(HeldSignIn {
+            method,
+            provider_id: integ.provider_id_of(method),
+        });
+    }
+    chosen(&integ.id)
+        .then(|| integ.methods.first())
+        .flatten()
+        .map(|method| HeldSignIn {
+            method,
+            provider_id: integ.id.clone(),
+        })
+}
+
+/// Repeats the held sign-in's configs under the key its value actually sits under, so a binding made before the connector grew a second way in can still drive its sign-in and token refresh.
+fn alias_legacy_signin_configs(
+    integ: &Connector,
+    held: &HeldSignIn<'_>,
+    out: &mut AppliedConnectors,
+) {
+    if held.provider_id == integ.provider_id_of(held.method) {
+        return;
+    }
+    let per_method = integ.provider_id_of(held.method);
+    if let Some(cfg) = out.oauth_configs.get(&per_method).cloned() {
+        out.oauth_configs.insert(held.provider_id.clone(), cfg);
+    }
+    if let Some(cfg) = out.pkce_configs.get(&per_method).cloned() {
+        out.pkce_configs.insert(held.provider_id.clone(), cfg);
+    }
+    out.owner.insert(held.provider_id.clone(), integ.id.clone());
+}
+
+/// The providers a connected connector puts on the wire: the method it holds a sign-in for, or — while the choice is still open — every method detect-only, so the domain stays gated and host detection still works without seeding anything.
+fn applied_providers(integ: &Connector, chosen: MethodChosen<'_>) -> Vec<DefProvider> {
+    match held_method(integ, chosen) {
+        Some(held) => vec![DefProvider::new(ProviderDef {
+            id: held.provider_id,
+            ..method_provider_def(integ, held.method)
+        })],
+        None => wire_providers(integ, false),
+    }
+}
+
 /// The oauth block usable for a device sign-in: the device flow with a client_id baked in (community builds ship none, so they fall back to the token paste).
-fn signin_oauth(integ: &Connector) -> Option<&OauthAuth> {
-    integ.default_method()?.oauth.as_ref().filter(|o| {
+fn signin_oauth(method: &SignInMethod) -> Option<&OauthAuth> {
+    method.oauth.as_ref().filter(|o| {
         o.flow == OauthFlow::Device && o.client_id.as_deref().is_some_and(|c| !c.is_empty())
     })
 }
 
 /// The oauth block usable for a pkce browser sign-in: the pkce flow with an authorization endpoint to redirect through.
-fn signin_pkce(integ: &Connector) -> Option<&OauthAuth> {
-    integ
-        .default_method()?
+fn signin_pkce(method: &SignInMethod) -> Option<&OauthAuth> {
+    method
         .oauth
         .as_ref()
         .filter(|o| o.flow == OauthFlow::Pkce && o.authorization_endpoint.is_some())
 }
 
-/// The env var and injection domains a connector discloses on its consent card, or `None` when its authKind carries no usable block.
+/// Records every sign-in config a connector's methods offer, each under the store id its method binds to, so a non-first oauth method is reachable too.
+fn collect_signin_configs(
+    integ: &Connector,
+    owner: &mut HashMap<String, String>,
+    oauth_configs: &mut HashMap<String, OauthAuth>,
+    pkce_configs: &mut HashMap<String, OauthAuth>,
+) {
+    for method in &integ.methods {
+        let provider_id = integ.provider_id_of(method);
+        owner.insert(provider_id.clone(), integ.id.clone());
+        if let Some(o) = signin_oauth(method) {
+            oauth_configs.insert(provider_id.clone(), o.clone());
+        }
+        if let Some(o) = signin_pkce(method) {
+            pkce_configs.insert(provider_id, o.clone());
+        }
+    }
+}
+
+/// True when this provider id is the sign-in the machine (or this workload) actually holds, so a connected connector reachable several ways seeds only the method the user picked.
+pub type MethodChosen<'a> = &'a dyn Fn(&str) -> bool;
+
+/// The env var and injection domains a connector discloses on its consent card. A connector reachable several ways discloses none — no one env var describes it — so a decision about it is recorded against the connector alone.
 pub fn disclosure_of(integ: &Connector) -> Option<(String, Vec<String>)> {
     wire_provider(integ).map(|p| p.disclosure_snapshot())
 }
 
-/// A connector this workload has already answered for, either way: a grant recorded against the same disclosure the card showed. A redefined connector is a different question, so neither a yes nor a no carries over to a new shape.
+/// A connector this workload has already answered for, either way: a grant recorded against the same disclosure the card showed. A redefined connector is a different question, so neither a yes nor a no carries over to a new shape — but a grant that disclosed nothing has no shape to drift, and answers the connector as a whole.
 fn is_decided(
     integ: &Connector,
     project: &str,
@@ -71,8 +203,9 @@ fn is_decided(
     let Some(grant) = grants.lookup(project, workload, &integ.id) else {
         return false;
     };
-    disclosure_of(integ)
-        .is_some_and(|(env_var, domains)| grant.matches_disclosure(&env_var, &domains))
+    grant.has_no_disclosure()
+        || disclosure_of(integ)
+            .is_some_and(|(env_var, domains)| grant.matches_disclosure(&env_var, &domains))
 }
 
 /// The policy a launch actually runs: the user's own rules minus the allows that would let a request past a connector nobody has decided yet, so the first request to a claimed domain is held and the connect offer gets its chance. Once the connector is connected or decided either way, the withheld rule applies as written. Only an `offerable` connector can withhold anything — a connector with no path to a card could never release the rule again.
@@ -102,7 +235,7 @@ pub fn withhold_undecided_connector_allows(
     out
 }
 
-/// Pairs each connectable connector's id with its catalog display name and route patterns, so a held request to one of those domains can offer to connect it instead of asking about the bare host.
+/// Pairs each connectable connector's id with its catalog display name, route patterns, and the sign-ins it offers, so a held request to one of those domains can offer to connect it instead of asking about the bare host.
 pub fn offerable_connectors(
     connectable: &ConnectableConnectors,
     catalog: &[Connector],
@@ -118,10 +251,22 @@ pub fn offerable_connectors(
                     .map(|i| i.display_name().to_string())
                     .unwrap_or_else(|| id.clone()),
                 patterns: routes.iter().map(|r| r.match_pattern.clone()).collect(),
-                token_fallback: entry
-                    .and_then(|i| i.default_method())
-                    .and_then(|m| m.token_fallback.clone()),
+                methods: entry.map(offer_methods).unwrap_or_default(),
             }
+        })
+        .collect()
+}
+
+/// Every sign-in a connector offers, each paired with the per-machine store id it binds under.
+fn offer_methods(integ: &Connector) -> Vec<crate::approval_flow::session::OfferMethod> {
+    integ
+        .methods
+        .iter()
+        .map(|method| crate::approval_flow::session::OfferMethod {
+            method_id: method.id.clone(),
+            provider_id: integ.provider_id_of(method),
+            display_name: method.display_name().to_string(),
+            token_fallback: method.token_fallback.clone(),
         })
         .collect()
 }
@@ -159,8 +304,41 @@ pub fn unknown_connectors_refusal(unknown: &[String]) -> String {
     )
 }
 
+/// Connected connectors reachable several ways that this machine holds no sign-in for. Each wires no provider, so nothing seeds a placeholder and — being connected, its routes already allowed — no card can ever be raised: every request would leave unauthenticated in silence.
+pub fn unchosen_connected_connectors(
+    policy: &Policy,
+    catalog: &[Connector],
+    chosen: MethodChosen<'_>,
+) -> Vec<String> {
+    catalog
+        .iter()
+        .filter(|integ| policy.connectors.iter().any(|id| id == &integ.id))
+        .filter(|integ| integ.sole_method().is_none())
+        .filter(|integ| held_method(integ, chosen).is_none())
+        .map(|integ| integ.id.clone())
+        .collect()
+}
+
+/// The launch-refusal message for a connected connector no sign-in is held for, pointing at the one recovery that works: disconnecting makes it connectable again, and its first use then asks which sign-in.
+pub fn unchosen_connectors_refusal(ids: &[String]) -> String {
+    let list = ids
+        .iter()
+        .map(|id| format!("\"{id}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "connector {list} is connected but this machine holds no sign-in for it, so nothing would authenticate its requests; \
+         run `lns connector disconnect {}` and the next request to its domain will ask which sign-in to use",
+        ids.first().map(String::as_str).unwrap_or_default()
+    )
+}
+
 /// Resolves the policy's applied connector ids against the effective catalog.
-pub fn resolve_applied_connectors(policy: &Policy, catalog: &[Connector]) -> AppliedConnectors {
+pub fn resolve_applied_connectors(
+    policy: &Policy,
+    catalog: &[Connector],
+    chosen: MethodChosen<'_>,
+) -> AppliedConnectors {
     let applied: HashSet<&str> = policy.connectors.iter().map(String::as_str).collect();
 
     let mut out = AppliedConnectors {
@@ -171,14 +349,15 @@ pub fn resolve_applied_connectors(policy: &Policy, catalog: &[Connector]) -> App
         if !applied.contains(integ.id.as_str()) {
             continue;
         }
-        if let Some(p) = wire_provider(integ) {
-            out.providers.push(p);
-        }
-        if let Some(o) = signin_oauth(integ) {
-            out.oauth_configs.insert(integ.id.clone(), o.clone());
-        }
-        if let Some(o) = signin_pkce(integ) {
-            out.pkce_configs.insert(integ.id.clone(), o.clone());
+        out.providers.extend(applied_providers(integ, chosen));
+        collect_signin_configs(
+            integ,
+            &mut out.owner,
+            &mut out.oauth_configs,
+            &mut out.pkce_configs,
+        );
+        if let Some(held) = held_method(integ, chosen) {
+            alias_legacy_signin_configs(integ, &held, &mut out);
         }
     }
     out
@@ -189,31 +368,36 @@ pub fn resolve_applied_with_slots(
     policy: &Policy,
     slots: &[lns_artifact::spec::CredentialSlot],
     catalog: &[Connector],
+    chosen: MethodChosen<'_>,
 ) -> AppliedConnectors {
     let slot_ids: HashSet<&str> = slots.iter().map(|s| s.name.as_str()).collect();
     let mut base = policy.clone();
     base.connectors.retain(|id| !slot_ids.contains(id.as_str()));
-    let mut out = resolve_applied_connectors(&base, catalog);
+    let mut out = resolve_applied_connectors(&base, catalog, chosen);
     let ceiling_denies = crate::artifact::policy::is_closed(policy);
     for slot in slots {
         let Some(integ) = catalog.iter().find(|i| i.id == slot.name) else {
             continue;
         };
-        if let Some(mut def) = wire_provider_def(integ) {
-            def.env_var = slot.env.clone();
-            out.providers.push(DefProvider::new(def));
-        }
+        // One slot carries one env name, so only the method this machine holds a sign-in for can fill it.
+        let Some(held) = held_method(integ, chosen) else {
+            continue;
+        };
+        let mut def = method_provider_def(integ, held.method);
+        def.id = held.provider_id;
+        def.env_var = slot.env.clone();
+        out.providers.push(DefProvider::new(def));
         // A slot is artifact-declared, so its route must not widen the user's lockdown.
         if !ceiling_denies {
             out.routes
                 .extend(integ.routes.iter().map(|r| r.to_route_rule()));
         }
-        if let Some(o) = signin_oauth(integ) {
-            out.oauth_configs.insert(integ.id.clone(), o.clone());
-        }
-        if let Some(o) = signin_pkce(integ) {
-            out.pkce_configs.insert(integ.id.clone(), o.clone());
-        }
+        collect_signin_configs(
+            integ,
+            &mut out.owner,
+            &mut out.oauth_configs,
+            &mut out.pkce_configs,
+        );
     }
     out
 }
@@ -362,20 +546,22 @@ fn resolve_connectable_with_declared(
         if collides {
             continue;
         }
-        if let Some(p) = wire_provider(integ) {
-            let seeds = declared.iter().any(|id| id == &integ.id);
-            out.providers.push(if seeds { p } else { p.detect_only() });
-            out.routes.insert(
-                integ.id.clone(),
-                integ.routes.iter().map(|r| r.to_route_rule()).collect(),
-            );
-            if let Some(o) = signin_oauth(integ) {
-                out.oauth_configs.insert(integ.id.clone(), o.clone());
-            }
-            if let Some(o) = signin_pkce(integ) {
-                out.pkce_configs.insert(integ.id.clone(), o.clone());
-            }
+        let seeds = declared.iter().any(|id| id == &integ.id);
+        let providers = wire_providers(integ, seeds);
+        if providers.is_empty() {
+            continue;
         }
+        out.providers.extend(providers);
+        out.routes.insert(
+            integ.id.clone(),
+            integ.routes.iter().map(|r| r.to_route_rule()).collect(),
+        );
+        collect_signin_configs(
+            integ,
+            &mut out.owner,
+            &mut out.oauth_configs,
+            &mut out.pkce_configs,
+        );
     }
     out
 }
@@ -416,6 +602,11 @@ mod tests {
         }
     }
 
+    /// A machine holding no sign-in at all; a connector with one way in ignores this, so it is the honest default for a single-method fixture.
+    fn nothing_chosen(_provider: &str) -> bool {
+        false
+    }
+
     fn policy_applying(ids: &[&str]) -> Policy {
         Policy {
             connectors: ids.iter().map(|s| s.to_string()).collect(),
@@ -453,7 +644,8 @@ mod tests {
     #[test]
     fn resolves_an_applied_credential_connector_into_a_provider_and_its_routes() {
         let catalog = vec![cred_connector("gitlab", "GITLAB_TOKEN", "gitlab.com")];
-        let out = resolve_applied_connectors(&policy_applying(&["gitlab"]), &catalog);
+        let out =
+            resolve_applied_connectors(&policy_applying(&["gitlab"]), &catalog, &nothing_chosen);
         assert_eq!(out.providers.len(), 1);
         assert_eq!(out.providers[0].id(), "gitlab");
         assert_eq!(out.providers[0].env_var(), "GITLAB_TOKEN");
@@ -463,10 +655,14 @@ mod tests {
     }
 
     fn provider_of(id: &str, env: &str, domain: &str) -> DefProvider {
-        resolve_applied_connectors(&policy_applying(&[id]), &[cred_connector(id, env, domain)])
-            .providers
-            .pop()
-            .expect("one provider")
+        resolve_applied_connectors(
+            &policy_applying(&[id]),
+            &[cred_connector(id, env, domain)],
+            &nothing_chosen,
+        )
+        .providers
+        .pop()
+        .expect("one provider")
     }
 
     fn allow_grants(
@@ -682,7 +878,9 @@ mod tests {
             "api.some-oauth.example",
         )];
         let slots = vec![slot("some-oauth", "REMAPPED_TOKEN", true)];
-        let providers = resolve_applied_with_slots(&Policy::default(), &slots, &catalog).providers;
+        let providers =
+            resolve_applied_with_slots(&Policy::default(), &slots, &catalog, &nothing_chosen)
+                .providers;
         let workload = WorkloadIdentity::Definition {
             dir: "/proj".into(),
         };
@@ -742,7 +940,7 @@ mod tests {
     #[test]
     fn skips_a_catalog_connector_that_is_not_applied() {
         let catalog = vec![cred_connector("gitlab", "GITLAB_TOKEN", "gitlab.com")];
-        let out = resolve_applied_connectors(&policy_applying(&[]), &catalog);
+        let out = resolve_applied_connectors(&policy_applying(&[]), &catalog, &nothing_chosen);
         assert!(out.providers.is_empty());
         assert!(out.routes.is_empty());
     }
@@ -799,6 +997,495 @@ mod tests {
         }
     }
 
+    /// A connector reachable two ways, each with its own env var — the shape a user must choose between.
+    fn two_method_connector(id: &str, domain: &str) -> Connector {
+        let mut connector = cred_connector(id, "SOME_TOKEN", domain);
+        connector.methods[0].id = "api-key".into();
+        connector.methods.push(SignInMethod::credential(
+            "subscription",
+            CredentialAuth {
+                env_var: "SOME_SUBSCRIPTION_TOKEN".into(),
+                placeholder: format!("lns-{id}-subscription-placeholder"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: domain.into(),
+                    header: None,
+                }],
+            },
+        ));
+        connector
+    }
+
+    #[test]
+    fn declining_a_connector_reachable_two_ways_is_remembered_although_no_env_var_describes_it() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::deny(
+            "/proj",
+            &workload,
+            "some-provider",
+            "",
+            Vec::new(),
+        ));
+        let mut policy = Policy::default();
+        policy.add_rule(RouteRule::allow_host("api.some-provider.example"));
+
+        let out = withhold_undecided_connector_allows(
+            &policy,
+            &catalog,
+            &HashSet::from(["some-provider".to_string()]),
+            "/proj",
+            &workload,
+            &grants,
+        );
+        assert_eq!(
+            out.network.egress.http.len(),
+            1,
+            "a connector reachable several ways discloses no single env var, so its refusal records none; reading that as undecided would hold the domain against the user's own rule for ever"
+        );
+    }
+
+    #[test]
+    fn a_connected_connector_reachable_two_ways_seeds_nothing_until_a_method_is_chosen() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_connectors(
+            &policy_applying(&["some-provider"]),
+            &catalog,
+            &nothing_chosen,
+        );
+
+        let seeded: Vec<&str> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| p.env_var())
+            .collect();
+        assert!(
+            seeded.is_empty(),
+            "connecting the connector does not answer which way in the user holds, so no env var may be seeded yet: {seeded:?}"
+        );
+    }
+
+    #[test]
+    fn a_sign_in_counts_as_chosen_when_the_machine_holds_a_value_or_this_workload_granted_it() {
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let mut state = lns_policy::credentials::CredentialStateFile::new();
+        state.insert(
+            "some-provider:api-key".into(),
+            lns_policy::credentials::CredentialEntry::HostDetect,
+        );
+        state.insert(
+            "some-provider:refused".into(),
+            lns_policy::credentials::CredentialEntry::Deny,
+        );
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::allow(
+            "/proj",
+            &workload,
+            "some-provider:subscription",
+            "SOME_SUBSCRIPTION_TOKEN",
+            vec![],
+        ));
+
+        let chosen = machine_holds_sign_in(&state, &grants, "/proj", &workload);
+
+        assert!(
+            chosen("some-provider:api-key"),
+            "choosing to use the host's own value is still a choice, so that sign-in seeds on the next launch"
+        );
+        assert!(
+            chosen("some-provider:subscription"),
+            "picking a sign-in on the offer card records only a grant — nothing was seeded for a value card to answer — so the grant alone must count, or the choice would evaporate"
+        );
+        assert!(
+            !chosen("some-provider:refused"),
+            "a refusal is not a sign-in the machine holds"
+        );
+        assert!(!chosen("some-provider:never-touched"));
+    }
+
+    #[test]
+    fn a_connected_connector_no_sign_in_is_held_for_names_itself_for_refusal() {
+        let catalog = vec![
+            two_method_connector("some-provider", "api.some-provider.example"),
+            cred_connector(
+                "other-provider",
+                "OTHER_TOKEN",
+                "api.other-provider.example",
+            ),
+        ];
+        let policy = policy_applying(&["some-provider", "other-provider"]);
+
+        assert_eq!(
+            unchosen_connected_connectors(&policy, &catalog, &nothing_chosen),
+            vec!["some-provider".to_string()],
+            "a connector with one way in is never in this state, and one whose sign-in is held is fine — only the silent case may refuse a launch"
+        );
+        assert!(
+            unchosen_connected_connectors(&policy, &catalog, &|provider| provider
+                == "some-provider:api-key")
+            .is_empty(),
+            "once a sign-in is held there is a value to inject, so the launch must proceed"
+        );
+    }
+
+    #[test]
+    fn the_refusal_points_at_disconnecting_so_first_use_can_ask_which_sign_in() {
+        let message = unchosen_connectors_refusal(&["some-provider".to_string()]);
+        assert!(
+            message.contains("lns connector disconnect some-provider"),
+            "the fix must name the one recovery that works — `lns connector connect` refuses a connector reachable several ways, so pointing there would be a dead end: {message}"
+        );
+    }
+
+    #[test]
+    fn a_slot_naming_a_connector_reachable_two_ways_remaps_the_held_methods_env() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_with_slots(
+            &policy_applying(&[]),
+            &[slot("some-provider", "REMAPPED_TOKEN", true)],
+            &catalog,
+            &|provider| provider == "some-provider:subscription",
+        );
+        let wired: Vec<(&str, &str)> = out
+            .providers
+            .iter()
+            .map(|p| (p.id(), p.env_var()))
+            .collect();
+        assert_eq!(
+            wired,
+            vec![("some-provider:subscription", "REMAPPED_TOKEN")],
+            "the slot renames the env var but the value still comes from the sign-in the machine holds"
+        );
+    }
+
+    #[test]
+    fn a_slot_wires_nothing_when_the_machine_holds_no_sign_in_for_the_connector() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_with_slots(
+            &policy_applying(&[]),
+            &[slot("some-provider", "REMAPPED_TOKEN", true)],
+            &catalog,
+            &nothing_chosen,
+        );
+        assert!(
+            out.providers.is_empty(),
+            "there is no value to inject, so wiring a provider would advertise a credential the workload never gets"
+        );
+    }
+
+    #[test]
+    fn a_value_bound_before_the_connector_grew_a_second_method_still_chooses_that_method() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        // What every release before sign-in methods wrote: one value under the bare connector id.
+        let out = resolve_applied_connectors(
+            &policy_applying(&["some-provider"]),
+            &catalog,
+            &|provider| provider == "some-provider",
+        );
+
+        let seeded: Vec<(&str, &str)> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| (p.id(), p.env_var()))
+            .collect();
+        assert_eq!(
+            seeded,
+            vec![("some-provider", "SOME_TOKEN")],
+            "the legacy binding sits under the bare id, so the provider must keep that key — keying it per-method would seed the placeholder while the stored value resolved to nothing"
+        );
+    }
+
+    #[test]
+    fn a_legacy_binding_on_an_oauth_first_method_still_finds_its_sign_in_config() {
+        let mut connector =
+            oauth_connector("some-oauth", "SOME_OAUTH_TOKEN", "api.some-oauth.example");
+        connector.methods.push(SignInMethod::credential(
+            "token",
+            CredentialAuth {
+                env_var: "SOME_PASTED_TOKEN".into(),
+                placeholder: "some-oauth-token-LNSPLACEHOLDER".into(),
+                injections: Vec::new(),
+            },
+        ));
+        let catalog = vec![connector];
+
+        let out =
+            resolve_applied_connectors(&policy_applying(&["some-oauth"]), &catalog, &|provider| {
+                provider == "some-oauth"
+            });
+
+        let provider_id = out.providers[0].id().to_string();
+        assert_eq!(
+            provider_id, "some-oauth",
+            "the legacy binding keys under the bare id"
+        );
+        let keys: Vec<&String> = out.oauth_configs.keys().collect();
+        assert!(
+            out.oauth_configs.contains_key(&provider_id),
+            "the sign-in config must be reachable under the same key the provider resolved to, or the device flow and its token refresh are silently lost: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn a_legacy_binding_on_a_pkce_first_method_still_finds_its_browser_sign_in_config() {
+        let mut connector = pkce_connector("some-pkce", "SOME_PKCE_TOKEN", "api.some-pkce.example");
+        connector.methods.push(SignInMethod::credential(
+            "token",
+            CredentialAuth {
+                env_var: "SOME_PASTED_TOKEN".into(),
+                placeholder: "some-pkce-token-LNSPLACEHOLDER".into(),
+                injections: Vec::new(),
+            },
+        ));
+        let catalog = vec![connector];
+
+        let out =
+            resolve_applied_connectors(&policy_applying(&["some-pkce"]), &catalog, &|provider| {
+                provider == "some-pkce"
+            });
+
+        let keys: Vec<&String> = out.pkce_configs.keys().collect();
+        assert!(
+            out.pkce_configs.contains_key("some-pkce"),
+            "the browser redirect is configured per method, so without the alias a legacy binding could never complete its sign-in: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn a_value_bound_before_the_connector_grew_a_second_method_still_arms_and_injects() {
+        use crate::credential_flow::registry::expand_credentials_for_wire_with_custom;
+        use lns_policy::credentials::{CredentialEntry, CredentialStateFile};
+
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        // Exactly what a release before sign-in methods wrote: value and grant both under the bare connector id.
+        let mut state = CredentialStateFile::new();
+        state.insert(
+            "some-provider".into(),
+            CredentialEntry::Stored {
+                value: "some-secret".into(),
+            },
+        );
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::allow(
+            "/proj",
+            &workload,
+            "some-provider",
+            "SOME_TOKEN",
+            vec!["api.some-provider.example".to_string()],
+        ));
+        let chosen = |provider: &str| {
+            state
+                .get(provider)
+                .is_some_and(|e| !matches!(e, CredentialEntry::Deny))
+        };
+
+        let applied =
+            resolve_applied_connectors(&policy_applying(&["some-provider"]), &catalog, &chosen);
+        let run = run_providers(applied.providers, Vec::new());
+        let armed = gate_armed_by_grant(&run.armed, &run.providers, "/proj", &workload, &grants);
+        assert_eq!(
+            armed,
+            HashSet::from(["some-provider".to_string()]),
+            "the grant the user already gave must still arm the connector, or the upgrade silently revokes their consent"
+        );
+
+        let wire = expand_credentials_for_wire_with_custom(&state, &run.providers, &armed);
+        assert!(
+            wire.iter().any(|c| !c.injections.is_empty()),
+            "the stored value must still reach the wire, or every request leaves unauthenticated while the tool believes it is signed in"
+        );
+    }
+
+    #[test]
+    fn an_explicit_method_choice_beats_the_value_bound_under_the_bare_id() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_connectors(
+            &policy_applying(&["some-provider"]),
+            &catalog,
+            &|provider| provider == "some-provider" || provider == "some-provider:subscription",
+        );
+
+        let seeded: Vec<&str> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| p.id())
+            .collect();
+        assert_eq!(
+            seeded,
+            vec!["some-provider:subscription"],
+            "a sign-in the user picked outright must win over the one inferred from a legacy binding"
+        );
+    }
+
+    #[test]
+    fn a_connected_connector_seeds_only_the_sign_in_method_the_machine_holds() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_connectors(
+            &policy_applying(&["some-provider"]),
+            &catalog,
+            &|provider| provider == "some-provider:subscription",
+        );
+
+        let seeded: Vec<(&str, &str)> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| (p.id(), p.env_var()))
+            .collect();
+        assert_eq!(
+            seeded,
+            vec![("some-provider:subscription", "SOME_SUBSCRIPTION_TOKEN")],
+            "the chosen method's env var is what the tool branches on to see it is signed in, and the method not chosen must not appear at all"
+        );
+        assert_eq!(
+            out.providers.len(),
+            1,
+            "a method the user did not choose has no business on the wire once another is bound"
+        );
+    }
+
+    #[test]
+    fn a_connected_connector_with_one_way_in_ignores_the_choice_predicate() {
+        let catalog = vec![cred_connector(
+            "some-provider",
+            "SOME_TOKEN",
+            "api.some-provider.example",
+        )];
+        let out = resolve_applied_connectors(
+            &policy_applying(&["some-provider"]),
+            &catalog,
+            &nothing_chosen,
+        );
+        let seeded: Vec<&str> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| p.id())
+            .collect();
+        assert_eq!(
+            seeded,
+            vec!["some-provider"],
+            "there is no choice to make, so a connector with one way in must keep seeding exactly as before this existed"
+        );
+    }
+
+    #[test]
+    fn a_catalog_entry_with_no_way_in_is_skipped_rather_than_offered_unconnectably() {
+        let mut methodless =
+            cred_connector("some-provider", "SOME_TOKEN", "api.some-provider.example");
+        methodless.methods.clear();
+        let out = resolve_connectable_connectors(&Policy::default(), &[methodless]);
+        assert!(
+            out.routes.is_empty() && out.providers.is_empty(),
+            "nothing could ever connect it, so offering it would hold the domain against a card that can never be answered"
+        );
+    }
+
+    #[test]
+    fn a_connector_reachable_two_ways_seeds_neither_env_var_until_the_user_picks_one() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_connectable_with_declared(
+            &Policy::default(),
+            &["some-provider".to_string()],
+            &catalog,
+        );
+
+        let seeded: Vec<&str> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| p.env_var())
+            .collect();
+        assert!(
+            seeded.is_empty(),
+            "seeding one env var picks the sign-in for the user and seeding both fakes a login state no real sign-in produces, so neither may reach the workload: {seeded:?}"
+        );
+    }
+
+    #[test]
+    fn a_connector_reachable_two_ways_still_wires_each_method_so_it_can_be_offered() {
+        let catalog = vec![two_method_connector(
+            "some-provider",
+            "api.some-provider.example",
+        )];
+        let out = resolve_connectable_connectors(&Policy::default(), &catalog);
+
+        let mut ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["some-provider:api-key", "some-provider:subscription"],
+            "each method needs its own wire provider under its own store key, or the MITM could not recognize its placeholder and the choice could not be bound"
+        );
+        assert!(
+            out.routes.contains_key("some-provider"),
+            "without its routes the connector is not offerable, so the first request to its domain could never raise the card"
+        );
+    }
+
+    #[test]
+    fn a_connector_with_one_way_in_still_seeds_its_placeholder_when_the_definition_declares_it() {
+        let catalog = vec![cred_connector(
+            "some-provider",
+            "SOME_TOKEN",
+            "api.some-provider.example",
+        )];
+        let out = resolve_connectable_with_declared(
+            &Policy::default(),
+            &["some-provider".to_string()],
+            &catalog,
+        );
+        let seeded: Vec<&str> = out
+            .providers
+            .iter()
+            .filter(|p| p.seeds_env())
+            .map(|p| p.id())
+            .collect();
+        assert_eq!(
+            seeded,
+            vec!["some-provider"],
+            "a connector with one way in has no choice to make, so declaring it must keep seeding under the bare id every stored value is already bound to"
+        );
+    }
+
     fn pkce_connector(id: &str, env_var: &str, domain: &str) -> Connector {
         Connector {
             id: id.into(),
@@ -841,7 +1528,8 @@ mod tests {
             "SOMESAAS_TOKEN",
             "api.somesaas.com",
         )];
-        let out = resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog);
+        let out =
+            resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog, &nothing_chosen);
         let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         assert_eq!(
             ids,
@@ -865,7 +1553,11 @@ mod tests {
             cred_connector("gitlab", "GITLAB_TOKEN", "gitlab.com"),
             cred_connector("huggingface", "HF_TOKEN", "huggingface.co"),
         ];
-        let out = resolve_applied_connectors(&policy_applying(&["huggingface"]), &catalog);
+        let out = resolve_applied_connectors(
+            &policy_applying(&["huggingface"]),
+            &catalog,
+            &nothing_chosen,
+        );
         let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         assert_eq!(ids, ["huggingface"]);
     }
@@ -888,6 +1580,7 @@ mod tests {
                 "SOME_TOKEN",
                 "api.example.test",
             )],
+            &nothing_chosen,
         );
         let connectable = resolve_connectable_connectors(
             &policy_applying(&[]),
@@ -1083,7 +1776,8 @@ mod tests {
             "SOMEPKCE_TOKEN",
             "api.somepkce.com",
         )];
-        let out = resolve_applied_connectors(&policy_applying(&["somepkce"]), &catalog);
+        let out =
+            resolve_applied_connectors(&policy_applying(&["somepkce"]), &catalog, &nothing_chosen);
         let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         assert_eq!(ids, ["somepkce"], "a pkce connector seeds its placeholder");
         assert_eq!(out.routes.len(), 1, "its routes apply");
@@ -1104,7 +1798,8 @@ mod tests {
             "SOMESAAS_TOKEN",
             "api.somesaas.com",
         )];
-        let out = resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog);
+        let out =
+            resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog, &nothing_chosen);
         assert!(out.oauth_configs.contains_key("somesaas"));
         assert!(
             out.pkce_configs.is_empty(),
@@ -1143,7 +1838,8 @@ mod tests {
             "SOMESAAS_TOKEN",
             "api.somesaas.com",
         )];
-        let out = resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog);
+        let out =
+            resolve_applied_connectors(&policy_applying(&["somesaas"]), &catalog, &nothing_chosen);
         let ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         assert_eq!(
             ids,
@@ -1176,6 +1872,7 @@ mod tests {
             &policy_applying(&[]),
             &[slot("some-provider", "PROVIDER_KEY", false)],
             &catalog,
+            &nothing_chosen,
         );
         assert_eq!(out.providers.len(), 1);
         assert_eq!(out.providers[0].id(), "some-provider");
@@ -1208,6 +1905,7 @@ mod tests {
             &policy_applying(&["some-provider"]),
             &[slot("some-provider", "PROVIDER_KEY", true)],
             &catalog,
+            &nothing_chosen,
         );
         assert_eq!(
             out.providers.len(),
@@ -1227,6 +1925,7 @@ mod tests {
             &policy_applying(&["other-provider"]),
             &[slot("some-provider", "SOME_TOKEN", false)],
             &catalog,
+            &nothing_chosen,
         );
         let mut ids: Vec<&str> = out.providers.iter().map(|p| p.id()).collect();
         ids.sort_unstable();
@@ -1239,6 +1938,7 @@ mod tests {
             &policy_applying(&[]),
             &[slot("some-unknown", "SOME_TOKEN", true)],
             &[],
+            &nothing_chosen,
         );
         assert!(
             out.providers.is_empty(),
@@ -1258,6 +1958,7 @@ mod tests {
             &policy_applying(&[]),
             &[slot("some-oauth", "OAUTH_KEY", true)],
             &catalog,
+            &nothing_chosen,
         );
         assert_eq!(out.providers[0].env_var(), "OAUTH_KEY");
         assert!(
@@ -1277,6 +1978,7 @@ mod tests {
             &policy_applying(&[]),
             &[slot("somepkce", "SOMEPKCE_TOKEN", false)],
             &catalog,
+            &nothing_chosen,
         );
         assert!(out.pkce_configs.contains_key("somepkce"));
         assert!(out.oauth_configs.is_empty());

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -64,6 +64,74 @@ fn signin_pkce(integ: &Connector) -> Option<&OauthAuth> {
         .filter(|o| o.flow == OauthFlow::Pkce && o.authorization_endpoint.is_some())
 }
 
+/// The env var and injection domains a connector discloses on its consent card, or `None` when its authKind carries no usable block.
+pub fn disclosure_of(integ: &Connector) -> Option<(String, Vec<String>)> {
+    wire_provider(integ).map(|p| p.disclosure_snapshot())
+}
+
+/// A connector this workload has already answered for, either way: a grant recorded against the same disclosure the card showed. A redefined connector is a different question, so neither a yes nor a no carries over to a new shape.
+fn is_decided(
+    integ: &Connector,
+    project: &str,
+    workload: &WorkloadIdentity,
+    grants: &WorkloadGrantFile,
+) -> bool {
+    let Some(grant) = grants.lookup(project, workload, &integ.id) else {
+        return false;
+    };
+    disclosure_of(integ)
+        .is_some_and(|(env_var, domains)| grant.matches_disclosure(&env_var, &domains))
+}
+
+/// The policy a launch actually runs: the user's own rules minus the allows that would let a request past a connector nobody has decided yet, so the first request to a claimed domain is held and the connect offer gets its chance. Once the connector is connected or decided either way, the withheld rule applies as written. Only an `offerable` connector can withhold anything — a connector with no path to a card could never release the rule again.
+pub fn withhold_undecided_connector_allows(
+    policy: &Policy,
+    catalog: &[Connector],
+    offerable: &HashSet<String>,
+    project: &str,
+    workload: &WorkloadIdentity,
+    grants: &WorkloadGrantFile,
+) -> Policy {
+    let undecided: Vec<&str> = catalog
+        .iter()
+        .filter(|integ| offerable.contains(&integ.id))
+        // `offerable` is a launch-time snapshot, so a connector connected since — by a policy edit, which writes no grant — is still in it.
+        .filter(|integ| !policy.connectors.iter().any(|id| id == &integ.id))
+        .filter(|integ| !is_decided(integ, project, workload, grants))
+        .flat_map(claimed_domains)
+        .collect();
+    let mut out = policy.clone();
+    out.network.egress.http.retain(|rule| {
+        rule.verdict != lns_policy::Verdict::Allow
+            || !undecided
+                .iter()
+                .any(|claimed| domains_overlap(claimed, &rule.match_pattern))
+    });
+    out
+}
+
+/// Pairs each connectable connector's id with its catalog display name and route patterns, so a held request to one of those domains can offer to connect it instead of asking about the bare host.
+pub fn offerable_connectors(
+    connectable: &ConnectableConnectors,
+    catalog: &[Connector],
+) -> Vec<crate::approval_flow::session::OfferableConnector> {
+    connectable
+        .routes
+        .iter()
+        .map(|(id, routes)| {
+            let entry = catalog.iter().find(|i| &i.id == id);
+            crate::approval_flow::session::OfferableConnector {
+                id: id.clone(),
+                display_name: entry
+                    .map(|i| i.display_name().to_string())
+                    .unwrap_or_else(|| id.clone()),
+                patterns: routes.iter().map(|r| r.match_pattern.clone()).collect(),
+                token_fallback: entry.and_then(|i| i.token_fallback.clone()),
+            }
+        })
+        .collect()
+}
+
 /// The allow-routes a set of connected connector ids contributes, re-derived from the catalog so boot and a watcher reload reconstruct the same live routes from an id-only policy.
 pub fn applied_connector_routes(ids: &[String], catalog: &[Connector]) -> Vec<RouteRule> {
     let applied: HashSet<&str> = ids.iter().map(String::as_str).collect();
@@ -367,6 +435,33 @@ mod tests {
             connectors: ids.iter().map(|s| s.to_string()).collect(),
             ..Policy::default()
         }
+    }
+
+    #[test]
+    fn a_connector_the_policy_itself_connects_keeps_its_routes_unwithheld() {
+        let catalog = vec![cred_connector("acme", "ACME_API_KEY", "api.acme.corp")];
+        // A `lns-policy.yaml` edit connects a connector without writing any grant, and the offerable set is a launch-time snapshot that still names it.
+        let mut policy = policy_applying(&["acme"]);
+        policy.add_rule(RouteRule::allow_host("api.acme.corp"));
+        let offerable = HashSet::from(["acme".to_string()]);
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+
+        let out = withhold_undecided_connector_allows(
+            &policy,
+            &catalog,
+            &offerable,
+            "proj",
+            &workload,
+            &WorkloadGrantFile::default(),
+        );
+
+        assert_eq!(
+            out.network.egress.http.len(),
+            1,
+            "a connected connector's own routes must survive withholding, or connecting by hand leaves them dead until a relaunch"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -185,6 +185,7 @@ pub struct CredentialSession {
     armed: Mutex<HashSet<String>>,
     slot_ids: HashSet<String>,
     grant_binding: Option<GrantBinding>,
+    connector_owners: Arc<HashMap<String, String>>,
     run_grants: Mutex<HashMap<String, GrantRecord>>,
     connect: ConnectEmitter,
     oauth_configs: HashMap<String, crate::oauth::OauthConfig>,
@@ -235,6 +236,7 @@ impl CredentialSession {
             armed: Mutex::new(HashSet::new()),
             slot_ids: HashSet::new(),
             grant_binding: None,
+            connector_owners: Arc::new(HashMap::new()),
             run_grants: Mutex::new(HashMap::new()),
             connect: Box::new(|_| {}),
             oauth_configs: HashMap::new(),
@@ -301,6 +303,12 @@ impl CredentialSession {
     /// Per-id user-facing labels (e.g. `some-oauth` → "GitHub") for connect prompts and the sign-in card; ids absent here fall back to the id itself.
     pub fn with_oauth_display_names(mut self, display_names: HashMap<String, String>) -> Self {
         self.oauth_display_names = display_names;
+        self
+    }
+
+    /// Which connector each provider id belongs to, so a `lns connector disconnect` — recorded against the connector — is recognized as cancelling a decision made for one of its sign-in methods.
+    pub fn with_connector_owners(mut self, owners: Arc<HashMap<String, String>>) -> Self {
+        self.connector_owners = owners;
         self
     }
 
@@ -381,7 +389,7 @@ impl CredentialSession {
         self.armed.lock().expect("armed mutex poisoned").clone()
     }
 
-    /// Reconcile the armed set against a reloaded policy without erasing this run's live consent: keep an id the reload still lists or that names a credential slot (a live connect isn't self-revoked by its own persist, and the policy file can't revoke an artifact slot), re-arm the ids the reloaded policy grants, and drop everything else (a `lns connector disconnect`) — so a reload can revoke arming but never re-arm a connector this workload never granted.
+    /// Reconcile the armed set against a reloaded policy without erasing this run's live consent: keep an id the reload still lists or that names a credential slot (a live connect isn't self-revoked by its own persist, and the policy file can't revoke an artifact slot), re-arm the ids the reloaded policy grants, and drop everything else (a `lns connector disconnect`) — so a reload can revoke arming but never re-arm a connector this workload never granted. `reloaded` arrives already expanded into the providers' own keyspace, because the policy names connectors rather than the sign-in method a value is bound under.
     pub fn reconcile_armed(&self, granted: &[String], reloaded: &[String]) {
         let reloaded_set: HashSet<&str> = reloaded.iter().map(String::as_str).collect();
         let mut armed = self.armed.lock().expect("armed mutex poisoned");
@@ -451,6 +459,13 @@ impl CredentialSession {
         Some(record)
     }
 
+    /// The id a forget is recorded against: the connector, not the sign-in method the user picked through it.
+    fn revocation_key<'a>(&'a self, provider: &'a str) -> &'a str {
+        self.connector_owners
+            .get(provider)
+            .map_or(provider, String::as_str)
+    }
+
     /// Pins the forget count a freshly-raised card is asked against, so a `lns connector disconnect` the developer did before it went up is a question this card answers rather than a cancellation of it; an unreadable sidecar leaves the previous count in place, which can only cancel.
     fn ask_against_current_revocations(&self, credential_id: &str) {
         let Some(binding) = &self.grant_binding else {
@@ -459,9 +474,10 @@ impl CredentialSession {
         let Ok(file) = binding.store.load() else {
             return;
         };
+        let connector = self.revocation_key(credential_id);
         binding.ask_against_revocations(
             credential_id,
-            file.revocations_of(&binding.project, credential_id),
+            file.revocations_of(&binding.project, connector),
         );
     }
 
@@ -471,9 +487,10 @@ impl CredentialSession {
             return;
         };
         let asked_against = binding.revocations_asked_against(&record.connector);
+        let connector = self.revocation_key(&record.connector).to_string();
         let mut forgotten_since = false;
         let outcome = binding.store.update(&mut |file| {
-            if file.revocations_of(&record.project, &record.connector) != asked_against {
+            if file.revocations_of(&record.project, &connector) != asked_against {
                 forgotten_since = true;
                 return false;
             }
@@ -733,22 +750,22 @@ impl CredentialSession {
     }
 
     /// Connects connector `id` outside the held-credential flow (e.g. accepting a network offer): a device sign-in for an oauth id, a straight route-allow for a plain connectable id; returns whether it is now connected.
-    pub async fn connect_connector_now(&self, id: &str) -> bool {
-        if self.is_signin(id) {
-            let ok = self.run_signin_connect(id).await == SignInOutcome::Connected;
+    pub async fn connect_connector_now(&self, provider: &str) -> bool {
+        if self.is_signin(provider) {
+            let ok = self.run_signin_connect(provider).await == SignInOutcome::Connected;
             if ok {
                 // The same connect arms the token, so any placeholder card already held for this connector is satisfied too — don't ask for it separately.
-                self.release_armed_holds(id);
+                self.release_armed_holds(provider);
             }
             return ok;
         }
-        if self.connectable.contains(id) {
-            self.grant_armed(id);
-            self.remember_grant(id, GrantVerdict::Allow);
-            (self.connect)(id);
+        if self.connectable.contains(provider) {
+            self.grant_armed(provider);
+            self.remember_grant(provider, GrantVerdict::Allow);
+            (self.connect)(provider);
             // The connect armed a value the wire expansion resolves (stored, oauth, or a host-detect that the host supplies), so a held value card asks an answered question; with nothing resolvable the card stays — that decision is still owed.
-            if self.has_resolvable_value(id) {
-                self.release_armed_holds(id);
+            if self.has_resolvable_value(provider) {
+                self.release_armed_holds(provider);
             }
             return true;
         }
@@ -1680,6 +1697,42 @@ mod tests {
                 .lookup("proj", &workload, "some-provider")
                 .is_some(),
             "a card raised after the forget is a new question, so answering it must land — otherwise one disconnect makes every later consent in this run un-rememberable, and the next run re-asks citing a disconnect the developer already undid"
+        );
+    }
+
+    #[test]
+    fn disconnecting_a_connector_mid_run_cancels_a_decision_made_for_one_of_its_sign_in_methods() {
+        let store = Arc::new(CapturingGrantStore::default());
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let method = DefProvider::new(lns_policy::providers::ProviderDef {
+            id: "some-provider:api-key".into(),
+            env_var: "SOME_TOKEN".into(),
+            placeholder: "some-placeholder-0000".into(),
+            injections: vec![lns_policy::providers::InjectionDef {
+                kind: lns_policy::providers::InjectionKind::BearerHeader,
+                domain: "api.some-provider.example".into(),
+                header: None,
+            }],
+        });
+        let session = grants_session(store.clone(), workload.clone(), vec![method])
+            .with_connector_owners(Arc::new(HashMap::from([(
+                "some-provider:api-key".to_string(),
+                "some-provider".to_string(),
+            )])));
+
+        session.submit_pending(pending("c1", "some-provider:api-key"), Instant::now());
+        forget_from_another_process(store.as_ref());
+        allow_stored(&session, "c1");
+
+        assert!(
+            store
+                .load()
+                .unwrap()
+                .lookup("proj", &workload, "some-provider:api-key")
+                .is_none(),
+            "the developer disconnected the connector, not one of its sign-ins, so the forget must still cancel the card it interrupted"
         );
     }
 

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -494,6 +494,11 @@ impl CredentialSession {
         }
     }
 
+    /// This workload's standing no for a connector whose offer was answered without taking it, so a later run stops raising the card.
+    pub fn decline_connector(&self, credential_id: &str) {
+        self.remember_grant(credential_id, GrantVerdict::Deny);
+    }
+
     /// Remembers a decision that writes no value of its own — a decline, or a grant of what is already bound on this machine — so nothing gates its durability.
     fn remember_grant(&self, credential_id: &str, verdict: GrantVerdict) {
         let record = self.remember_grant_for_the_run(credential_id, verdict);
@@ -2133,6 +2138,36 @@ mod tests {
         assert_eq!(
             decision_frame(&mut rx).decision,
             CredentialDecisionKind::Allow
+        );
+    }
+
+    #[test]
+    fn declining_a_connector_offer_persists_this_workloads_standing_no() {
+        let store = Arc::new(CapturingGrantStore::default());
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let session = CredentialSession::new(
+            CredentialStateFile::new(),
+            Arc::new(RecordingNotifier::default()),
+            Arc::new(CapturingStore::default()),
+            tx,
+            TEST_TIMEOUT,
+        )
+        .with_custom_providers(Arc::new(vec![some_provider()]))
+        .with_grants("proj".into(), workload.clone(), store.clone());
+
+        session.decline_connector("some-provider");
+
+        let persisted = store.load().unwrap();
+        let grant = persisted
+            .lookup("proj", &workload, "some-provider")
+            .expect("a declined offer leaves a standing no in the sidecar");
+        assert_eq!(
+            grant.verdict,
+            GrantVerdict::Deny,
+            "the network card's decline must reach the same sidecar the credential card writes, or the next run re-asks"
         );
     }
 

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -346,7 +346,8 @@ pub(crate) async fn run_connector_sign_in(
     let Some(oauth) = catalog
         .iter()
         .find(|i| i.id == id)
-        .and_then(|i| i.oauth.as_ref())
+        .and_then(|i| i.default_method())
+        .and_then(|m| m.oauth.as_ref())
     else {
         return Response::OauthSignInFailed {
             reason: format!("{id:?} is not an oauth connector"),

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -269,7 +269,12 @@ async fn run_credential_bind(id: &str) -> Response {
     };
     let Some(prompt) = bind_prompt(integ) else {
         return Response::CredentialBindFailed {
-            reason: format!("{id:?} is not a credential connector"),
+            reason: match integ.sole_method() {
+                Some(_) => format!("{id:?} is not a credential connector"),
+                None => format!(
+                    "{id:?} has several sign-in methods; connect it from the offer card, which asks which one"
+                ),
+            },
         };
     };
     // Fail fast instead of holding the CLI on a card a headless service can never show.
@@ -343,10 +348,17 @@ pub(crate) async fn run_connector_sign_in(
     )
     .unwrap_or_default();
     let catalog = lns_policy::connectors::effective_connectors(&user);
-    let Some(oauth) = catalog
-        .iter()
-        .find(|i| i.id == id)
-        .and_then(|i| i.default_method())
+    let entry = catalog.iter().find(|i| i.id == id);
+    // A connector reachable several ways binds each sign-in under its own key, so signing in without naming one would store a token nothing reads.
+    if entry.is_some_and(|i| i.sole_method().is_none()) {
+        return Response::OauthSignInFailed {
+            reason: format!(
+                "{id:?} has several sign-in methods; connect it from the offer card, which asks which one"
+            ),
+        };
+    }
+    let Some(oauth) = entry
+        .and_then(|i| i.sole_method())
         .and_then(|m| m.oauth.as_ref())
     else {
         return Response::OauthSignInFailed {

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -91,6 +91,8 @@ async fn orchestrate(
         resolved_image,
         sandbox_plan.as_ref().and_then(|p| p.digest.as_deref()),
     )?;
+    // Directory state, not definition state, so a plain `lns run` is gated too.
+    crate::artifact::real::refuse_unchosen_connected_connectors(policy.as_deref(), &workload)?;
     let mut signed_in = Vec::new();
     let mut revocations_at_gate = std::collections::HashMap::new();
     if let Some(plan) = &sandbox_plan {

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -421,6 +421,36 @@ fn make_policy_emitter(
     })
 }
 
+/// The per-machine sign-in state a reload-time decision reads: both the credential values and the grant sidecar, re-read each call so a decision landed earlier in this run takes effect immediately. An unreadable file reads as "nothing held", which can only over-ask, never over-allow.
+fn sign_in_state_now(
+    credential_store: &dyn CredentialStore,
+    grant_store: &dyn GrantStore,
+) -> (CredentialStateFile, WorkloadGrantFile) {
+    (
+        credential_store.load().unwrap_or_default(),
+        grant_store.load().unwrap_or_default(),
+    )
+}
+
+/// The connected connectors this machine holds no sign-in for, recomputed per card so being listed in `connectors:` stops suppressing an offer the user still has to answer.
+fn make_unchosen_connectors(
+    catalog: Vec<lns_policy::connectors::Connector>,
+    project: String,
+    workload: WorkloadIdentity,
+    grant_store: Arc<dyn GrantStore>,
+    credential_store: Arc<dyn CredentialStore>,
+) -> crate::approval_flow::session::UnchosenConnectors {
+    Box::new(move |policy| {
+        let (state, grants) = sign_in_state_now(credential_store.as_ref(), grant_store.as_ref());
+        let chosen = crate::credential_flow::connectors::machine_holds_sign_in(
+            &state, &grants, &project, &workload,
+        );
+        crate::credential_flow::connectors::unchosen_connected_connectors(policy, &catalog, &chosen)
+            .into_iter()
+            .collect()
+    })
+}
+
 /// A watcher reload re-reads the user's own allows from disk, so the launch's withholding is re-applied here too — otherwise a reload mid-run hands back the allow that would swallow an undecided connector's first-use offer. Each call re-reads the sidecar, so a decline landed earlier in this run stops withholding immediately instead of waiting for a relaunch.
 fn make_policy_withholder(
     catalog: Vec<lns_policy::connectors::Connector>,
@@ -428,12 +458,15 @@ fn make_policy_withholder(
     project: String,
     workload: WorkloadIdentity,
     grant_store: Arc<dyn GrantStore>,
+    credential_store: Arc<dyn CredentialStore>,
 ) -> crate::approval_flow::session::PolicyWithholder {
     Box::new(move |policy| {
-        // An unreadable sidecar withholds as if nothing were decided, so a lost read can never leak a domain past its offer.
-        let grants = grant_store.load().unwrap_or_default();
+        let (state, grants) = sign_in_state_now(credential_store.as_ref(), grant_store.as_ref());
+        let chosen = crate::credential_flow::connectors::machine_holds_sign_in(
+            &state, &grants, &project, &workload,
+        );
         crate::credential_flow::connectors::withhold_undecided_connector_allows(
-            policy, &catalog, &offerable, &project, &workload, &grants,
+            policy, &catalog, &offerable, &project, &workload, &grants, &chosen,
         )
     })
 }
@@ -769,6 +802,12 @@ pub(super) async fn start(
         &project,
         &workload,
         &grants,
+        &crate::credential_flow::connectors::machine_holds_sign_in(
+            &credential_state,
+            &grants,
+            &project,
+            &workload,
+        ),
     );
 
     let store = Arc::new(FilePolicyStore::new(policy_path.to_path_buf()));
@@ -779,12 +818,20 @@ pub(super) async fn start(
             .with_offers(offerable),
     );
 
+    session.set_unchosen_connectors(make_unchosen_connectors(
+        catalog.clone(),
+        project.clone(),
+        workload.clone(),
+        grant_store.clone(),
+        credential_store.clone(),
+    ));
     session.set_policy_withholder(make_policy_withholder(
         catalog.clone(),
         offerable_ids,
         project.clone(),
         workload.clone(),
         grant_store.clone(),
+        credential_store.clone(),
     ));
     session.set_connector_route_deriver(make_connector_route_deriver(catalog.clone()));
     if let Some(baseline) = sandbox_policy {
@@ -1927,6 +1974,82 @@ mod tests {
         );
     }
 
+    /// A two-method connector, the shape whose sign-in the user must pick.
+    fn two_method_catalog() -> Vec<lns_policy::connectors::Connector> {
+        vec![lns_policy::connectors::Connector {
+            id: "acme".into(),
+            name: None,
+            routes: Vec::new(),
+            methods: vec![
+                lns_policy::connectors::SignInMethod::credential(
+                    "api-key",
+                    lns_policy::connectors::CredentialAuth {
+                        env_var: "ACME_API_KEY".into(),
+                        placeholder: "acme_LNSPLACEHOLDER".into(),
+                        injections: Vec::new(),
+                    },
+                ),
+                lns_policy::connectors::SignInMethod::credential(
+                    "subscription",
+                    lns_policy::connectors::CredentialAuth {
+                        env_var: "ACME_SUBSCRIPTION".into(),
+                        placeholder: "acme_sub_LNSPLACEHOLDER".into(),
+                        injections: Vec::new(),
+                    },
+                ),
+            ],
+        }]
+    }
+
+    fn connected_acme() -> Policy {
+        let mut policy = Policy::default();
+        policy.connect("acme");
+        policy
+    }
+
+    #[test]
+    fn the_unchosen_set_names_a_connected_connector_whose_sign_in_is_not_held() {
+        let workload = acme_workload();
+        let (credential_store, _dir) = tempfile_credential_store();
+        let unchosen = make_unchosen_connectors(
+            two_method_catalog(),
+            "proj".into(),
+            workload.clone(),
+            grant_store_holding(WorkloadGrantFile::default()),
+            credential_store,
+        );
+        assert_eq!(
+            unchosen(&connected_acme()),
+            HashSet::from(["acme".to_string()]),
+            "listing a connector it cannot authenticate must not suppress the card that asks which sign-in to use"
+        );
+    }
+
+    #[test]
+    fn the_unchosen_set_drops_a_connector_whose_sign_in_this_workload_granted() {
+        let workload = acme_workload();
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::allow(
+            "proj",
+            &workload,
+            "acme:api-key",
+            "ACME_API_KEY",
+            vec![],
+        ));
+        let (credential_store, _dir) = tempfile_credential_store();
+        let unchosen = make_unchosen_connectors(
+            two_method_catalog(),
+            "proj".into(),
+            workload.clone(),
+            grant_store_holding(grants),
+            credential_store,
+        );
+        assert!(
+            unchosen(&connected_acme()).is_empty(),
+            "the sign-in is held, so re-offering it would ask a question the user already answered"
+        );
+    }
+
     #[test]
     fn a_policy_reload_keeps_the_chosen_sign_in_of_a_connector_reachable_several_ways_armed() {
         let (session, _frame_rx) = fixture_credential_session_armed(
@@ -2384,6 +2507,7 @@ mod tests {
             "proj".into(),
             workload.clone(),
             store.clone(),
+            tempfile_credential_store().0,
         );
         let mut policy = Policy::default();
         policy.add_rule(RouteRule::allow_host("api.acme.corp"));

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -421,6 +421,27 @@ fn make_policy_emitter(
     })
 }
 
+/// The policy the launch enforces, withheld against the sign-in state the launch itself holds rather than a re-read of disk — a boot sign-in whose grant could not be persisted still decides this run.
+#[allow(clippy::too_many_arguments)] // the launch's whole withholding input, threaded once so a test can compose it without booting
+fn boot_running_policy(
+    base: &Policy,
+    connector_routes: Vec<RouteRule>,
+    catalog: &[lns_policy::connectors::Connector],
+    offerable: &HashSet<String>,
+    project: &str,
+    workload: &WorkloadIdentity,
+    grants: &WorkloadGrantFile,
+    state: &CredentialStateFile,
+) -> Policy {
+    let chosen =
+        crate::credential_flow::connectors::machine_holds_sign_in(state, grants, project, workload);
+    crate::artifact::policy::compose_running_policy(base, connector_routes, &|policy| {
+        crate::credential_flow::connectors::withhold_undecided_connector_allows(
+            policy, catalog, offerable, project, workload, grants, &chosen,
+        )
+    })
+}
+
 /// The per-machine sign-in state a reload-time decision reads: both the credential values and the grant sidecar, re-read each call so a decision landed earlier in this run takes effect immediately. An unreadable file reads as "nothing held", which can only over-ask, never over-allow.
 fn sign_in_state_now(
     credential_store: &dyn CredentialStore,
@@ -713,7 +734,7 @@ pub(super) async fn start(
 ) -> Result<SupervisorSession> {
     let sandbox_credentials = consent.credentials;
     let workload = consent.workload;
-    let mut policy = effective_running_policy(policy_path, sandbox_policy)?;
+    let policy = effective_running_policy(policy_path, sandbox_policy)?;
     // Applied connectors resolve against the effective catalog (bundled ∪ user) into both wire credentials and allow-routes, captured once at boot so a later edit can't reach an already-forked workload.
     let user_catalog =
         load_user_catalog_or_warn(&lns_policy::connectors::default_connectors_path());
@@ -747,10 +768,7 @@ pub(super) async fn start(
         &declared_connectors,
         &catalog,
     );
-    crate::artifact::policy::splice_connector_routes(
-        &mut policy.network.egress.http,
-        applied.routes,
-    );
+    let applied_routes = applied.routes;
     let offerable =
         crate::credential_flow::connectors::offerable_connectors(&connectable, &catalog);
     let connectable_routes = Arc::new(connectable.routes);
@@ -795,19 +813,15 @@ pub(super) async fn start(
 
     // An allow the user wrote for a connector's domain would let the first request past before the connector was ever offered, so it waits until this workload connects or declines.
     let offerable_ids: HashSet<String> = offerable.iter().map(|o| o.id.clone()).collect();
-    let policy = crate::credential_flow::connectors::withhold_undecided_connector_allows(
+    let policy = boot_running_policy(
         &policy,
+        applied_routes,
         &catalog,
         &offerable_ids,
         &project,
         &workload,
         &grants,
-        &crate::credential_flow::connectors::machine_holds_sign_in(
-            &credential_state,
-            &grants,
-            &project,
-            &workload,
-        ),
+        &credential_state,
     );
 
     let store = Arc::new(FilePolicyStore::new(policy_path.to_path_buf()));
@@ -2005,6 +2019,56 @@ mod tests {
         let mut policy = Policy::default();
         policy.connect("acme");
         policy
+    }
+
+    #[test]
+    fn a_boot_sign_in_whose_grant_could_not_be_persisted_still_keeps_its_domains_allow() {
+        let workload = acme_workload();
+        let mut catalog = two_method_catalog();
+        catalog[0].routes = vec![lns_policy::connectors::ConnectorRoute {
+            match_pattern: "api.acme.corp".into(),
+            transport: None,
+            scheme: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+        }];
+        // The sign-in connected it, so the policy lists it.
+        let mut policy = Policy::default();
+        policy.connect("acme");
+        policy.add_rule(RouteRule::allow_host("api.acme.corp"));
+        // The sidecar write failed, so the grant the sign-in earned lives only in this launch's snapshot.
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::allow(
+            "proj",
+            &workload,
+            "acme:api-key",
+            "ACME_API_KEY",
+            vec!["api.acme.corp".into()],
+        ));
+
+        let composed = boot_running_policy(
+            &policy,
+            Vec::new(),
+            &catalog,
+            &HashSet::from(["acme".to_string()]),
+            "proj",
+            &workload,
+            &grants,
+            &CredentialStateFile::new(),
+        );
+
+        let survivors: Vec<&str> = composed
+            .network
+            .egress
+            .http
+            .iter()
+            .map(|r| r.match_pattern.as_str())
+            .collect();
+        assert_eq!(
+            survivors,
+            vec!["api.acme.corp"],
+            "the developer just completed this sign-in, so withholding its domain would raise a card for the credential they already granted — a failed sidecar write must not decide the run"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -140,12 +140,14 @@ async fn decision_delivery_loop(
                 session.dismiss_request(&delivery.id);
             }
             // Accepting a connector offer drives a connect (async) rather than a per-request verdict.
-            RequestAction::ConnectConnector => {
-                session.connect_offer(&delivery.id).await;
+            RequestAction::ConnectConnector { method } => {
+                session.connect_offer(&delivery.id, method.as_deref()).await;
             }
             // A pasted token connects the connector without the interactive sign-in.
-            RequestAction::UseToken { value } => {
-                session.connect_offer_with_token(&delivery.id, value).await;
+            RequestAction::UseToken { method, value } => {
+                session
+                    .connect_offer_with_token(&delivery.id, method.as_deref(), value)
+                    .await;
             }
         }
     }
@@ -361,15 +363,31 @@ fn make_armed_reconciler(
     workload: WorkloadIdentity,
     grant_store: Arc<dyn GrantStore>,
     providers: Arc<Vec<DefProvider>>,
+    owners: Arc<HashMap<String, String>>,
 ) -> crate::approval_flow::session::ArmedReconciler {
     let weak = Arc::downgrade(credential_session);
     Box::new(move |connectors| {
         if let Some(cs) = weak.upgrade() {
-            let reloaded: HashSet<String> = connectors.iter().cloned().collect();
+            let reloaded: HashSet<&str> = connectors.iter().map(String::as_str).collect();
+            // The policy names connectors, never the sign-in method a value is bound under, so a reload is compared in the providers' own keyspace.
+            let reloaded_providers: HashSet<String> = providers
+                .iter()
+                .map(|p| p.id().to_string())
+                .filter(|id| reloaded.contains(owners.get(id).map_or(id.as_str(), String::as_str)))
+                .collect();
             // An unreadable sidecar arms nothing rather than falling back to a snapshot a revoke may since have invalidated.
             let grants = grant_store.load().unwrap_or_default();
-            let granted = gate_armed_by_grant(&reloaded, &providers, &project, &workload, &grants);
-            cs.reconcile_armed(&granted.into_iter().collect::<Vec<_>>(), connectors);
+            let granted = gate_armed_by_grant(
+                &reloaded_providers,
+                &providers,
+                &project,
+                &workload,
+                &grants,
+            );
+            cs.reconcile_armed(
+                &granted.into_iter().collect::<Vec<_>>(),
+                &reloaded_providers.into_iter().collect::<Vec<_>>(),
+            );
         }
     })
 }
@@ -427,14 +445,16 @@ fn make_connector_route_deriver(
     Box::new(move |ids| applied_connector_routes(ids, &catalog))
 }
 
-/// Connecting an un-connected catalog connector allows its routes on the approval session's live policy (and persists `connectors:`), so the held request proceeds without a relaunch.
+/// Connecting an un-connected catalog connector allows its routes on the approval session's live policy (and persists `connectors:`), so the held request proceeds without a relaunch. The policy records the connector, never the sign-in method the user picked — which auth you hold is per-machine state and has no place in a shared file.
 fn make_connect_emitter(
     session: Arc<ApprovalSession>,
     routes: Arc<HashMap<String, Vec<RouteRule>>>,
+    owners: Arc<HashMap<String, String>>,
 ) -> crate::credential_flow::session::ConnectEmitter {
-    Box::new(move |id| {
-        let rules = routes.get(id).cloned().unwrap_or_default();
-        session.connect_connector(id, rules);
+    Box::new(move |provider| {
+        let connector = owners.get(provider).map_or(provider, String::as_str);
+        let rules = routes.get(connector).cloned().unwrap_or_default();
+        session.connect_connector(connector, rules);
     })
 }
 
@@ -481,6 +501,25 @@ const OAUTH_REFRESH_SKEW_SECS: u64 = 60;
 
 const WINDOW_NOT_INSTALLED: &str = "approval window state was not installed at boot; tray::run_tray must run before any policy-bearing run starts";
 
+/// The artifact slot ids a reload must not disarm, named in the providers' own keyspace: a slot on a connector reachable several ways arms under the chosen sign-in's id, so naming the bare connector would let a reload withdraw it.
+fn slot_provider_ids(
+    slots: &[lns_artifact::spec::CredentialSlot],
+    catalog: &[lns_policy::connectors::Connector],
+    providers: &[DefProvider],
+    owners: &HashMap<String, String>,
+) -> HashSet<String> {
+    let slot_connectors: HashSet<&str> = slots
+        .iter()
+        .filter(|slot| catalog.iter().any(|i| i.id == slot.name))
+        .map(|slot| slot.name.as_str())
+        .collect();
+    providers
+        .iter()
+        .map(|p| p.id().to_string())
+        .filter(|id| slot_connectors.contains(owners.get(id).map_or(id.as_str(), String::as_str)))
+        .collect()
+}
+
 /// The run's consent boundary at boot: which ids arm a resolved value (`armed`), the artifact-declared credential slot ids a policy reload must not disarm (`slot_ids`), which ids are offered for a live connect (`connectable_ids`), and the grant identity (`project`/`workload`) plus sidecar (`grant_store`) that a live consent persists to and a reload re-gates a reconnected connector against.
 struct CredentialConsent {
     armed: HashSet<String>,
@@ -499,20 +538,33 @@ struct OauthWiring {
     token_fallbacks: HashMap<String, lns_policy::connectors::TokenFallback>,
 }
 
+/// How a live connect reaches the policy: each connectable connector's held routes, and which connector each provider id belongs to.
+struct ConnectWiring {
+    routes: Arc<HashMap<String, Vec<RouteRule>>>,
+    owners: Arc<HashMap<String, String>>,
+}
+
+/// The per-machine credential file read once at launch, so the sign-in a connector's chosen method is bound to is resolved from the same state the credential session then owns.
+struct CredentialStateAtBoot {
+    path: PathBuf,
+    store: Arc<dyn CredentialStore>,
+    state: CredentialStateFile,
+}
+
 async fn start_credential_subsystem(
     session: Arc<ApprovalSession>,
     credential_frame_tx: tokio::sync::mpsc::UnboundedSender<HostFrame>,
     custom_providers: Arc<Vec<DefProvider>>,
     consent: CredentialConsent,
-    connectable_routes: Arc<HashMap<String, Vec<RouteRule>>>,
+    connect: ConnectWiring,
+    credentials: CredentialStateAtBoot,
     oauth: OauthWiring,
 ) -> Result<CredentialSubsystem> {
-    // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
-    let credentials_path = default_credentials_path();
-    let credential_store: Arc<dyn CredentialStore> =
-        Arc::new(JsonFileCredentialStore::new(credentials_path.clone()));
-    let mut initial_credential_state =
-        load_credentials_or_warn(credential_store.as_ref(), &credentials_path);
+    let CredentialStateAtBoot {
+        path: credentials_path,
+        store: credential_store,
+        state: mut initial_credential_state,
+    } = credentials;
     // Renew any oauth grant that expired since last use before the session arms it (the dominant case; a mid-run expiry falls back to the held-request re-prompt).
     crate::oauth::refresh_due_entries(
         &mut initial_credential_state,
@@ -535,7 +587,8 @@ async fn start_credential_subsystem(
         credential_frame_tx.clone(),
         custom_providers.clone(),
     );
-    let connect_emitter = make_connect_emitter(session.clone(), connectable_routes);
+    let ConnectWiring { routes, owners } = connect;
+    let connect_emitter = make_connect_emitter(session.clone(), routes, owners.clone());
     let reconciler_providers = custom_providers.clone();
     let credential_session = Arc::new(
         CredentialSession::with_policy_emitter(
@@ -575,6 +628,7 @@ async fn start_credential_subsystem(
             Box::new(crate::oauth::PkceChallenge::generate),
             crate::credential_flow::session::PKCE_SIGN_IN_TIMEOUT,
         )
+        .with_connector_owners(owners.clone())
         .with_oauth_display_names(oauth.display_names)
         .with_token_fallbacks(oauth.token_fallbacks),
     );
@@ -596,6 +650,7 @@ async fn start_credential_subsystem(
         consent.workload,
         consent.grant_store,
         reconciler_providers,
+        owners,
     ));
 
     let credential_watcher = CredentialWatcher::spawn(credentials_path, credential_session.clone())
@@ -630,7 +685,25 @@ pub(super) async fn start(
     let user_catalog =
         load_user_catalog_or_warn(&lns_policy::connectors::default_connectors_path());
     let catalog = lns_policy::connectors::effective_connectors(&user_catalog);
-    let applied = resolve_applied_with_slots(&policy, sandbox_credentials, &catalog);
+    // A machine-global value arms only for a connector this workload holds an allow grant for, so a cloned overlay or a declared slot re-offers at first use instead of silently spending the credential.
+    let grants_path = default_workload_grants_path();
+    let grant_store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(grants_path.clone()));
+    let mut grants = load_grants_or_warn(grant_store.as_ref(), &grants_path);
+    let project = project_key(policy_path);
+    // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
+    let credentials_path = default_credentials_path();
+    let credential_store: Arc<dyn CredentialStore> =
+        Arc::new(JsonFileCredentialStore::new(credentials_path.clone()));
+    let credential_state = load_credentials_or_warn(credential_store.as_ref(), &credentials_path);
+    let applied = {
+        let chosen = crate::credential_flow::connectors::machine_holds_sign_in(
+            &credential_state,
+            &grants,
+            &project,
+            &workload,
+        );
+        resolve_applied_with_slots(&policy, sandbox_credentials, &catalog, &chosen)
+    };
     // Un-connected catalog connectors resolve as connectable — detect-only unless definition-declared — so their use offers a live connect.
     let declared_connectors = sandbox_policy
         .map(|p| p.connectors.clone())
@@ -648,6 +721,9 @@ pub(super) async fn start(
     let offerable =
         crate::credential_flow::connectors::offerable_connectors(&connectable, &catalog);
     let connectable_routes = Arc::new(connectable.routes);
+    let mut owners = applied.owner;
+    owners.extend(connectable.owner);
+    let connector_owners = Arc::new(owners);
     let run =
         crate::credential_flow::connectors::run_providers(applied.providers, connectable.providers);
     let connectable_ids = run.connectable_ids;
@@ -661,11 +737,6 @@ pub(super) async fn start(
     ));
     log::info!("Approvals", "window ready");
 
-    // A machine-global value arms only for a connector this workload holds an allow grant for, so a cloned overlay or a declared slot re-offers at first use instead of silently spending the credential.
-    let grants_path = default_workload_grants_path();
-    let grant_store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(grants_path.clone()));
-    let mut grants = load_grants_or_warn(grant_store.as_ref(), &grants_path);
-    let project = project_key(policy_path);
     record_boot_sign_in_grants(
         BootSignIns {
             signed_in: &consent.signed_in,
@@ -680,11 +751,12 @@ pub(super) async fn start(
     );
     let armed_ids = gate_armed_by_grant(&run.armed, &run.providers, &project, &workload, &grants);
     // A reload re-gates overlay connectors but must never disarm an artifact slot the run consented to, so every catalog-known slot id is retained across a reload regardless of grant.
-    let slot_ids: HashSet<String> = sandbox_credentials
-        .iter()
-        .filter(|slot| catalog.iter().any(|i| i.id == slot.name))
-        .map(|slot| slot.name.clone())
-        .collect();
+    let slot_ids: HashSet<String> = slot_provider_ids(
+        sandbox_credentials,
+        &catalog,
+        &run.providers,
+        &connector_owners,
+    );
     let custom_providers = Arc::new(run.providers);
     let managed_env_vars = collect_managed_env_vars(&custom_providers);
 
@@ -738,17 +810,22 @@ pub(super) async fn start(
         .chain(connectable.pkce_configs.iter())
         .map(|(id, auth)| (id.clone(), crate::oauth::PkceConfig::from(auth)))
         .collect();
+    // Keyed per sign-in method, so a connector reachable more than one way shows the fallback belonging to the way the user picked rather than the first one listed.
     let oauth_display_names: HashMap<String, String> = catalog
         .iter()
-        .filter(|i| i.default_method().is_some_and(|m| m.oauth.is_some()))
-        .map(|i| (i.id.clone(), i.display_name().to_string()))
+        .flat_map(|i| {
+            i.methods
+                .iter()
+                .filter(|m| m.oauth.is_some())
+                .map(move |m| (i.provider_id_of(m), i.display_name().to_string()))
+        })
         .collect();
     let token_fallbacks: HashMap<String, lns_policy::connectors::TokenFallback> = catalog
         .iter()
-        .filter_map(|i| {
-            i.default_method()
-                .and_then(|m| m.token_fallback.clone())
-                .map(|tf| (i.id.clone(), tf))
+        .flat_map(|i| {
+            i.methods
+                .iter()
+                .filter_map(move |m| m.token_fallback.clone().map(|tf| (i.provider_id_of(m), tf)))
         })
         .collect();
     let (credential_session, credential_watcher) = start_credential_subsystem(
@@ -763,7 +840,15 @@ pub(super) async fn start(
             workload,
             grant_store,
         },
-        connectable_routes,
+        ConnectWiring {
+            routes: connectable_routes,
+            owners: connector_owners,
+        },
+        CredentialStateAtBoot {
+            path: credentials_path,
+            store: credential_store,
+            state: credential_state,
+        },
         OauthWiring {
             configs: oauth_configs,
             pkce_configs,
@@ -963,7 +1048,12 @@ mod tests {
                 id: "some-oauth".into(),
                 display_name: "GitHub".into(),
                 patterns: vec!["api.some-oauth.example".into()],
-                token_fallback: None,
+                methods: vec![crate::approval_flow::session::OfferMethod {
+                    method_id: "device".into(),
+                    provider_id: "some-oauth".into(),
+                    display_name: "device".into(),
+                    token_fallback: None,
+                }],
             }]),
         );
         let connector = Arc::new(RecordingConnector::default());
@@ -982,7 +1072,7 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<DecisionDelivery>();
         tx.send(DecisionDelivery {
             id: "r1".into(),
-            action: RequestAction::ConnectConnector,
+            action: RequestAction::ConnectConnector { method: None },
         })
         .unwrap();
         drop(tx);
@@ -1027,7 +1117,12 @@ mod tests {
                 id: "some-oauth".into(),
                 display_name: "GitHub".into(),
                 patterns: vec!["api.some-oauth.example".into()],
-                token_fallback: None,
+                methods: vec![crate::approval_flow::session::OfferMethod {
+                    method_id: "device".into(),
+                    provider_id: "some-oauth".into(),
+                    display_name: "device".into(),
+                    token_fallback: None,
+                }],
             }]),
         );
         let connector = Arc::new(RecordingConnector::default());
@@ -1047,6 +1142,7 @@ mod tests {
         tx.send(DecisionDelivery {
             id: "r1".into(),
             action: RequestAction::UseToken {
+                method: None,
                 value: "some-pasted-token".into(),
             },
         })
@@ -1092,7 +1188,12 @@ mod tests {
                 id: "some-oauth".into(),
                 display_name: "GitHub".into(),
                 patterns: vec!["api.some-oauth.example".into()],
-                token_fallback: None,
+                methods: vec![crate::approval_flow::session::OfferMethod {
+                    method_id: "device".into(),
+                    provider_id: "some-oauth".into(),
+                    display_name: "device".into(),
+                    token_fallback: None,
+                }],
             }]),
         );
         let connector = Arc::new(RecordingConnector::default());
@@ -1742,6 +1843,7 @@ mod tests {
             workload.clone(),
             grant_store_holding(acme_grants(&workload)),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         reconcile(&["acme".to_string()]);
         assert_eq!(
@@ -1757,6 +1859,110 @@ mod tests {
         );
     }
 
+    /// A per-method provider and the grant that arms it, the shape a connector reachable several ways produces.
+    fn acme_method_custom() -> Arc<Vec<DefProvider>> {
+        use lns_policy::providers::{InjectionDef, InjectionKind, ProviderDef};
+        Arc::new(vec![DefProvider::new(ProviderDef {
+            id: "acme:api-key".into(),
+            env_var: "ACME_API_KEY".into(),
+            placeholder: "acme_LNSPLACEHOLDER".into(),
+            injections: vec![InjectionDef {
+                kind: InjectionKind::BearerHeader,
+                domain: "api.acme.corp".into(),
+                header: None,
+            }],
+        })])
+    }
+
+    fn acme_method_grants(workload: &WorkloadIdentity) -> WorkloadGrantFile {
+        let mut grants = WorkloadGrantFile::default();
+        grants.upsert(GrantRecord::allow(
+            "proj",
+            workload,
+            "acme:api-key",
+            "ACME_API_KEY",
+            vec!["api.acme.corp".into()],
+        ));
+        grants
+    }
+
+    #[test]
+    fn an_artifact_slot_on_a_connector_reachable_several_ways_is_named_by_its_chosen_sign_in() {
+        use lns_artifact::spec::CredentialSlot;
+        let catalog = vec![lns_policy::connectors::Connector {
+            id: "acme".into(),
+            name: None,
+            routes: Vec::new(),
+            methods: vec![
+                lns_policy::connectors::SignInMethod::credential(
+                    "api-key",
+                    lns_policy::connectors::CredentialAuth {
+                        env_var: "ACME_API_KEY".into(),
+                        placeholder: "acme_LNSPLACEHOLDER".into(),
+                        injections: Vec::new(),
+                    },
+                ),
+                lns_policy::connectors::SignInMethod::credential(
+                    "subscription",
+                    lns_policy::connectors::CredentialAuth {
+                        env_var: "ACME_SUBSCRIPTION".into(),
+                        placeholder: "acme_sub_LNSPLACEHOLDER".into(),
+                        injections: Vec::new(),
+                    },
+                ),
+            ],
+        }];
+        let slots = vec![CredentialSlot {
+            name: "acme".into(),
+            env: "REMAPPED".into(),
+            required: false,
+        }];
+        let providers = acme_method_custom();
+        let owners = HashMap::from([("acme:api-key".to_string(), "acme".to_string())]);
+
+        assert_eq!(
+            slot_provider_ids(&slots, &catalog, &providers, &owners),
+            HashSet::from(["acme:api-key".to_string()]),
+            "the slot arms under the sign-in it resolved to, so naming the bare connector would let a policy reload withdraw a credential the artifact requires"
+        );
+    }
+
+    #[test]
+    fn a_policy_reload_keeps_the_chosen_sign_in_of_a_connector_reachable_several_ways_armed() {
+        let (session, _frame_rx) = fixture_credential_session_armed(
+            acme_method_custom(),
+            HashSet::from(["acme:api-key".to_string()]),
+            HashSet::new(),
+        );
+        let workload = acme_workload();
+        let reconcile = make_armed_reconciler(
+            &session,
+            "proj".into(),
+            workload.clone(),
+            grant_store_holding(acme_method_grants(&workload)),
+            acme_method_custom(),
+            Arc::new(HashMap::from([(
+                "acme:api-key".to_string(),
+                "acme".to_string(),
+            )])),
+        );
+
+        // The policy never names a sign-in method, so a reload lists the bare connector id.
+        reconcile(&["acme".to_string()]);
+
+        assert_eq!(
+            session.armed_ids(),
+            HashSet::from(["acme:api-key".to_string()]),
+            "the policy names connectors, never methods, so a reload that still lists the connector must not withdraw the injection its chosen sign-in is arming"
+        );
+
+        reconcile(&[]);
+        assert!(
+            session.armed_ids().is_empty(),
+            "disconnecting the connector must still revoke the method it was reached through"
+        );
+    }
+
     #[test]
     fn make_armed_reconciler_does_not_arm_an_unconsented_reloaded_connector() {
         let (session, _frame_rx) =
@@ -1767,6 +1973,7 @@ mod tests {
             acme_workload(),
             grant_store_holding(WorkloadGrantFile::default()),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         reconcile(&["acme".to_string()]);
         assert!(
@@ -1787,6 +1994,7 @@ mod tests {
             workload,
             store.clone(),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         // `lns connector disconnect acme` forgets the grants and drops the id; the reload its write triggers disarms it.
         store
@@ -1813,6 +2021,7 @@ mod tests {
             acme_workload(),
             Arc::new(MemoryGrantStore::unreadable()),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         reconcile(&["acme".to_string()]);
         assert!(
@@ -1835,6 +2044,7 @@ mod tests {
             acme_workload(),
             grant_store_holding(WorkloadGrantFile::default()),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         // A live connect persists "acme" into the policy, which the watcher reloads; the arming just granted must not self-revoke even though no grant is recorded to disk yet.
         reconcile(&["acme".to_string()]);
@@ -1853,6 +2063,7 @@ mod tests {
             acme_workload(),
             grant_store_holding(WorkloadGrantFile::default()),
             acme_custom(),
+            Arc::new(HashMap::new()),
         );
         drop(session);
         reconcile(&["acme".to_string()]);
@@ -1875,6 +2086,7 @@ mod tests {
             workload.clone(),
             grant_store_holding(acme_grants(&workload)),
             acme_custom(),
+            Arc::new(HashMap::new()),
         ));
         // A reload whose policy no longer lists "acme" (a disconnect) must revoke its arming.
         session.apply_external_policy(Policy::default());
@@ -1913,7 +2125,8 @@ mod tests {
             "gitlab".to_string(),
             vec![lns_policy::RouteRule::allow_host("gitlab.com")],
         );
-        let connect = make_connect_emitter(session.clone(), Arc::new(routes));
+        let connect =
+            make_connect_emitter(session.clone(), Arc::new(routes), Arc::new(HashMap::new()));
         connect("gitlab");
         assert_eq!(session.current_policy().connectors, ["gitlab"]);
         assert!(
@@ -1932,7 +2145,11 @@ mod tests {
     #[test]
     fn make_connect_emitter_with_no_routes_for_an_id_still_connects_it() {
         let (session, _rx) = fixture_session();
-        let connect = make_connect_emitter(session.clone(), Arc::new(HashMap::new()));
+        let connect = make_connect_emitter(
+            session.clone(),
+            Arc::new(HashMap::new()),
+            Arc::new(HashMap::new()),
+        );
         connect("gitlab");
         assert_eq!(session.current_policy().connectors, ["gitlab"]);
     }
@@ -2024,7 +2241,7 @@ mod tests {
             vec!["api.some-oauth.example".to_string()]
         );
         assert_eq!(
-            offerable[0].token_fallback,
+            offerable[0].methods[0].token_fallback,
             Some(TokenFallback {
                 help: Some("https://example.com/pat".into()),
                 command: None,

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -403,6 +403,23 @@ fn make_policy_emitter(
     })
 }
 
+/// A watcher reload re-reads the user's own allows from disk, so the launch's withholding is re-applied here too — otherwise a reload mid-run hands back the allow that would swallow an undecided connector's first-use offer. Each call re-reads the sidecar, so a decline landed earlier in this run stops withholding immediately instead of waiting for a relaunch.
+fn make_policy_withholder(
+    catalog: Vec<lns_policy::connectors::Connector>,
+    offerable: HashSet<String>,
+    project: String,
+    workload: WorkloadIdentity,
+    grant_store: Arc<dyn GrantStore>,
+) -> crate::approval_flow::session::PolicyWithholder {
+    Box::new(move |policy| {
+        // An unreadable sidecar withholds as if nothing were decided, so a lost read can never leak a domain past its offer.
+        let grants = grant_store.load().unwrap_or_default();
+        crate::credential_flow::connectors::withhold_undecided_connector_allows(
+            policy, &catalog, &offerable, &project, &workload, &grants,
+        )
+    })
+}
+
 /// A watcher reload replaces the live policy from disk, where connected connectors are recorded id-only; this deriver re-applies their catalog routes so the reload doesn't drop them.
 fn make_connector_route_deriver(
     catalog: Vec<lns_policy::connectors::Connector>,
@@ -419,34 +436,6 @@ fn make_connect_emitter(
         let rules = routes.get(id).cloned().unwrap_or_default();
         session.connect_connector(id, rules);
     })
-}
-
-/// Pairs each connectable connector's id with its catalog display name and route patterns, so a held request to one of those domains can offer to connect it instead of asking about the bare host.
-fn build_offerable(
-    connectable: &crate::credential_flow::connectors::ConnectableConnectors,
-    catalog: &[lns_policy::connectors::Connector],
-) -> Vec<crate::approval_flow::session::OfferableConnector> {
-    connectable
-        .routes
-        .iter()
-        .map(|(id, routes)| {
-            let display_name = catalog
-                .iter()
-                .find(|i| &i.id == id)
-                .map(|i| i.display_name().to_string())
-                .unwrap_or_else(|| id.clone());
-            let token_fallback = catalog
-                .iter()
-                .find(|i| &i.id == id)
-                .and_then(|i| i.token_fallback.clone());
-            crate::approval_flow::session::OfferableConnector {
-                id: id.clone(),
-                display_name,
-                patterns: routes.iter().map(|r| r.match_pattern.clone()).collect(),
-                token_fallback,
-            }
-        })
-        .collect()
 }
 
 /// Bridges an accepted network offer to the credential subsystem's connect; `Weak` so it never keeps the credential session alive past the run.
@@ -474,6 +463,11 @@ impl crate::approval_flow::session::ConnectPort for CredentialConnector {
                 None => false,
             }
         })
+    }
+    fn decline(&self, id: &str) {
+        if let Some(cs) = self.credential_session.upgrade() {
+            cs.decline_connector(id);
+        }
     }
 }
 
@@ -651,7 +645,8 @@ pub(super) async fn start(
         &mut policy.network.egress.http,
         applied.routes,
     );
-    let offerable = build_offerable(&connectable, &catalog);
+    let offerable =
+        crate::credential_flow::connectors::offerable_connectors(&connectable, &catalog);
     let connectable_routes = Arc::new(connectable.routes);
     let run =
         crate::credential_flow::connectors::run_providers(applied.providers, connectable.providers);
@@ -693,6 +688,17 @@ pub(super) async fn start(
     let custom_providers = Arc::new(run.providers);
     let managed_env_vars = collect_managed_env_vars(&custom_providers);
 
+    // An allow the user wrote for a connector's domain would let the first request past before the connector was ever offered, so it waits until this workload connects or declines.
+    let offerable_ids: HashSet<String> = offerable.iter().map(|o| o.id.clone()).collect();
+    let policy = crate::credential_flow::connectors::withhold_undecided_connector_allows(
+        &policy,
+        &catalog,
+        &offerable_ids,
+        &project,
+        &workload,
+        &grants,
+    );
+
     let store = Arc::new(FilePolicyStore::new(policy_path.to_path_buf()));
     let (frame_tx, frame_rx) = tokio::sync::mpsc::unbounded_channel::<HostFrame>();
     let credential_frame_tx = frame_tx.clone();
@@ -701,6 +707,13 @@ pub(super) async fn start(
             .with_offers(offerable),
     );
 
+    session.set_policy_withholder(make_policy_withholder(
+        catalog.clone(),
+        offerable_ids,
+        project.clone(),
+        workload.clone(),
+        grant_store.clone(),
+    ));
     session.set_connector_route_deriver(make_connector_route_deriver(catalog.clone()));
     if let Some(baseline) = sandbox_policy {
         session.set_policy_floor(baseline.clone());
@@ -827,6 +840,7 @@ mod tests {
     struct RecordingConnector {
         connects: std::sync::Mutex<Vec<String>>,
         token_connects: std::sync::Mutex<Vec<(String, String)>>,
+        declines: std::sync::Mutex<Vec<String>>,
     }
 
     impl crate::approval_flow::session::ConnectPort for RecordingConnector {
@@ -848,6 +862,9 @@ mod tests {
                     .push((id.to_string(), value));
                 true
             })
+        }
+        fn decline(&self, id: &str) {
+            self.declines.lock().unwrap().push(id.to_string());
         }
     }
 
@@ -1049,6 +1066,62 @@ mod tests {
             }
             other => panic!("expected RequestDecision, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn a_plain_allow_on_an_offer_card_declines_the_connector_through_the_bridge() {
+        use crate::approval_flow::protocol::{Decision, RequestPending, Treatment};
+        use crate::approval_flow::session::OfferableConnector;
+        use crate::approval_flow::session::tests::{CapturingStore, RecordingNotifier};
+        let notifier = Arc::new(RecordingNotifier::default());
+        let store = Arc::new(CapturingStore::default());
+        let (frame_tx, _frame_rx) = mpsc::unbounded_channel::<HostFrame>();
+        let session = Arc::new(
+            ApprovalSession::new(
+                Policy::default(),
+                notifier,
+                store,
+                frame_tx,
+                std::time::Duration::from_secs(30),
+            )
+            .with_offers(vec![OfferableConnector {
+                id: "some-oauth".into(),
+                display_name: "GitHub".into(),
+                patterns: vec!["api.some-oauth.example".into()],
+                token_fallback: None,
+            }]),
+        );
+        let connector = Arc::new(RecordingConnector::default());
+        session.set_connector(connector.clone());
+        session.submit_pending(
+            RequestPending {
+                id: "r1".into(),
+                host: "api.some-oauth.example".into(),
+                action: "CONNECT api.some-oauth.example:443".into(),
+                reason: "policy-ambiguous".into(),
+                treatment: Treatment::Inspected,
+            },
+            std::time::Instant::now(),
+        );
+
+        let (tx, rx) = mpsc::unbounded_channel::<DecisionDelivery>();
+        tx.send(DecisionDelivery {
+            id: "r1".into(),
+            action: RequestAction::Decide(Decision::AllowAlways),
+        })
+        .unwrap();
+        drop(tx);
+        decision_delivery_loop(Arc::downgrade(&session), rx).await;
+
+        assert_eq!(
+            connector.declines.lock().unwrap().as_slice(),
+            ["some-oauth"],
+            "allowing the destination instead of taking the offer must reach the sidecar as a standing no"
+        );
+        assert!(
+            connector.connects.lock().unwrap().is_empty(),
+            "declining must not also run the interactive connect"
+        );
     }
 
     #[tokio::test]
@@ -1928,7 +2001,8 @@ mod tests {
             &Policy::default(),
             &catalog,
         );
-        let offerable = build_offerable(&connectable, &catalog);
+        let offerable =
+            crate::credential_flow::connectors::offerable_connectors(&connectable, &catalog);
         assert_eq!(offerable.len(), 1);
         assert_eq!(offerable[0].id, "some-oauth");
         assert_eq!(offerable[0].display_name, "GitHub", "uses the catalog name");
@@ -1956,7 +2030,7 @@ mod tests {
             )]),
             ..Default::default()
         };
-        let offerable = build_offerable(&connectable, &[]);
+        let offerable = crate::credential_flow::connectors::offerable_connectors(&connectable, &[]);
         assert_eq!(offerable.len(), 1);
         assert_eq!(offerable[0].id, "stray");
         assert_eq!(
@@ -2039,6 +2113,120 @@ mod tests {
             }),
             "the token is armed in the session's state"
         );
+    }
+
+    #[test]
+    fn the_policy_withholder_re_reads_the_sidecar_so_an_in_run_decline_frees_the_rule() {
+        use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute, CredentialAuth};
+        use lns_policy::providers::{InjectionDef, InjectionKind};
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        let store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(path));
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let connector = Connector {
+            id: "acme".into(),
+            name: None,
+            auth_kind: AuthKind::Credential,
+            routes: vec![ConnectorRoute {
+                match_pattern: "api.acme.corp".into(),
+                transport: None,
+                scheme: None,
+                tls_terminate: false,
+                rules: Vec::new(),
+            }],
+            credential: Some(CredentialAuth {
+                env_var: "ACME_API_KEY".into(),
+                placeholder: "acme_LNSPLACEHOLDER".into(),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: "api.acme.corp".into(),
+                    header: None,
+                }],
+            }),
+            oauth: None,
+            token_fallback: None,
+        };
+        let withhold = make_policy_withholder(
+            vec![connector.clone()],
+            HashSet::from(["acme".to_string()]),
+            "proj".into(),
+            workload.clone(),
+            store.clone(),
+        );
+        let mut policy = Policy::default();
+        policy.add_rule(RouteRule::allow_host("api.acme.corp"));
+
+        assert!(
+            withhold(&policy).network.egress.http.is_empty(),
+            "an undecided connector's domain is withheld so its offer can fire"
+        );
+
+        let (env_var, domains) =
+            crate::credential_flow::connectors::disclosure_of(&connector).expect("a disclosure");
+        let mut file = store.load().unwrap_or_default();
+        file.upsert(GrantRecord::deny(
+            "proj", &workload, "acme", env_var, domains,
+        ));
+        store.save(&file).expect("persist the decline");
+
+        assert_eq!(
+            withhold(&policy).network.egress.http.len(),
+            1,
+            "a decline landed mid-run must free the user's own rule at the next reload, not wait for a relaunch"
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_connector_decline_persists_the_standing_no_through_the_session() {
+        use crate::approval_flow::session::ConnectPort;
+        use crate::credential_flow::notification::NoopCredentialNotifier;
+        use lns_policy::grants::{GrantVerdict, WorkloadIdentity};
+        let (store, _dir) = tempfile_credential_store();
+        let (frame_tx, _frame_rx) = mpsc::unbounded_channel::<HostFrame>();
+        let grants_dir = tempfile::TempDir::new().expect("tempdir");
+        let grants_path = grants_dir.path().join("grants.json");
+        let grants = Arc::new(JsonFileGrantStore::new(grants_path.clone()));
+        let workload = WorkloadIdentity::Definition {
+            dir: "/proj".into(),
+        };
+        let session = Arc::new(
+            CredentialSession::new(
+                CredentialStateFile::new(),
+                Arc::new(NoopCredentialNotifier),
+                store,
+                frame_tx,
+                std::time::Duration::from_secs(30),
+            )
+            .with_custom_providers(acme_custom())
+            .with_grants("proj".into(), workload.clone(), grants.clone()),
+        );
+        let connector = CredentialConnector {
+            credential_session: Arc::downgrade(&session),
+        };
+
+        connector.decline("acme");
+
+        let persisted = grants.load().unwrap();
+        assert_eq!(
+            persisted
+                .lookup("proj", &workload, "acme")
+                .expect("the bridge must carry the decline to the sidecar")
+                .verdict,
+            GrantVerdict::Deny
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_connector_decline_is_a_no_op_when_the_session_is_dropped() {
+        use crate::approval_flow::session::ConnectPort;
+        let (session, _frame_rx) = fixture_credential_session();
+        let connector = CredentialConnector {
+            credential_session: Arc::downgrade(&session),
+        };
+        drop(session);
+        connector.decline("gitlab");
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -740,12 +740,16 @@ pub(super) async fn start(
         .collect();
     let oauth_display_names: HashMap<String, String> = catalog
         .iter()
-        .filter(|i| i.oauth.is_some())
+        .filter(|i| i.default_method().is_some_and(|m| m.oauth.is_some()))
         .map(|i| (i.id.clone(), i.display_name().to_string()))
         .collect();
     let token_fallbacks: HashMap<String, lns_policy::connectors::TokenFallback> = catalog
         .iter()
-        .filter_map(|i| i.token_fallback.clone().map(|tf| (i.id.clone(), tf)))
+        .filter_map(|i| {
+            i.default_method()
+                .and_then(|m| m.token_fallback.clone())
+                .map(|tf| (i.id.clone(), tf))
+        })
         .collect();
     let (credential_session, credential_watcher) = start_credential_subsystem(
         session.clone(),
@@ -1565,22 +1569,22 @@ mod tests {
 
     #[test]
     fn load_user_catalog_or_warn_reads_an_existing_user_catalog() {
-        use lns_policy::connectors::{AuthKind, Catalog, Connector, CredentialAuth};
+        use lns_policy::connectors::{Catalog, Connector, CredentialAuth, SignInMethod};
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join(".lns-connectors.yaml");
         Catalog {
             connectors: vec![Connector {
                 id: "acme".into(),
                 name: None,
-                auth_kind: AuthKind::Credential,
                 routes: Vec::new(),
-                credential: Some(CredentialAuth {
-                    env_var: "ACME_API_KEY".into(),
-                    placeholder: "acme_LNSPLACEHOLDER".into(),
-                    injections: Vec::new(),
-                }),
-                oauth: None,
-                token_fallback: None,
+                methods: vec![SignInMethod::credential(
+                    "token",
+                    CredentialAuth {
+                        env_var: "ACME_API_KEY".into(),
+                        placeholder: "acme_LNSPLACEHOLDER".into(),
+                        injections: Vec::new(),
+                    },
+                )],
             }],
         }
         .save_atomic(&path)
@@ -1935,11 +1939,10 @@ mod tests {
 
     #[test]
     fn make_connector_route_deriver_maps_connected_ids_to_catalog_routes() {
-        use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute};
+        use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute, SignInMethod};
         let catalog = vec![Connector {
             id: "some-oauth".into(),
             name: None,
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.some-oauth.example".into(),
                 transport: None,
@@ -1947,9 +1950,14 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod {
+                id: "device".into(),
+                name: None,
+                kind: AuthKind::Oauth,
+                credential: None,
+                oauth: None,
+                token_fallback: None,
+            }],
         }];
         let derive = make_connector_route_deriver(catalog);
         let routes = derive(&["some-oauth".to_string()]);
@@ -1964,12 +1972,11 @@ mod tests {
     #[test]
     fn build_offerable_pairs_id_display_name_route_patterns_and_token_fallback() {
         use lns_policy::connectors::{
-            AuthKind, Connector, ConnectorRoute, OauthAuth, TokenFallback,
+            Connector, ConnectorRoute, OauthAuth, SignInMethod, TokenFallback,
         };
         let catalog = vec![Connector {
             id: "some-oauth".into(),
             name: Some("GitHub".into()),
-            auth_kind: AuthKind::Oauth,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.some-oauth.example".into(),
                 transport: None,
@@ -1977,25 +1984,31 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: None,
-            oauth: Some(OauthAuth {
-                userinfo_endpoint: None,
-                account_field: None,
-                flow: lns_policy::connectors::OauthFlow::Device,
-                client_id: Some("Iv1.x".into()),
-                client_secret: None,
-                scopes: vec![],
-                device_authorization_endpoint: Some("https://example.com/device/code".into()),
-                authorization_endpoint: None,
-                token_endpoint: "https://example.com/oauth/token".into(),
-                env_var: "SOME_OAUTH_TOKEN".into(),
-                placeholder: "some-oauth-placeholder".into(),
-                injections: Vec::new(),
-            }),
-            token_fallback: Some(TokenFallback {
-                help: Some("https://example.com/pat".into()),
-                command: None,
-            }),
+            methods: vec![
+                SignInMethod::oauth(
+                    "device",
+                    OauthAuth {
+                        userinfo_endpoint: None,
+                        account_field: None,
+                        flow: lns_policy::connectors::OauthFlow::Device,
+                        client_id: Some("Iv1.x".into()),
+                        client_secret: None,
+                        scopes: vec![],
+                        device_authorization_endpoint: Some(
+                            "https://example.com/device/code".into(),
+                        ),
+                        authorization_endpoint: None,
+                        token_endpoint: "https://example.com/oauth/token".into(),
+                        env_var: "SOME_OAUTH_TOKEN".into(),
+                        placeholder: "some-oauth-placeholder".into(),
+                        injections: Vec::new(),
+                    },
+                )
+                .with_token_fallback(TokenFallback {
+                    help: Some("https://example.com/pat".into()),
+                    command: None,
+                }),
+            ],
         }];
         let connectable = crate::credential_flow::connectors::resolve_connectable_connectors(
             &Policy::default(),
@@ -2117,7 +2130,7 @@ mod tests {
 
     #[test]
     fn the_policy_withholder_re_reads_the_sidecar_so_an_in_run_decline_frees_the_rule() {
-        use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute, CredentialAuth};
+        use lns_policy::connectors::{Connector, ConnectorRoute, CredentialAuth, SignInMethod};
         use lns_policy::providers::{InjectionDef, InjectionKind};
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join("grants.json");
@@ -2128,7 +2141,6 @@ mod tests {
         let connector = Connector {
             id: "acme".into(),
             name: None,
-            auth_kind: AuthKind::Credential,
             routes: vec![ConnectorRoute {
                 match_pattern: "api.acme.corp".into(),
                 transport: None,
@@ -2136,17 +2148,18 @@ mod tests {
                 tls_terminate: false,
                 rules: Vec::new(),
             }],
-            credential: Some(CredentialAuth {
-                env_var: "ACME_API_KEY".into(),
-                placeholder: "acme_LNSPLACEHOLDER".into(),
-                injections: vec![InjectionDef {
-                    kind: InjectionKind::BearerHeader,
-                    domain: "api.acme.corp".into(),
-                    header: None,
-                }],
-            }),
-            oauth: None,
-            token_fallback: None,
+            methods: vec![SignInMethod::credential(
+                "token",
+                CredentialAuth {
+                    env_var: "ACME_API_KEY".into(),
+                    placeholder: "acme_LNSPLACEHOLDER".into(),
+                    injections: vec![InjectionDef {
+                        kind: InjectionKind::BearerHeader,
+                        domain: "api.acme.corp".into(),
+                        header: None,
+                    }],
+                },
+            )],
         };
         let withhold = make_policy_withholder(
             vec![connector.clone()],

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -600,30 +600,30 @@ mod tests {
             connectors: vec![lns_policy::connectors::Connector {
                 id: "some-oauth".into(),
                 name: None,
-                auth_kind: lns_policy::connectors::AuthKind::Oauth,
                 routes: Vec::new(),
-                credential: None,
-                oauth: Some(lns_policy::connectors::OauthAuth {
-                    flow: lns_policy::connectors::OauthFlow::Device,
-                    client_id: Some("some-client".into()),
-                    client_secret: None,
-                    scopes: Vec::new(),
-                    device_authorization_endpoint: Some(
-                        "https://api.some-oauth.example/device".into(),
-                    ),
-                    authorization_endpoint: None,
-                    token_endpoint: "https://api.some-oauth.example/token".into(),
-                    userinfo_endpoint: None,
-                    account_field: None,
-                    env_var: "CATALOG_DEFAULT_TOKEN".into(),
-                    placeholder: "some-oauth-LNSPLACEHOLDER0000".into(),
-                    injections: vec![lns_policy::providers::InjectionDef {
-                        kind: lns_policy::providers::InjectionKind::BearerHeader,
-                        domain: "api.some-oauth.example".into(),
-                        header: None,
-                    }],
-                }),
-                token_fallback: None,
+                methods: vec![lns_policy::connectors::SignInMethod::oauth(
+                    "device",
+                    lns_policy::connectors::OauthAuth {
+                        flow: lns_policy::connectors::OauthFlow::Device,
+                        client_id: Some("some-client".into()),
+                        client_secret: None,
+                        scopes: Vec::new(),
+                        device_authorization_endpoint: Some(
+                            "https://api.some-oauth.example/device".into(),
+                        ),
+                        authorization_endpoint: None,
+                        token_endpoint: "https://api.some-oauth.example/token".into(),
+                        userinfo_endpoint: None,
+                        account_field: None,
+                        env_var: "CATALOG_DEFAULT_TOKEN".into(),
+                        placeholder: "some-oauth-LNSPLACEHOLDER0000".into(),
+                        injections: vec![lns_policy::providers::InjectionDef {
+                            kind: lns_policy::providers::InjectionKind::BearerHeader,
+                            domain: "api.some-oauth.example".into(),
+                            header: None,
+                        }],
+                    },
+                )],
             }],
         }
         .save_atomic(&dir.path().join(".lns-connectors.yaml"))

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -10,7 +10,7 @@ use tray_icon::menu::{Menu, MenuEvent, MenuItem};
 use tray_icon::{Icon, TrayIconBuilder};
 
 use crate::approval_flow::protocol::Decision;
-use crate::approval_flow::session::PendingPrompt;
+use crate::approval_flow::session::{OfferPrompt, PendingPrompt};
 use crate::approval_flow::window::{
     self, CredentialCardPrompt, SignInCard, Snapshot, StackItem, WindowState,
 };
@@ -482,16 +482,16 @@ impl eframe::App for TrayApp {
                 apply_dismissal(&self.window_state, &Dismissal::Credential { id });
                 ui.ctx().request_repaint();
             }
-            Some(CardAction::ConnectOffer { id }) => {
-                self.window_state.connect_offer(&id);
+            Some(CardAction::ConnectOffer { id, method }) => {
+                self.window_state.connect_offer(&id, method);
                 ui.ctx().request_repaint();
             }
             Some(CardAction::DeclineOffer { id }) => {
                 self.window_state.decline_offer(&id);
                 ui.ctx().request_repaint();
             }
-            Some(CardAction::UseOfferToken { id, value }) => {
-                self.window_state.use_offer_token(&id, value);
+            Some(CardAction::UseOfferToken { id, method, value }) => {
+                self.window_state.use_offer_token(&id, method, value);
                 ui.ctx().request_repaint();
             }
             Some(CardAction::UseTokenSignIn {
@@ -540,12 +540,14 @@ pub enum CardAction {
     },
     ConnectOffer {
         id: String,
+        method: Option<String>,
     },
     DeclineOffer {
         id: String,
     },
     UseOfferToken {
         id: String,
+        method: Option<String>,
         value: String,
     },
     UseTokenSignIn {
@@ -1249,9 +1251,9 @@ fn render_item(
         }
         StackItem::Network(i) => {
             let prompt = &snapshot.pending[i];
-            if let Some(display_name) = &prompt.offer {
+            if let Some(offer) = &prompt.offer {
                 let draft = token_drafts.entry(prompt.id.clone()).or_default();
-                render_offer_card(ui, prompt, display_name, draft, width)
+                render_offer_card(ui, prompt, offer, draft, width)
             } else {
                 let flag = remember.entry(prompt.id.clone()).or_default();
                 render_network_card(ui, prompt, flag, width)
@@ -1472,7 +1474,7 @@ fn remember_toggle(ui: &mut egui::Ui, remember: &mut bool) {
 fn render_offer_card(
     ui: &mut egui::Ui,
     prompt: &PendingPrompt,
-    display_name: &str,
+    offer: &OfferPrompt,
     draft: &mut TokenDraft,
     width: f32,
 ) -> (Option<CardAction>, egui::Response) {
@@ -1486,7 +1488,7 @@ fn render_offer_card(
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_LINK, "CONNECT");
             ui.add_space(6.0);
             ui.label(
-                RichText::new(format!("Connect to {display_name}?"))
+                RichText::new(format!("Connect to {}?", offer.display_name))
                     .size(theme::FONT_TITLE)
                     .strong()
                     .color(window::TEXT_ACCENT),
@@ -1499,21 +1501,18 @@ fn render_offer_card(
             );
         },
         |ui| {
-            let mut action: Option<CardAction> = None;
-            ui.columns(2, |cols| {
-                if primary_button(&mut cols[0], "Connect").clicked() {
-                    action = Some(CardAction::ConnectOffer { id: id.clone() });
-                }
-                if secondary_button(&mut cols[1], "Not now").clicked() {
-                    action = Some(CardAction::DeclineOffer { id: id.clone() });
-                }
-            });
+            let mut action = render_offer_choices(ui, &id, offer);
+            if action.is_none() && secondary_button(ui, "Not now").clicked() {
+                action = Some(CardAction::DeclineOffer { id: id.clone() });
+            }
             if action.is_none()
-                && let Some(fallback) = &prompt.token_fallback
+                && let Some(method) = offer.methods.first().filter(|_| offer.methods.len() == 1)
+                && let Some(fallback) = &method.token_fallback
             {
                 action = match render_token_fallback(ui, fallback, draft) {
                     Some(TokenFallbackEvent::Save(value)) => Some(CardAction::UseOfferToken {
                         id: id.clone(),
+                        method: None,
                         value,
                     }),
                     Some(TokenFallbackEvent::OpenHelp(url)) => {
@@ -1526,6 +1525,28 @@ fn render_offer_card(
         },
     );
     (out.inner, out.response)
+}
+
+/// The connect controls: one button per way in, so a service reachable more than one way never picks for the user. A connector with a single way in keeps the plain "Connect".
+fn render_offer_choices(ui: &mut egui::Ui, id: &str, offer: &OfferPrompt) -> Option<CardAction> {
+    if offer.methods.len() < 2 {
+        return primary_button(ui, "Connect")
+            .clicked()
+            .then(|| CardAction::ConnectOffer {
+                id: id.to_string(),
+                method: None,
+            });
+    }
+    let mut action = None;
+    for method in &offer.methods {
+        if primary_button(ui, &method.display_name).clicked() {
+            action = Some(CardAction::ConnectOffer {
+                id: id.to_string(),
+                method: Some(method.id.clone()),
+            });
+        }
+    }
+    action
 }
 
 fn render_credential_card(
@@ -2236,7 +2257,6 @@ mod tests {
                 host: "api.example.test".into(),
                 action: "CONNECT api.example.test:443".into(),
                 offer: None,
-                token_fallback: None,
                 treatment: Treatment::Inspected,
             }],
             pending_credentials: Vec::new(),
@@ -2279,6 +2299,66 @@ mod tests {
             connecting: Vec::new(),
             order: vec![StackItem::Credential(0)],
         }
+    }
+
+    /// One offer card for a connector reachable `methods` ways.
+    fn offer_card(methods: Vec<(&str, &str)>) -> Snapshot {
+        Snapshot {
+            pending: vec![PendingPrompt {
+                id: "n1".into(),
+                host: "api.some-provider.example".into(),
+                action: "CONNECT api.some-provider.example:443".into(),
+                offer: Some(OfferPrompt {
+                    connector_id: "some-provider".into(),
+                    display_name: "Some Provider".into(),
+                    methods: methods
+                        .into_iter()
+                        .map(
+                            |(id, name)| crate::approval_flow::session::OfferMethodPrompt {
+                                id: id.into(),
+                                display_name: name.into(),
+                                token_fallback: None,
+                            },
+                        )
+                        .collect(),
+                }),
+                treatment: Treatment::Inspected,
+            }],
+            pending_credentials: Vec::new(),
+            sign_ins: Vec::new(),
+            informs: Vec::new(),
+            connecting: Vec::new(),
+            order: vec![StackItem::Network(0)],
+        }
+    }
+
+    #[test]
+    fn an_offer_card_for_a_connector_reachable_two_ways_connects_the_sign_in_that_was_clicked() {
+        let card = offer_card(vec![
+            ("api-key", "API key"),
+            ("subscription", "Subscription"),
+        ]);
+        assert_eq!(
+            click_labelled_control(card, "Subscription", false),
+            Some(CardAction::ConnectOffer {
+                id: "n1".into(),
+                method: Some("subscription".into()),
+            }),
+            "each way in needs its own button, and the button must carry the sign-in it names"
+        );
+    }
+
+    #[test]
+    fn an_offer_card_for_a_connector_with_one_way_in_keeps_the_plain_connect_button() {
+        let card = offer_card(vec![("token", "token")]);
+        assert_eq!(
+            click_labelled_control(card, "Connect", false),
+            Some(CardAction::ConnectOffer {
+                id: "n1".into(),
+                method: None,
+            }),
+            "there is no choice to make, so the card must not name a sign-in the user was never shown"
+        );
     }
 
     fn card_with_deny_scope(scope: DenyScope) -> Snapshot {
@@ -2354,7 +2434,6 @@ mod tests {
                 host: "api.example.test".into(),
                 action: "CONNECT api.example.test:443".into(),
                 offer: None,
-                token_fallback: None,
                 treatment: Treatment::Inspected,
             },
             net_tx,
@@ -2438,8 +2517,11 @@ mod tests {
             id: id.into(),
             host: host.into(),
             action: format!("CONNECT {host}:443"),
-            offer: offer.map(str::to_string),
-            token_fallback: None,
+            offer: offer.map(|name| OfferPrompt {
+                connector_id: name.into(),
+                display_name: name.into(),
+                methods: Vec::new(),
+            }),
             treatment: Treatment::Inspected,
         };
         Snapshot {

--- a/crates/lns-service/tests/behaviours.rs
+++ b/crates/lns-service/tests/behaviours.rs
@@ -8,6 +8,8 @@ mod bind_rig;
 mod credential_rig;
 #[path = "behaviours/declared_rig.rs"]
 mod declared_rig;
+#[path = "behaviours/first_use_rig.rs"]
+mod first_use_rig;
 #[path = "behaviours/forward_rig.rs"]
 mod forward_rig;
 #[path = "behaviours/image_rig.rs"]

--- a/crates/lns-service/tests/behaviours/connector_first_use.feature
+++ b/crates/lns-service/tests/behaviours/connector_first_use.feature
@@ -1,0 +1,78 @@
+Feature: a connector is offered on first use, whatever the policy already allows
+  A connector reaches a workload because the workload reaches its domain, not
+  because a file named it first. Nothing in `./lns.yaml` and nothing in
+  `lns-policy.yaml` has to mention a connector for it to be offered: the
+  machine catalog claims the domain, and the first request there raises the
+  connect offer. An allow rule the user already wrote for that domain must not
+  swallow the offer, so the launch withholds that rule until the connector is
+  decided — the request is held, the offer is answered, and the user's own rule
+  then applies as written. A decline is remembered for this workload alone, and
+  from then on the rule stands and the request goes out unoffered.
+
+  Scenario: A connector is offered on a domain nothing mentioned
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy lists no connectors
+    When the workload requests "api.some-provider.example"
+    Then the approval window offers to connect "some-provider"
+
+  Scenario: An already-allowed domain still offers the connector
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And the directory policy lists no connectors
+    When the workload requests "api.some-provider.example"
+    Then the approval window offers to connect "some-provider"
+    And the request is held until the offer is answered
+
+  Scenario: Answering the offer without connecting is remembered as a decline
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And the directory policy lists no connectors
+    When the workload requests "api.some-provider.example"
+    And the developer answers the card without connecting
+    Then the "some-provider" decline is remembered for this workload
+
+  Scenario: A declined offer is not raised again for this workload
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And this workload declined the "some-provider" connect offer
+    When the workload requests "api.some-provider.example"
+    Then no offer is presented
+    And the request proceeds under the network policy alone
+
+  Scenario: A connected connector is not offered again
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy connects "some-provider"
+    When the workload requests "api.some-provider.example"
+    Then no offer is presented
+    And the request proceeds under the network policy alone
+
+  Scenario: Another workload's decline does not silence this one's offer
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And another workload declined the "some-provider" connect offer
+    When the workload requests "api.some-provider.example"
+    Then the approval window offers to connect "some-provider"
+
+  Scenario: A connector this workload already granted is not withheld or re-offered
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And this workload granted the "some-provider" connect offer
+    When the workload requests "api.some-provider.example"
+    Then no offer is presented
+    And the request proceeds under the network policy alone
+
+  Scenario: A connector that shares a connected connector's domain withholds nothing
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the catalog claims "api.some-provider.example" for connector "other-provider" managing "OTHER_TOKEN"
+    And the directory policy connects "some-provider"
+    When the workload requests "api.some-provider.example"
+    Then no offer is presented
+    And the request proceeds under the network policy alone
+
+  Scenario: An unrelated domain's allow rule is left alone
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" managing "SOME_TOKEN"
+    And the directory policy allows "api.unrelated.example"
+    And the directory policy lists no connectors
+    When the workload requests "api.unrelated.example"
+    Then no offer is presented
+    And the request proceeds under the network policy alone

--- a/crates/lns-service/tests/behaviours/connector_first_use.feature
+++ b/crates/lns-service/tests/behaviours/connector_first_use.feature
@@ -76,3 +76,15 @@ Feature: a connector is offered on first use, whatever the policy already allows
     When the workload requests "api.unrelated.example"
     Then no offer is presented
     And the request proceeds under the network policy alone
+
+  Scenario: The offer card asks which sign-in method a connector reachable two ways uses
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" reachable by "api-key" on "SOME_TOKEN" and "subscription" on "SOME_SUBSCRIPTION_TOKEN"
+    And the directory policy lists no connectors
+    When the workload requests "api.some-provider.example"
+    Then the approval window offers to connect "some-provider"
+    And the offer card lists the sign-in methods "api-key, subscription"
+
+  Scenario: A connector reachable two ways seeds neither placeholder until one is picked
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" reachable by "api-key" on "SOME_TOKEN" and "subscription" on "SOME_SUBSCRIPTION_TOKEN"
+    And the directory policy connects "some-provider"
+    Then the workload environment carries neither "SOME_TOKEN" nor "SOME_SUBSCRIPTION_TOKEN"

--- a/crates/lns-service/tests/behaviours/connector_first_use.feature
+++ b/crates/lns-service/tests/behaviours/connector_first_use.feature
@@ -88,3 +88,11 @@ Feature: a connector is offered on first use, whatever the policy already allows
     Given the catalog claims "api.some-provider.example" for connector "some-provider" reachable by "api-key" on "SOME_TOKEN" and "subscription" on "SOME_SUBSCRIPTION_TOKEN"
     And the directory policy connects "some-provider"
     Then the workload environment carries neither "SOME_TOKEN" nor "SOME_SUBSCRIPTION_TOKEN"
+
+  Scenario: A policy reload that connects a connector with no sign-in still offers it
+    Given the catalog claims "api.some-provider.example" for connector "some-provider" reachable by "api-key" on "SOME_TOKEN" and "subscription" on "SOME_SUBSCRIPTION_TOKEN"
+    And the directory policy allows "api.some-provider.example"
+    And the policy is reloaded connecting "some-provider"
+    When the workload requests "api.some-provider.example"
+    Then the approval window offers to connect "some-provider"
+    And the offer card lists the sign-in methods "api-key, subscription"

--- a/crates/lns-service/tests/behaviours/first_use_rig.rs
+++ b/crates/lns-service/tests/behaviours/first_use_rig.rs
@@ -10,6 +10,8 @@ pub struct FirstUseRig {
     pub grants: WorkloadGrantFile,
     /// The policy the launch composed, after withholding the allows of any undecided connector.
     pub running_policy: Option<Policy>,
+    /// Connectors a mid-run policy write connected, so the launch-time offerable snapshot still names them.
+    pub connected_mid_run: Vec<String>,
     /// Connector ids the approval card offered for the request.
     pub offered: Vec<String>,
     /// The sign-in methods the presented offer card listed, in the order the user reads them.

--- a/crates/lns-service/tests/behaviours/first_use_rig.rs
+++ b/crates/lns-service/tests/behaviours/first_use_rig.rs
@@ -12,6 +12,8 @@ pub struct FirstUseRig {
     pub running_policy: Option<Policy>,
     /// Connector ids the approval card offered for the request.
     pub offered: Vec<String>,
+    /// The sign-in methods the presented offer card listed, in the order the user reads them.
+    pub offered_methods: Vec<String>,
     pub held: bool,
     pub proceeded: bool,
     /// The session under test, kept so a later step can answer the card it raised.

--- a/crates/lns-service/tests/behaviours/first_use_rig.rs
+++ b/crates/lns-service/tests/behaviours/first_use_rig.rs
@@ -1,0 +1,33 @@
+use lns_policy::Policy;
+use lns_policy::connectors::Connector;
+use lns_policy::grants::WorkloadGrantFile;
+
+/// Drives the first-use offer path: catalog + directory policy + this workload's grants in, the policy the launch actually runs and whether the request was held with an offer out.
+#[derive(Default)]
+pub struct FirstUseRig {
+    pub catalog: Vec<Connector>,
+    pub overlay: Policy,
+    pub grants: WorkloadGrantFile,
+    /// The policy the launch composed, after withholding the allows of any undecided connector.
+    pub running_policy: Option<Policy>,
+    /// Connector ids the approval card offered for the request.
+    pub offered: Vec<String>,
+    pub held: bool,
+    pub proceeded: bool,
+    /// The session under test, kept so a later step can answer the card it raised.
+    pub session: Option<std::sync::Arc<lns_service::approval_flow::session::ApprovalSession>>,
+    /// The card id the request raised.
+    pub card: Option<String>,
+    /// Connector ids the session declined through its connect port.
+    pub declined: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl std::fmt::Debug for FirstUseRig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FirstUseRig")
+            .field("offered", &self.offered)
+            .field("held", &self.held)
+            .field("proceeded", &self.proceeded)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
+++ b/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
@@ -162,6 +162,13 @@ fn policy_allows(w: &mut BehaviourWorld, host: String) {
     rig(w).overlay.add_rule(RouteRule::allow_host(&host));
 }
 
+#[given(regex = r#"^the policy is reloaded connecting "([^"]+)"$"#)]
+fn policy_reloaded_connecting(w: &mut BehaviourWorld, id: String) {
+    let rig = rig(w);
+    rig.overlay.connect(&id);
+    rig.connected_mid_run.push(id);
+}
+
 #[given(regex = r#"^the directory policy connects "([^"]+)"$"#)]
 fn policy_connects(w: &mut BehaviourWorld, id: String) {
     rig(w).overlay.connectors.push(id);
@@ -231,9 +238,22 @@ fn workload_requests(w: &mut BehaviourWorld, host: String) {
                 &rig.overlay.connectors,
                 &rig.catalog,
             ));
-        let connectable = resolve_connectable_connectors(&rig.overlay, &rig.catalog);
+        // The offerable set is a launch-time snapshot, so a connector connected since is still in it.
+        let mut at_boot = rig.overlay.clone();
+        at_boot
+            .connectors
+            .retain(|id| !rig.connected_mid_run.contains(id));
+        let connectable = resolve_connectable_connectors(&at_boot, &rig.catalog);
         let offers = offerable_connectors(&connectable, &rig.catalog);
         let offerable_ids = offers.iter().map(|o| o.id.clone()).collect();
+        let state = lns_policy::credentials::CredentialStateFile::new();
+        let workload = this_workload();
+        let chosen = lns_service::credential_flow::connectors::machine_holds_sign_in(
+            &state,
+            &rig.grants,
+            PROJECT,
+            &workload,
+        );
         let running = withhold_undecided_connector_allows(
             &composed,
             &rig.catalog,
@@ -241,6 +261,7 @@ fn workload_requests(w: &mut BehaviourWorld, host: String) {
             PROJECT,
             &this_workload(),
             &rig.grants,
+            &chosen,
         );
         (running, offers)
     };
@@ -264,6 +285,25 @@ fn workload_requests(w: &mut BehaviourWorld, host: String) {
         )
         .with_offers(offers),
     );
+    let unchosen_catalog = rig(w).catalog.clone();
+    let unchosen_grants = rig(w).grants.clone();
+    session.set_unchosen_connectors(Box::new(move |policy| {
+        let state = lns_policy::credentials::CredentialStateFile::new();
+        let workload = this_workload();
+        let chosen = lns_service::credential_flow::connectors::machine_holds_sign_in(
+            &state,
+            &unchosen_grants,
+            PROJECT,
+            &workload,
+        );
+        lns_service::credential_flow::connectors::unchosen_connected_connectors(
+            policy,
+            &unchosen_catalog,
+            &chosen,
+        )
+        .into_iter()
+        .collect()
+    }));
     session.submit_pending(
         RequestPending {
             id: "req-1".into(),

--- a/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
+++ b/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
@@ -1,0 +1,307 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cucumber::{given, then, when};
+use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute, CredentialAuth};
+use lns_policy::grants::{GrantRecord, WorkloadIdentity};
+use lns_policy::matching::domain_matches;
+use lns_policy::providers::{InjectionDef, InjectionKind};
+use lns_policy::{Policy, RouteRule, Verdict};
+use lns_service::approval_flow::protocol::{RequestPending, Treatment};
+use lns_service::approval_flow::session::ApprovalSession;
+use lns_service::credential_flow::connectors::{
+    applied_connector_routes, offerable_connectors, resolve_connectable_connectors,
+    withhold_undecided_connector_allows,
+};
+
+use crate::approval_rig::TestNotifier;
+use crate::first_use_rig::FirstUseRig;
+use crate::world::BehaviourWorld;
+
+const PROJECT: &str = "rig-project";
+
+fn this_workload() -> WorkloadIdentity {
+    WorkloadIdentity::Definition {
+        dir: "/rig/project".into(),
+    }
+}
+
+fn other_workload() -> WorkloadIdentity {
+    WorkloadIdentity::Definition {
+        dir: "/rig/other".into(),
+    }
+}
+
+fn rig(w: &mut BehaviourWorld) -> &mut FirstUseRig {
+    w.first_use.get_or_insert_with(Default::default)
+}
+
+#[given(regex = r#"^the catalog claims "([^"]+)" for connector "([^"]+)" managing "([^"]+)"$"#)]
+fn catalog_claims(w: &mut BehaviourWorld, host: String, id: String, env: String) {
+    rig(w).catalog.push(Connector {
+        id: id.clone(),
+        name: None,
+        auth_kind: AuthKind::Credential,
+        routes: vec![ConnectorRoute {
+            match_pattern: host.clone(),
+            transport: None,
+            scheme: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+        }],
+        credential: Some(CredentialAuth {
+            env_var: env,
+            placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+            injections: vec![InjectionDef {
+                kind: InjectionKind::BearerHeader,
+                domain: host,
+                header: None,
+            }],
+        }),
+        oauth: None,
+        token_fallback: None,
+    });
+}
+
+#[given("the directory policy lists no connectors")]
+fn policy_lists_no_connectors(w: &mut BehaviourWorld) {
+    assert!(
+        rig(w).overlay.connectors.is_empty(),
+        "the rig policy unexpectedly connects a connector"
+    );
+}
+
+#[given(regex = r#"^the directory policy allows "([^"]+)"$"#)]
+fn policy_allows(w: &mut BehaviourWorld, host: String) {
+    rig(w).overlay.add_rule(RouteRule::allow_host(&host));
+}
+
+#[given(regex = r#"^the directory policy connects "([^"]+)"$"#)]
+fn policy_connects(w: &mut BehaviourWorld, id: String) {
+    rig(w).overlay.connectors.push(id);
+}
+
+fn record_decline(w: &mut BehaviourWorld, id: &str, workload: &WorkloadIdentity) {
+    let rig = rig(w);
+    let connector = rig
+        .catalog
+        .iter()
+        .find(|c| c.id == id)
+        .expect("a Given step must put the connector in the catalog");
+    let (env_var, domains) = lns_service::credential_flow::connectors::disclosure_of(connector)
+        .expect("a credential connector discloses an env var and domains");
+    rig.grants
+        .upsert(GrantRecord::deny(PROJECT, workload, id, env_var, domains));
+}
+
+#[given(regex = r#"^this workload declined the "([^"]+)" connect offer$"#)]
+fn this_workload_declined(w: &mut BehaviourWorld, id: String) {
+    record_decline(w, &id, &this_workload());
+}
+
+#[given(regex = r#"^this workload granted the "([^"]+)" connect offer$"#)]
+fn this_workload_granted(w: &mut BehaviourWorld, id: String) {
+    let workload = this_workload();
+    let rig = rig(w);
+    let connector = rig
+        .catalog
+        .iter()
+        .find(|c| c.id == id)
+        .expect("a Given step must put the connector in the catalog");
+    let (env_var, domains) = lns_service::credential_flow::connectors::disclosure_of(connector)
+        .expect("a credential connector discloses an env var and domains");
+    rig.grants.upsert(GrantRecord::allow(
+        PROJECT, &workload, &id, env_var, domains,
+    ));
+}
+
+#[given(regex = r#"^another workload declined the "([^"]+)" connect offer$"#)]
+fn other_workload_declined(w: &mut BehaviourWorld, id: String) {
+    record_decline(w, &id, &other_workload());
+}
+
+fn first_match_allows(policy: &Policy, host: &str) -> bool {
+    // The guest gate is first-match-wins; only a leading allow lets the request past without a card.
+    policy
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|r| domain_matches(&r.match_pattern, host))
+        .is_some_and(|r| r.verdict == Verdict::Allow)
+}
+
+#[when(regex = r#"^the workload requests "([^"]+)"$"#)]
+fn workload_requests(w: &mut BehaviourWorld, host: String) {
+    let (running, offers) = {
+        let rig = rig(w);
+        // The launch splices a connected connector's own routes in before anything is withheld.
+        let mut composed = rig.overlay.clone();
+        composed
+            .network
+            .egress
+            .http
+            .extend(applied_connector_routes(
+                &rig.overlay.connectors,
+                &rig.catalog,
+            ));
+        let connectable = resolve_connectable_connectors(&rig.overlay, &rig.catalog);
+        let offers = offerable_connectors(&connectable, &rig.catalog);
+        let offerable_ids = offers.iter().map(|o| o.id.clone()).collect();
+        let running = withhold_undecided_connector_allows(
+            &composed,
+            &rig.catalog,
+            &offerable_ids,
+            PROJECT,
+            &this_workload(),
+            &rig.grants,
+        );
+        (running, offers)
+    };
+    if first_match_allows(&running, &host) {
+        let rig = rig(w);
+        rig.running_policy = Some(running);
+        rig.proceeded = true;
+        return;
+    }
+    let notifier = Arc::new(TestNotifier::default());
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let session = Arc::new(
+        ApprovalSession::new(
+            running.clone(),
+            notifier.clone(),
+            Arc::new(crate::approval_rig::FlakyStore::new(
+                std::env::temp_dir().join("lns-first-use-rig-unused.yaml"),
+            )),
+            tx,
+            Duration::from_secs(30),
+        )
+        .with_offers(offers),
+    );
+    session.submit_pending(
+        RequestPending {
+            id: "req-1".into(),
+            host: host.clone(),
+            action: format!("CONNECT {host}:443"),
+            reason: "policy-ambiguous".into(),
+            treatment: Treatment::Inspected,
+        },
+        Instant::now(),
+    );
+    let presented = notifier.presented.lock().unwrap().clone();
+    let rig = rig(w);
+    session.set_connector(Arc::new(DeclineRecorder {
+        declined: rig.declined.clone(),
+    }));
+    rig.running_policy = Some(running);
+    rig.held = !presented.is_empty();
+    rig.offered = presented.iter().filter_map(|p| p.offer.clone()).collect();
+    rig.card = presented.first().map(|p| p.id.clone());
+    rig.session = Some(session);
+}
+
+/// A connect port that never connects, so answering the card exercises the decline path alone.
+struct DeclineRecorder {
+    declined: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl lns_service::approval_flow::session::ConnectPort for DeclineRecorder {
+    fn connect<'a>(&'a self, _id: &'a str) -> futures_util::future::BoxFuture<'a, bool> {
+        Box::pin(async { false })
+    }
+    fn connect_with_token<'a>(
+        &'a self,
+        _id: &'a str,
+        _value: String,
+    ) -> futures_util::future::BoxFuture<'a, bool> {
+        Box::pin(async { false })
+    }
+    fn decline(&self, id: &str) {
+        self.declined.lock().unwrap().push(id.to_string());
+    }
+}
+
+#[when("the developer answers the card without connecting")]
+fn developer_answers_without_connecting(w: &mut BehaviourWorld) {
+    let rig = rig(w);
+    let card = rig
+        .card
+        .clone()
+        .expect("the request must have raised a card");
+    let session = rig.session.clone().expect("the request built a session");
+    session.record_decision(
+        &card,
+        lns_service::approval_flow::protocol::Decision::AllowOnce,
+    );
+}
+
+#[then(regex = r#"^the "([^"]+)" decline is remembered for this workload$"#)]
+fn decline_remembered(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let rig = w.first_use.as_ref().ok_or("no request happened")?;
+    let declined = rig.declined.lock().unwrap().clone();
+    if declined.contains(&id) {
+        Ok(())
+    } else {
+        Err(format!(
+            "answering the offer card without connecting left no standing no for {id}; declined: {declined:?}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the approval window offers to connect "([^"]+)"$"#)]
+fn window_offers_connect(w: &mut BehaviourWorld, id: String) -> Result<(), String> {
+    let rig = w.first_use.as_ref().ok_or("no request happened")?;
+    let connector = rig
+        .catalog
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or_else(|| format!("{id} is not in the rig catalog"))?;
+    let expected = connector.display_name();
+    if rig.offered.iter().any(|o| o == expected) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected an offer to connect {expected}; offers: {:?}, held: {}, proceeded: {}",
+            rig.offered, rig.held, rig.proceeded
+        ))
+    }
+}
+
+#[then("the request is held until the offer is answered")]
+fn request_is_held(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.first_use.as_ref().ok_or("no request happened")?;
+    if rig.proceeded {
+        return Err("the request went out under an allow rule instead of being held".to_string());
+    }
+    if rig.held {
+        Ok(())
+    } else {
+        Err("no card was presented, so nothing held the request".to_string())
+    }
+}
+
+#[then("no offer is presented")]
+fn no_offer_presented(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.first_use.as_ref().ok_or("no request happened")?;
+    if rig.offered.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("an offer was presented: {:?}", rig.offered))
+    }
+}
+
+#[then("the request proceeds under the network policy alone")]
+fn request_proceeds(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.first_use.as_ref().ok_or("no request happened")?;
+    if rig.proceeded {
+        Ok(())
+    } else {
+        Err(format!(
+            "the request did not go out under the policy; held: {}, policy: {:?}",
+            rig.held,
+            rig.running_policy
+                .as_ref()
+                .map(|p| p.network.egress.http.clone())
+        ))
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
+++ b/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use cucumber::{given, then, when};
-use lns_policy::connectors::{AuthKind, Connector, ConnectorRoute, CredentialAuth};
+use lns_policy::connectors::{Connector, ConnectorRoute, CredentialAuth, SignInMethod};
 use lns_policy::grants::{GrantRecord, WorkloadIdentity};
 use lns_policy::matching::domain_matches;
 use lns_policy::providers::{InjectionDef, InjectionKind};
@@ -41,7 +41,6 @@ fn catalog_claims(w: &mut BehaviourWorld, host: String, id: String, env: String)
     rig(w).catalog.push(Connector {
         id: id.clone(),
         name: None,
-        auth_kind: AuthKind::Credential,
         routes: vec![ConnectorRoute {
             match_pattern: host.clone(),
             transport: None,
@@ -49,17 +48,18 @@ fn catalog_claims(w: &mut BehaviourWorld, host: String, id: String, env: String)
             tls_terminate: false,
             rules: Vec::new(),
         }],
-        credential: Some(CredentialAuth {
-            env_var: env,
-            placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-            injections: vec![InjectionDef {
-                kind: InjectionKind::BearerHeader,
-                domain: host,
-                header: None,
-            }],
-        }),
-        oauth: None,
-        token_fallback: None,
+        methods: vec![SignInMethod::credential(
+            "token",
+            CredentialAuth {
+                env_var: env,
+                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: host,
+                    header: None,
+                }],
+            },
+        )],
     });
 }
 

--- a/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
+++ b/crates/lns-service/tests/behaviours/steps/connector_first_use.rs
@@ -63,6 +63,92 @@ fn catalog_claims(w: &mut BehaviourWorld, host: String, id: String, env: String)
     });
 }
 
+#[given(
+    regex = r#"^the catalog claims "([^"]+)" for connector "([^"]+)" reachable by "([^"]+)" on "([^"]+)" and "([^"]+)" on "([^"]+)"$"#
+)]
+fn catalog_claims_two_ways(
+    w: &mut BehaviourWorld,
+    host: String,
+    id: String,
+    first: String,
+    first_env: String,
+    second: String,
+    second_env: String,
+) {
+    let method = |method_id: &str, env: &str| {
+        SignInMethod::credential(
+            method_id,
+            CredentialAuth {
+                env_var: env.into(),
+                placeholder: format!("{id}-{method_id}-LNSPLACEHOLDER"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: host.clone(),
+                    header: None,
+                }],
+            },
+        )
+    };
+    rig(w).catalog.push(Connector {
+        id: id.clone(),
+        name: None,
+        routes: vec![ConnectorRoute {
+            match_pattern: host.clone(),
+            transport: None,
+            scheme: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+        }],
+        methods: vec![method(&first, &first_env), method(&second, &second_env)],
+    });
+}
+
+#[then(regex = r#"^the offer card lists the sign-in methods "([^"]+)"$"#)]
+fn offer_lists_methods(w: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    let listed = rig(w).offered_methods.join(", ");
+    (listed == expected)
+        .then_some(())
+        .ok_or_else(|| format!("the card listed [{listed}], expected [{expected}]"))
+}
+
+#[then(regex = r#"^the workload environment carries neither "([^"]+)" nor "([^"]+)"$"#)]
+fn environment_carries_neither(
+    w: &mut BehaviourWorld,
+    first: String,
+    second: String,
+) -> Result<(), String> {
+    use lns_service::credential_flow::providers::Provider;
+    let rig = rig(w);
+    // The launch's own predicate, driven by the rig's machine state, so this asserts what a real boot would seed rather than a hardcoded answer.
+    let state = lns_policy::credentials::CredentialStateFile::new();
+    let workload = this_workload();
+    let chosen = lns_service::credential_flow::connectors::machine_holds_sign_in(
+        &state,
+        &rig.grants,
+        PROJECT,
+        &workload,
+    );
+    let applied = lns_service::credential_flow::connectors::resolve_applied_connectors(
+        &rig.overlay,
+        &rig.catalog,
+        &chosen,
+    );
+    let seeded: Vec<String> = applied
+        .providers
+        .iter()
+        .filter(|p| p.seeds_env())
+        .map(|p| p.env_var().to_string())
+        .collect();
+    let leaked: Vec<&String> = seeded
+        .iter()
+        .filter(|env| *env == &first || *env == &second)
+        .collect();
+    leaked
+        .is_empty()
+        .then_some(())
+        .ok_or_else(|| format!("expected neither {first} nor {second} seeded, got {seeded:?}"))
+}
+
 #[given("the directory policy lists no connectors")]
 fn policy_lists_no_connectors(w: &mut BehaviourWorld) {
     assert!(
@@ -195,7 +281,15 @@ fn workload_requests(w: &mut BehaviourWorld, host: String) {
     }));
     rig.running_policy = Some(running);
     rig.held = !presented.is_empty();
-    rig.offered = presented.iter().filter_map(|p| p.offer.clone()).collect();
+    rig.offered_methods = presented
+        .iter()
+        .filter_map(|p| p.offer.as_ref())
+        .flat_map(|o| o.methods.iter().map(|m| m.id.clone()))
+        .collect();
+    rig.offered = presented
+        .iter()
+        .filter_map(|p| p.offer.as_ref().map(|o| o.display_name.clone()))
+        .collect();
     rig.card = presented.first().map(|p| p.id.clone());
     rig.session = Some(session);
 }

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -102,7 +102,8 @@ fn launch(
         return;
     }
     let mut policy = merge_effective(resolved.policy.as_ref(), &rig.overlay);
-    let applied = resolve_applied_with_slots(&policy, &resolved.credentials, &rig.catalog);
+    let applied =
+        resolve_applied_with_slots(&policy, &resolved.credentials, &rig.catalog, &|_| false);
     policy
         .network
         .egress

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -1,6 +1,6 @@
 use cucumber::{given, then, when};
 use lns_policy::connectors::{
-    AuthKind, Connector, ConnectorRoute, CredentialAuth, OauthAuth, OauthFlow,
+    Connector, ConnectorRoute, CredentialAuth, OauthAuth, OauthFlow, SignInMethod,
 };
 use lns_policy::grants::{GrantRecord, WorkloadGrantFile, WorkloadIdentity};
 use lns_policy::providers::{InjectionDef, InjectionKind};
@@ -25,7 +25,6 @@ fn credential_connector(id: &str, env_var: &str, route: Option<&str>) -> Connect
     Connector {
         id: id.into(),
         name: None,
-        auth_kind: AuthKind::Credential,
         routes: route
             .map(|host| {
                 vec![ConnectorRoute {
@@ -37,17 +36,18 @@ fn credential_connector(id: &str, env_var: &str, route: Option<&str>) -> Connect
                 }]
             })
             .unwrap_or_default(),
-        credential: Some(CredentialAuth {
-            env_var: env_var.into(),
-            placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-            injections: vec![InjectionDef {
-                kind: InjectionKind::BearerHeader,
-                domain: domain.into(),
-                header: None,
-            }],
-        }),
-        oauth: None,
-        token_fallback: None,
+        methods: vec![SignInMethod::credential(
+            "token",
+            CredentialAuth {
+                env_var: env_var.into(),
+                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: domain.into(),
+                    header: None,
+                }],
+            },
+        )],
     }
 }
 
@@ -247,28 +247,28 @@ fn oauth_connector(id: &str) -> Connector {
     Connector {
         id: id.into(),
         name: None,
-        auth_kind: AuthKind::Oauth,
         routes: Vec::new(),
-        credential: None,
-        oauth: Some(OauthAuth {
-            flow: OauthFlow::Device,
-            client_id: Some("some-client".into()),
-            client_secret: None,
-            scopes: Vec::new(),
-            device_authorization_endpoint: Some("https://api.some-oauth.example/device".into()),
-            authorization_endpoint: None,
-            token_endpoint: "https://api.some-oauth.example/token".into(),
-            userinfo_endpoint: None,
-            account_field: None,
-            env_var: "SOME_OAUTH_TOKEN".into(),
-            placeholder: format!("{id}-LNSPLACEHOLDER0000"),
-            injections: vec![InjectionDef {
-                kind: InjectionKind::BearerHeader,
-                domain: "api.some-oauth.example".into(),
-                header: None,
-            }],
-        }),
-        token_fallback: None,
+        methods: vec![SignInMethod::oauth(
+            "device",
+            OauthAuth {
+                flow: OauthFlow::Device,
+                client_id: Some("some-client".into()),
+                client_secret: None,
+                scopes: Vec::new(),
+                device_authorization_endpoint: Some("https://api.some-oauth.example/device".into()),
+                authorization_endpoint: None,
+                token_endpoint: "https://api.some-oauth.example/token".into(),
+                userinfo_endpoint: None,
+                account_field: None,
+                env_var: "SOME_OAUTH_TOKEN".into(),
+                placeholder: format!("{id}-LNSPLACEHOLDER0000"),
+                injections: vec![InjectionDef {
+                    kind: InjectionKind::BearerHeader,
+                    domain: "api.some-oauth.example".into(),
+                    header: None,
+                }],
+            },
+        )],
     }
 }
 

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -1,5 +1,6 @@
 pub mod approval_flow;
 pub mod artifact_dispatch;
+pub mod connector_first_use;
 pub mod credential_at_boot;
 pub mod credential_flow;
 pub mod declared_connectors;

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -57,6 +57,7 @@ pub struct BehaviourWorld {
     pub policy: Option<PolicyRig>,
 
     pub declared: Option<DeclaredRig>,
+    pub first_use: Option<crate::first_use_rig::FirstUseRig>,
     pub tools: Option<crate::tools_rig::ToolsRig>,
 
     /// The sandbox definition JSON a fileset-planning scenario stages.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -140,6 +140,15 @@ held and the card appears. Your rule then applies exactly as written:
 A connector you have already connected is never re-offered, and an allow rule
 for a domain no connector claims is never withheld.
 
+Where a connector accepts more than one kind of credential, the card asks which
+one you hold — one button per [sign-in method](#sign-in-methods) instead of a
+single **Connect**. Until you pick one, none of that connector's environment
+variables is seeded, because seeding one would choose for you and seeding both
+would claim a sign-in state no real login produces. Your choice is per-machine —
+it records which credential you hold, so it stays out of the shareable
+`lns-policy.yaml` — and the variable for the method you picked appears at the
+next launch.
+
 ## The catalog file
 
 The bundled and user catalogs share one schema, so an entry is portable between them:
@@ -185,6 +194,12 @@ Two rules keep a connector honest, and the catalog refuses to load if either bre
 - A connector must declare at least one method, or nothing could ever connect it.
 - No two methods may write the same environment variable, because a workload reading
   that variable could not tell which sign-in it got.
+
+A connector with one method binds its value under the connector id; one with several
+binds each method separately, so holding an API key and a subscription token at the
+same time is fine and neither overwrites the other. `lns connector connect <id>` binds
+the single-method case only — for a connector with a choice to make, connect it from
+the first-use card, which is where the choice is presented.
 
 Each method's `kind` is `credential` or `oauth`. An `oauth` method authenticates by an
 interactive **sign-in** the background service drives for you — `lns connector

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -147,32 +147,50 @@ The bundled and user catalogs share one schema, so an entry is portable between 
 ```yaml
 connectors:
   - id: gitlab
-    authKind: credential
     routes:
       - match: gitlab.com
-    credential:
-      envVar: GITLAB_TOKEN
-      placeholder: glpat-LNSPLACEHOLDER0000000000000000
-      injections:
-        - kind: api_key_header
-          domain: gitlab.com
-          header: PRIVATE-TOKEN
-        - kind: bearer_header
-          domain: gitlab.com
+    methods:
+      - id: token
+        kind: credential
+        credential:
+          envVar: GITLAB_TOKEN
+          placeholder: glpat-LNSPLACEHOLDER0000000000000000
+          injections:
+            - kind: api_key_header
+              domain: gitlab.com
+              header: PRIVATE-TOKEN
+            - kind: bearer_header
+              domain: gitlab.com
 ```
 
-An entry may list several injections so one credential reaches a service however its
+A connector owns its domain and lists under `methods:` the ways to sign in to it. A
+method may list several injections so one credential reaches a service however its
 clients send it — here both the `PRIVATE-TOKEN` header `glab` uses and the
 `Authorization: Bearer` form OAuth-style clients send.
 
 A route may carry the same detail a [policy rule](policy.md#rules) can — a `scheme`
 and HTTP method/path `rules` for least-privilege access — beyond the bare `match`.
 
-`authKind` is `credential` or `oauth`. An `oauth` connector authenticates by an
+### Sign-in methods
+
+Most connectors have one method. Some services accept more than one kind of
+credential, and then the connector carries one method per kind. The bundled
+`anthropic` connector is the example: an API key on `ANTHROPIC_API_KEY`, or a Claude
+Code subscription token on `CLAUDE_CODE_OAUTH_TOKEN`. Both reach the same
+`api.anthropic.com`, so both belong to the same connector rather than competing for
+the domain.
+
+Two rules keep a connector honest, and the catalog refuses to load if either breaks:
+
+- A connector must declare at least one method, or nothing could ever connect it.
+- No two methods may write the same environment variable, because a workload reading
+  that variable could not tell which sign-in it got.
+
+Each method's `kind` is `credential` or `oauth`. An `oauth` method authenticates by an
 interactive **sign-in** the background service drives for you — `lns connector
 connect <id>` walks you through it and records the connector only once it completes,
 and the obtained credential is injected at the boundary like any other, stored per
-machine and never in `lns-policy.yaml`. An `oauth` entry carries an `oauth:` block (in
+machine and never in `lns-policy.yaml`. An `oauth` method carries an `oauth:` block (in
 place of `credential:`) whose `flow` selects one of two shapes:
 
 - **`flow: device`** (RFC 8628, the default) — `connect` prints a verification URL and

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -116,6 +116,30 @@ the launch when unbound (or blocks on the sign-in for an `oauth` slot), so the
 workload never starts half-provisioned. A new connector reaches a workload
 only at launch, so relaunch a running sandbox to pick it up.
 
+### First use always offers
+
+Nothing has to name a connector for it to be offered. The catalog claims the
+domain, so the first request a workload makes there raises the connect offer —
+whether or not `./lns.yaml` or `lns-policy.yaml` ever mentioned the connector.
+
+An allow rule you already wrote for that domain does not swallow the offer. The
+launch withholds that one rule until you decide the connector, so the request is
+held and the card appears. Your rule then applies exactly as written:
+
+- **Connect** — the connector's routes open and its value arms, and the held
+  request goes on.
+- **Answer the card as a plain destination** — that is a no to the connector. It
+  becomes a standing no for this workload, recorded in
+  [`~/.lns-workload-grants.json`](credentials.md#workload-grants); the rest of
+  the run stops offering it, and from the next launch your own rule decides
+  every request unoffered. Your other projects, and other workloads in this
+  one, are still offered the connector.
+- **Close the card** — nothing is decided and nothing is recorded, so the next
+  run asks again.
+
+A connector you have already connected is never re-offered, and an allow rule
+for a domain no connector claims is never withheld.
+
 ## The catalog file
 
 The bundled and user catalogs share one schema, so an entry is portable between them:

--- a/docs/examples/claude-code/README.md
+++ b/docs/examples/claude-code/README.md
@@ -10,7 +10,7 @@ hosts you allow.
 - **`lns.yaml`** — the sandbox definition: a slim Debian base with node declared
   under `spec.tools` (provisioned once per machine by the service, outside the
   policy cage), a first-boot install of Claude Code itself, the network
-  allowlist, the `claude-code-subscription` connector, and inline seed state
+  allowlist, the `anthropic` connector, and inline seed state
   mounted at the workload's home (`/home/sandbox`). The inline `.claude.json` skips onboarding
   and pre-accepts the `/workspace` trust dialog. The inline
   `.claude/settings.json` runs Claude in `bypassPermissions` and turns **off

--- a/docs/examples/claude-code/lns.yaml
+++ b/docs/examples/claude-code/lns.yaml
@@ -33,7 +33,7 @@ spec:
         - match: downloads.claude.ai
           verdict: allow
   connectors:
-    - claude-code-subscription
+    - anthropic
   volumes:
     - type: bind
       source: .

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -812,7 +812,7 @@ or `lns pull` simply fetches or rebuilds it again.
 [`examples/claude-code/`](examples/claude-code/) is a complete recipe that ties
 these pieces together: it runs Claude Code inside a sandbox using `spec.image`
 plus node declared under `spec.tools`, `spec.env`, a tight `policy` allowlist,
-the `claude-code-subscription` connector, a `.` bind at `/workspace`, and a
+the `anthropic` connector, a `.` bind at `/workspace`, and a
 self-contained inline fileset that seeds the agent's home. Copy its `lns.yaml`
 into your project and `lns run`.
 


### PR DESCRIPTION
## Problem

A connector's connect offer had exactly one production trigger: the relay's `request_pending` frame, which only exists when the guest gate **holds** a request. An allow rule for a domain a connector claims meant no hold, so no frame, so no offer — permanently.

The user hit this in real use. Approve `api.some-provider.example` once as a plain destination and that directory can never be offered the connector again. No card, ever; the workload sends an unauthenticated request and fails with a 401 it cannot explain. That is exactly the dead end "policy you run into, not write" is supposed to prevent.

This is slice A of a larger agreed redesign (connectors are demand-driven, never named in `lns.yaml`). It is independently landable and fixes the pain on its own.

## Approach

Invert the trigger from *mention* to *domain*. The launch withholds the user's own allow for a domain claimed by a connector this workload has neither connected nor decided. The request then has no deciding rule, the gate holds it, and the existing offer path fires. Once the connector is decided, the rule applies exactly as written.

No `lens-sandbox-core` change and no new frame type — the gate already holds anything no rule decides.

Three filters keep the withholding honest:

- Only a connector that is actually **offerable** can withhold anything. An unofferable collider (the `anthropic` vs `claude-code-subscription` case on `api.anthropic.com`) would otherwise strip a connected connector's route with no path to ever release it.
- A connector the policy itself **connects** is decided. `offerable` is a launch-time snapshot, so connecting by editing `lns-policy.yaml` — which writes no grant — must not leave the routes dead until relaunch.
- Any grant whose disclosure still **matches** counts as decided, yes or no. A redefined connector is a different question, so neither carries over.

Every policy reload re-applies the withholding against a fresh read of the grant sidecar, so a decline landed mid-run frees the rule at once.

## Declining

Answering an offer card as a plain network decision is now a no to the connector. `ConnectPort::decline` persists this workload's standing no to `~/.lns-workload-grants.json`, and the session stops offering it for the rest of the run. Other projects, and other workloads in this one, are still offered it. Closing the card still decides nothing.

## Tests

Layer 2 — `crates/lns-service/tests/behaviours/connector_first_use.feature`, 9 scenarios: offered where nothing mentioned it; offered on an already-allowed domain and held; the decline recorded; not re-offered after a decline; a connected connector not re-offered; another workload's decline not silencing this one; an unrelated allow left alone; an already-granted connector not withheld; a collider on a connected connector's domain withholding nothing.

Layer 3 — the withholder re-reads the sidecar so an in-run decline frees the rule; a policy-connected connector keeps its routes; the reload path still withholds; the decline bridge persists through the credential session; closing a card and a card carrying no offer both decline nothing.

Each new scenario was confirmed red for the stated reason before the fix, and the withholding itself was mutation-checked — stubbing it to a no-op fails exactly the two scenarios that depend on it.

## Gates

`make lint`, `make complexity`, `make coverage` (100% floor), `make test`, `make e2e` (69/69) all green locally.

## Docs

`docs/connectors.md` gains a "First use always offers" section covering the three ways to answer the card.