### PR TITLE
fix(service): Put a declared tool's real bin dirs on the workload PATH

### DIFF
--- a/crates/e2e-tests/features/microvm_tools.feature
+++ b/crates/e2e-tests/features/microvm_tools.feature
@@ -31,6 +31,12 @@ Feature: declared developer tools reach a real guest
     Then it prints a node 22 version
     And nothing is provisioned again
 
+  Scenario: A tool whose upstream archive nests its bin dir is still on the PATH
+    Given the Lens Sandbox service is running
+    And a lns.yaml declaring tools ["gh@2"] over the pinned base image
+    When the sandbox runs "gh --version"
+    Then it prints a gh version
+
   Scenario: A declared tool wins over the base image's copy
     Given the Lens Sandbox service is running
     And a base image that ships node 20 and a lns.yaml declaring tools ["node@22"]

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -910,6 +910,15 @@ fn prints_a_gh_version(world: &mut E2eWorld) {
     );
 }
 
+/// The workload writes to the same stdout as the supervisor's log, so a bare version is one line among many rather than the whole capture.
+fn is_bare_version_triple(line: &str) -> bool {
+    let parts: Vec<&str> = line.trim().split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+}
+
 #[then("it prints an npm version")]
 fn prints_an_npm_version(world: &mut E2eWorld) {
     let result = world.result.as_ref().expect("a run result");
@@ -918,12 +927,8 @@ fn prints_an_npm_version(world: &mut E2eWorld) {
         "run failed:\n{}\n{}",
         result.stdout, result.stderr
     );
-    let parts: Vec<&str> = result.stdout.trim().split('.').collect();
     assert!(
-        parts.len() == 3
-            && parts
-                .iter()
-                .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit())),
+        result.stdout.lines().any(is_bare_version_triple),
         "expected npm to print its version, got:\n{}\n{}",
         result.stdout,
         result.stderr

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -894,6 +894,22 @@ fn prints_a_node_22_version(world: &mut E2eWorld) {
     );
 }
 
+#[then("it prints a gh version")]
+fn prints_a_gh_version(world: &mut E2eWorld) {
+    let result = world.result.as_ref().expect("a run result");
+    assert_eq!(
+        result.exit_code, 0,
+        "run failed:\n{}\n{}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("gh version 2."),
+        "expected a gh 2 version, got:\n{}\n{}",
+        result.stdout,
+        result.stderr
+    );
+}
+
 #[then("it prints an npm version")]
 fn prints_an_npm_version(world: &mut E2eWorld) {
     let result = world.result.as_ref().expect("a run result");

--- a/crates/lns-service/src/tools/cache.rs
+++ b/crates/lns-service/src/tools/cache.rs
@@ -9,7 +9,7 @@ use crate::archive_limits::{ArchiveLimits, LimitedReader};
 use crate::content_store::ContentStore;
 use crate::runtime_layer::{RuntimeFileSpec, RuntimeSource};
 
-pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
+pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
 
 /// A provisioned tool tree, ingested into the content store and described entry-by-entry so injection composes specs without re-reading any file body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/lns-service/src/tools/provisioner/mod.rs
+++ b/crates/lns-service/src/tools/provisioner/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn provisioner_runtime_specs(
     specs
 }
 
-/// One shell driver per provision: each tool installs under its own engine state so no install resolves a version a sibling left behind, tars its tree into the staging share, and emits one `LNS_TOOL <name> <resolved> <binpath>` marker; any failure names its tool with `LNS_FAIL` and stops.
+/// One shell driver per provision: each tool installs under its own engine state so no install resolves a version a sibling left behind, tars its tree into the staging share, and emits one `LNS_TOOL <name> <resolved> <binpaths>` marker whose bin dirs are colon-joined and relative to the tree root; any failure names its tool with `LNS_FAIL` and stops.
 pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
     let mut script = String::from(
         "#!/bin/sh\nset -u\nexport PATH=/.lens/tools-engine/bin:$PATH\nmkdir -p /tmp/mise/home\n",
@@ -75,7 +75,9 @@ pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
              if ! mise install '{spec}' >&2; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
              path=\"$(mise where '{spec}')\" || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
              resolved=\"$(basename \"$path\")\"\n\
-             if [ -d \"$path/bin\" ]; then bp=bin; else bp=.; fi\n\
+             bp=\"$(mise bin-paths \"{name}@$resolved\" 2>/dev/null | while IFS= read -r d; do case \"$d\" in (\"$path\") printf '.:' ;; (\"$path\"/*) printf '%s:' \"${{d#\"$path\"/}}\" ;; esac; done)\"\n\
+             bp=\"${{bp%:}}\"\n\
+             if [ -z \"$bp\" ]; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
              tar -cf '{STAGING}/{name}.tar' -C \"$path\" . >&2 || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
              echo \"LNS_TOOL {name} $resolved $bp\"\n"
         ));
