### PR TITLE
refactor(tools): Stop the engine from shimming npm instead of repairing it

### DIFF
--- a/crates/lns-service/src/tools/cache.rs
+++ b/crates/lns-service/src/tools/cache.rs
@@ -46,30 +46,6 @@ pub enum EntryKind {
     Symlink { target: String },
 }
 
-const NPM_LAUNCHER: &str = "bin/npm";
-const NPM_CLI: &str = "lib/node_modules/npm/bin/npm-cli.js";
-const STOCK_NPM_TARGET: &str = "../lib/node_modules/npm/bin/npm-cli.js";
-
-/// The engine replaces node's `bin/npm` symlink with a shim that reshims through `mise` under bash — neither of which a workload guest has — so the tree goes back to the launcher the upstream tarball ships. The tree root is the install prefix, so node's own layout sits at some depth below it and only the tail of the path is fixed.
-fn restore_stock_npm(entries: &mut [ManifestEntry]) {
-    let prefixes: Vec<String> = entries
-        .iter()
-        .filter_map(|entry| {
-            entry
-                .path
-                .strip_suffix(NPM_CLI)
-                .map(|prefix| format!("{prefix}{NPM_LAUNCHER}"))
-        })
-        .collect();
-    for entry in entries {
-        if prefixes.contains(&entry.path) && matches!(entry.kind, EntryKind::Regular { .. }) {
-            entry.kind = EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.to_string(),
-            };
-        }
-    }
-}
-
 /// The one place a tool tree ever lives: the provisioner installs it here and the workload reads it here, so an install that bakes its own absolute paths stays valid across the two guests.
 pub const TOOLS_ROOT: &str = "/.lens/tools";
 
@@ -204,7 +180,7 @@ impl ToolCache for RealToolCache {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
         };
