### PR TITLE
fix(tools): Take a tool's whole install, not the dir the engine names

### DIFF
--- a/crates/e2e-tests/features/microvm_tools.feature
+++ b/crates/e2e-tests/features/microvm_tools.feature
@@ -10,7 +10,10 @@ Feature: declared developer tools reach a real guest
   too: only a real guest proves the tree carries its payload and the env that
   finds it. That one declares a glibc base image, because rustup publishes no
   musl host toolchain, and a longer budget, because its payload is a whole
-  compiler rather than a single binary.
+  compiler rather than a single binary. It builds rather than printing a
+  version, because the tool also has to *write* inside its own tree: cargo puts
+  its package-cache lock and registry under a CARGO_HOME the engine placed
+  there, and `rustc --version` passes even when that directory is read-only.
 
   Scenario: A declared tool is available to the workload
     Given the Lens Sandbox service is running
@@ -46,8 +49,9 @@ Feature: declared developer tools reach a real guest
     Given the Lens Sandbox service is running
     And a lns.yaml declaring tools ["rust@1.95.0"] over a glibc base image
     And a provisioning budget of 15 minutes
-    When the sandbox runs "rustc --version"
-    Then it prints a rustc 1.95.0 version
+    And the sandbox may reach the crates.io hosts
+    When the sandbox builds a rust library that has one dependency
+    Then the build succeeds
 
   Scenario: A declared tool wins over the base image's copy
     Given the Lens Sandbox service is running

--- a/crates/e2e-tests/features/microvm_tools.feature
+++ b/crates/e2e-tests/features/microvm_tools.feature
@@ -5,7 +5,12 @@ Feature: declared developer tools reach a real guest
   of the base image's own copies, and a pulled sandbox's pinned tools are
   pre-provisioned at pull time, so its first run fetches nothing — which is
   what "starts offline" means here, since tool bodies come from upstream hosts
-  rather than from the registry the harness can take down.
+  rather than from the registry the harness can take down. A tool the engine
+  installs outside its own install dir (rust, through rustup) is covered here
+  too: only a real guest proves the tree carries its payload and the env that
+  finds it. That one declares a glibc base image, because rustup publishes no
+  musl host toolchain, and a longer budget, because its payload is a whole
+  compiler rather than a single binary.
 
   Scenario: A declared tool is available to the workload
     Given the Lens Sandbox service is running
@@ -36,6 +41,13 @@ Feature: declared developer tools reach a real guest
     And a lns.yaml declaring tools ["gh@2"] over the pinned base image
     When the sandbox runs "gh --version"
     Then it prints a gh version
+
+  Scenario: A tool the engine installs outside its own install dir still runs
+    Given the Lens Sandbox service is running
+    And a lns.yaml declaring tools ["rust@1.95.0"] over a glibc base image
+    And a provisioning budget of 15 minutes
+    When the sandbox runs "rustc --version"
+    Then it prints a rustc 1.95.0 version
 
   Scenario: A declared tool wins over the base image's copy
     Given the Lens Sandbox service is running

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -38,6 +38,8 @@ pub struct E2eWorld {
     pub project_inline_filesets: Vec<(String, String, String, Option<String>)>,
     pub project_tools: Vec<String>,
     pub project_image: Option<String>,
+    /// Raises the per-run budget for a tool whose upstream payload is far larger than the usual one.
+    pub run_budget: Option<std::time::Duration>,
 }
 
 impl E2eWorld {

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -40,6 +40,8 @@ pub struct E2eWorld {
     pub project_image: Option<String>,
     /// Raises the per-run budget for a tool whose upstream payload is far larger than the usual one.
     pub run_budget: Option<std::time::Duration>,
+    /// Destinations the definition's own policy allows, so a scenario whose workload really fetches something is not left at an approval prompt.
+    pub project_egress: Vec<String>,
 }
 
 impl E2eWorld {

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -120,6 +120,14 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
             spec_tail.push_str(&format!("\n    - {id}"));
         }
     }
+    if !world.project_egress.is_empty() {
+        spec_tail.push_str("\n  policy:\n    egress:\n      http:");
+        for host in &world.project_egress {
+            spec_tail.push_str(&format!(
+                "\n        - match: {host}\n          verdict: allow"
+            ));
+        }
+    }
     if !world.project_tools.is_empty() {
         spec_tail.push_str("\n  tools:");
         for tool in &world.project_tools {
@@ -778,7 +786,16 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
 }
 
 const NODE20_IMAGE: &str = "public.ecr.aws/docker/library/node:20-bookworm-slim";
-const DEBIAN12_IMAGE: &str = "public.ecr.aws/docker/library/debian:12-slim";
+/// The glibc base for a tool with no musl build: the provisioner's own digest-pinned gnu rootfs, which every tools run already fetches, so this scenario adds no registry traffic to be rate-limited.
+fn glibc_base_image() -> String {
+    lns_service::tools::mise::manifest()
+        .rootfs_reference(
+            lns_service::tools::Libc::Gnu,
+            lns_service::tools::host_arch(),
+        )
+        .expect("the engine manifest pins a gnu rootfs for this arch")
+        .to_string()
+}
 
 fn parse_tools_list(entries: &str) -> Vec<String> {
     entries
@@ -794,8 +811,53 @@ fn tools_over_pinned_base(world: &mut E2eWorld, entries: String) {
 
 #[given(regex = r#"^a lns\.yaml declaring tools \[(.*)\] over a glibc base image$"#)]
 fn tools_over_glibc_base(world: &mut E2eWorld, entries: String) {
-    world.project_image = Some(DEBIAN12_IMAGE.to_string());
+    world.project_image = Some(glibc_base_image());
     world.project_tools = parse_tools_list(&entries);
+}
+
+#[given("the sandbox may reach the crates.io hosts")]
+fn sandbox_may_reach_crates_io(world: &mut E2eWorld) {
+    world.project_egress = ["crates.io", "index.crates.io", "static.crates.io"]
+        .iter()
+        .map(|host| host.to_string())
+        .collect();
+}
+
+/// A library target with one dependency: cargo must write the registry into the `CARGO_HOME` the engine put inside the tool tree, and an rlib needs no linker the slim base image lacks.
+#[when("the sandbox builds a rust library that has one dependency")]
+fn sandbox_builds_a_rust_library(world: &mut E2eWorld) {
+    let script = concat!(
+        "set -e; d=/tmp/p; mkdir -p $d/src; ",
+        "printf '[package]\\nname=\"p\"\\nversion=\"0.1.0\"\\nedition=\"2021\"\\n",
+        "[dependencies]\\nunicode-ident=\"1\"\\n' > $d/Cargo.toml; ",
+        "printf 'pub fn f() {}\\n' > $d/src/lib.rs; ",
+        // The marker is assembled at run time: the run summary echoes the command it launches, so a literal here would match itself in the captured output.
+        "cd $d; cargo build --quiet && printf 'CARGO_BUILD_%s\\n' OK"
+    );
+    run_lns_microvm(
+        world,
+        vec![
+            "--".to_string(),
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            script.to_string(),
+        ],
+    );
+}
+
+#[then("the build succeeds")]
+fn the_build_succeeds(world: &mut E2eWorld) {
+    let result = world.result.as_ref().expect("a run result");
+    let output = format!("{}\n{}", result.stdout, result.stderr);
+    assert_eq!(result.exit_code, 0, "the build failed:\n{output}");
+    assert!(
+        !output.contains("Permission denied"),
+        "the workload could not write inside its own tool tree:\n{output}"
+    );
+    assert!(
+        result.stdout.contains("CARGO_BUILD_OK"),
+        "cargo never reported a finished build:\n{output}"
+    );
 }
 
 #[given(regex = r#"^a provisioning budget of (\d+) minutes$"#)]

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -233,8 +233,8 @@ fn run_lns_microvm_as(world: &mut E2eWorld, verb: &[&str], tail: Vec<String>) {
         args.push(policy.to_string_lossy().into_owned());
     }
     args.extend(tail);
-    let result =
-        run_cli_with_timeout_in_dir(&project, args, socket_env(world), MICROVM_RUN_TIMEOUT);
+    let budget = world.run_budget.unwrap_or(MICROVM_RUN_TIMEOUT);
+    let result = run_cli_with_timeout_in_dir(&project, args, socket_env(world), budget);
     world.last_run_id = parse_run_id(&format!("{}\n{}", result.stdout, result.stderr));
     world.result = Some(result);
 }
@@ -355,8 +355,8 @@ fn run_command_from_declarative_sandbox(world: &mut E2eWorld, cmd_line: String) 
     let project = write_declarative_definition(world);
     let mut args = vec!["run".to_string(), "--".to_string()];
     args.extend(split_args(&cmd_line));
-    let result =
-        run_cli_with_timeout_in_dir(&project, args, socket_env(world), MICROVM_RUN_TIMEOUT);
+    let budget = world.run_budget.unwrap_or(MICROVM_RUN_TIMEOUT);
+    let result = run_cli_with_timeout_in_dir(&project, args, socket_env(world), budget);
     world.last_run_id = parse_run_id(&format!("{}\n{}", result.stdout, result.stderr));
     world.result = Some(result);
 }
@@ -778,6 +778,7 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
 }
 
 const NODE20_IMAGE: &str = "public.ecr.aws/docker/library/node:20-bookworm-slim";
