### PR TITLE
fix: refuse a single-file bind instead of booting a guest that dies

### DIFF
--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -6,6 +6,7 @@ use lns_policy::host_bind_decisions::{HostBindDecisionStore, SecretDisposition};
 
 pub trait DirScan {
     fn exists(&self, path: &Path) -> bool;
+    fn is_dir(&self, path: &Path) -> bool;
     fn entries(&self, dir: &Path) -> Vec<String>;
     fn read_to_string(&self, path: &Path) -> Option<String>;
 }
@@ -15,6 +16,10 @@ pub struct RealDirScan;
 impl DirScan for RealDirScan {
     fn exists(&self, path: &Path) -> bool {
         path.exists()
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
     }
 
     fn entries(&self, dir: &Path) -> Vec<String> {
@@ -128,6 +133,12 @@ pub fn resolve_binds(
         if !scan.exists(root) {
             bail!("host path does not exist: {}", spec.host_source);
         }
+        if !scan.is_dir(root) {
+            bail!(
+                "host bind source must be a directory: {} — bind its parent directory instead",
+                spec.host_source
+            );
+        }
         let ignore = lensignore_patterns(scan, root);
         let mut kept = Vec::new();
         let mut dropped = Vec::new();
@@ -223,6 +234,9 @@ mod tests {
     impl DirScan for FakeDir {
         fn exists(&self, path: &Path) -> bool {
             !self.missing.contains(&path.to_string_lossy().into_owned())
+        }
+        fn is_dir(&self, path: &Path) -> bool {
+            self.exists(path)
         }
         fn entries(&self, _dir: &Path) -> Vec<String> {
             self.entries.clone()
@@ -410,6 +424,11 @@ mod tests {
         let scan = RealDirScan;
         assert!(scan.exists(&dir.path().join(".env")));
         assert!(!scan.exists(&dir.path().join("absent")));
+        assert!(scan.is_dir(dir.path()));
+        assert!(
+            !scan.is_dir(&dir.path().join(".env")),
+            "a regular file is not a directory the guest can share"
+        );
         assert!(scan.entries(dir.path()).contains(&".env".to_string()));
         assert_eq!(
             scan.read_to_string(&dir.path().join(".lensignore")),

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -37,6 +37,11 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     When the user runs `lns run -v /Users/me/typo:/work alpine` interactively
     Then the command fails with "host path does not exist"
 
+  Scenario: A single-file host source is refused before the run starts
+    Given the host path "/Users/me/.gitconfig" is a file, not a directory
+    When the user runs `lns run -v /Users/me/.gitconfig:/etc/gitconfig:ro alpine` interactively
+    Then the command fails with "must be a directory"
+
   Scenario: A clean bind with no secret-shaped files runs without prompting
     Given the host directory "/Users/me/proj" contains no secret-shaped files
     When the user runs `lns run -v /Users/me/proj:/work alpine` interactively

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -141,6 +141,10 @@ impl DirScan for FakeDir {
         !self.missing
     }
 
+    fn is_dir(&self, _path: &Path) -> bool {
+        !self.missing
+    }
+
     fn entries(&self, _dir: &Path) -> Vec<String> {
         self.entries.clone()
     }

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -70,10 +70,14 @@ struct FakeDir {
     entries: Vec<String>,
     lensignore: Option<String>,
     missing: bool,
+    not_a_dir: bool,
 }
 impl DirScan for FakeDir {
     fn exists(&self, _path: &Path) -> bool {
         !self.missing
+    }
+    fn is_dir(&self, _path: &Path) -> bool {
+        !self.missing && !self.not_a_dir
     }
     fn entries(&self, _dir: &Path) -> Vec<String> {
         self.entries.clone()
@@ -112,6 +116,7 @@ fn dir_from(world: &BehaviourWorld) -> FakeDir {
         entries: world.host_bind.entries.clone(),
         lensignore: world.host_bind.lensignore.clone(),
         missing: world.host_bind.missing,
+        not_a_dir: world.host_bind.not_a_dir,
     }
 }
 
@@ -167,6 +172,11 @@ fn resolved_binds(world: &BehaviourWorld) -> Result<&[ResolvedBind], String> {
 #[given(regex = r#"^the host path "([^"]+)" does not exist$"#)]
 fn host_path_missing(world: &mut BehaviourWorld, _path: String) {
     world.host_bind.missing = true;
+}
+
+#[given(regex = r#"^the host path "([^"]+)" is a file, not a directory$"#)]
+fn host_path_is_a_file(world: &mut BehaviourWorld, _path: String) {
+    world.host_bind.not_a_dir = true;
 }
 
 #[given(regex = r#"^the host directory "([^"]+)" contains no secret-shaped files$"#)]

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -57,6 +57,7 @@ pub struct HostBindRig {
     pub entries: Vec<String>,
     pub lensignore: Option<String>,
     pub missing: bool,
+    pub not_a_dir: bool,
     pub decisions: std::collections::HashMap<String, SecretDisposition>,
     pub answer: Option<String>,
     pub outcome: Option<HostBindOutcome>,

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -522,8 +522,9 @@ lns run -v /etc/myapp:/config:ro ghcr.io/acme/app   # read-only
 
 The format is `/host/path:/absolute/target[:ro]`. The source must be an absolute
 path that already exists (a missing path is refused, not silently created — the one
-deliberate divergence from `docker run`). Binds default to read-write; append `:ro`
-for read-only. Disambiguation is by shape: a leading `/` is a host bind, anything
+deliberate divergence from `docker run`) and it must be a **directory**. To give the
+workload a single host file, bind the directory that holds it. Binds default to
+read-write; append `:ro` for read-only. Disambiguation is by shape: a leading `/` is a host bind, anything
 else is a named volume, so `-v build-cache:/cache` is still a volume.
 
 #### Secrets in a bind


### PR DESCRIPTION
## Problem

```
$ lns run -f x.yaml -v ~/.gitconfig:/etc/devbox/host-gitconfig:ro ...
  Bind:      /Users/…/.gitconfig → /etc/devbox/host-gitconfig (read-only)
  …
✗  connect_to_guest_port(1029) timed out after 30s: connectToPort(1029) failed:
   Invalid virtual machine state. The virtual machine is no longer live.
```

A **directory** bind of the same content works. So the input is wrong, but it presents as a crash: `lns` accepts it, boots a microVM, and reports a vsock timeout for a guest that is already dead.

## Root cause

Nothing on the path from `-v` to VM boot asks whether the source is a directory.

- The only filesystem check is `if !scan.exists(root)` in `resolve_binds` (`crates/lns-cli/src/run/host_bind.rs`), and `exists()` is true for a regular file.
- macOS Vz then builds `NSURL fileURLWithPath:isDirectory:true` → `VZSharedDirectory` → `VZSingleDirectoryShare` from it.
- Linux Cloud Hypervisor hands the same path to virtiofsd `--shared-dir`.

Neither can share a regular file, so the guest dies during boot and the CLI only ever sees the connect timeout.

Worth noting the secret scan degraded silently too: `entries()` on a file returns empty, so the KEEP/DROP scan found nothing to ask about.

## The change

`DirScan` gains `is_dir`, and `resolve_binds` bails immediately **after** the existing exists-check — so a missing path still says `host path does not exist` and only a present non-directory says:

```
host bind source must be a directory: /Users/…/.gitconfig — bind its parent directory instead
```

This fails before any request reaches the service, so no VM boots.

`lns-ipc`'s `validate_bind_source` is deliberately untouched: it is pure string validation with no filesystem access by design, and the CLI is the only layer that both can stat and can fail before boot. A non-CLI IPC client can still send a file path and reproduce the guest death — that hardening (`vm/cloud_hypervisor/orchestrate.rs`, `vm/vz/ffi.rs`) is a follow-up, not this PR.

`Path::is_dir` follows symlinks, so a symlinked project directory keeps working. A device node, socket or FIFO is refused by the same check, which is the intent.

## Tests

Red proven first: the new Layer 2 scenario failed with

```
expected failure containing "must be a directory", got Ok([ResolvedBind { host_source: "/Users/me/.gitconfig", target: "/etc/gitconfig", read_only: true, kept: [], dropped: [] }])
```

Now 371/371 scenarios and 804/804 lib tests pass. `RealDirScan::is_dir` is pinned by the existing tempfile-based adapter test.

Docs: `docs/running-workloads.md` now states that a bind source must be a directory, and that a single host file means binding the directory that holds it.

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-cli" make coverage` all green — 32 files at 100%, 0 failures.

Fixes item 2 of the devbox findings. Item 12 (declaring a host file in a definition) is the real answer for the underlying use case and stays open.