@@ -88,7 +90,7 @@ pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
 pub(crate) struct DriverResult {
     pub name: String,
     pub resolved: SafeVersion,
-    pub bin_path: String,
+    pub bin_paths: Vec<String>,
 }
 
 /// Map the driver's stdout back to per-tool outcomes: a complete run yields one result per request; `LNS_FAIL` attributes the failure to its tool with the engine's diagnostics as the cause; anything else is an engine fault. Markers are only ever read from stdout, which the driver redirects everything else away from — a partial write from a tool's own install code would otherwise prefix the next marker and lose it.
@@ -105,17 +107,20 @@ pub(crate) fn parse_driver_output(
         };
         let mut parts = marker.split_whitespace();
         // Exactly three fields: a driver whose `basename` came back empty would otherwise shift the bin path into the version slot and cache the tree under it.
-        let (Some(name), Some(resolved), Some(bin_path), None) =
+        let (Some(name), Some(resolved), Some(bin_field), None) =
             (parts.next(), parts.next(), parts.next(), parts.next())
         else {
             continue;
         };
+        let bin_paths: Vec<&str> = bin_field.split(':').collect();
         let (Ok(resolved), true) = (
             resolved.parse::<SafeVersion>(),
-            lns_artifact::tools::is_safe_bin_path(bin_path),
+            bin_paths
+                .iter()
+                .all(|bin_path| lns_artifact::tools::is_safe_bin_path(bin_path)),
         ) else {
             return Err(ProvisionError::Engine(format!(
-                "the provisioner driver reported an unusable location for {name}: {resolved:?} {bin_path:?}"
+                "the provisioner driver reported an unusable location for {name}: {resolved:?} {bin_field:?}"
             )));
         };
         if results.iter().any(|result| result.name == name) {
@@ -126,7 +131,7 @@ pub(crate) fn parse_driver_output(
         results.push(DriverResult {
             name: name.to_string(),
             resolved,
-            bin_path: bin_path.to_string(),
+            bin_paths: bin_paths.into_iter().map(str::to_string).collect(),
         });
     }
     if exit_code == 0 && stdout.lines().any(|line| line.trim() == "LNS_DONE") {
@@ -356,7 +361,7 @@ pub(crate) fn staged_tools_from_results(
                     .map(ToolRef::to_string)
                     .collect(),
                 tar: StagedTar::File(staging.join(format!("{}.tar", request.name))),
-                bin_paths: vec![result.bin_path.clone()],
+                bin_paths: result.bin_paths.clone(),
             })
         })
         .collect()
@@ -512,12 +517,12 @@ mod tests {
                 DriverResult {
                     name: "node".into(),
                     resolved: version("22.11.0"),
-                    bin_path: "bin".into(),
+                    bin_paths: vec!["bin".into()],
                 },
                 DriverResult {
                     name: "jq".into(),
                     resolved: version("1.7.1"),
-                    bin_path: ".".into(),
+                    bin_paths: vec![".".into()],
                 },
             ]
         );
@@ -624,7 +629,78 @@ mod tests {
             &[tool("node@22")],
         )
         .unwrap();
