### PR TITLE
fix: let the flag read the memory size a definition writes

### DIFF
--- a/crates/lns-artifact/src/lib.rs
+++ b/crates/lns-artifact/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod memory;
 pub mod registry;
 pub mod sandbox;
 pub mod spec;

--- a/crates/lns-artifact/src/memory.rs
+++ b/crates/lns-artifact/src/memory.rs
@@ -1,0 +1,120 @@
+use std::fmt;
+
+const MIB: u128 = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError(String);
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Reads a Docker-style memory size — a bare integer of MiB, or digits with a binary unit — into whole MiB.
+pub fn parse_mib(spec: &str) -> Result<usize, ParseError> {
+    let lower = spec.trim().to_ascii_lowercase();
+    let digits_end = lower
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(lower.len());
+    let (digits, unit) = lower.split_at(digits_end);
+    let value: u128 = digits.parse().map_err(|_| {
+        ParseError(format!(
+            "invalid memory size `{spec}`: expected MiB, e.g. `512`, or `2g`"
+        ))
+    })?;
+    let mib = match unit {
+        "" | "m" | "mb" | "mi" | "mib" => value,
+        "b" => value.div_ceil(MIB),
+        "k" | "kb" | "ki" | "kib" => value.div_ceil(1024),
+        "g" | "gb" | "gi" | "gib" => value.checked_mul(1024).ok_or_else(|| out_of_range(spec))?,
+        _ => {
+            return Err(ParseError(format!(
+                "invalid memory size `{spec}`: unknown unit `{unit}` (use b, k, m, or g; `Mi`/`Gi` also work)"
+            )));
+        }
+    };
+    if mib == 0 {
+        return Err(ParseError(format!(
+            "invalid memory size `{spec}`: must be at least 1 MiB"
+        )));
+    }
+    usize::try_from(mib).map_err(|_| out_of_range(spec))
+}
+
+fn out_of_range(spec: &str) -> ParseError {
+    ParseError(format!("memory size `{spec}` is out of range"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_number_is_mib() {
+        assert_eq!(parse_mib("512").unwrap(), 512);
+        assert_eq!(parse_mib(" 640 ").unwrap(), 640);
+    }
+
+    #[test]
+    fn every_spelling_of_a_unit_means_the_same_size() {
+        for spec in ["512m", "512mb", "512mi", "512mib", "512M", "512MiB"] {
+            assert_eq!(parse_mib(spec).unwrap(), 512, "spec: {spec}");
+        }
+        for spec in ["2g", "2gb", "2gi", "2gib", "2G", "2Gi", "2GiB"] {
+            assert_eq!(parse_mib(spec).unwrap(), 2048, "spec: {spec}");
+        }
+        for spec in ["2048k", "2048kb", "2048ki", "2048KiB"] {
+            assert_eq!(parse_mib(spec).unwrap(), 2, "spec: {spec}");
+        }
+    }
+
+    #[test]
+    fn a_size_below_a_whole_mib_rounds_up_so_the_guest_still_boots() {
+        assert_eq!(parse_mib("1024k").unwrap(), 1);
+        assert_eq!(parse_mib("1500k").unwrap(), 2);
+        assert_eq!(parse_mib("1b").unwrap(), 1);
+        assert_eq!(parse_mib("1048577b").unwrap(), 2);
+    }
+
+    #[test]
+    fn a_zero_size_is_refused_because_no_guest_boots_on_it() {
+        for spec in ["0", "0g", "0b", "0Gi"] {
+            let err = parse_mib(spec).unwrap_err().to_string();
+            assert!(err.contains("at least 1 MiB"), "spec {spec}: {err}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_unit_is_named_back_to_the_author() {
+        for (spec, unit) in [("12parsecs", "parsecs"), ("38gg", "gg"), ("4t", "t")] {
+            let err = parse_mib(spec).unwrap_err().to_string();
+            assert!(
+                err.contains(&format!("unknown unit `{unit}`")),
+                "spec {spec}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_unit_with_no_number_is_refused() {
+        for spec in ["g", "", "Gi"] {
+            let err = parse_mib(spec).unwrap_err().to_string();
+            assert!(err.contains("expected MiB"), "spec {spec}: {err}");
+        }
+    }
+
+    #[test]
+    fn a_size_that_cannot_be_held_is_refused_rather_than_wrapped() {
+        for spec in [
+            format!("{}g", u64::MAX),
+            format!("{}g", u128::MAX),
+            format!("{}", u128::MAX),
+        ] {
+            let err = parse_mib(&spec).unwrap_err().to_string();
+            assert!(err.contains("out of range"), "spec {spec}: {err}");
+        }
+    }
+}

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -385,8 +385,8 @@ fn is_valid_env_key(key: &str) -> bool {
             .any(|c| c == '=' || c.is_control() || c.is_whitespace())
 }
 
-/// A cpu/memory request is a positive count or size — a bare integer ≥ 1 or a digits-then-unit string like `500m`/`2Gi` whose numeric part is non-zero — while the service's unit-aware resolver keeps ownership of the host ceiling and the fallback for anything else.
-fn quantity_is_positive(quantity: &spec::Quantity) -> bool {
+/// A cpu request is a positive count — a bare integer ≥ 1 or a millicore string like `500m` — while the service's resolver keeps ownership of the host ceiling and the fallback for anything else.
+fn cpu_is_positive(quantity: &spec::Quantity) -> bool {
     match quantity {
         spec::Quantity::Int(n) => *n >= 1,
         spec::Quantity::Text(text) => {
@@ -401,12 +401,19 @@ fn quantity_is_positive(quantity: &spec::Quantity) -> bool {
 }
 
 fn validate_resources(resources: &Resources) -> Result<()> {
-    for (field, quantity) in [("cpu", &resources.cpu), ("memory", &resources.memory)] {
-        if let Some(quantity) = quantity
-            && !quantity_is_positive(quantity)
-        {
-            bail!("resources.{field} {quantity:?} must be a positive count or size");
+    if let Some(cpu) = &resources.cpu
+        && !cpu_is_positive(cpu)
+    {
+        bail!("resources.cpu {cpu:?} must be a positive count or size");
+    }
+    match &resources.memory {
+        Some(memory @ spec::Quantity::Int(n)) if *n < 1 => {
+            bail!("resources.memory {memory:?} must be a positive count or size")
         }
+        Some(spec::Quantity::Text(text)) => {
+            crate::memory::parse_mib(text).context("resources.memory")?;
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -809,13 +816,40 @@ mod tests {
             r#"{"image":"x:1","resources":{"cpu":0}}"#,
             r#"{"image":"x:1","resources":{"cpu":-2}}"#,
             r#"{"image":"x:1","resources":{"memory":0}}"#,
-            r#"{"image":"x:1","resources":{"memory":"lots"}}"#,
-            r#"{"image":"x:1","resources":{"memory":"0Gi"}}"#,
         ] {
             let err = parse(&def_json(spec)).unwrap_err();
             assert!(
                 format!("{err:#}").contains("must be a positive count or size"),
                 "spec {spec}: got: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_a_memory_size_the_flag_would_also_reject() {
+        for (spec, expected) in [
+            (
+                r#"{"image":"x:1","resources":{"memory":"38gg"}}"#,
+                "unknown unit `gg`",
+            ),
+            (
+                r#"{"image":"x:1","resources":{"memory":"12parsecs"}}"#,
+                "unknown unit `parsecs`",
+            ),
+            (
+                r#"{"image":"x:1","resources":{"memory":"lots"}}"#,
+                "expected MiB",
+            ),
+            (
+                r#"{"image":"x:1","resources":{"memory":"0Gi"}}"#,
+                "at least 1 MiB",
+            ),
+        ] {
+            let err = parse(&def_json(spec)).unwrap_err();
+            let rendered = format!("{err:#}");
+            assert!(
+                rendered.contains("resources.memory") && rendered.contains(expected),
+                "spec {spec}: got: {rendered}"
             );
         }
     }
@@ -831,6 +865,10 @@ mod tests {
         ))
         .unwrap();
         parse(&def_json(r#"{"image":"x:1","resources":{"memory":"640"}}"#)).unwrap();
+        parse(&def_json(r#"{"image":"x:1","resources":{"memory":"2gi"}}"#)).unwrap();
+        parse(&def_json(r#"{"image":"x:1","resources":{"memory":"2g"}}"#)).unwrap();
+        parse(&def_json(r#"{"image":"x:1","resources":{"memory":512}}"#)).unwrap();
+        parse(&def_json(r#"{"image":"x:1","resources":{"cpu":4}}"#)).unwrap();
     }
 
     #[test]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -492,34 +492,8 @@ fn user_spec_uid(spec: &str) -> Option<u32> {
         .ok()
 }
 
-const MIB: u128 = 1024 * 1024;
-
 pub(crate) fn parse_mem_arg(s: &str) -> Result<usize, String> {
-    let lower = s.trim().to_ascii_lowercase();
-    let digits_end = lower
-        .find(|c: char| !c.is_ascii_digit())
-        .unwrap_or(lower.len());
-    let (digits, suffix) = lower.split_at(digits_end);
-    let value: u128 = digits
-        .parse()
-        .map_err(|_| format!("invalid memory size `{s}`: expected MiB, e.g. `512`, or `2g`"))?;
-    let mib = match suffix {
-        "" | "m" | "mb" | "mib" => value,
-        "b" => value.div_ceil(MIB),
-        "k" | "kb" | "kib" => value.div_ceil(1024),
-        "g" | "gb" | "gib" => value
-            .checked_mul(1024)
-            .ok_or_else(|| format!("memory size `{s}` is out of range"))?,
-        _ => {
-            return Err(format!(
-                "invalid memory size `{s}`: unknown unit `{suffix}` (use b, k, m, or g)"
-            ));
-        }
-    };
-    if mib == 0 {
-        return Err(format!("invalid memory size `{s}`: must be at least 1 MiB"));
-    }
-    usize::try_from(mib).map_err(|_| format!("memory size `{s}` is out of range"))
+    lns_artifact::memory::parse_mib(s).map_err(|e| e.to_string())
 }
 
 pub(crate) fn parse_publish_arg(s: &str) -> Result<PortPublish, String> {
@@ -876,56 +850,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_mem_arg_bare_number_is_mib() {
+    fn parse_mem_arg_reads_the_same_grammar_a_definition_writes() {
         assert_eq!(parse_mem_arg("512").unwrap(), 512);
-    }
-
-    #[test]
-    fn parse_mem_arg_m_suffixes_are_mib_passthrough() {
-        for spec in ["512m", "512mb", "512mib", "512M", "512MiB"] {
-            assert_eq!(parse_mem_arg(spec).unwrap(), 512, "spec: {spec}");
-        }
-    }
-
-    #[test]
-    fn parse_mem_arg_g_suffixes_scale_to_mib() {
-        for spec in ["2g", "2gb", "2gib", "2G"] {
-            assert_eq!(parse_mem_arg(spec).unwrap(), 2048, "spec: {spec}");
-        }
-    }
-
-    #[test]
-    fn parse_mem_arg_k_and_b_round_up_to_a_whole_mib() {
-        assert_eq!(parse_mem_arg("1024k").unwrap(), 1);
-        assert_eq!(parse_mem_arg("1500k").unwrap(), 2);
-        assert_eq!(parse_mem_arg("1b").unwrap(), 1);
-        assert_eq!(parse_mem_arg("1048577b").unwrap(), 2);
-    }
-
-    #[test]
-    fn parse_mem_arg_rejects_zero() {
-        for spec in ["0", "0g", "0b"] {
-            let err = parse_mem_arg(spec).unwrap_err();
-            assert!(err.contains("at least 1 MiB"), "spec {spec}: {err}");
-        }
-    }
-
-    #[test]
-    fn parse_mem_arg_rejects_an_unknown_unit() {
+        assert_eq!(parse_mem_arg("38Gi").unwrap(), 38912);
         let err = parse_mem_arg("12parsecs").unwrap_err();
         assert!(err.contains("unknown unit"), "got: {err}");
-    }
-
-    #[test]
-    fn parse_mem_arg_rejects_a_unit_with_no_number() {
-        let err = parse_mem_arg("g").unwrap_err();
-        assert!(err.contains("expected MiB"), "got: {err}");
-    }
-
-    #[test]
-    fn parse_mem_arg_rejects_a_size_beyond_usize() {
-        let err = parse_mem_arg(&format!("{}g", u128::from(u64::MAX))).unwrap_err();
-        assert!(err.contains("out of range"), "got: {err}");
     }
 
     #[test]

--- a/crates/lns-cli/tests/behaviours/run_resources.feature
+++ b/crates/lns-cli/tests/behaviours/run_resources.feature
@@ -14,6 +14,11 @@ Feature: lns run resource limits — vCPU count and memory size flags
     When the summary is printed
     Then the summary shows `Resources: 1 vCPU · 2048 MiB`
 
+  Scenario: The flag accepts the same unit a definition writes
+    Given the command is `lns run -m 38Gi someimage`
+    When the summary is printed
+    Then the summary shows `Resources: 1 vCPU · 38912 MiB`
+
   Scenario: --memory works as an alias of --mem
     Given the command is `lns run --memory 1g someimage`
     When the summary is printed

--- a/crates/lns-service/src/artifact/resources.rs
+++ b/crates/lns-service/src/artifact/resources.rs
@@ -55,21 +55,18 @@ const MAX_MEM_MIB: usize = 256 * 1024;
 
 fn quantity_to_mib(quantity: &Quantity) -> Option<usize> {
     let mib = match quantity {
-        Quantity::Int(n) => usize::try_from(*n).ok()?,
-        Quantity::Text(text) => parse_mem_text(text)?,
+        Quantity::Int(n) => usize::try_from(*n).ok(),
+        Quantity::Text(text) => lns_artifact::memory::parse_mib(text).ok(),
     };
-    (1..=MAX_MEM_MIB).contains(&mib).then_some(mib)
-}
-
-fn parse_mem_text(text: &str) -> Option<usize> {
-    let text = text.trim();
-    if let Some(gib) = text.strip_suffix("Gi") {
-        return gib.trim().parse::<usize>().ok()?.checked_mul(1024);
+    match mib {
+        Some(mib) if (1..=MAX_MEM_MIB).contains(&mib) => Some(mib),
+        _ => {
+            crate::log::warn!(
+                "memory request {quantity:?} is not a size this host will grant; using the default instead"
+            );
+            None
+        }
     }
-    if let Some(mib) = text.strip_suffix("Mi") {
-        return mib.trim().parse::<usize>().ok();
-    }
-    text.parse::<usize>().ok()
 }
 
 #[cfg(test)]
@@ -126,6 +123,89 @@ mod tests {
             resolve_size(Some(&plain), &ResourceOverrides::default(), DEFAULTS).mem_mib,
             640
         );
+    }
+
+    #[derive(Default)]
+    struct MessageCapture(std::sync::Mutex<Vec<String>>);
+
+    struct MessageLayer(std::sync::Arc<MessageCapture>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for MessageLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            struct Message<'a>(&'a mut String);
+            impl tracing::field::Visit for Message<'_> {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        *self.0 = format!("{value:?}");
+                    }
+                }
+            }
+            let mut message = String::new();
+            event.record(&mut Message(&mut message));
+            self.0.0.lock().unwrap().push(message);
+        }
+    }
+
+    fn captured_messages(f: impl FnOnce()) -> Vec<String> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let capture = std::sync::Arc::new(MessageCapture::default());
+        let subscriber =
+            tracing_subscriber::registry().with(MessageLayer(std::sync::Arc::clone(&capture)));
+        tracing::subscriber::with_default(subscriber, f);
+        capture.0.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn a_memory_request_this_host_will_not_grant_is_said_out_loud() {
+        let over_ceiling = Resources {
+            cpu: None,
+            memory: Some(Quantity::Text("999999Gi".into())),
+        };
+        let messages = captured_messages(|| {
+            assert_eq!(
+                resolve_size(Some(&over_ceiling), &ResourceOverrides::default(), DEFAULTS).mem_mib,
+                DEFAULTS.mem_mib
+            );
+        });
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("not a size this host will grant")),
+            "an ignored memory request must not be silent; got: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn a_definition_reads_every_size_the_mem_flag_accepts() {
+        for (text, mem_mib) in [
+            ("38Gi", 38912),
+            ("38gi", 38912),
+            ("38GiB", 38912),
+            ("2g", 2048),
+            ("2GB", 2048),
+            ("512m", 512),
+            ("768Mi", 768),
+            ("1024k", 1),
+            ("640", 640),
+        ] {
+            let res = Resources {
+                cpu: None,
+                memory: Some(Quantity::Text(text.into())),
+            };
+            assert_eq!(
+                resolve_size(Some(&res), &ResourceOverrides::default(), DEFAULTS).mem_mib,
+                mem_mib,
+                "memory: {text}"
+            );
+        }
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -96,7 +96,7 @@ the `./lns.yaml` definition with its command overridden.
 | Option                       | Default          | Meaning                                                                 |
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
 | `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
-| `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; rounded up to a whole MiB); falls back to the `run.mem` config default. |
+| `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`, `-m 38Gi` — the same sizes `spec.resources.memory` accepts, all binary, rounded up to a whole MiB); falls back to the `run.mem` config default. |
 | `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory roots the definition's relative binds and filesets. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -214,12 +214,16 @@ lns run -u 1000:1000 -h build-box ghcr.io/acme/agent:1.0.0
 | `-m`, `--mem`, `--memory <SIZE>` | `512` | RAM in mebibytes, or with a unit suffix. |
 
 Memory accepts Docker-style unit suffixes (`b`, `k`, `m`, `g`, plus `kb`/`kib`
-and friends), rounded up to a whole MiB:
+and friends), rounded up to a whole MiB. The flag reads the same sizes that
+`spec.resources.memory` writes, so `512Mi` and `38Gi` work in both places:
 
 ```bash
 lns run --cpus 4 -m 2g ghcr.io/acme/builder
 lns run --mem 2048 ghcr.io/acme/builder        # same thing, in MiB
+lns run -m 38Gi ghcr.io/acme/builder           # the unit a definition uses
 ```
+
+Every suffix is binary: `2g`, `2gb`, `2Gi` and `2GiB` all mean 2048 MiB.
 
 ### Working directory
 


### PR DESCRIPTION
## Problem

`lns run -m 38Gi` is refused while `spec.resources.memory: 38Gi` is valid:

```
error: invalid value '38Gi' for '--mem <SIZE>': invalid memory size `38Gi`:
unknown unit `gi` (use b, k, m, or g)
```

A consumer that computes a size and wants to pass it as a flag has to translate `38Gi` → `38g`.

## What was actually wrong

Three grammars, disagreeing in every direction:

| Site | Accepted | Silently wrong |
|---|---|---|
| `lns-cli::parse_mem_arg` | `m/mb/mib`, `b`, `k/kb/kib`, `g/gb/gib` | — (it errors) |
| `lns-service::parse_mem_text` | case-**sensitive** `Gi`/`Mi`, bare | `2g`, `512m`, `2GiB` and lowercase `2gi` → 512 MiB default |
| `lns-artifact::quantity_is_positive` | any digits-then-letters | `38gg`, `12parsecs` load fine, then → 512 MiB |

So the reported error was the *least* bad of the three. A definition asking for `2gi` booted with 512 MiB and said nothing.

## The change

One grammar in `crates/lns-artifact/src/memory.rs` (`parse_mib`), read by all three sites.

- Every suffix is binary: `2g == 2gb == 2Gi == 2GiB == 2048 MiB`. That is what the flag already did and what `docs/running-workloads.md` already promised ("Docker-style unit suffixes"); it is not a new convention.
- The memory arm of `validate_resources` now uses the real parser, so a bad unit is a load error naming the unit instead of a silent default.
- `cpu` keeps its own check, because `m` means millicores there, not MiB. No cpu behaviour changed.
- The one fallback the grammar cannot decide — a parseable request over the service's `MAX_MEM_MIB` ceiling — now emits a warning instead of resizing the guest in silence.

## Behaviour change worth knowing

An already-published artifact whose `spec.resources.memory` is junk (`38gg`) now fails to load instead of booting at 512 MiB. That is the intended direction: silent-wrong becomes loud.

## Tests

Red proven first at all three sites:

- `38gg` loaded without error → now a load error naming the unit.
- `38gi` resolved to 512 instead of 38912 → now 38912.
- New Layer 2 scenario `lns run -m 38Gi someimage` failed with "unknown unit `gi`" → now shows `Resources: 1 vCPU · 38912 MiB`.

Layer 3 grammar table in the new module; the six duplicated `parse_mem_arg_*` tests collapse to one delegation test.

## Gate

`make lint`, `make complexity`, and `COVERAGE_CRATES="lns-artifact lns-cli lns-service" make coverage` all green — lns-artifact 8 files at 100%, lns-cli 32 at 100%, lns-service 104 at 100%, 0 failures.

Fixes item 7 of the devbox findings.