-        let mut manifest: ToolManifest = match serde_json::from_slice(&bytes) {
+        let manifest: ToolManifest = match serde_json::from_slice(&bytes) {
             Ok(manifest) => manifest,
             Err(_) => return Ok(None),
         };
@@ -227,7 +203,6 @@ impl ToolCache for RealToolCache {
         {
             return Ok(None);
         }
-        restore_stock_npm(&mut manifest.entries);
         if let Err(e) = validate_tree(&manifest.entries, &manifest.bin_paths, &manifest.env) {
             crate::log::warn!("ignoring the cached tool tree at {}: {e:#}", dir.display());
             return Ok(None);
@@ -244,14 +219,13 @@ impl ToolCache for RealToolCache {
 
     fn ingest(&self, key: &ToolCacheKey, staged: &StagedTool) -> Result<ToolManifest> {
         let root = guest_root(&key.name, &key.resolved);
-        let mut entries = match &staged.tar {
+        let entries = match &staged.tar {
             StagedTar::File(path) => {
                 let file = open_staged_tar(path)?;
                 ingest_tar_entries(file, &self.store, &root)?
             }
             StagedTar::Bytes(bytes) => ingest_tar_entries(&bytes[..], &self.store, &root)?,
         };
-        restore_stock_npm(&mut entries);
         validate_tree(&entries, &staged.bin_paths, &staged.env)?;
         let manifest = ToolManifest {
             schema_version: MANIFEST_SCHEMA_VERSION,
@@ -604,64 +578,6 @@ mod tests {
         dir.set_cksum();
         builder.append(&dir, std::io::empty()).unwrap();
         builder.into_inner().unwrap()
-    }
-
-    fn file_header(path: &str, mode: u32, size: u64) -> tar::Header {
-        let mut header = tar::Header::new_gnu();
-        header.set_path(path).unwrap();
-        header.set_size(size);
-        header.set_mode(mode);
-        header.set_cksum();
-        header
-    }
-
-    fn npm_tar(npm: EntryKind) -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        let launcher = b"#!/usr/bin/env node\n";
-        builder
-            .append(
-                &file_header(
-                    "lib/node_modules/npm/bin/npm-cli.js",
-                    0o755,
-                    launcher.len() as u64,
-                ),
-                &launcher[..],
-            )
-            .unwrap();
-        match npm {
-            EntryKind::Regular { .. } => {
-                let shim = b"#!/usr/bin/env bash\nmise reshim\n";
-                builder
-                    .append(&file_header("bin/npm", 0o755, shim.len() as u64), &shim[..])
-                    .unwrap();
-            }
-            EntryKind::Symlink { target } => {
-                let mut link = tar::Header::new_gnu();
-                link.set_entry_type(tar::EntryType::Symlink);
-                link.set_path("bin/npm").unwrap();
-                link.set_link_name(&target).unwrap();
-                link.set_size(0);
-                link.set_mode(0o777);
-                link.set_cksum();
-                builder.append(&link, std::io::empty()).unwrap();
-            }
-        }
-        builder.into_inner().unwrap()
-    }
-
-    fn shimmed_npm() -> EntryKind {
-        EntryKind::Regular {
-            digest: String::new(),
-            size: 0,
-        }
-    }
-
-    fn npm_entry(manifest: &ToolManifest) -> &ManifestEntry {
-        manifest
-            .entries
-            .iter()
-            .find(|entry| entry.path == "bin/npm")
-            .expect("the tree carries bin/npm")
     }
 
     fn tree_dir(root: &Path) -> PathBuf {
@@ -1447,124 +1363,6 @@ mod tests {
             format!("{err:#}").contains("escapes the tool tree"),
             "a sibling prefix shares the root's spelling without being inside it: {err:#}"
         );
-    }
-
-    #[test]
-    fn a_shimmed_npm_launcher_nested_under_the_prefix_is_restored_too() {
-        // The tree root is the install prefix, so node's own files sit under the engine's data dir rather than at the root; matching only the root spelling silently left the engine's mise-and-bash shim in place.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let nested = "data/installs/node/22.23.2/";
-        let mut builder = tar::Builder::new(Vec::new());
-        let launcher = b"#!/usr/bin/env node\n";
-        builder
-            .append(
-                &file_header(
-                    &format!("{nested}lib/node_modules/npm/bin/npm-cli.js"),
-                    0o755,
-                    launcher.len() as u64,
-                ),
-                &launcher[..],
-            )
-            .unwrap();
-        let shim = b"#!/usr/bin/env bash\nmise reshim\n";
-        builder
-            .append(
-                &file_header(&format!("{nested}bin/npm"), 0o755, shim.len() as u64),
-                &shim[..],
-            )
-            .unwrap();
-        let manifest = cache
-            .ingest(&key(), &staged(builder.into_inner().unwrap()))
-            .unwrap();
-        let npm = manifest
-            .entries
-            .iter()
-            .find(|entry| entry.path == format!("{nested}bin/npm"))
-            .expect("the tree carries the launcher");
-        assert_eq!(
-            npm.kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            }
-        );
-    }
-
-    #[test]
-    fn a_shimmed_npm_launcher_is_restored_to_the_stock_symlink_at_ingest() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let manifest = cache
-            .ingest(&key(), &staged(npm_tar(shimmed_npm())))
-            .unwrap();
-        assert_eq!(
-            npm_entry(&manifest).kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            }
-        );
-    }
-
-    #[test]
-    fn a_tree_cached_with_the_shim_is_restored_on_lookup() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let mut manifest = cache
-            .ingest(&key(), &staged(npm_tar(shimmed_npm())))
-            .unwrap();
-        let shim = EntryKind::Regular {
-            digest: format!("sha256:{}", "1".repeat(64)),
-            size: 31,
-        };
-        for entry in &mut manifest.entries {
-            if entry.path == "bin/npm" {
-                entry.kind = shim.clone();
-            }
-        }
-        std::fs::write(
-            tree_dir(dir.path()).join("manifest.json"),
-            serde_json::to_vec(&manifest).unwrap(),
-        )
-        .unwrap();
-        let read_back = cache.lookup(&key(), &[]).unwrap().expect("a cache hit");
-        assert_eq!(
-            npm_entry(&read_back).kind,
-            EntryKind::Symlink {
-                target: STOCK_NPM_TARGET.into()
-            },
-            "a tree ingested before the shim was known must not keep launching it"
-        );
-    }
-
-    #[test]
-    fn an_npm_launcher_without_the_stock_tree_beside_it_is_left_alone() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let mut builder = tar::Builder::new(Vec::new());
-        let body = b"#!/usr/bin/env bash\n";
-        builder
-            .append(&file_header("bin/npm", 0o755, body.len() as u64), &body[..])
-            .unwrap();
-        let manifest = cache
-            .ingest(&key(), &staged(builder.into_inner().unwrap()))
-            .unwrap();
-        assert!(
-            matches!(npm_entry(&manifest).kind, EntryKind::Regular { .. }),
-            "a symlink to a launcher the tree does not carry would break npm outright"
-        );
-    }
-
-    #[test]
-    fn a_stock_npm_symlink_survives_ingest_unchanged() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let cache = cache(dir.path());
-        let stock = EntryKind::Symlink {
-            target: STOCK_NPM_TARGET.into(),
-        };
-        let manifest = cache
-            .ingest(&key(), &staged(npm_tar(stock.clone())))
-            .unwrap();
-        assert_eq!(npm_entry(&manifest).kind, stock);
     }
 
     #[test]