-        assert_eq!(results[0].bin_path, "libexec/bin");
+        assert_eq!(results[0].bin_paths, vec!["libexec/bin".to_string()]);
+    }
+
+    #[test]
+    fn the_driver_asks_the_engine_where_a_tool_s_bin_dirs_are() {
+        // `mise where` is the tree root, and gh's upstream archive nests its bin dir one level below it; probing the root for `bin/` therefore puts a directory holding no executables on the workload PATH, and the tool installs but never resolves.
+        let script = render_driver(&[tool("gh@2")]);
+        assert!(
+            script.contains("mise bin-paths \"gh@$resolved\""),
+            "got: {script}"
+        );
+    }
+
+    #[test]
+    fn the_bin_dirs_are_asked_for_by_resolved_version_not_by_the_request() {
+        // The engine answers `bin-paths` under the version component it was asked with, so a fuzzy `gh@2` reports `installs/gh/2/...` while `where` reports `installs/gh/2.97.0` — the two never share a prefix and every bin dir is discarded.
+        let script = render_driver(&[tool("gh@2")]);
+        assert!(!script.contains("mise bin-paths 'gh@2'"), "got: {script}");
+    }
+
+    #[test]
+    fn a_tool_whose_bin_dirs_the_engine_cannot_place_fails_its_provision() {
+        // Guessing a bin dir is what put a directory holding no executables on the PATH; a tool we cannot locate must name itself in the failure instead of installing into an unusable PATH entry.
+        let script = render_driver(&[tool("gh@2")]);
+        assert!(
+            script.contains("if [ -z \"$bp\" ]; then echo \"LNS_FAIL gh\"; exit 3; fi"),
+            "got: {script}"
+        );
+    }
+
+    #[test]
+    fn the_bin_dir_case_patterns_are_parenthesized_so_bash_as_bin_sh_still_parses_the_marker() {
+        // The driver runs under whatever `/bin/sh` the provisioner base image ships; bash misparses an unparenthesized `case` pattern inside `$(...)` and emits its own source as the bin dir instead of failing.
+        let script = render_driver(&[tool("gh@2")]);
+        assert!(
+            script.contains("case \"$d\" in (\"$path\") ") && script.contains(" (\"$path\"/*) "),
+            "got: {script}"
+        );
+    }
+
+    #[test]
+    fn every_bin_dir_the_engine_reports_reaches_the_path() {
+        let results = parse_driver_output(
+            "LNS_TOOL gh 2.97.0 gh_2.97.0_linux_arm64/bin:libexec\nLNS_DONE\n",
+            "",
+            0,
+            &[tool("gh@2")],
+        )
+        .unwrap();
+        assert_eq!(
+            results[0].bin_paths,
+            vec![
+                "gh_2.97.0_linux_arm64/bin".to_string(),
+                "libexec".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_blank_bin_dir_segment_fails_the_provision() {
+        // An empty PATH entry is the current directory to execvp, so a marker that would produce one is refused before it can be cached.
+        let err = parse_driver_output(
+            "LNS_TOOL gh 2.97.0 bin::x\nLNS_DONE\n",
+            "",
+            0,
+            &[tool("gh@2")],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("unusable location for gh"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -749,12 +825,12 @@ mod tests {
             DriverResult {
                 name: "jq".into(),
                 resolved: version("1.7.1"),
-                bin_path: ".".into(),
+                bin_paths: vec![".".into()],
             },
             DriverResult {
                 name: "node".into(),
                 resolved: version("22.11.0"),
-                bin_path: "bin".into(),
+                bin_paths: vec!["bin".into()],
             },
         ];
         let staged = staged_tools_from_results(&requests, &results, Path::new("/staging")).unwrap();

--- a/crates/lns-service/src/tools/provisioner/mod.rs
+++ b/crates/lns-service/src/tools/provisioner/mod.rs
@@ -75,7 +75,7 @@ pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
              if ! mise install '{spec}' >&2; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
              path=\"$(mise where '{spec}')\" || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
              resolved=\"$(basename \"$path\")\"\n\
-             bp=\"$(mise bin-paths \"{name}@$resolved\" 2>/dev/null | while IFS= read -r d; do case \"$d\" in (\"$path\") printf '.:' ;; (\"$path\"/*) printf '%s:' \"${{d#\"$path\"/}}\" ;; esac; done)\"\n\
+             bp=\"$(mise bin-paths \"{name}@$resolved\" | while IFS= read -r d; do case \"$d\" in (\"$path\") printf '.:' ;; (\"$path\"/*) printf '%s:' \"${{d#\"$path\"/}}\" ;; esac; done)\"\n\
              bp=\"${{bp%:}}\"\n\
              if [ -z \"$bp\" ]; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
              tar -cf '{STAGING}/{name}.tar' -C \"$path\" . >&2 || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
@@ -647,6 +647,16 @@ mod tests {
         // The engine answers `bin-paths` under the version component it was asked with, so a fuzzy `gh@2` reports `installs/gh/2/...` while `where` reports `installs/gh/2.97.0` — the two never share a prefix and every bin dir is discarded.
         let script = render_driver(&[tool("gh@2")]);
         assert!(!script.contains("mise bin-paths 'gh@2'"), "got: {script}");
+    }
+
+    #[test]
+    fn the_bin_dir_query_keeps_its_diagnostics_for_the_failure_cause() {
+        // `LNS_FAIL` on an unplaceable bin dir reports the tool but not the reason; the engine's own complaint is the only thing that names it, so it has to reach the stderr `failure_cause` reads.
+        let script = render_driver(&[tool("gh@2")]);
+        assert!(
+            !script.contains("mise bin-paths \"gh@$resolved\" 2>/dev/null"),
+            "got: {script}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A sandbox declaring `tools: [node@22, jq@1, gh@2, yq@4, rust@1.95.0]` booted with `gh` installed correctly but unreachable: `gh --version` returned `sh: gh: not found`. The tool tree was present and complete at `/.lens/tools/gh/2.97.0/`, and the PATH entry pointed at it — but the executable lives one level down, in `gh_2.97.0_linux_arm64/bin/`.

The provisioner driver **guessed** each tool's bin dir by probing the tree root:

```sh
if [ -d "$path/bin" ]; then bp=bin; else bp=.; fi
```

The guess is right for the two common archive shapes and wrong for the third:

| shape | example | tree root contains | guess | correct |
|---|---|---|---|---|
| `bin/` subdir | `node`, `rust` | `bin/` | `bin` | ✅ |
| bare binary | `jq`, `yq` | the binary itself | `.` | ✅ |
| nested platform dir | `gh` | `gh_<ver>_<os>_<arch>/` only | `.` | ❌ |

For the third shape the PATH entry is a directory holding no executables, so the tool installs, is disclosed, is audited — and never resolves.

### 1. Take the bin dirs from the engine instead of guessing

`mise bin-paths` reports where a tool's executables actually are. The driver now uses it, colon-joined and relative to the tree root, so `DriverResult.bin_paths` is a `Vec` and a tool may contribute more than one dir.

### 2. Ask by resolved version, not by the request

The engine answers `bin-paths` under the version component it was **given**, while `mise where` answers under the **resolved** one:

```
mise where     gh@2      → …/installs/gh/2.97.0
mise bin-paths gh@2      → …/installs/gh/2/gh_2.97.0_…/bin      ← requested component
mise bin-paths gh@2.97.0 → …/installs/gh/2.97.0/gh_2.97.0_…/bin ← agrees with `where`
```

A fuzzy query therefore shares no prefix with the tree root and every reported bin dir is discarded. This is worth calling out because the first version of this fix used the request spec, passed every unit test, and silently fell back to the old guess — only the live-guest e2e caught it.

### 3. Fail closed when a bin dir cannot be placed

Guessing is what put an unusable entry on the PATH, so the driver no longer falls back to it. A tool whose bin dirs the engine cannot place emits `LNS_FAIL <name>`, and the query keeps its stderr so `failure_cause` can report *why* rather than just naming the tool.

### 4. Invalidate trees cached under the guess

`MANIFEST_SCHEMA_VERSION` 2 → 3. The cache key is `(name, resolved, arch, libc)`, so an already-cached manifest carrying `bin_paths: ["."]` would stay a hit and the fix would not reach anyone who had already run the tool.

### 5. Regression cover at the layer that catches this

`microvm_tools.feature` only exercised `node` and `jq` — both shapes the guess got right, which is why it survived. Added a `@microvm` scenario for the nested shape. Also fixed the neighbouring `npm` step, which split the entire captured stdout on `.` and expected exactly three numeric parts; the workload shares stdout with the supervisor's log, so it could never pass. It now matches a bare version line, keeping the shape check.

Only `gh` was affected among the five declared tools.

## Test instructions

1. Nested-archive shape reaches the PATH: with `tools: [gh@2]` over a glibc or musl base image, `lns run . -- gh --version` prints `gh version 2.x`. Before this change it printed `sh: gh: not found`.
2. The shapes the guess got right still work: `node --version` prints `v22.x`, and `jq --version` prints `jq-1.7.1` — `bin/` and bare-binary trees are unchanged.
3. Multiple declared tools compose: declare `[node@22, jq@1, gh@2]` and confirm each resolves in the same guest.
4. Warm path is unaffected: run twice and confirm the second run reports nothing provisioned.
5. Stale cache is evicted, not reinterpreted: with a tree cached before this change, confirm the run re-provisions rather than reusing the wrong `bin_paths`.
6. Full check: `make e2e-microvm` filtered to the tools feature passes 7/7 scenarios on a virt-capable host.

Note for anyone verifying locally: a tree cached by an in-progress build of this branch carries schema 3 with the old paths, so the bump will not evict it — `rm -rf ~/Library/Caches/lns/tools/trees/gh` first.

## Screenshots
### Before
<!-- Add recording showing `gh --version` failing with `sh: gh: not found` -->

### After
<!-- Add recording showing `gh --version` printing its version -->