+const DEBIAN12_IMAGE: &str = "public.ecr.aws/docker/library/debian:12-slim";
 
 fn parse_tools_list(entries: &str) -> Vec<String> {
     entries
@@ -789,6 +790,17 @@ fn parse_tools_list(entries: &str) -> Vec<String> {
 #[given(regex = r#"^a lns\.yaml declaring tools \[(.*)\] over the pinned base image$"#)]
 fn tools_over_pinned_base(world: &mut E2eWorld, entries: String) {
     world.project_tools = parse_tools_list(&entries);
+}
+
+#[given(regex = r#"^a lns\.yaml declaring tools \[(.*)\] over a glibc base image$"#)]
+fn tools_over_glibc_base(world: &mut E2eWorld, entries: String) {
+    world.project_image = Some(DEBIAN12_IMAGE.to_string());
+    world.project_tools = parse_tools_list(&entries);
+}
+
+#[given(regex = r#"^a provisioning budget of (\d+) minutes$"#)]
+fn a_provisioning_budget(world: &mut E2eWorld, minutes: u64) {
+    world.run_budget = Some(Duration::from_secs(minutes * 60));
 }
 
 #[given(regex = r#"^a lns\.yaml declaring tools \[([^\]]*)\]$"#)]
@@ -905,6 +917,22 @@ fn prints_a_gh_version(world: &mut E2eWorld) {
     assert!(
         result.stdout.contains("gh version 2."),
         "expected a gh 2 version, got:\n{}\n{}",
+        result.stdout,
+        result.stderr
+    );
+}
+
+#[then("it prints a rustc 1.95.0 version")]
+fn prints_a_rustc_version(world: &mut E2eWorld) {
+    let result = world.result.as_ref().expect("a run result");
+    assert_eq!(
+        result.exit_code, 0,
+        "run failed:\n{}\n{}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("rustc 1.95.0"),
+        "expected rustc 1.95.0, got:\n{}\n{}",
         result.stdout,
         result.stderr
     );

--- a/crates/lns-artifact/src/tools/mod.rs
+++ b/crates/lns-artifact/src/tools/mod.rs
@@ -20,6 +20,18 @@ pub fn is_safe_bin_path(bin_path: &str) -> bool {
     bin_path == "." || bin_path.split('/').all(is_safe_version)
 }
 
+/// Whether a name the engine reports for a tool's environment is one we may hand a workload. `PATH` and `HOME` are the workload's own to compose; the loader and shell hooks (`LD_*`, `BASH_ENV`, `ENV`, `IFS`) would reach every process in the workload rather than only the tool's own binaries; and anything outside the POSIX name shape would arrive from a source that is not the engine.
+pub fn is_safe_env_name(name: &str) -> bool {
+    const WORKLOAD_OWNED: &[&str] = &["PATH", "HOME", "BASH_ENV", "ENV", "IFS"];
+    !name.is_empty()
+        && !WORKLOAD_OWNED.contains(&name)
+        && !name.starts_with("LD_")
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
 /// A version that has passed [`is_safe_version`], so no source of one — index, driver output, or a file on disk a later process could edit — can reach a path component or the shell driver unchecked.
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -192,6 +204,30 @@ pub fn parse_all(entries: &[String]) -> Result<Vec<ToolRef>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_tool_may_set_its_own_vars_but_never_the_workloads_own() {
+        // A tool's env is composed into the workload and into every later `lns exec`; PATH is the bin dirs' job and HOME belongs to the workload, so neither may arrive this way.
+        assert!(is_safe_env_name("RUSTUP_HOME"));
+        assert!(is_safe_env_name("SOME_TOOL_2"));
+        // The loader and shell hooks reach every process in the workload, not just the tool's own binaries.
+        for refused in [
+            "PATH",
+            "HOME",
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "BASH_ENV",
+            "ENV",
+            "IFS",
+            "",
+            "2BAD",
+            "lowercase",
+            "HAS SPACE",
+            "A=B",
+        ] {
+            assert!(!is_safe_env_name(refused), "{refused:?} must be refused");
+        }
+    }
 
     #[test]
     #[serial_test::serial(env)]

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -302,6 +302,34 @@ fn group_gid(newroot: &str, name: &str) -> Option<u32> {
 
 const FILESET_OWNED_MANIFEST: &str = "/.lens/fileset-owned";
 
+/// Where the service injects a run's declared tool trees; PID 1 stays dependency-free, so this is spelled here as well as in lns-service's tool cache.
+const TOOLS_ROOT: &str = "/.lens/tools";
+
+/// A tool writes inside its own prefix (the engine puts cargo's `CARGO_HOME` there) but every injected entry lands uid 0, so the resolved workload gets the directories — never the files — and its writes go to the overlay's upper layer and vanish at teardown.
+fn chown_tool_dirs(sys: &dyn Syscalls, newroot: &str, run_ids: Option<(u32, u32)>) {
+    let Some((uid, gid)) = run_ids else {
+        return;
+    };
+    let root = format!("{newroot}{TOOLS_ROOT}");
+    if !std::path::Path::new(&root).is_dir() {
+        return;
+    }
+    let mut pending = vec![std::path::PathBuf::from(&root)];
+    while let Some(dir) = pending.pop() {
+        lchown_logged(sys, &dir.to_string_lossy(), uid, gid);
+        // A directory the walk cannot read costs its subtree, not the rest of the trees.
+        let Ok(listing) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in listing.flatten() {
+            // Symlinks are not followed: a link's own target is already an entry of this tree, and following one could walk out of it.
+            if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+                pending.push(entry.path());
+            }
+        }
+    }
+}
+
 /// Transfer the fileset paths the definition marked `owner: workload` to the run-as ids; the host ships the list inside the runtime layer because only the guest can resolve a named image user.
 fn chown_fileset_owned(sys: &dyn Syscalls, newroot: &str, run_ids: Option<(u32, u32)>) {
     let Some((uid, gid)) = run_ids else {
@@ -317,17 +345,19 @@ fn chown_fileset_owned(sys: &dyn Syscalls, newroot: &str, run_ids: Option<(u32, 
             );
             continue;
         }
-        let full = format!("{newroot}{path}");
-        match CString::new(full.as_str()) {
-            Ok(full_c) => {
-                if let Err(err) = sys.lchown(&full_c, uid, gid) {
-                    eprintln!("lns-init: lchown({full:?}, {uid}, {gid}) failed: {err}");
-                }
-            }
-            Err(_) => {
-                eprintln!("lns-init: skipping fileset-owned entry {path:?} — interior NUL");
+        lchown_logged(sys, &format!("{newroot}{path}"), uid, gid);
+    }
+}
+
+/// One place converts a path for `lchown` and logs what went wrong, so a path the syscall cannot take or a failure on one entry never abandons the rest of the walk.
+fn lchown_logged(sys: &dyn Syscalls, path: &str, uid: u32, gid: u32) {
+    match CString::new(path) {
+        Ok(c_path) => {
+            if let Err(err) = sys.lchown(&c_path, uid, gid) {
+                eprintln!("lns-init: lchown({path:?}, {uid}, {gid}) failed: {err}");
             }
         }
+        Err(_) => eprintln!("lns-init: skipping {path:?} — interior NUL"),
     }
 }
 
@@ -777,6 +807,8 @@ fn mount_composefs_and_exec_broker_inner(
     }
 
     chown_fileset_owned(sys, newroot, run_ids);
+
+    chown_tool_dirs(sys, newroot, run_ids);
 
     mount_volumes(sys, &params.volumes, newroot, run_ids)?;
 
@@ -2017,6 +2049,118 @@ mod tests {
         std::fs::create_dir_all(format!("{newroot}/.lens")).unwrap();
         std::fs::write(format!("{newroot}{FILESET_OWNED_MANIFEST}"), listing).unwrap();
         newroot
+    }
+
+    #[test]
+    fn the_workload_owns_the_directories_of_its_tool_trees_but_not_their_files() {
+        // A tool writes into its own prefix — cargo's package-cache lock and registry live under a CARGO_HOME the engine put inside the tree — and every injected entry lands uid 0, so a non-root workload could not write there. Directories only: the binaries stay owned by root.
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap().to_string();
+        for sub in ["rust/1.95.0/home/.cargo", "rust/1.95.0/data/installs"] {
+            std::fs::create_dir_all(format!("{newroot}{TOOLS_ROOT}/{sub}")).unwrap();
+        }
+        std::fs::write(
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0/home/.cargo/env"),
+            "x",
+        )
+        .unwrap();
+        let sys = FakeSyscalls::new();
+        chown_tool_dirs(&sys, &newroot, Some((65534, 65534)));
+
+        let owned = sys.calls.borrow().clone();
+        for dir in [
+            format!("{newroot}{TOOLS_ROOT}"),
+            format!("{newroot}{TOOLS_ROOT}/rust"),
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0"),
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0/home"),
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0/home/.cargo"),
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0/data"),
+            format!("{newroot}{TOOLS_ROOT}/rust/1.95.0/data/installs"),
+        ] {
+            assert!(
+                owned.contains(&handed_over(&dir)),
+                "{dir} was not handed to the workload"
+            );
+        }
+        assert!(
+            !owned.iter().any(
+                |call| matches!(call, Call::Lchown { path, .. } if path.ends_with("/home/.cargo/env"))
+            ),
+            "a tool's files stay root-owned: {owned:?}"
+        );
+    }
+
+    /// What the walk is expected to have done to one directory: hand it to the resolved workload ids.
+    fn handed_over(path: &str) -> Call {
+        Call::Lchown {
+            path: path.to_string(),
+            uid: 65534,
+            gid: 65534,
+        }
+    }
+
+    #[test]
+    fn an_unreadable_tool_directory_costs_its_subtree_and_not_the_rest() {
+        // One tool tree the walk cannot descend must not leave every other tool's dirs root-owned.
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap().to_string();
+        let closed = format!("{newroot}{TOOLS_ROOT}/closed/1.0.0");
+        std::fs::create_dir_all(format!("{closed}/inner")).unwrap();
+        std::fs::create_dir_all(format!("{newroot}{TOOLS_ROOT}/open/1.0.0")).unwrap();
+        std::fs::set_permissions(&closed, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let sys = FakeSyscalls::new();
+        chown_tool_dirs(&sys, &newroot, Some((65534, 65534)));
+        let owned = sys.calls.borrow().clone();
+        std::fs::set_permissions(&closed, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(owned.contains(&handed_over(&format!("{newroot}{TOOLS_ROOT}/open/1.0.0"))));
+        assert!(
+            owned.contains(&handed_over(&closed)),
+            "the dir itself is still handed over"
+        );
+        assert!(
+            !owned.contains(&handed_over(&format!("{closed}/inner"))),
+            "its unreadable subtree is skipped: {owned:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_chown_does_not_abandon_the_remaining_tool_dirs() {
+        // The tool trees come from one cache; a single entry the guest cannot take must not silently stop the walk.
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap().to_string();
+        for tool in ["jq/1.8.2", "node/22.23.2"] {
+            std::fs::create_dir_all(format!("{newroot}{TOOLS_ROOT}/{tool}")).unwrap();
+        }
+        let sys = FakeSyscalls::new().fail_when(|call| {
+            matches!(call, Call::Lchown { .. }).then_some(std::io::ErrorKind::PermissionDenied)
+        });
+        chown_tool_dirs(&sys, &newroot, Some((65534, 65534)));
+        assert_eq!(
+            sys.calls.borrow().len(),
+            5,
+            "every dir is attempted: the root, both tools, and both versions"
+        );
+    }
+
+    #[test]
+    fn a_run_with_no_tool_trees_or_no_resolved_user_chowns_nothing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap().to_string();
+        let sys = FakeSyscalls::new();
+        chown_tool_dirs(&sys, &newroot, Some((65534, 65534)));
+        assert!(
+            sys.calls.borrow().is_empty(),
+            "no tool trees, nothing to do"
+        );
+
+        std::fs::create_dir_all(format!("{newroot}{TOOLS_ROOT}/jq/1.8.2")).unwrap();
+        chown_tool_dirs(&sys, &newroot, None);
+        assert!(
+            sys.calls.borrow().is_empty(),
+            "a root workload already writes its own trees"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -561,7 +561,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
             logs,
             config,
-            tool_bin_paths: Vec::new(),
+            tools: Default::default(),
         },
     );
     drop(runtime_cache_registration);

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -479,7 +479,7 @@ pub(super) fn build_session_params(
 ) -> crate::vm::session_client::SessionParams {
     let mut env = args.env;
     // The run's declared tools reach exec through the same rule the workload's PATH was built with; the image's own PATH additions are not part of an exec session, which inherits the guest default.
-    crate::workload_env::compose_guest_path(&mut env, &crate::run_registry::tool_bin_paths(run_id));
+    crate::workload_env::compose_guest_tool_env(&mut env, &crate::run_registry::tools(run_id));
     crate::vm::session_client::SessionParams {
         argv: args.argv,
         env,
@@ -930,7 +930,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tool_bin_paths: Vec::new(),
+                tools: Default::default(),
             },
         );
 
@@ -1290,7 +1290,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tool_bin_paths: Vec::new(),
+            tools: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
         let resp = handle_request(
@@ -1325,7 +1325,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tool_bin_paths: Vec::new(),
+            tools: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
 
@@ -1381,7 +1381,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tool_bin_paths: Vec::new(),
+            tools: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
 
@@ -1470,7 +1470,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tool_bin_paths: Vec::new(),
+                tools: Default::default(),
             },
         );
     }
@@ -1818,7 +1818,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tool_bin_paths: Vec::new(),
+                tools: Default::default(),
             },
         );
 
@@ -1919,7 +1919,13 @@ mod tests {
     #[serial_test::serial(global_runs)]
     async fn exec_and_the_workload_compose_the_same_path_for_the_same_tools() {
         // Two copies of the PATH rule drift into "run finds node, exec does not"; this fails the moment they disagree.
-        let tools = vec!["/.lens/tools/node/22.11.0/bin".to_string()];
+        let tools = crate::workload_env::ToolRuntime {
+            bin_paths: vec!["/.lens/tools/node/22.11.0/bin".to_string()],
+            env: vec![(
+                "SOME_TOOL_HOME".to_string(),
+                "/.lens/tools/node/22.11.0/home".to_string(),
+            )],
+        };
         let workload = crate::workload_env::run_workload_env(
             Some(&["PATH=/usr/bin".into()]),
             &[],
@@ -1933,10 +1939,15 @@ mod tests {
             .iter()
             .find(|kv| kv.starts_with("PATH="))
             .expect("the workload gets a PATH");
+        let workload_tool_var = workload
+            .env
+            .iter()
+            .find(|kv| kv.starts_with("SOME_TOOL_HOME="))
+            .expect("the workload gets the tool's own var");
 
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tool_bin_paths = tools.clone();
+        handle.tools = tools.clone();
         crate::run_registry::register_named(run_id.clone(), None, handle).expect("register");
         let mut args = exec_args(vec!["node".into()], false, false);
         args.env = vec!["PATH=/usr/bin".into()];
@@ -1948,16 +1959,27 @@ mod tests {
             Some(workload_path),
             "exec must reach the PATH the workload got"
         );
+        assert_eq!(
+            params
+                .env
+                .iter()
+                .find(|kv| kv.starts_with("SOME_TOOL_HOME=")),
+            Some(workload_tool_var),
+            "and the vars the tools need to find their own payload"
+        );
     }
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
     async fn an_exec_carrying_no_env_still_puts_the_runs_tool_dirs_first() {
         // What `lns exec` actually sends is an empty env, so the composed PATH has to hold up on that input and not just on a hand-supplied one.
-        let tools = vec!["/.lens/tools/node/22.11.0/bin".to_string()];
+        let tools = crate::workload_env::ToolRuntime {
+            bin_paths: vec!["/.lens/tools/node/22.11.0/bin".to_string()],
+            env: Vec::new(),
+        };
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tool_bin_paths = tools.clone();
+        handle.tools = tools.clone();
         crate::run_registry::register_named(run_id.clone(), None, handle).expect("register");
         let args = exec_args(vec!["node".into()], false, false);
         assert!(args.env.is_empty(), "the CLI sends no env for exec");
@@ -1981,7 +2003,10 @@ mod tests {
         // `lns ps` shows names and the docs use them, so a name that loses the tool PATH is the common path, not the edge case.
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tool_bin_paths = vec!["/.lens/tools/node/22.11.0/bin".to_string()];
+        handle.tools = crate::workload_env::ToolRuntime {
+            bin_paths: vec!["/.lens/tools/node/22.11.0/bin".to_string()],
+            env: Vec::new(),
+        };
         crate::run_registry::register_named(run_id.clone(), Some("calm-finch".into()), handle)
             .expect("register the run");
 

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -62,7 +62,7 @@ pub(super) struct EnvInputs<'a> {
     pub user_env: &'a [String],
     pub extra_managed: &'a [String],
     pub workdir: Option<&'a str>,
-    pub tool_bin_paths: &'a [String],
+    pub tools: &'a crate::workload_env::ToolRuntime,
 }
 
 pub(super) fn exec_env_strings(
@@ -87,7 +87,7 @@ pub(super) fn exec_env_strings(
         agent_command.as_deref(),
         inputs.workdir,
         inputs.extra_managed,
-        inputs.tool_bin_paths,
+        inputs.tools,
     )
 }
 
@@ -442,7 +442,7 @@ mod tests {
                 user_env: &[],
                 extra_managed: &[],
                 workdir: None,
-                tool_bin_paths: &[],
+                tools: &Default::default(),
             },
         );
         assert!(
@@ -466,7 +466,7 @@ mod tests {
                 user_env: &[],
                 extra_managed: &[],
                 workdir: None,
-                tool_bin_paths: &[],
+                tools: &Default::default(),
             },
         );
         let agent = env
@@ -491,7 +491,7 @@ mod tests {
                 user_env: &["FOO=bar".into()],
                 extra_managed: &[],
                 workdir: None,
-                tool_bin_paths: &[],
+                tools: &Default::default(),
             },
         );
         assert_eq!(
@@ -540,7 +540,7 @@ mod tests {
                 user_env: &[],
                 extra_managed: &[],
                 workdir: None,
-                tool_bin_paths: &[],
+                tools: &Default::default(),
             },
         );
         assert!(env.env.contains(&"AGENT_COMMAND=/srv arg".to_string()));
@@ -566,7 +566,7 @@ mod tests {
                 user_env: &["PORT=4000".into()],
                 extra_managed: &[],
                 workdir: None,
-                tool_bin_paths: &[],
+                tools: &Default::default(),
             },
         );
         assert!(

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -453,6 +453,8 @@ async fn orchestrate(
             }))
             .await;
     }
+    // What an `lns exec` into this run may re-apply: a var the definition already owns kept its own value here, and exec composes against an empty env, so only what took effect travels.
+    let applied_tools = tool_runtime.as_applied(&composed.env);
     let env: Vec<String> = composed.env;
 
     let params = vm::session_client::SessionParams {
@@ -500,7 +502,11 @@ async fn orchestrate(
         "microVM   ({:.2}s)",
         boot_start.elapsed().as_secs_f64()
     );
-    crate::run_registry::set_connector_with_tools(&run_id, connector.clone(), tool_runtime.clone());
+    crate::run_registry::set_connector_with_tools(
+        &run_id,
+        connector.clone(),
+        applied_tools.clone(),
+    );
     let _vm_stop_guard = vm::VmStopGuard::new(connector.clone());
 
     log::progress("Connecting", "session", 0, 0);

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -422,6 +422,13 @@ async fn orchestrate(
         args.workdir.as_deref(),
         crate::workload_cwd::image_workdir(image.config.as_ref()).as_deref(),
     );
+    let tool_runtime = ensured_tools
+        .as_ref()
+        .map(|ensured| crate::workload_env::ToolRuntime {
+            bin_paths: ensured.bin_paths.clone(),
+            env: ensured.env.clone(),
+        })
+        .unwrap_or_default();
     let composed = exec_env_strings(
         image.config.as_ref(),
         args.entrypoint.as_deref(),
@@ -434,10 +441,7 @@ async fn orchestrate(
                 .map(|s| s.managed_env_vars.as_slice())
                 .unwrap_or(&[]),
             workdir: workdir.as_deref(),
-            tool_bin_paths: ensured_tools
-                .as_ref()
-                .map(|ensured| ensured.bin_paths.as_slice())
-                .unwrap_or_default(),
+            tools: &tool_runtime,
         },
     );
     for refused in &composed.refused {
@@ -496,14 +500,7 @@ async fn orchestrate(
         "microVM   ({:.2}s)",
         boot_start.elapsed().as_secs_f64()
     );
-    crate::run_registry::set_connector_with_tool_bin_paths(
-        &run_id,
-        connector.clone(),
-        ensured_tools
-            .as_ref()
-            .map(|ensured| ensured.bin_paths.clone())
-            .unwrap_or_default(),
-    );
+    crate::run_registry::set_connector_with_tools(&run_id, connector.clone(), tool_runtime.clone());
     let _vm_stop_guard = vm::VmStopGuard::new(connector.clone());
 
     log::progress("Connecting", "session", 0, 0);

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -30,8 +30,8 @@ pub struct RunHandle {
     pub status: std::sync::Mutex<RunStatus>,
     pub logs: std::sync::Arc<crate::run_log::RunLogBuffer>,
     pub config: lns_ipc::RunConfig,
-    /// Where this run's declared tools landed in its guest, so `lns exec` into the same guest sees the same PATH the workload does.
-    pub tool_bin_paths: Vec<String>,
+    /// What this run's declared tools contribute to its guest environment, so `lns exec` into the same guest resolves them the way the workload does.
+    pub tools: crate::workload_env::ToolRuntime,
 }
 
 pub fn allocate_run_id() -> String {
@@ -198,11 +198,11 @@ pub fn connector(run_id: &str) -> Option<std::sync::Arc<dyn GuestTransport>> {
         .and_then(|h| h.connector.clone())
 }
 
-pub fn tool_bin_paths(run_id: &str) -> Vec<String> {
+pub fn tools(run_id: &str) -> crate::workload_env::ToolRuntime {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     g.as_ref()
         .and_then(|m| m.get(run_id))
-        .map(|h| h.tool_bin_paths.clone())
+        .map(|h| h.tools.clone())
         .unwrap_or_default()
 }
 
@@ -213,15 +213,15 @@ pub fn set_connector(run_id: &str, connector: std::sync::Arc<dyn GuestTransport>
     }
 }
 
-/// The connector is what makes a run exec-able, so a run that has tool paths publishes both in one mutation — an exec that saw the gate open but not the paths would run with the tool dirs missing from its PATH and no error.
-pub fn set_connector_with_tool_bin_paths(
+/// The connector is what makes a run exec-able, so a run that has declared tools publishes both in one mutation — an exec that saw the gate open but not the tools would run without them and with no error.
+pub fn set_connector_with_tools(
     run_id: &str,
     connector: std::sync::Arc<dyn GuestTransport>,
-    paths: Vec<String>,
+    tools: crate::workload_env::ToolRuntime,
 ) {
     let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
     if let Some(h) = g.as_mut().and_then(|m| m.get_mut(run_id)) {
-        h.tool_bin_paths = paths;
+        h.tools = tools;
         h.connector = Some(connector);
     }
 }
@@ -410,7 +410,7 @@ pub(crate) fn test_handle() -> (RunHandle, oneshot::Receiver<i32>) {
             status: std::sync::Mutex::new(RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tool_bin_paths: Vec::new(),
+            tools: Default::default(),
         },
         cancel_rx,
     )
@@ -647,29 +647,38 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
-    async fn a_runs_tool_paths_are_readable_for_the_life_of_the_run() {
-        // `lns exec` enters the same guest later and has to compose the same PATH.
+    async fn a_runs_tool_environment_is_readable_for_the_life_of_the_run() {
+        // `lns exec` enters the same guest later and has to compose the same PATH and the same tool vars.
         let id = allocate_run_id();
         let (mut h, _rx) = make_handle();
-        h.tool_bin_paths = vec!["/.lens/tools/node/22.11.0/bin".to_string()];
+        h.tools = tool_runtime();
         register_named(id.clone(), None, h).unwrap();
-        assert_eq!(tool_bin_paths(&id), vec!["/.lens/tools/node/22.11.0/bin"]);
-        assert!(tool_bin_paths("ghost").is_empty());
+        assert_eq!(tools(&id), tool_runtime());
+        assert_eq!(tools("ghost"), Default::default());
         deregister(&id);
-        assert!(tool_bin_paths(&id).is_empty());
+        assert_eq!(tools(&id), Default::default());
+    }
+
+    fn tool_runtime() -> crate::workload_env::ToolRuntime {
+        crate::workload_env::ToolRuntime {
+            bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".to_string()],
+            env: vec![(
+                "SOME_TOOL_HOME".to_string(),
+                "/.lens/tools/some-tool/1.2.3/home".to_string(),
+            )],
+        }
     }
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
-    async fn a_run_never_becomes_exec_able_before_its_tool_paths_are_readable() {
-        // The connector is the gate `lns exec` passes; publishing it a moment before the PATH would let an exec in that window run with no tool dirs and no error.
+    async fn a_run_never_becomes_exec_able_before_its_tool_environment_is_readable() {
+        // The connector is the gate `lns exec` passes; publishing it a moment before the tools would let an exec in that window run without them and with no error.
         let id = allocate_run_id();
         let (h, _rx) = make_handle();
         register_named(id.clone(), None, h).unwrap();
-        let paths = vec!["/.lens/tools/node/22.11.0/bin".to_string()];
-        set_connector_with_tool_bin_paths(&id, std::sync::Arc::new(StubTransport), paths.clone());
+        set_connector_with_tools(&id, std::sync::Arc::new(StubTransport), tool_runtime());
         assert!(connector(&id).is_some());
-        assert_eq!(tool_bin_paths(&id), paths);
+        assert_eq!(tools(&id), tool_runtime());
         deregister(&id);
     }
 

--- a/crates/lns-service/src/tools/cache.rs
+++ b/crates/lns-service/src/tools/cache.rs
@@ -9,7 +9,7 @@ use crate::archive_limits::{ArchiveLimits, LimitedReader};
 use crate::content_store::ContentStore;
 use crate::runtime_layer::{RuntimeFileSpec, RuntimeSource};
 
-pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
+pub const MANIFEST_SCHEMA_VERSION: u32 = 4;
 
 /// A provisioned tool tree, ingested into the content store and described entry-by-entry so injection composes specs without re-reading any file body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +27,8 @@ pub struct ToolManifest {
     pub co_installed: Vec<String>,
     pub entries: Vec<ManifestEntry>,
     pub bin_paths: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<ToolEnvVar>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,13 +50,19 @@ const NPM_LAUNCHER: &str = "bin/npm";
 const NPM_CLI: &str = "lib/node_modules/npm/bin/npm-cli.js";
 const STOCK_NPM_TARGET: &str = "../lib/node_modules/npm/bin/npm-cli.js";
 
-/// The engine replaces node's `bin/npm` symlink with a shim that reshims through `mise` under bash — neither of which a workload guest has — so the tree goes back to the launcher the upstream tarball ships.
+/// The engine replaces node's `bin/npm` symlink with a shim that reshims through `mise` under bash — neither of which a workload guest has — so the tree goes back to the launcher the upstream tarball ships. The tree root is the install prefix, so node's own layout sits at some depth below it and only the tail of the path is fixed.
 fn restore_stock_npm(entries: &mut [ManifestEntry]) {
-    if !entries.iter().any(|entry| entry.path == NPM_CLI) {
-        return;
-    }
+    let prefixes: Vec<String> = entries
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .path
+                .strip_suffix(NPM_CLI)
+                .map(|prefix| format!("{prefix}{NPM_LAUNCHER}"))
+        })
+        .collect();
     for entry in entries {
-        if entry.path == NPM_LAUNCHER && matches!(entry.kind, EntryKind::Regular { .. }) {
+        if prefixes.contains(&entry.path) && matches!(entry.kind, EntryKind::Regular { .. }) {
             entry.kind = EntryKind::Symlink {
                 target: STOCK_NPM_TARGET.to_string(),
             };
@@ -62,8 +70,26 @@ fn restore_stock_npm(entries: &mut [ManifestEntry]) {
     }
 }
 
+/// The one place a tool tree ever lives: the provisioner installs it here and the workload reads it here, so an install that bakes its own absolute paths stays valid across the two guests.
+pub const TOOLS_ROOT: &str = "/.lens/tools";
+
 pub fn guest_root(tool: &str, resolved: &lns_artifact::tools::SafeVersion) -> String {
-    format!("/.lens/tools/{tool}/{resolved}")
+    format!("{TOOLS_ROOT}/{tool}/{resolved}")
+}
+
+/// One env var a tool needs to find its own payload, as the engine reported it: a value inside the tree travels as a tree-relative path, anything else as itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolEnvVar {
+    pub name: String,
+    #[serde(flatten)]
+    pub value: ToolEnvValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ToolEnvValue {
+    Tree { path: String },
+    Literal { value: String },
 }
 
 impl ToolManifest {
@@ -85,6 +111,22 @@ impl ToolManifest {
                     mode: entry.mode,
                     source,
                 })
+            })
+            .collect()
+    }
+
+    /// The env the workload needs for this tool, with every tree-relative value resolved against the root the tree is injected at.
+    pub fn guest_env(&self) -> Vec<(String, String)> {
+        let root = guest_root(&self.tool, &self.resolved);
+        self.env
+            .iter()
+            .map(|var| {
+                let value = match &var.value {
+                    ToolEnvValue::Literal { value } => value.clone(),
+                    ToolEnvValue::Tree { path } if path == "." => root.clone(),
+                    ToolEnvValue::Tree { path } => format!("{root}/{path}"),
+                };
+                (var.name.clone(), value)
             })
             .collect()
     }
@@ -186,7 +228,7 @@ impl ToolCache for RealToolCache {
             return Ok(None);
         }
         restore_stock_npm(&mut manifest.entries);
-        if let Err(e) = validate_tree(&manifest.entries, &manifest.bin_paths) {
+        if let Err(e) = validate_tree(&manifest.entries, &manifest.bin_paths, &manifest.env) {
             crate::log::warn!("ignoring the cached tool tree at {}: {e:#}", dir.display());
             return Ok(None);
         }
@@ -201,15 +243,16 @@ impl ToolCache for RealToolCache {
     }
 
     fn ingest(&self, key: &ToolCacheKey, staged: &StagedTool) -> Result<ToolManifest> {
+        let root = guest_root(&key.name, &key.resolved);
         let mut entries = match &staged.tar {
             StagedTar::File(path) => {
                 let file = open_staged_tar(path)?;
-                ingest_tar_entries(file, &self.store)?
+                ingest_tar_entries(file, &self.store, &root)?
             }
-            StagedTar::Bytes(bytes) => ingest_tar_entries(&bytes[..], &self.store)?,
+            StagedTar::Bytes(bytes) => ingest_tar_entries(&bytes[..], &self.store, &root)?,
         };
         restore_stock_npm(&mut entries);
-        validate_tree(&entries, &staged.bin_paths)?;
+        validate_tree(&entries, &staged.bin_paths, &staged.env)?;
         let manifest = ToolManifest {
             schema_version: MANIFEST_SCHEMA_VERSION,
             tool: key.name.clone(),
@@ -220,6 +263,7 @@ impl ToolCache for RealToolCache {
             co_installed: staged.co_installed.clone(),
             entries,
             bin_paths: staged.bin_paths.clone(),
+            env: staged.env.clone(),
         };
         let dir = self.key_dir(key);
         std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
@@ -255,13 +299,36 @@ fn open_staged_tar(path: &Path) -> Result<std::fs::File> {
 }
 
 /// Expand a staged tool tar into content-store entries. Fail-closed like fileset ingestion — escaping paths and exotic entry types are refused — but tool trees legitimately carry symlinks (`bin/node -> ../lib/...`) and hardlinks (JDK layouts), so those are preserved as manifest entries.
-fn ingest_tar_entries<R: Read>(tar: R, store: &ContentStore) -> Result<Vec<ManifestEntry>> {
-    ingest_tar_entries_with_limits(tar, store, ArchiveLimits::PRODUCTION)
+fn ingest_tar_entries<R: Read>(
+    tar: R,
+    store: &ContentStore,
+    install_root: &str,
+) -> Result<Vec<ManifestEntry>> {
+    ingest_tar_entries_with_limits(tar, store, install_root, ArchiveLimits::PRODUCTION)
+}
+
+/// The provisioner installs a tree at the path the workload reads it from, so an install may link inside itself by absolute path (rustup does). Spell it relative instead: injection only ever creates in-tree links, and that is what keeps the escape guards sound.
+fn relative_in_tree_link(link_rel: &str, target: &Path, install_root: &str) -> Option<String> {
+    let below = target
+        .to_str()?
+        .strip_prefix(install_root)
+        .filter(|rest| rest.is_empty() || rest.starts_with('/'))?
+        .trim_start_matches('/');
+    let climb = link_rel.split('/').count() - 1;
+    let mut spelled = "../".repeat(climb);
+    spelled.push_str(below);
+    let spelled = spelled.trim_end_matches('/');
+    Some(if spelled.is_empty() {
+        ".".to_string()
+    } else {
+        spelled.to_string()
+    })
 }
 
 fn ingest_tar_entries_with_limits<R: Read>(
     tar: R,
     store: &ContentStore,
+    install_root: &str,
     limits: ArchiveLimits,
 ) -> Result<Vec<ManifestEntry>> {
     let mut entries = Vec::new();
@@ -301,7 +368,11 @@ fn ingest_tar_entries_with_limits<R: Read>(
                 .link_name()
                 .context("reading symlink target")?
                 .with_context(|| format!("tool symlink {} has no target", path.display()))?;
-            if !target_stays_in_tree(&rel, &target) {
+            let spelled = match relative_in_tree_link(&rel, &target, install_root) {
+                Some(relative) => relative,
+                None => target.to_string_lossy().into_owned(),
+            };
+            if !target_stays_in_tree(&rel, Path::new(&spelled)) {
                 bail!(
                     "tool symlink {} -> {} escapes the tool tree",
                     path.display(),
@@ -311,9 +382,7 @@ fn ingest_tar_entries_with_limits<R: Read>(
             entries.push(ManifestEntry {
                 path: rel,
                 mode,
-                kind: EntryKind::Symlink {
-                    target: target.to_string_lossy().into_owned(),
-                },
+                kind: EntryKind::Symlink { target: spelled },
             });
             continue;
         }
@@ -363,10 +432,25 @@ fn ingest_tar_entries_with_limits<R: Read>(
 }
 
 /// Every guard the tar walk applies, restated over the finished tree so a manifest read back off disk gets them too — the provision path is not the only way these entries reach a guest, and the file on disk is exactly the kind of input the version and schema checks already refuse to trust.
-fn validate_tree(entries: &[ManifestEntry], bin_paths: &[String]) -> Result<()> {
+fn validate_tree(
+    entries: &[ManifestEntry],
+    bin_paths: &[String],
+    env: &[ToolEnvVar],
+) -> Result<()> {
     for bin_path in bin_paths {
         if !lns_artifact::tools::is_safe_bin_path(bin_path) {
             bail!("tool bin path {bin_path:?} escapes the tool tree");
+        }
+    }
+    // Every var here is put in the workload's environment and in every later `lns exec`, so a hand-edited manifest gets the same guards the driver's output got.
+    for var in env {
+        if !lns_artifact::tools::is_safe_env_name(&var.name) {
+            bail!("tool env var {:?} is not one a tool may set", var.name);
+        }
+        if let ToolEnvValue::Tree { path } = &var.value
+            && !lns_artifact::tools::is_safe_bin_path(path)
+        {
+            bail!("tool env var {} points outside the tool tree", var.name);
         }
     }
     for entry in entries {
@@ -491,6 +575,7 @@ mod tests {
             source_host: Some("upstream.example.test".into()),
             tar: StagedTar::Bytes(tar),
             bin_paths: vec!["bin".into()],
+            env: Vec::new(),
         }
     }
 
@@ -606,6 +691,7 @@ mod tests {
         let err = ingest_tar_entries_with_limits(
             &tool_tar()[..],
             &ContentStore::new(dir.path().join("content")),
+            "/.lens/tools/some-tool/1.2.3",
             ArchiveLimits {
                 bytes: u64::MAX,
                 entries: 2,
@@ -621,6 +707,7 @@ mod tests {
         let err = ingest_tar_entries_with_limits(
             &tool_tar()[..],
             &ContentStore::new(dir.path().join("content")),
+            "/.lens/tools/some-tool/1.2.3",
             ArchiveLimits {
                 bytes: 512,
                 entries: usize::MAX,
@@ -900,6 +987,7 @@ mod tests {
                     source_host: Some("upstream.example.test".into()),
                     tar: StagedTar::File(staged_path),
                     bin_paths: vec!["bin".into()],
+                    env: Vec::new(),
                 },
             )
             .unwrap_err();
@@ -929,6 +1017,7 @@ mod tests {
                     source_host: Some("upstream.example.test".into()),
                     tar: StagedTar::File(staged_path),
                     bin_paths: vec!["bin".into()],
+                    env: Vec::new(),
                 },
             )
             .unwrap_err();
@@ -1230,6 +1319,174 @@ mod tests {
         assert_eq!(
             manifest.guest_bin_paths(),
             vec!["/.lens/tools/some-tool/1.2.3".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_tools_env_reaches_the_guest_resolved_against_the_root_the_tree_lands_at() {
+        // rustup's proxies are the tool's only binaries and they read RUSTUP_HOME; without it the workload has a rustc that cannot find a toolchain.
+        let dir = tempfile::TempDir::new().unwrap();
+        let cache = cache(dir.path());
+        let mut with_env = staged(tool_tar());
+        with_env.env = vec![
+            ToolEnvVar {
+                name: "SOME_TOOL_HOME".into(),
+                value: ToolEnvValue::Tree {
+                    path: "home/.some-tool".into(),
+                },
+            },
+            ToolEnvVar {
+                name: "SOME_TOOL_ROOT".into(),
+                value: ToolEnvValue::Tree { path: ".".into() },
+            },
+            ToolEnvVar {
+                name: "SOME_TOOL_PIN".into(),
+                value: ToolEnvValue::Literal {
+                    value: "1.2.3".into(),
+                },
+            },
+        ];
+        let manifest = cache.ingest(&key(), &with_env).unwrap();
+        assert_eq!(
+            manifest.guest_env(),
+            vec![
+                (
+                    "SOME_TOOL_HOME".to_string(),
+                    "/.lens/tools/some-tool/1.2.3/home/.some-tool".to_string()
+                ),
+                (
+                    "SOME_TOOL_ROOT".to_string(),
+                    "/.lens/tools/some-tool/1.2.3".to_string()
+                ),
+                ("SOME_TOOL_PIN".to_string(), "1.2.3".to_string()),
+            ]
+        );
+        assert_eq!(cache.lookup(&key(), &[]).unwrap(), Some(manifest));
+    }
+
+    #[test]
+    fn a_cached_manifest_whose_env_escapes_the_tree_or_owns_the_workloads_vars_is_a_miss() {
+        // Every var here is put in the workload's environment and in every later `lns exec`, so a tampered file must not be readable.
+        let dir = tempfile::TempDir::new().unwrap();
+        let cache = cache(dir.path());
+        for env in [
+            serde_json::json!([{"name": "SOME_TOOL_HOME", "kind": "tree", "path": "../../../../etc"}]),
+            serde_json::json!([{"name": "PATH", "kind": "literal", "value": "/pwn"}]),
+            serde_json::json!([{"name": "HOME", "kind": "literal", "value": "/pwn"}]),
+            serde_json::json!([{"name": "LD_PRELOAD=x", "kind": "literal", "value": "/pwn"}]),
+        ] {
+            cache.ingest(&key(), &staged(tool_tar())).unwrap();
+            tamper_manifest(dir.path(), |raw| raw["env"] = env.clone());
+            assert_eq!(cache.lookup(&key(), &[]).unwrap(), None, "env {env}");
+        }
+    }
+
+    #[test]
+    fn an_absolute_link_inside_the_installed_tree_is_kept_as_a_tree_relative_one() {
+        // The provisioner installs at the path the workload reads, so an install may link inside itself absolutely (rustup's install dir is one); injection only ever creates in-tree links.
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut link = tar::Header::new_gnu();
+        link.set_entry_type(tar::EntryType::Symlink);
+        link.set_path("data/installs/some-tool/1.2.3").unwrap();
+        link.set_link_name("/.lens/tools/some-tool/1.2.3/home/.cargo/bin")
+            .unwrap();
+        link.set_size(0);
+        link.set_mode(0o777);
+        link.set_cksum();
+        builder.append(&link, std::io::empty()).unwrap();
+        let tar = builder.into_inner().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = cache(dir.path()).ingest(&key(), &staged(tar)).unwrap();
+        assert_eq!(
+            manifest.entries[0].kind,
+            EntryKind::Symlink {
+                target: "../../../home/.cargo/bin".into()
+            }
+        );
+    }
+
+    #[test]
+    fn an_absolute_link_to_the_tree_root_itself_becomes_the_current_dir() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut link = tar::Header::new_gnu();
+        link.set_entry_type(tar::EntryType::Symlink);
+        link.set_path("self").unwrap();
+        link.set_link_name("/.lens/tools/some-tool/1.2.3").unwrap();
+        link.set_size(0);
+        link.set_mode(0o777);
+        link.set_cksum();
+        builder.append(&link, std::io::empty()).unwrap();
+        let tar = builder.into_inner().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = cache(dir.path()).ingest(&key(), &staged(tar)).unwrap();
+        assert_eq!(
+            manifest.entries[0].kind,
+            EntryKind::Symlink { target: ".".into() }
+        );
+    }
+
+    #[test]
+    fn an_absolute_link_to_another_tools_tree_is_still_refused() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut link = tar::Header::new_gnu();
+        link.set_entry_type(tar::EntryType::Symlink);
+        link.set_path("bin/esc").unwrap();
+        link.set_link_name("/.lens/tools/some-tool/1.2.3-evil/bin")
+            .unwrap();
+        link.set_size(0);
+        link.set_mode(0o777);
+        link.set_cksum();
+        builder.append(&link, std::io::empty()).unwrap();
+        let tar = builder.into_inner().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = cache(dir.path()).ingest(&key(), &staged(tar)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("escapes the tool tree"),
+            "a sibling prefix shares the root's spelling without being inside it: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_shimmed_npm_launcher_nested_under_the_prefix_is_restored_too() {
+        // The tree root is the install prefix, so node's own files sit under the engine's data dir rather than at the root; matching only the root spelling silently left the engine's mise-and-bash shim in place.
+        let dir = tempfile::TempDir::new().unwrap();
+        let cache = cache(dir.path());
+        let nested = "data/installs/node/22.23.2/";
+        let mut builder = tar::Builder::new(Vec::new());
+        let launcher = b"#!/usr/bin/env node\n";
+        builder
+            .append(
+                &file_header(
+                    &format!("{nested}lib/node_modules/npm/bin/npm-cli.js"),
+                    0o755,
+                    launcher.len() as u64,
+                ),
+                &launcher[..],
+            )
+            .unwrap();
+        let shim = b"#!/usr/bin/env bash\nmise reshim\n";
+        builder
+            .append(
+                &file_header(&format!("{nested}bin/npm"), 0o755, shim.len() as u64),
+                &shim[..],
+            )
+            .unwrap();
+        let manifest = cache
+            .ingest(&key(), &staged(builder.into_inner().unwrap()))
+            .unwrap();
+        let npm = manifest
+            .entries
+            .iter()
+            .find(|entry| entry.path == format!("{nested}bin/npm"))
+            .expect("the tree carries the launcher");
+        assert_eq!(
+            npm.kind,
+            EntryKind::Symlink {
+                target: STOCK_NPM_TARGET.into()
+            }
         );
     }
 

--- a/crates/lns-service/src/tools/cache.rs
+++ b/crates/lns-service/src/tools/cache.rs
@@ -46,30 +46,6 @@ pub enum EntryKind {
     Symlink { target: String },
 }
 
-const NPM_LAUNCHER: &str = "bin/npm";
-const NPM_CLI: &str = "lib/node_modules/npm/bin/npm-cli.js";
-const STOCK_NPM_TARGET: &str = "../lib/node_modules/npm/bin/npm-cli.js";
-
-/// The engine replaces node's `bin/npm` symlink with a shim that reshims through `mise` under bash — neither of which a workload guest has — so the tree goes back to the launcher the upstream tarball ships. The tree root is the install prefix, so node's own layout sits at some depth below it and only the tail of the path is fixed.
-fn restore_stock_npm(entries: &mut [ManifestEntry]) {
-    let prefixes: Vec<String> = entries
-        .iter()
-        .filter_map(|entry| {
-            entry
-                .path
-                .strip_suffix(NPM_CLI)
-                .map(|prefix| format!("{prefix}{NPM_LAUNCHER}"))
-        })
-        .collect();
-    for entry in entries {
-        if prefixes.contains(&entry.path) && matches!(entry.kind, EntryKind::Regular { .. }) {
-            entry.kind = EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.to_string(),
-            };
-        }
-    }
-}
-
 /// The one place a tool tree ever lives: the provisioner installs it here and the workload reads it here, so an install that bakes its own absolute paths stays valid across the two guests.
 pub const TOOLS_ROOT: &str = "/.lens/tools";
 
@@ -204,7 +180,7 @@ impl ToolCache for RealToolCache {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
         };
-        let mut manifest: ToolManifest = match serde_json::from_slice(&bytes) {
+        let manifest: ToolManifest = match serde_json::from_slice(&bytes) {
             Ok(manifest) => manifest,
             Err(_) => return Ok(None),
         };
@@ -227,7 +203,6 @@ impl ToolCache for RealToolCache {
         {
             return Ok(None);
         }
-        restore_stock_npm(&mut manifest.entries);
         if let Err(e) = validate_tree(&manifest.entries, &manifest.bin_paths, &manifest.env) {
             crate::log::warn!("ignoring the cached tool tree at {}: {e:#}", dir.display());
             return Ok(None);
@@ -244,14 +219,13 @@ impl ToolCache for RealToolCache {
 
     fn ingest(&self, key: &ToolCacheKey, staged: &StagedTool) -> Result<ToolManifest> {
         let root = guest_root(&key.name, &key.resolved);
-        let mut entries = match &staged.tar {
+        let entries = match &staged.tar {
             StagedTar::File(path) => {
                 let file = open_staged_tar(path)?;
                 ingest_tar_entries(file, &self.store, &root)?
             }
             StagedTar::Bytes(bytes) => ingest_tar_entries(&bytes[..], &self.store, &root)?,
         };
-        restore_stock_npm(&mut entries);
         validate_tree(&entries, &staged.bin_paths, &staged.env)?;
         let manifest = ToolManifest {
             schema_version: MANIFEST_SCHEMA_VERSION,
@@ -604,64 +578,6 @@ mod tests {
         dir.set_cksum();
         builder.append(&dir, std::io::empty()).unwrap();
         builder.into_inner().unwrap()
-    }
-
-    fn file_header(path: &str, mode: u32, size: u64) -> tar::Header {
-        let mut header = tar::Header::new_gnu();
-        header.set_path(path).unwrap();
-        header.set_size(size);
-        header.set_mode(mode);
-        header.set_cksum();
-        header
-    }
-
-    fn npm_tar(npm: EntryKind) -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        let launcher = b"#!/usr/bin/env node\n";
-        builder
-            .append(
-                &file_header(
-                    "lib/node_modules/npm/bin/npm-cli.js",
-                    0o755,
-                    launcher.len() as u64,
-                ),
-                &launcher[..],
-            )
-            .unwrap();
-        match npm {
-            EntryKind::Regular { .. } => {
-                let shim = b"#!/usr/bin/env bash\nmise reshim\n";
-                builder
-                    .append(&file_header("bin/npm", 0o755, shim.len() as u64), &shim[..])
-                    .unwrap();
-            }
-            EntryKind::Symlink { target } => {
-                let mut link = tar::Header::new_gnu();
-                link.set_entry_type(tar::EntryType::Symlink);
-                link.set_path("bin/npm").unwrap();
-                link.set_link_name(&target).unwrap();
-                link.set_size(0);
-                link.set_mode(0o777);
-                link.set_cksum();
-                builder.append(&link, std::io::empty()).unwrap();
-            }
-        }
-        builder.into_inner().unwrap()
-    }
-
-    fn shimmed_npm() -> EntryKind {
-        EntryKind::Regular {
-            digest: String::new(),
-            size: 0,
-        }
-    }
-
-    fn npm_entry(manifest: &ToolManifest) -> &ManifestEntry {
-        manifest
-            .entries
-            .iter()
-            .find(|entry| entry.path == "bin/npm")
-            .expect("the tree carries bin/npm")
     }
 
     fn tree_dir(root: &Path) -> PathBuf {
@@ -1447,124 +1363,6 @@ mod tests {
             format!("{err:#}").contains("escapes the tool tree"),
             "a sibling prefix shares the root's spelling without being inside it: {err:#}"
         );
-    }
-
-    #[test]
-    fn a_shimmed_npm_launcher_nested_under_the_prefix_is_restored_too() {
-        // The tree root is the install prefix, so node's own files sit under the engine's data dir rather than at the root; matching only the root spelling silently left the engine's mise-and-bash shim in place.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let nested = "data/installs/node/22.23.2/";
-        let mut builder = tar::Builder::new(Vec::new());
-        let launcher = b"#!/usr/bin/env node\n";
-        builder
-            .append(
-                &file_header(
-                    &format!("{nested}lib/node_modules/npm/bin/npm-cli.js"),
-                    0o755,
-                    launcher.len() as u64,
-                ),
-                &launcher[..],
-            )
-            .unwrap();
-        let shim = b"#!/usr/bin/env bash\nmise reshim\n";
-        builder
-            .append(
-                &file_header(&format!("{nested}bin/npm"), 0o755, shim.len() as u64),
-                &shim[..],
-            )
-            .unwrap();
-        let manifest = cache
-            .ingest(&key(), &staged(builder.into_inner().unwrap()))
-            .unwrap();
-        let npm = manifest
-            .entries
-            .iter()
-            .find(|entry| entry.path == format!("{nested}bin/npm"))
-            .expect("the tree carries the launcher");
-        assert_eq!(
-            npm.kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            }
-        );
-    }
-
-    #[test]
-    fn a_shimmed_npm_launcher_is_restored_to_the_stock_symlink_at_ingest() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let manifest = cache
-            .ingest(&key(), &staged(npm_tar(shimmed_npm())))
-            .unwrap();
-        assert_eq!(
-            npm_entry(&manifest).kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            }
-        );
-    }
-
-    #[test]
-    fn a_tree_cached_with_the_shim_is_restored_on_lookup() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let mut manifest = cache
-            .ingest(&key(), &staged(npm_tar(shimmed_npm())))
-            .unwrap();
-        let shim = EntryKind::Regular {
-            digest: format!("sha256:{}", "1".repeat(64)),
-            size: 31,
-        };
-        for entry in &mut manifest.entries {
-            if entry.path == "bin/npm" {
-                entry.kind = shim.clone();
-            }
-        }
-        std::fs::write(
-            tree_dir(dir.path()).join("manifest.json"),
-            serde_json::to_vec(&manifest).unwrap(),
-        )
-        .unwrap();
-        let read_back = cache.lookup(&key(), &[]).unwrap().expect("a cache hit");
-        assert_eq!(
-            npm_entry(&read_back).kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            },
-            "a tree ingested before the shim was known must not keep launching it"
-        );
-    }
-
-    #[test]
-    fn an_npm_launcher_without_the_stock_tree_beside_it_is_left_alone() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let mut builder = tar::Builder::new(Vec::new());
-        let body = b"#!/usr/bin/env bash\n";
-        builder
-            .append(&file_header("bin/npm", 0o755, body.len() as u64), &body[..])
-            .unwrap();
-        let manifest = cache
-            .ingest(&key(), &staged(builder.into_inner().unwrap()))
-            .unwrap();
-        assert!(
-            matches!(npm_entry(&manifest).kind, EntryKind::Regular { .. }),
-            "a symlink to a launcher the tree does not carry would break npm outright"
-        );
-    }
-
-    #[test]
-    fn a_stock_npm_symlink_survives_ingest_unchanged() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let stock = EntryKind::Symlink {
-            target: STOCK_NPM_TARGET.into(),
-        };
-        let manifest = cache
-            .ingest(&key(), &staged(npm_tar(stock.clone())))
-            .unwrap();
-        assert_eq!(npm_entry(&manifest).kind, stock);
     }
 
     #[test]

--- a/crates/lns-service/src/tools/mise.rs
+++ b/crates/lns-service/src/tools/mise.rs
@@ -142,6 +142,8 @@ pub fn provision_env() -> Vec<(String, String)> {
         ("MISE_PYTHON_COMPILE", "0"),
         ("MISE_NODE_COMPILE", "0"),
         ("MISE_YES", "1"),
+        // The engine's own `bin/npm` replaces node's launcher with a script that reshims through mise under bash, and a workload guest has neither; off, the tree keeps the symlink the upstream tarball ships.
+        ("MISE_NODE_NPM_SHIM", "0"),
         // Every backend that is not download-only: the snapshot records the download backend a tool is gated and audited against, so mise must not silently pick a different one (oxlint via npm, tokei via cargo, imagemagick via conda).
         (
             "MISE_DISABLE_BACKENDS",
@@ -304,6 +306,8 @@ mod tests {
         };
         assert_eq!(get("MISE_PYTHON_COMPILE"), "0");
         assert_eq!(get("MISE_NODE_COMPILE"), "0");
+        // With the shim on, the tree ships an `npm` that launches mise under bash — neither of which a workload guest has — so the tool installs and never runs.
+        assert_eq!(get("MISE_NODE_NPM_SHIM"), "0");
         let disabled = get("MISE_DISABLE_BACKENDS");
         for backend in [
             "asdf", "vfox", "npm", "cargo", "pipx", "gem", "go", "dotnet", "conda", "spm",

--- a/crates/lns-service/src/tools/mod.rs
+++ b/crates/lns-service/src/tools/mod.rs
@@ -79,6 +79,8 @@ pub struct StagedTool {
     pub source_host: Option<String>,
     pub tar: StagedTar,
     pub bin_paths: Vec<String>,
+    /// What the tool needs in the workload's environment to find its own payload, as the engine reported it.
+    pub env: Vec<cache::ToolEnvVar>,
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +113,8 @@ pub struct ProvisionOutcome {
 pub struct EnsuredTools {
     pub specs: Vec<crate::runtime_layer::RuntimeFileSpec>,
     pub bin_paths: Vec<String>,
+    /// What the declared tools need in the workload's environment beyond `PATH`.
+    pub env: Vec<(String, String)>,
     /// Only newly-fetched tools — empty on a warm run, so audit events match actual acquisition.
     pub provisioned: Vec<ProvisionOutcome>,
 }
@@ -352,6 +356,7 @@ fn compose(
 ) -> Result<EnsuredTools, ProvisionError> {
     let mut specs = Vec::new();
     let mut bin_paths = Vec::new();
+    let mut env = Vec::new();
     for request in requests {
         let manifest = hits
             .get(&request.name)
@@ -362,10 +367,12 @@ fn compose(
                 .map_err(|e| ProvisionError::Engine(format!("composing {request}: {e:#}")))?,
         );
         bin_paths.extend(manifest.guest_bin_paths());
+        env.extend(manifest.guest_env());
     }
     Ok(EnsuredTools {
         specs,
         bin_paths,
+        env,
         provisioned,
     })
 }
@@ -640,6 +647,7 @@ mod tests {
                 *remaining -= 1;
             }
             let manifest = cache::ToolManifest {
+                env: Vec::new(),
                 schema_version: cache::MANIFEST_SCHEMA_VERSION,
                 tool: staged.name.clone(),
                 resolved: staged.resolved.clone(),
@@ -773,6 +781,7 @@ mod tests {
                 requests
                     .iter()
                     .map(|request| StagedTool {
+                        env: Vec::new(),
                         name: request.name.clone(),
                         co_installed: requests
                             .iter()
@@ -1671,6 +1680,7 @@ mod tests {
                     libc: Libc::Gnu,
                 },
                 &StagedTool {
+                    env: Vec::new(),
                     name: "some-tool".into(),
                     co_installed: Vec::new(),
                     resolved: version("1"),

--- a/crates/lns-service/src/tools/provisioner/mod.rs
+++ b/crates/lns-service/src/tools/provisioner/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
+use super::cache::{ToolEnvValue, ToolEnvVar};
 use super::{
     Libc, ProvisionError, ProvisionTarget, SafeVersion, StagedTar, StagedTool, ToolRef, mise,
 };
@@ -59,8 +60,9 @@ pub(crate) fn provisioner_runtime_specs(
     specs
 }
 
-/// One shell driver per provision: each tool installs under its own engine state so no install resolves a version a sibling left behind, tars its tree into the staging share, and emits one `LNS_TOOL <name> <resolved> <binpaths>` marker whose bin dirs are colon-joined and relative to the tree root; any failure names its tool with `LNS_FAIL` and stops.
+/// One shell driver per provision: each tool resolves its version, installs into a prefix of its own at the path the workload will read it from, tars that whole prefix into the staging share, and emits an `LNS_TOOL <name> <resolved> <binpaths>` marker plus the `LNS_ENV <name> <json>` the engine reports for it; any failure names its tool with `LNS_FAIL` and stops.
 pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
+    let root = crate::tools::cache::TOOLS_ROOT;
     let mut script = String::from(
         "#!/bin/sh\nset -u\nexport PATH=/.lens/tools-engine/bin:$PATH\nmkdir -p /tmp/mise/home\n",
     );
@@ -68,18 +70,28 @@ pub(crate) fn render_driver(requests: &[ToolRef]) -> String {
         let spec = request.to_string();
         let name = &request.name;
         script.push_str(&format!(
-            "mkdir -p '{ENGINE_STATE}/{name}/data' '{ENGINE_STATE}/{name}/cache'\n\
-             MISE_DATA_DIR='{ENGINE_STATE}/{name}/data'\n\
+            "mkdir -p '{ENGINE_STATE}/{name}/home' '{ENGINE_STATE}/{name}/cache'\n\
+             HOME='{ENGINE_STATE}/{name}/home'\n\
              MISE_CACHE_DIR='{ENGINE_STATE}/{name}/cache'\n\
-             export MISE_DATA_DIR MISE_CACHE_DIR\n\
-             if ! mise install '{spec}' >&2; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
-             path=\"$(mise where '{spec}')\" || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
-             resolved=\"$(basename \"$path\")\"\n\
-             bp=\"$(mise bin-paths \"{name}@$resolved\" | while IFS= read -r d; do case \"$d\" in (\"$path\") printf '.:' ;; (\"$path\"/*) printf '%s:' \"${{d#\"$path\"/}}\" ;; esac; done)\"\n\
+             MISE_DATA_DIR='{ENGINE_STATE}/{name}/data'\n\
+             export HOME MISE_CACHE_DIR MISE_DATA_DIR\n\
+             resolved=\"$(mise latest '{spec}')\" || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
+             if [ -z \"$resolved\" ]; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
+             root='{root}/{name}'/\"$resolved\"\n\
+             mkdir -p \"$root/home\" \"$root/data\"\n\
+             HOME=\"$root/home\"\n\
+             MISE_DATA_DIR=\"$root/data\"\n\
+             export HOME MISE_DATA_DIR\n\
+             if ! mise install \"{name}@$resolved\" >&2; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
+             bp=\"$(mise bin-paths \"{name}@$resolved\" | while IFS= read -r d; do case \"$d\" in (\"$root\") printf '.:' ;; (\"$root\"/*) printf '%s:' \"${{d#\"$root\"/}}\" ;; esac; done)\"\n\
              bp=\"${{bp%:}}\"\n\
              if [ -z \"$bp\" ]; then echo \"LNS_FAIL {name}\"; exit 3; fi\n\
-             tar -cf '{STAGING}/{name}.tar' -C \"$path\" . >&2 || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
-             echo \"LNS_TOOL {name} $resolved $bp\"\n"
+             toolenv=\"$(mise env --json \"{name}@$resolved\" | tr -d '\\n')\" || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
+             case \":$bp:\" in (*:data/shims*) echo \"LNS_FAIL {name}\"; exit 3 ;; esac\n\
+             rm -rf \"$root/data/downloads\" \"$root/data/shims\"\n\
+             tar -cf '{STAGING}/{name}.tar' -C \"$root\" . >&2 || {{ echo \"LNS_FAIL {name}\"; exit 3; }}\n\
+             echo \"LNS_TOOL {name} $resolved $bp\"\n\
+             printf 'LNS_ENV %s %s\\n' '{name}' \"$toolenv\"\n"
         ));
     }
     script.push_str("echo LNS_DONE\n");
@@ -91,6 +103,58 @@ pub(crate) struct DriverResult {
     pub name: String,
     pub resolved: SafeVersion,
     pub bin_paths: Vec<String>,
+    pub env: Vec<ToolEnvVar>,
+}
+
+/// The engine reports a tool's env as absolute paths in the guest it installed in. Keep only what the tree carries: `PATH` is the bin dirs' job, a value inside the tree travels tree-relative, and a value naming anything else would send the workload to a path only the disposable guest had.
+fn tool_env_from_engine(
+    name: &str,
+    root: &str,
+    json: &str,
+) -> Result<Vec<ToolEnvVar>, ProvisionError> {
+    let reported: std::collections::BTreeMap<String, String> =
+        serde_json::from_str(json).map_err(|e| {
+            ProvisionError::Engine(format!(
+                "the provisioner driver reported an unreadable env for {name}: {e}"
+            ))
+        })?;
+    let mut env = Vec::new();
+    for (var, value) in reported {
+        if var == "PATH" {
+            continue;
+        }
+        if !lns_artifact::tools::is_safe_env_name(&var) {
+            return Err(ProvisionError::Engine(format!(
+                "the provisioner driver reported an unusable env var for {name}: {var:?}"
+            )));
+        }
+        // A sibling prefix (`<root>-evil/bin`) shares the root's spelling without being inside it, so only the root itself or a path below it counts as in-tree.
+        let inside = value
+            .strip_prefix(root)
+            .filter(|rest| rest.is_empty() || rest.starts_with('/'));
+        let value = match inside {
+            Some("") => ToolEnvValue::Tree { path: ".".into() },
+            Some(rest) => {
+                let path = rest.trim_start_matches('/');
+                if !lns_artifact::tools::is_safe_bin_path(path) {
+                    return Err(ProvisionError::Engine(format!(
+                        "the provisioner driver reported an unusable env value for {name}: {var}={value:?}"
+                    )));
+                }
+                ToolEnvValue::Tree {
+                    path: path.to_string(),
+                }
+            }
+            None if value.starts_with('/') => {
+                return Err(ProvisionError::Engine(format!(
+                    "the env var {var} the engine reports for {name} points outside the tool tree: {value:?}"
+                )));
+            }
+            None => ToolEnvValue::Literal { value },
+        };
+        env.push(ToolEnvVar { name: var, value });
+    }
+    Ok(env)
 }
 
 /// Map the driver's stdout back to per-tool outcomes: a complete run yields one result per request; `LNS_FAIL` attributes the failure to its tool with the engine's diagnostics as the cause; anything else is an engine fault. Markers are only ever read from stdout, which the driver redirects everything else away from — a partial write from a tool's own install code would otherwise prefix the next marker and lose it.
@@ -128,10 +192,35 @@ pub(crate) fn parse_driver_output(
                 "the provisioner driver reported {name} twice"
             )));
         }
+        let root = crate::tools::cache::guest_root(name, &resolved);
+        // One marker per tool, as with LNS_TOOL: a sibling's install code can forge a marker but not suppress the genuine one, so a second one is the tell rather than something to pick a winner from.
+        let reported: Vec<&str> = stdout
+            .lines()
+            .filter_map(|line| {
+                line.strip_prefix("LNS_ENV ")
+                    .and_then(|marker| marker.split_once(' '))
+                    .filter(|(tool, _)| *tool == name)
+                    .map(|(_, json)| json)
+            })
+            .collect();
+        let env = match reported.as_slice() {
+            [json] => tool_env_from_engine(name, &root, json)?,
+            [] => {
+                return Err(ProvisionError::Engine(format!(
+                    "the provisioner driver reported no env for {name}"
+                )));
+            }
+            _ => {
+                return Err(ProvisionError::Engine(format!(
+                    "the provisioner driver reported the env for {name} twice"
+                )));
+            }
+        };
         results.push(DriverResult {
             name: name.to_string(),
             resolved,
             bin_paths: bin_paths.into_iter().map(str::to_string).collect(),
+            env,
         });
     }
     if exit_code == 0 && stdout.lines().any(|line| line.trim() == "LNS_DONE") {
@@ -362,6 +451,7 @@ pub(crate) fn staged_tools_from_results(
                     .collect(),
                 tar: StagedTar::File(staging.join(format!("{}.tar", request.name))),
                 bin_paths: result.bin_paths.clone(),
+                env: result.env.clone(),
             })
         })
         .collect()
@@ -437,18 +527,18 @@ mod tests {
         // Separate state per tool, so no install resolves a version a sibling's install left behind; a tool that deliberately writes a sibling's dir still can, since they share the guest as root.
         let script = render_driver(&[tool("node@22"), tool("jq@latest")]);
         assert!(
-            script.contains("MISE_DATA_DIR='/tmp/mise/tools/node/data'")
+            script.contains("root='/.lens/tools/node'/\"$resolved\"")
                 && script.contains("MISE_CACHE_DIR='/tmp/mise/tools/node/cache'"),
             "got: {script}"
         );
         assert!(
-            script.contains("MISE_DATA_DIR='/tmp/mise/tools/jq/data'")
+            script.contains("root='/.lens/tools/jq'/\"$resolved\"")
                 && script.contains("MISE_CACHE_DIR='/tmp/mise/tools/jq/cache'"),
             "got: {script}"
         );
-        let node_install = script.find("mise install 'node@22'").unwrap();
+        let node_install = script.find("mise install \"node@$resolved\"").unwrap();
         let jq_state = script
-            .find("MISE_DATA_DIR='/tmp/mise/tools/jq/data'")
+            .find("MISE_CACHE_DIR='/tmp/mise/tools/jq/cache'")
             .unwrap();
         assert!(
             jq_state > node_install,
@@ -466,9 +556,9 @@ mod tests {
     fn the_driver_installs_tars_and_marks_each_request_in_order() {
         let script = render_driver(&[tool("node@22"), tool("jq@latest")]);
         assert!(script.starts_with("#!/bin/sh\nset -u\n"), "got: {script}");
-        assert!(script.contains("mise install 'node@22'"));
+        assert!(script.contains("mise install \"node@$resolved\""));
         assert!(script.contains("tar -cf '/staging/node.tar'"));
-        assert!(script.contains("mise install 'jq@latest'"));
+        assert!(script.contains("mise latest 'jq@latest'"));
         assert!(
             script.find("node@22").unwrap() < script.find("jq@latest").unwrap(),
             "declaration order is preserved"
@@ -508,18 +598,20 @@ mod tests {
 
     #[test]
     fn a_complete_driver_run_parses_into_per_tool_results() {
-        let stdout = "fetching...\nLNS_TOOL node 22.11.0 bin\nLNS_TOOL jq 1.7.1 .\nLNS_DONE\n";
+        let stdout = "fetching...\nLNS_TOOL node 22.11.0 bin\nLNS_ENV node {}\nLNS_TOOL jq 1.7.1 .\nLNS_ENV jq {}\nLNS_DONE\n";
         let results =
             parse_driver_output(stdout, "", 0, &[tool("node@22"), tool("jq@latest")]).unwrap();
         assert_eq!(
             results,
             vec![
                 DriverResult {
+                    env: Vec::new(),
                     name: "node".into(),
                     resolved: version("22.11.0"),
                     bin_paths: vec!["bin".into()],
                 },
                 DriverResult {
+                    env: Vec::new(),
                     name: "jq".into(),
                     resolved: version("1.7.1"),
                     bin_paths: vec![".".into()],
@@ -567,7 +659,7 @@ mod tests {
         // Merged into one buffer, a partial stderr line splices onto the next marker and a good install reads as an engine fault.
         let noisy = "downloading node 50%\rmise WARN something\n";
         let results = parse_driver_output(
-            "LNS_TOOL node 22.11.0 bin\nLNS_DONE\n",
+            "LNS_TOOL node 22.11.0 bin\nLNS_ENV node {}\nLNS_DONE\n",
             noisy,
             0,
             &[tool("node@22")],
@@ -613,8 +705,7 @@ mod tests {
     #[test]
     fn a_second_marker_for_one_tool_fails_the_whole_provision() {
         // A tool's own install code runs in this guest, so it can forge a sibling's marker — but it cannot suppress the genuine one, and two markers is the tell.
-        let stdout =
-            "LNS_TOOL jq 6.6.6 bin\nLNS_TOOL node 22.11.0 bin\nLNS_TOOL jq 1.7.1 .\nLNS_DONE\n";
+        let stdout = "LNS_TOOL jq 6.6.6 bin\nLNS_ENV jq {}\nLNS_TOOL node 22.11.0 bin\nLNS_ENV node {}\nLNS_TOOL jq 1.7.1 .\nLNS_DONE\n";
         let err =
             parse_driver_output(stdout, "", 0, &[tool("node@22"), tool("jq@latest")]).unwrap_err();
         assert!(err.to_string().contains("reported jq twice"), "got: {err}");
@@ -623,13 +714,204 @@ mod tests {
     #[test]
     fn a_nested_bin_dir_is_still_accepted() {
         let results = parse_driver_output(
-            "LNS_TOOL node 22.11.0 libexec/bin\nLNS_DONE\n",
+            "LNS_TOOL node 22.11.0 libexec/bin\nLNS_ENV node {}\nLNS_DONE\n",
             "",
             0,
             &[tool("node@22")],
         )
         .unwrap();
         assert_eq!(results[0].bin_paths, vec!["libexec/bin".to_string()]);
+    }
+
+    #[test]
+    fn a_tool_installs_at_the_path_it_will_occupy_in_the_workload() {
+        // An install may bake its own absolute paths (rustup writes them into its toolchain state), so the tree is built where the workload will read it rather than moved there afterwards.
+        let script = render_driver(&[tool("rust@1.95.0")]);
+        assert!(
+            script.contains("root='/.lens/tools/rust'/\"$resolved\""),
+            "got: {script}"
+        );
+        assert!(
+            script.contains("HOME=\"$root/home\"")
+                && script.contains("MISE_DATA_DIR=\"$root/data\""),
+            "everything the install writes lands inside the tree: {script}"
+        );
+    }
+
+    #[test]
+    fn the_version_resolves_before_the_install_under_this_tools_own_engine_state() {
+        let script = render_driver(&[tool("jq@latest")]);
+        let state = script
+            .find("MISE_CACHE_DIR='/tmp/mise/tools/jq/cache'")
+            .expect("the resolve step gets this tool's own cache");
+        assert!(
+            state
+                < script
+                    .find("mise latest 'jq@latest'")
+                    .expect("a resolve step"),
+            "the resolve must not run under a sibling's state: {script}"
+        );
+        let resolve = script
+            .find("mise latest 'jq@latest'")
+            .expect("a resolve step");
+        let install = script
+            .find("mise install \"jq@$resolved\"")
+            .expect("install");
+        assert!(resolve < install, "got: {script}");
+    }
+
+    #[test]
+    fn the_engine_state_the_workload_cannot_use_is_dropped_before_the_tar() {
+        // The whole prefix is tarred, so the engine's download cache would double every tree's size for bytes no workload reads, and its shims are absolute links to the engine binary — which no workload guest has, and which the tree guard refuses outright.
+        let script = render_driver(&[tool("jq@1")]);
+        let drop = script
+            .find("rm -rf \"$root/data/downloads\" \"$root/data/shims\"")
+            .expect("the drop step");
+        assert!(
+            drop < script.find("tar -cf").expect("the tar"),
+            "got: {script}"
+        );
+    }
+
+    #[test]
+    fn a_bin_dir_under_dropped_engine_state_fails_the_provision() {
+        // The bin dirs are read before the drop, so an engine that ever answered with one would otherwise put a directory the tar does not carry on the workload's PATH, with no error.
+        let script = render_driver(&[tool("jq@1")]);
+        assert!(
+            script
+                .contains("case \":$bp:\" in (*:data/shims*) echo \"LNS_FAIL jq\"; exit 3 ;; esac"),
+            "got: {script}"
+        );
+    }
+
+    #[test]
+    fn the_whole_prefix_is_tarred_rather_than_one_install_dir() {
+        let script = render_driver(&[tool("rust@1.95.0")]);
+        assert!(
+            script.contains("tar -cf '/staging/rust.tar' -C \"$root\" ."),
+            "got: {script}"
+        );
+        assert!(!script.contains("mise where"), "got: {script}");
+    }
+
+    #[test]
+    fn the_driver_asks_the_engine_which_env_vars_a_tool_needs() {
+        // A tool whose binaries are launchers (rustup's proxies) resolves its real payload through env vars; the engine is the only thing that knows which.
+        let script = render_driver(&[tool("rust@1.95.0")]);
+        assert!(
+            script.contains("mise env --json \"rust@$resolved\""),
+            "got: {script}"
+        );
+        assert!(script.contains("LNS_ENV"), "got: {script}");
+    }
+
+    #[test]
+    fn a_tool_s_env_arrives_tree_relative_and_the_engine_s_path_is_dropped() {
+        let root = "/.lens/tools/rust/1.95.0";
+        let stdout = format!(
+            "LNS_TOOL rust 1.95.0 home/.cargo/bin\nLNS_ENV rust {{\"PATH\": \"{root}/home/.cargo/bin:/usr/bin\", \"RUSTUP_HOME\": \"{root}/home/.rustup\", \"RUSTUP_TOOLCHAIN\": \"1.95.0\"}}\nLNS_DONE\n"
+        );
+        let results = parse_driver_output(&stdout, "", 0, &[tool("rust@1.95.0")]).unwrap();
+        assert_eq!(
+            results[0].env,
+            vec![
+                ToolEnvVar {
+                    name: "RUSTUP_HOME".into(),
+                    value: ToolEnvValue::Tree {
+                        path: "home/.rustup".into()
+                    },
+                },
+                ToolEnvVar {
+                    name: "RUSTUP_TOOLCHAIN".into(),
+                    value: ToolEnvValue::Literal {
+                        value: "1.95.0".into()
+                    },
+                },
+            ],
+            "PATH is the bin dirs' job, and a path inside the tree travels with it"
+        );
+    }
+
+    #[test]
+    fn a_tool_reporting_no_env_beyond_path_needs_none() {
+        let stdout = "LNS_TOOL jq 1.8.2 bin\nLNS_ENV jq {\"PATH\": \"/usr/bin\"}\nLNS_DONE\n";
+        let results = parse_driver_output(stdout, "", 0, &[tool("jq@1")]).unwrap();
+        assert!(results[0].env.is_empty());
+    }
+
+    #[test]
+    fn an_env_value_pointing_outside_the_tree_fails_the_provision() {
+        // It would name a path in the disposable guest, so the workload would read whatever the image happens to have there — or nothing.
+        let stdout = "LNS_TOOL rust 1.95.0 bin\nLNS_ENV rust {\"RUSTUP_HOME\": \"/tmp/mise/home/.rustup\"}\nLNS_DONE\n";
+        let err = parse_driver_output(stdout, "", 0, &[tool("rust@1.95.0")]).unwrap_err();
+        assert!(
+            err.to_string().contains("RUSTUP_HOME") && err.to_string().contains("outside"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_env_var_the_workload_owns_is_refused() {
+        for var in ["HOME", "not lowercase", "2BAD"] {
+            let stdout =
+                format!("LNS_TOOL jq 1.8.2 bin\nLNS_ENV jq {{\"{var}\": \"x\"}}\nLNS_DONE\n");
+            let err = parse_driver_output(&stdout, "", 0, &[tool("jq@1")]).unwrap_err();
+            assert!(
+                err.to_string().contains("unusable env"),
+                "{var}: got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_env_value_that_climbs_out_of_the_tree_fails_the_provision() {
+        // The value is put in the workload's environment verbatim, so a path spelled through the tree but landing outside it must never be composed.
+        let stdout = "LNS_TOOL rust 1.95.0 bin\nLNS_ENV rust {\"RUSTUP_HOME\": \"/.lens/tools/rust/1.95.0/../../../etc\"}\nLNS_DONE\n";
+        let err = parse_driver_output(stdout, "", 0, &[tool("rust@1.95.0")]).unwrap_err();
+        assert!(
+            err.to_string().contains("unusable env value for rust"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_second_env_marker_for_one_tool_fails_the_whole_provision() {
+        // Every tool's install code runs as root in the one guest, so it can forge a sibling's marker but not suppress the genuine one. A forged env would otherwise plant vars in the workload — and in every later `lns exec` — under that sibling's name.
+        let stdout = "LNS_TOOL jq 1.8.2 bin\nLNS_ENV jq {\"SOME_VAR\": \"forged\"}\nLNS_ENV jq {}\nLNS_DONE\n";
+        let err = parse_driver_output(stdout, "", 0, &[tool("jq@1")]).unwrap_err();
+        assert!(
+            err.to_string().contains("reported the env for jq twice"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn the_env_marker_is_printed_rather_than_echoed() {
+        // `$toolenv` is raw JSON, and dash and busybox `echo` expand backslash escapes in it: a value carrying a newline would split the marker line and truncate the JSON, failing a legitimate tool and putting a forged second line on the marker channel. `printf` with the value outside the format string cannot.
+        let script = render_driver(&[tool("rust@1.95.0")]);
+        assert!(
+            script.contains("printf 'LNS_ENV %s %s\\n' 'rust' \"$toolenv\""),
+            "got: {script}"
+        );
+        assert!(
+            !script.contains("echo \"LNS_ENV"),
+            "no echo may carry the engine's JSON: {script}"
+        );
+    }
+
+    #[test]
+    fn an_env_marker_that_is_not_the_engine_s_json_is_an_engine_fault() {
+        let stdout = "LNS_TOOL jq 1.8.2 bin\nLNS_ENV jq not-json\nLNS_DONE\n";
+        let err = parse_driver_output(stdout, "", 0, &[tool("jq@1")]).unwrap_err();
+        assert!(err.to_string().contains("env"), "got: {err}");
+    }
+
+    #[test]
+    fn a_tool_with_no_env_marker_at_all_is_an_engine_fault() {
+        // The driver emits one per tool, so a missing marker means the output was truncated or forged rather than "this tool needs nothing".
+        let stdout = "LNS_TOOL jq 1.8.2 bin\nLNS_DONE\n";
+        let err = parse_driver_output(stdout, "", 0, &[tool("jq@1")]).unwrap_err();
+        assert!(err.to_string().contains("no env"), "got: {err}");
     }
 
     #[test]
@@ -674,7 +956,7 @@ mod tests {
         // The driver runs under whatever `/bin/sh` the provisioner base image ships; bash misparses an unparenthesized `case` pattern inside `$(...)` and emits its own source as the bin dir instead of failing.
         let script = render_driver(&[tool("gh@2")]);
         assert!(
-            script.contains("case \"$d\" in (\"$path\") ") && script.contains(" (\"$path\"/*) "),
+            script.contains("case \"$d\" in (\"$root\") ") && script.contains(" (\"$root\"/*) "),
             "got: {script}"
         );
     }
@@ -682,7 +964,7 @@ mod tests {
     #[test]
     fn every_bin_dir_the_engine_reports_reaches_the_path() {
         let results = parse_driver_output(
-            "LNS_TOOL gh 2.97.0 gh_2.97.0_linux_arm64/bin:libexec\nLNS_DONE\n",
+            "LNS_TOOL gh 2.97.0 gh_2.97.0_linux_arm64/bin:libexec\nLNS_ENV gh {}\nLNS_DONE\n",
             "",
             0,
             &[tool("gh@2")],
@@ -725,7 +1007,7 @@ mod tests {
 
     #[test]
     fn a_complete_run_missing_a_request_is_an_engine_fault() {
-        let stdout = "LNS_TOOL node 22.11.0 bin\nLNS_DONE\n";
+        let stdout = "LNS_TOOL node 22.11.0 bin\nLNS_ENV node {}\nLNS_DONE\n";
         let err =
             parse_driver_output(stdout, "", 0, &[tool("node@22"), tool("jq@latest")]).unwrap_err();
         assert!(
@@ -833,11 +1115,13 @@ mod tests {
         let requests = [tool("node@22"), tool("jq@latest")];
         let results = vec![
             DriverResult {
+                env: Vec::new(),
                 name: "jq".into(),
                 resolved: version("1.7.1"),
                 bin_paths: vec![".".into()],
             },
             DriverResult {
+                env: Vec::new(),
                 name: "node".into(),
                 resolved: version("22.11.0"),
                 bin_paths: vec!["bin".into()],

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -72,6 +72,25 @@ pub struct ToolRuntime {
     pub env: Vec<(String, String)>,
 }
 
+impl ToolRuntime {
+    /// The contribution that actually took effect on a composed workload env. `lns exec` composes against its own env — nearly always empty — so a var the image or `-e` already owns has to be dropped here or the exec session gets the tool's value where the workload got the definition's.
+    pub fn as_applied(&self, composed_env: &[String]) -> ToolRuntime {
+        ToolRuntime {
+            bin_paths: self.bin_paths.clone(),
+            env: self
+                .env
+                .iter()
+                .filter(|(name, value)| {
+                    composed_env
+                        .iter()
+                        .any(|kv| kv == &format!("{name}={value}"))
+                })
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
 /// Everything the declared tools add to a guest's environment. `lns exec` into the same guest applies this same function, so what an exec session resolves matches the workload's.
 pub fn compose_guest_tool_env(env: &mut Vec<String>, tools: &ToolRuntime) {
     compose_guest_path(env, &tools.bin_paths);
@@ -393,6 +412,52 @@ mod tests {
             c.env.is_empty(),
             "an unsupervised run's cwd travels via the session, not env: {:?}",
             c.env
+        );
+    }
+
+    #[test]
+    fn only_the_tool_vars_that_took_effect_travel_to_an_exec_session() {
+        // `lns exec` composes against its own (usually empty) env, so a var the definition already set would come back as the tool's value there — one sandbox, two CARGO_HOMEs, no warning.
+        let tools = ToolRuntime {
+            bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
+            env: vec![
+                (
+                    "SOME_TOOL_CACHE".to_string(),
+                    "/.lens/tools/some-tool/1.2.3/home/.cache".to_string(),
+                ),
+                (
+                    "SOME_TOOL_HOME".to_string(),
+                    "/.lens/tools/some-tool/1.2.3/home".to_string(),
+                ),
+            ],
+        };
+        let composed = run_workload_env(
+            Some(&["SOME_TOOL_CACHE=/workspace/mine".into()]),
+            &[],
+            None,
+            None,
+            &[],
+            &tools,
+        );
+        let applied = tools.as_applied(&composed.env);
+        assert_eq!(
+            applied.env,
+            vec![(
+                "SOME_TOOL_HOME".to_string(),
+                "/.lens/tools/some-tool/1.2.3/home".to_string()
+            )],
+            "the var the definition owns must not reach exec as the tool's"
+        );
+        assert_eq!(
+            applied.bin_paths, tools.bin_paths,
+            "the PATH rule is unchanged"
+        );
+
+        let mut exec_env = Vec::new();
+        compose_guest_tool_env(&mut exec_env, &applied);
+        assert!(
+            !exec_env.iter().any(|kv| kv.starts_with("SOME_TOOL_CACHE=")),
+            "got: {exec_env:?}"
         );
     }
 

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -65,6 +65,28 @@ pub fn compose_workload_env(
 pub const GUEST_DEFAULT_PATH: &str =
     "/.lens/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
+/// What a run's declared tools contribute to a workload's environment: the dirs that go on `PATH`, and the vars a tool needs to find its own payload (rustup's proxies read `RUSTUP_HOME`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolRuntime {
+    pub bin_paths: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+/// Everything the declared tools add to a guest's environment. `lns exec` into the same guest applies this same function, so what an exec session resolves matches the workload's.
+pub fn compose_guest_tool_env(env: &mut Vec<String>, tools: &ToolRuntime) {
+    compose_guest_path(env, &tools.bin_paths);
+    for (name, value) in &tools.env {
+        // A tool's own env only fills what nothing else set: a workload that declares its own CARGO_HOME means it.
+        let already_set = env
+            .iter()
+            .any(|kv| kv.split_once('=').is_some_and(|(key, _)| key == name));
+        if already_set {
+            continue;
+        }
+        env.push(format!("{name}={value}"));
+    }
+}
+
 /// The one PATH rule for a guest: declared tool dirs win over whatever the image (or `-e`) composed, and no blank segment survives either way. `lns exec` into the same guest applies this same rule, so the tool dirs it resolves match the workload's — two copies of this drift into exactly the "run finds node, exec does not" bug.
 pub fn compose_guest_path(env: &mut Vec<String>, tool_bin_paths: &[String]) {
     let declared = env.iter().find_map(|kv| kv.strip_prefix("PATH="));
@@ -102,12 +124,12 @@ pub fn run_workload_env(
     agent_command: Option<&str>,
     workdir: Option<&str>,
     extra_managed: &[String],
-    tool_bin_paths: &[String],
+    tools: &ToolRuntime,
 ) -> WorkloadEnv {
     const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
     let mut composed = compose_workload_env(image_env, user_env, extra_managed);
     // The broker's last-wins putenv would otherwise let the image PATH shadow the tool dirs.
-    compose_guest_path(&mut composed.env, tool_bin_paths);
+    compose_guest_tool_env(&mut composed.env, tools);
     if let Some(agent_command) = agent_command {
         // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the supervisor PTY opt-in, the command, or the agent cwd.
         composed.env.push(format!("AGENT_COMMAND={agent_command}"));
@@ -139,6 +161,13 @@ mod tests {
 
     fn env(c: &WorkloadEnv) -> &[String] {
         &c.env
+    }
+
+    fn tools(bin_paths: &[&str]) -> ToolRuntime {
+        ToolRuntime {
+            bin_paths: bin_paths.iter().map(|p| p.to_string()).collect(),
+            env: Vec::new(),
+        }
     }
 
     #[test]
@@ -221,13 +250,27 @@ mod tests {
 
     #[test]
     fn run_workload_env_carries_user_env_for_an_unsupervised_run() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None, None, &[], &[]);
+        let c = run_workload_env(
+            None,
+            &["FOO=bar".into()],
+            None,
+            None,
+            &[],
+            &Default::default(),
+        );
         assert_eq!(c.env, ["FOO=bar"], "user -e must reach a policy-less run");
     }
 
     #[test]
     fn run_workload_env_adds_no_supervisor_vars_when_unsupervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], None, None, &[], &[]);
+        let c = run_workload_env(
+            None,
+            &["FOO=bar".into()],
+            None,
+            None,
+            &[],
+            &Default::default(),
+        );
         assert!(
             !c.env
                 .iter()
@@ -239,7 +282,14 @@ mod tests {
 
     #[test]
     fn run_workload_env_appends_agent_command_and_term_when_supervised() {
-        let c = run_workload_env(None, &["FOO=bar".into()], Some("echo hi"), None, &[], &[]);
+        let c = run_workload_env(
+            None,
+            &["FOO=bar".into()],
+            Some("echo hi"),
+            None,
+            &[],
+            &Default::default(),
+        );
         assert!(c.env.contains(&"FOO=bar".to_string()), "got: {:?}", c.env);
         assert!(c.env.contains(&"AGENT_COMMAND=echo hi".to_string()));
         assert!(c.env.contains(&"TERM=xterm-256color".to_string()));
@@ -247,7 +297,14 @@ mod tests {
 
     #[test]
     fn run_workload_env_keeps_supervisor_term_after_a_user_term_so_it_cannot_be_clobbered() {
-        let c = run_workload_env(None, &["TERM=dumb".into()], Some("sh"), None, &[], &[]);
+        let c = run_workload_env(
+            None,
+            &["TERM=dumb".into()],
+            Some("sh"),
+            None,
+            &[],
+            &Default::default(),
+        );
         let last_term = c.env.iter().rposition(|e| e.starts_with("TERM=")).unwrap();
         assert_eq!(c.env[last_term], "TERM=xterm-256color");
     }
@@ -260,7 +317,7 @@ mod tests {
             None,
             None,
             &["SOME_TOKEN".to_string()],
-            &[],
+            &Default::default(),
         );
         assert_eq!(c.refused, ["SOME_TOKEN"]);
         assert!(c.env.is_empty());
@@ -274,7 +331,7 @@ mod tests {
             None,
             None,
             &["GITLAB_TOKEN".to_string()],
-            &[],
+            &Default::default(),
         );
         assert_eq!(c.refused, ["GITLAB_TOKEN"]);
         assert!(c.env.is_empty());
@@ -282,7 +339,14 @@ mod tests {
 
     #[test]
     fn run_workload_env_pins_workspace_path_for_a_supervised_run() {
-        let c = run_workload_env(None, &[], Some("sh"), Some("/app"), &[], &[]);
+        let c = run_workload_env(
+            None,
+            &[],
+            Some("sh"),
+            Some("/app"),
+            &[],
+            &Default::default(),
+        );
         assert!(
             c.env.contains(&"WORKSPACE_PATH=/app".to_string()),
             "got: {:?}",
@@ -292,7 +356,7 @@ mod tests {
 
     #[test]
     fn run_workload_env_omits_workspace_path_without_a_workdir() {
-        let c = run_workload_env(None, &[], Some("sh"), None, &[], &[]);
+        let c = run_workload_env(None, &[], Some("sh"), None, &[], &Default::default());
         assert!(
             !c.env.iter().any(|e| e.starts_with("WORKSPACE_PATH=")),
             "got: {:?}",
@@ -308,7 +372,7 @@ mod tests {
             Some("sh"),
             Some("/app"),
             &[],
-            &[],
+            &Default::default(),
         );
         let last = c
             .env
@@ -324,7 +388,7 @@ mod tests {
 
     #[test]
     fn run_workload_env_adds_no_workspace_path_when_unsupervised() {
-        let c = run_workload_env(None, &[], None, Some("/app"), &[], &[]);
+        let c = run_workload_env(None, &[], None, Some("/app"), &[], &Default::default());
         assert!(
             c.env.is_empty(),
             "an unsupervised run's cwd travels via the session, not env: {:?}",
@@ -340,14 +404,27 @@ mod tests {
             None,
             None,
             &[],
-            &["/.lens/tools/some-tool/1.2.3/bin".into()],
+            &ToolRuntime {
+                bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
+                env: Vec::new(),
+            },
         );
         assert_eq!(c.env, ["PATH=/.lens/tools/some-tool/1.2.3/bin:/usr/bin"]);
     }
 
     #[test]
     fn tool_bin_paths_extend_the_guest_default_when_the_image_sets_no_path() {
-        let c = run_workload_env(None, &[], None, None, &[], &["/t/bin".into()]);
+        let c = run_workload_env(
+            None,
+            &[],
+            None,
+            None,
+            &[],
+            &ToolRuntime {
+                bin_paths: vec!["/t/bin".into()],
+                env: Vec::new(),
+            },
+        );
         assert_eq!(c.env, [format!("PATH=/t/bin:{GUEST_DEFAULT_PATH}")]);
     }
 
@@ -360,7 +437,7 @@ mod tests {
             None,
             None,
             &[],
-            &["/t/bin".into()],
+            &tools(&["/t/bin"]),
         );
         assert_eq!(c.env, [format!("PATH=/t/bin:{GUEST_DEFAULT_PATH}")]);
     }
@@ -373,7 +450,7 @@ mod tests {
             None,
             None,
             &[],
-            &["/t/bin".into()],
+            &tools(&["/t/bin"]),
         );
         assert_eq!(c.env, ["PATH=/t/bin:/usr/bin"]);
     }
@@ -387,7 +464,7 @@ mod tests {
             None,
             None,
             &[],
-            &[],
+            &Default::default(),
         );
         assert_eq!(c.env, ["PATH=/usr/bin"]);
     }
@@ -395,7 +472,7 @@ mod tests {
     #[test]
     fn a_run_with_no_tools_and_no_image_path_is_left_to_the_kernel_default() {
         // Composing one here would put a second copy of the same value in the env for no reason; lns-init already exports it.
-        let c = run_workload_env(None, &[], None, None, &[], &[]);
+        let c = run_workload_env(None, &[], None, None, &[], &Default::default());
         assert!(
             !c.env.iter().any(|kv| kv.starts_with("PATH=")),
             "got: {:?}",
@@ -407,7 +484,17 @@ mod tests {
     fn the_guest_default_path_carries_the_guest_tools_dir() {
         // The workload inherits the kernel PATH, so declaring a tool must not drop /.lens/bin as a side effect.
         assert!(GUEST_DEFAULT_PATH.starts_with("/.lens/bin:"));
-        let c = run_workload_env(None, &[], None, None, &[], &["/t/bin".into()]);
+        let c = run_workload_env(
+            None,
+            &[],
+            None,
+            None,
+            &[],
+            &ToolRuntime {
+                bin_paths: vec!["/t/bin".into()],
+                env: Vec::new(),
+            },
+        );
         assert!(c.env[0].contains("/.lens/bin"), "got: {:?}", c.env[0]);
     }
 
@@ -419,7 +506,7 @@ mod tests {
             Some("sh"),
             None,
             &[],
-            &["/t/a/bin".into(), "/t/b".into()],
+            &tools(&["/t/a/bin", "/t/b"]),
         );
         let path = c.env.iter().position(|e| e.starts_with("PATH=")).unwrap();
         assert!(

--- a/crates/lns-service/tests/behaviours/declared_tools.feature
+++ b/crates/lns-service/tests/behaviours/declared_tools.feature
@@ -9,7 +9,9 @@ Feature: declared developer tools are provisioned once per machine, outside work
   this feature pins is that the policy does not *refuse* the install.
   Provisioned tool sets are cached per machine and reused without network; the
   workload receives them read-only, and its own traffic stays inside the normal
-  policy cage (covered against a live guest by the @microvm suite).
+  policy cage (covered against a live guest by the @microvm suite). A tool whose
+  binaries are launchers rather than the payload itself resolves the rest through
+  its own environment, so the workload gets those vars too — unless it sets them.
 
   Scenario: The strictest policy does not gate provisioning
     Given a lns.yaml declaring tools ["node@22"] that denies every destination
@@ -37,6 +39,17 @@ Feature: declared developer tools are provisioned once per machine, outside work
     When I run the sandbox for the first time
     Then the resolved exact version is recorded on this machine
     And later runs here use the recorded version even after upstream releases a newer 22.x
+
+  Scenario: A tool whose binaries resolve through an env var gets it in the workload
+    Given a lns.yaml declaring a tool whose binaries resolve through an env var
+    When I run the sandbox
+    Then the workload environment carries that var pointing inside the tool tree
+
+  Scenario: The sandbox's own value for a tool's env var wins
+    Given a lns.yaml declaring a tool whose binaries resolve through an env var
+    And the sandbox sets that var itself
+    When I run the sandbox
+    Then the workload keeps the sandbox's value
 
   Scenario: Tool provisioning is audited
     When tools are provisioned for a run

--- a/crates/lns-service/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_tools.rs
@@ -125,6 +125,68 @@ fn tool_download_cannot_complete(w: &mut BehaviourWorld) {
         Some("fetching https://nodejs.org/dist/: connection timed out".into());
 }
 
+const TOOL_VAR: &str = "SOME_TOOL_HOME";
+
+#[given("a lns.yaml declaring a tool whose binaries resolve through an env var")]
+fn tool_resolving_through_an_env_var(w: &mut BehaviourWorld) {
+    let rig = w.tools.get_or_insert_with(Default::default);
+    rig.definition = Some(definition_with_tools(r#""node@22""#));
+    *rig.provisioner.tool_env.lock().unwrap() = vec![lns_service::tools::cache::ToolEnvVar {
+        name: TOOL_VAR.to_string(),
+        value: lns_service::tools::cache::ToolEnvValue::Tree {
+            path: "home".to_string(),
+        },
+    }];
+}
+
+#[given("the sandbox sets that var itself")]
+fn the_sandbox_sets_that_var_itself(w: &mut BehaviourWorld) {
+    let rig = w.tools.get_or_insert_with(Default::default);
+    rig.sandbox_env = vec![format!("{TOOL_VAR}=/workspace/mine")];
+}
+
+fn composed_workload_env(w: &BehaviourWorld) -> Result<Vec<String>, String> {
+    let rig = w.tools.as_ref().ok_or("no launch happened")?;
+    if let Some(error) = &rig.error {
+        return Err(format!("the launch failed: {error}"));
+    }
+    let ensured = rig.ensured.as_ref().ok_or("no tools were composed")?;
+    Ok(lns_service::workload_env::run_workload_env(
+        None,
+        &rig.sandbox_env,
+        None,
+        None,
+        &[],
+        &lns_service::workload_env::ToolRuntime {
+            bin_paths: ensured.bin_paths.clone(),
+            env: ensured.env.clone(),
+        },
+    )
+    .env)
+}
+
+#[then("the workload environment carries that var pointing inside the tool tree")]
+fn workload_carries_the_tool_var(w: &mut BehaviourWorld) -> Result<(), String> {
+    let env = composed_workload_env(w)?;
+    let want = format!("{TOOL_VAR}=/.lens/tools/node/22.11.0/home");
+    if env.contains(&want) {
+        Ok(())
+    } else {
+        Err(format!("expected {want:?} in: {env:?}"))
+    }
+}
+
+#[then("the workload keeps the sandbox's value")]
+fn workload_keeps_its_own_value(w: &mut BehaviourWorld) -> Result<(), String> {
+    let env = composed_workload_env(w)?;
+    let want = format!("{TOOL_VAR}=/workspace/mine");
+    if env.contains(&want) {
+        Ok(())
+    } else {
+        Err(format!("expected {want:?} in: {env:?}"))
+    }
+}
+
 #[when("I run the sandbox")]
 async fn run_the_sandbox(w: &mut BehaviourWorld) {
     launch(w).await;

--- a/crates/lns-service/tests/behaviours/steps/env_injection.rs
+++ b/crates/lns-service/tests/behaviours/steps/env_injection.rs
@@ -45,7 +45,7 @@ fn when_user_runs(world: &mut BehaviourWorld, cmd: String) {
         None,
         None,
         &managed,
-        &[],
+        &Default::default(),
     ));
     world.user_env = user_env;
 }

--- a/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
@@ -26,7 +26,7 @@ pub fn fresh_handle(
         status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
         logs: std::sync::Arc::new(lns_service::run_log::RunLogBuffer::default()),
         config,
-        tool_bin_paths: Vec::new(),
+        tools: Default::default(),
     }
 }
 

--- a/crates/lns-service/tests/behaviours/steps/workdir.rs
+++ b/crates/lns-service/tests/behaviours/steps/workdir.rs
@@ -55,7 +55,7 @@ fn compose_run_env(world: &mut BehaviourWorld, cmd: &str, agent_command: Option<
         agent_command,
         workdir.as_deref(),
         &world.managed_vars,
-        &[],
+        &Default::default(),
     ));
 }
 

--- a/crates/lns-service/tests/behaviours/tools_rig.rs
+++ b/crates/lns-service/tests/behaviours/tools_rig.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Mutex;
 
-use lns_service::tools::cache::{MANIFEST_SCHEMA_VERSION, ToolCache, ToolManifest};
+use lns_service::tools::cache::{MANIFEST_SCHEMA_VERSION, ToolCache, ToolEnvVar, ToolManifest};
 use lns_service::tools::record::{ResolvedRecord, ToolRecordStore};
 use lns_service::tools::{
     EnsuredTools, ProvisionError, ProvisionTarget, StagedTar, StagedTool, ToolProvisioner, ToolRef,
@@ -20,6 +20,8 @@ pub struct ToolsRig {
     pub cache: MemToolCache,
     pub provisioner: ScriptedProvisioner,
     pub audit: Option<(tempfile::TempDir, std::path::PathBuf)>,
+    /// What the definition sets itself, so a scenario can pin whose value wins for a var a tool also reports.
+    pub sandbox_env: Vec<String>,
 }
 
 impl ToolsRig {
@@ -83,6 +85,7 @@ impl ToolCache for MemToolCache {
         staged: &StagedTool,
     ) -> anyhow::Result<ToolManifest> {
         let manifest = ToolManifest {
+            env: staged.env.clone(),
             schema_version: MANIFEST_SCHEMA_VERSION,
             co_installed: staged.co_installed.clone(),
             tool: staged.name.clone(),
@@ -107,6 +110,8 @@ pub struct ScriptedProvisioner {
     pub upstream_patch: Mutex<String>,
     pub fail_next: Mutex<Option<String>>,
     pub calls: Mutex<Vec<Vec<ToolRef>>>,
+    /// What the engine reports every staged tool needs in the workload's env.
+    pub tool_env: Mutex<Vec<ToolEnvVar>>,
 }
 
 impl Default for ScriptedProvisioner {
@@ -115,6 +120,7 @@ impl Default for ScriptedProvisioner {
             upstream_patch: Mutex::new("11.0".into()),
             fail_next: Mutex::new(None),
             calls: Mutex::new(Vec::new()),
+            tool_env: Mutex::new(Vec::new()),
         }
     }
 }
@@ -133,6 +139,7 @@ impl ToolProvisioner for ScriptedProvisioner {
         self.calls.lock().unwrap().push(requests.to_vec());
         let fail = self.fail_next.lock().unwrap().take();
         let patch = self.upstream_patch.lock().unwrap().clone();
+        let tool_env = self.tool_env.lock().unwrap().clone();
         let staged: Vec<StagedTool> = requests
             .iter()
             .map(|request| {
@@ -142,6 +149,7 @@ impl ToolProvisioner for ScriptedProvisioner {
                     format!("{}.{patch}", request.version)
                 };
                 StagedTool {
+                    env: tool_env.clone(),
                     name: request.name.clone(),
                     co_installed: Vec::new(),
                     resolved: resolved.parse().expect("a usable version"),


### PR DESCRIPTION
## Summary

`spec.tools` treated a declared tool as the one directory `mise where` reports. That only holds for a backend whose install is self-contained. mise installs rust through **rustup**, which writes the compiler to `$RUSTUP_HOME` and the proxies to `$CARGO_HOME/bin` — so `mise where rust@1.95.0` is merely a symlink to the latter. Every bin dir the engine reported therefore fell outside the tarred tree, the driver's filter dropped all of them, and the launch failed:

```
✗  provisioning rust@1.95.0 failed: mise rust@1.95.0 [1/3] 1.95.0-aarch64-unknown-linux-gnu installed …
   Nothing was cached; the next run retries from a clean state
```

The tree it *would* have cached held rustup's proxies with the toolchain left behind in a guest that is then destroyed, so rust never worked here — only the failure is new (it arrived with #, which replaced a bin-dir guess with the engine's own answer). rust is just the first declared tool of that shape; npm-, GOROOT-, and python-prefix-shaped backends can all break the same way, so the fix is to drop the containment assumption rather than to teach the driver about rustup.

### 1. The install's own prefix is the tree

Each tool now installs under a prefix of its own, with `HOME` and the engine's data dir inside it, and that prefix is what gets tarred. Whatever the backend writes, wherever it writes it, is captured. `mise where` is no longer consulted at all.

### 2. The prefix is built where the workload will read it

An install may bake its own absolute paths (rustup does, into its toolchain state), so the provisioner guest builds the tree at `/.lens/tools/<name>/<resolved>` — the same path the workload guest sees. That requires knowing the resolved version up front, so `mise latest` runs before the install.

### 3. A tool's environment travels with its tree

A tool whose binaries are launchers needs vars to find its real payload, and the engine is the only thing that knows which. `mise env --json <tool>@<resolved>` supplies them:

| Tool | Reported env |
|------|--------------|
| `jq@1`, `node@22`, `gh@2` | *(nothing beyond `PATH`)* |
| `rust@1.95.0` | `RUSTUP_HOME`, `CARGO_HOME`, `RUSTUP_TOOLCHAIN` |

`PATH` is dropped — the bin dirs own it. A value inside the tree travels tree-relative and is resolved against the injection root; a value naming anything else fails the provision, since it would point at a path only the disposable guest had. The vars reach the workload **and** every later `lns exec`, and fill only what the image and `-e` left unset, so a sandbox that sets its own `CARGO_HOME` keeps it.

### 4. Fail-closed handling of what the guest reports

The provisioner guest is disposable but its output is untrusted input:

- Var names must match the POSIX shape, and `PATH`, `HOME`, `LD_*`, `BASH_ENV`, `ENV`, `IFS` are refused — a loader hook would reach every process in the workload, not just the tool's own binaries.
- One `LNS_ENV` marker per tool, as with `LNS_TOOL`: a sibling's install code can forge a marker but not suppress the genuine one, so two is an engine fault rather than something to pick a winner from.
- The marker is emitted with `printf`, not `echo`: dash and busybox expand `\n` inside the engine's JSON, which would split the marker line and put attacker-influenced text on the marker channel.
- An absolute symlink pointing *inside* the installed tree is respelled relative at ingest, so injection keeps creating in-tree links only. Anything else absolute is still refused, including a sibling prefix (`…/1.2.3-evil`) that shares the root's spelling.

### 5. The workload owns the directories of its own tool trees

A tool env var may name a directory the tool *writes*, not only one it reads — the engine puts cargo's `CARGO_HOME` inside the tree. Every injected entry lands uid 0, and a workload whose image sets no `USER` runs as 65534, so `cargo build` on any project with a dependency failed on the registry it had to create.

Classing the variables would mean a list of names per backend (`GOMODCACHE`, npm's cache, …), and a missing name stays silent until someone runs a real build. The mode of the tree is the actual problem, so `lns-init` fixes that: once it has resolved the workload user from the guest's `/etc/passwd`, it hands that user every **directory** under `/.lens/tools`. Files stay root-owned, so no tool binary is edited in place, and the overlay's upper layer takes the writes and drops them at teardown.

| | `CARGO_HOME` | `cargo build` with one dependency |
|---|---|---|
| before | `drwxr-xr-x root root` | `failed to create directory …/registry/cache/…: Permission denied`, exit 101 |
| after | `drwxr-xr-x sandbox sandbox` | builds, exit 0 |

### 6. `lns exec` no longer contradicts its run

`run_workload_env` filtered the tool vars against the composed image+`-e` env, but `lns exec` composes against its own, nearly always empty, env. A definition setting `CARGO_HOME=/opt/cargo` therefore got `/opt/cargo` in the run and the tool tree's path in an exec session — one sandbox, two registries, no warning. `ToolRuntime::as_applied` keeps only the vars that took effect on the workload, and that narrowed set is what an exec session re-applies. A var the definition owns is now *unset* in exec rather than wrong, which matches exec carrying none of the run's other env.

### 7. npm stops being a special case

npm was the one tool with production code of its own, and it is not even a declared tool: it arrives inside node's tree, where the engine replaces node's stock `bin/npm` symlink with a script that re-shims through `mise` under `bash`. `MISE_NODE_NPM_SHIM=0` stops the rewrite, so the tree keeps the symlink the upstream tarball ships — byte-for-byte what the repair reconstructed. The repair, its constants, both call sites, and its tests are gone: 204 lines out, 6 in. The general rule stays — the driver still deletes the engine's shim dir, and a reported bin dir under it still fails the provision.

## Breaking changes

Manifest schema 3 → 4. Tool trees cached under the old containment rule are a miss and re-provision once, rather than being reinterpreted under today's semantics.

## Screenshots

### Before

```
✗  provisioning rust@1.95.0 failed: … Nothing was cached; the next run retries from a clean state
```

### After

```
✓ tools     rust@1.95.0 → 1.95.0 (static.rust-lang.org)
$ cargo build   # a project with one dependency, inside the sandbox
CARGO_BUILD_OK
```

## Test instructions

1. Declare `rust@1.95.0` in a `lns.yaml` over a glibc base image and run `rustc --version`. The tool provisions and prints `rustc 1.95.0`; before this change the launch was refused.
2. `lns exec <run> -- rustc --version` in the same run prints the same version — the tool's env reaches an exec session, not just the workload.
3. Set `CARGO_HOME=/opt/cargo` in the definition's `env` and run `sh -c 'echo $CARGO_HOME'`. The sandbox's own value wins over the one the tool reports.
4. Declare `node@22` and run `npm --version`. It prints a version rather than failing — the engine's mise-and-bash shim is replaced by the stock launcher even though node's layout now sits below the prefix.
5. Run the same definition twice. The second run provisions nothing (`✓ tools` reports the cached tree) and starts without network for the tool bodies.
6. Declare a musl base image with `rust@1.95.0`. rustup publishes no musl host toolchain, so this is expected to fail; the failure names the tool and its cause.
7. In a sandbox declaring `rust@1.95.0`, run `cargo build` on a project with a dependency. It succeeds — before this change it failed with `Permission denied` on `$CARGO_HOME/registry`.
8. Inspect a provisioned node tree: `bin/npm` is a symlink to `../lib/node_modules/npm/bin/npm-cli.js`, not a bash script, and `npm --version` runs in the guest.

## Verification

- `make lint`, `make complexity`, `make coverage` (100% per-file on `lns-service` and `lns-artifact`) — green.
- `cargo test -p lns-service`: 2083 unit tests, 188 scenarios — green.
- `make e2e-microvm`: the whole declared-tools feature passes against a real guest — the cargo build above, the npm launcher with the repair deleted, the nested `gh` bin dir, and both pulled-offline scenarios.
- The tool-tree ownership fix was verified in both directions: the cargo scenario goes red with `chown_tool_dirs` disabled and green with it. An earlier version of that scenario was vacuous — it asserted a literal the run summary's own command echo contained — so the marker is now assembled at run time and the step also requires exit code 0 and no `Permission denied`.
- Six failures elsewhere in that suite (2 credential, 2 trust-store, 2 registry-pull) are unrelated to this change by their own error messages (a malformed local grants sidecar; a base image with no `/bin/sh`; registry rate limits), but they are **not** baselined against `origin/main` yet, so treat them as unverified rather than known-good.