--- a/crates/lns-service/src/tools/mise.rs
+++ b/crates/lns-service/src/tools/mise.rs
@@ -142,6 +142,8 @@ pub fn provision_env() -> Vec<(String, String)> {
         ("MISE_PYTHON_COMPILE", "0"),
         ("MISE_NODE_COMPILE", "0"),
         ("MISE_YES", "1"),
+        // The engine's own `bin/npm` replaces node's launcher with a script that reshims through mise under bash, and a workload guest has neither; off, the tree keeps the symlink the upstream tarball ships.
+        ("MISE_NODE_NPM_SHIM", "0"),
         // Every backend that is not download-only: the snapshot records the download backend a tool is gated and audited against, so mise must not silently pick a different one (oxlint via npm, tokei via cargo, imagemagick via conda).
         (
             "MISE_DISABLE_BACKENDS",
@@ -304,6 +306,8 @@ mod tests {
         };
         assert_eq!(get("MISE_PYTHON_COMPILE"), "0");
         assert_eq!(get("MISE_NODE_COMPILE"), "0");
+        // With the shim on, the tree ships an `npm` that launches mise under bash — neither of which a workload guest has — so the tool installs and never runs.
+        assert_eq!(get("MISE_NODE_NPM_SHIM"), "0");
         let disabled = get("MISE_DISABLE_BACKENDS");
         for backend in [
             "asdf", "vfox", "npm", "cargo", "pipx", "gem", "go", "dotnet", "conda", "spm",


### PR DESCRIPTION
## Summary

Stacked on #192 — review that one first.

npm is the only tool with production code of its own, and it is not even a declared tool. It arrives inside node's tree, where mise replaces node's stock `bin/npm` symlink with a script that re-shims through `mise` under `bash`. A workload guest has neither, so `restore_stock_npm` in the tool cache put the upstream symlink back at ingest and again on cache read.

That is repairing damage we can simply decline. The engine has a switch for the rewrite, verified against the pinned engine (mise 2026.7.14):

| Setting | `bin/npm` in the tree |
|---|---|
| default (`node.npm_shim = true`) | a 1831-byte `#!/usr/bin/env bash` script that re-shims through mise |
| `MISE_NODE_NPM_SHIM=0` | `../lib/node_modules/npm/bin/npm-cli.js` — the stock symlink |

The second row is byte-for-byte what the repair reconstructed, so one line in `mise::provision_env()` replaces the whole mechanism: the function, its three path constants, both call sites, its five tests, and the test helpers only it used. 204 lines out, 6 in.

### What stays

The general rule this special case sat beside is untouched: nothing in a tool tree may reference the engine. The driver still deletes the engine's shim dir (whose entries are absolute symlinks to the engine binary), and a reported bin dir under that dir still fails the provision.

### Cache safety

No second schema bump. Lookup already rejects any manifest whose `schema_version` is not 4, #192 introduced 4, and every build that writes 4 repaired at ingest — so the lookup-time repair this removes could not fire for any cache a user can have.

## Test instructions

1. Declare `node@22` and run `npm --version` in a real guest (`make e2e-microvm`, scenario "A launcher the provisioning engine rewrote still runs in the guest"). It prints a version, with no repair code in the path.
2. Inspect a freshly provisioned tree: `bin/npm` is a symlink to `../lib/node_modules/npm/bin/npm-cli.js`, not a bash script.
3. `lns run` a definition declaring `node@22` twice; the second run reuses the cached tree and npm still runs.

## Verification

- `make lint`, `make complexity`, `make coverage` (`lns-service`, 100% per-file) — green.
- `make e2e-microvm`: the declared-tools feature passed on this exact diff, including the npm scenario, before the rebase onto #192's latest commit. That commit only touches `lns-init` tool-tree ownership, so it is orthogonal — but the suite should be re-run once before the stack merges.