### PR TITLE
fix: stop offering `lns exec` a session it cannot open

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -297,9 +297,10 @@ pub struct ExecArgs {
         action = clap::ArgAction::Set,
         num_args = 0..=1,
         require_equals = true,
-        default_value_t = true,
+        default_value_t = false,
         default_missing_value = "true",
-        help = "`-i` — keep stdin open. Mirrors `docker exec -i`. Pass `--interactive=false` (or `-i=false`) for a non-interactive exec."
+        value_parser = refuse_exec_session,
+        hide = true
     )]
     pub interactive: bool,
 
@@ -309,9 +310,10 @@ pub struct ExecArgs {
         action = clap::ArgAction::Set,
         num_args = 0..=1,
         require_equals = true,
-        default_value_t = true,
+        default_value_t = false,
         default_missing_value = "true",
-        help = "Allocate a PTY for the exec session. Pass `--tty=false` (or `-t=false`) for a non-interactive exec."
+        value_parser = refuse_exec_session,
+        hide = true
     )]
     pub tty: bool,
 
@@ -490,6 +492,18 @@ fn user_spec_uid(spec: &str) -> Option<u32> {
         .map_or(spec, |(user, _)| user)
         .parse::<u32>()
         .ok()
+}
+
+fn refuse_exec_session(s: &str) -> Result<bool, String> {
+    match s {
+        "false" => Ok(false),
+        _ => Err(
+            "an interactive exec is not yet supported: input routing for exec sessions \
+                  awaits an IPC discriminator. Drop -i/-t and pass the command after `--`; \
+                  `lns attach` reaches the run's own terminal"
+                .to_string(),
+        ),
+    }
 }
 
 pub(crate) fn parse_mem_arg(s: &str) -> Result<usize, String> {
@@ -776,10 +790,28 @@ mod tests {
     }
 
     #[test]
-    fn exec_interactive_and_tty_default_to_true() {
+    fn exec_interactive_and_tty_default_to_false() {
         let args = parse_exec(&["demo", "--", "echo", "hi"]).expect("defaults parse");
-        assert!(args.interactive);
-        assert!(args.tty);
+        assert!(!args.interactive);
+        assert!(!args.tty);
+    }
+
+    #[test]
+    fn exec_refuses_a_session_it_cannot_route_input_to() {
+        for flag in ["-i", "-t", "--interactive=true", "--tty=true"] {
+            let err = parse_exec(&[flag, "demo", "--", "sh"])
+                .err()
+                .unwrap_or_else(|| panic!("{flag} must be refused at parse time"));
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "flag {flag}: {err}"
+            );
+            assert!(
+                err.to_string().contains("not yet supported"),
+                "flag {flag}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lns-cli/src/command.rs
+++ b/crates/lns-cli/src/command.rs
@@ -520,12 +520,23 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_exec_expands_a_leading_it_cluster_into_session_flags() {
-        let exec = sandbox_exec_args(&["lns", "sandbox", "exec", "-it", "demo", "sh"]);
-        assert!(exec.interactive);
-        assert!(exec.tty);
+    fn sandbox_exec_with_no_session_flags_decodes_a_plain_command() {
+        let exec = sandbox_exec_args(&["lns", "sandbox", "exec", "demo", "--", "printenv", "HOME"]);
+        assert!(!exec.interactive);
+        assert!(!exec.tty);
         assert_eq!(exec.run, "demo");
-        assert_eq!(exec.cmd, ["sh"]);
+        assert_eq!(exec.cmd, ["printenv", "HOME"]);
+    }
+
+    #[test]
+    fn sandbox_exec_expands_a_leading_it_cluster_then_refuses_the_session() {
+        let parsed: clap::error::Result<crate::cli::ExecArgs> =
+            parse_args(["lns", "sandbox", "exec", "-it", "demo", "sh"]);
+        let err = parsed
+            .err()
+            .unwrap_or_else(|| panic!("a session exec must be refused"));
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(err.to_string().contains("not yet supported"), "{err}");
     }
 
     #[test]
@@ -677,13 +688,17 @@ mod tests {
     }
 
     #[test]
-    fn exec_expands_a_leading_it_cluster_into_session_flags() {
-        let args: crate::cli::ExecArgs =
-            parse_args(["lns", "exec", "-it", "demo", "--", "sh"]).unwrap();
-        assert!(args.interactive);
-        assert!(args.tty);
-        assert_eq!(args.run, "demo");
-        assert_eq!(args.cmd, ["sh"]);
+    fn exec_expands_a_leading_it_cluster_then_refuses_the_session() {
+        let parsed: clap::error::Result<crate::cli::ExecArgs> =
+            parse_args(["lns", "exec", "-it", "demo", "--", "sh"]);
+        let err = parsed
+            .err()
+            .unwrap_or_else(|| panic!("a session exec must be refused"));
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(
+            err.to_string().contains("not yet supported"),
+            "the cluster must expand so the user reads our refusal, not `unexpected argument`: {err}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -47,7 +47,9 @@ pub enum SandboxCommand {
     Ls(LsArgs),
     #[command(about = "Run a sandbox in a microVM (the top-level `lns run`).")]
     Run(Box<RunArgs>),
-    #[command(about = "Open a new session (`docker exec`-style) against a running run.")]
+    #[command(
+        about = "Run one non-interactive command against a running run (`docker exec`-style); use `lns attach` for its terminal."
+    )]
     Exec(ExecArgs),
     #[command(about = "Send a signal to a running run (`docker kill`-style).")]
     Kill(KillArgs),
@@ -1112,6 +1114,7 @@ where
         stdout,
         stderr,
         false,
+        crate::service::StdinForwarding::ToRun,
     )
     .await
 }

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -23,9 +23,10 @@ const NOT_RUNNING_MESSAGE: &str =
 
 mod orchestrator;
 pub use orchestrator::{
-    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, dispatch, drive_attached_session_with_writers,
-    drive_pre_phase, exec_command, exec_image, launch_run, pre_phase_step, render_started_run,
-    render_status_line, require_running, run_command, run_image,
+    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, dispatch,
+    drive_attached_session_with_writers, drive_pre_phase, exec_command, exec_image, launch_run,
+    pre_phase_step, render_started_run, render_status_line, require_running, run_command,
+    run_image,
 };
 
 use crate::command::{CommandSpec, subcommand};

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -381,6 +381,7 @@ pub async fn run_image(
         detach_chord,
         DetachBehaviour::DetachRun,
         quiet,
+        StdinForwarding::of(stdin),
     )
     .await
 }
@@ -437,8 +438,26 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
         detach_chord,
         DetachBehaviour::SignalAndDrain,
         args.quiet,
+        StdinForwarding::of(stdin),
     )
     .await
+}
+
+/// Whether host stdin reaches the session's workload; a session opened without `-i` still watches for the detach chord but hands the run nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdinForwarding {
+    ToRun,
+    Withheld,
+}
+
+impl StdinForwarding {
+    fn of(interactive: bool) -> Self {
+        if interactive {
+            Self::ToRun
+        } else {
+            Self::Withheld
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -448,6 +467,7 @@ pub enum DetachBehaviour {
     DetachRun,
 }
 
+#[allow(clippy::too_many_arguments)] // one session-shape argument per wire field; the writer seam lives in the _with_writers twin
 pub(crate) async fn drive_attached_session<S>(
     stream: S,
     aux_socket: Option<PathBuf>,
@@ -456,6 +476,7 @@ pub(crate) async fn drive_attached_session<S>(
     detach_chord: Vec<u8>,
     detach: DetachBehaviour,
     quiet: bool,
+    stdin: StdinForwarding,
 ) -> Result<i32>
 where
     S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
@@ -473,6 +494,7 @@ where
         &mut stdout,
         &mut stderr,
         quiet,
+        stdin,
     )
     .await
 }
@@ -489,6 +511,7 @@ pub async fn drive_attached_session_with_writers<S, O, E>(
     stdout: &mut O,
     stderr: &mut E,
     quiet: bool,
+    stdin: StdinForwarding,
 ) -> Result<i32>
 where
     S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
@@ -518,14 +541,14 @@ where
             });
             let pump_chord = detach_chord;
             let pump_early_exit = early_exit_tx.clone();
-            let stdin = tokio::spawn(async move {
-                let r = run_stdin_pump(socket, run_id, pump_chord, detach).await;
+            let stdin_task = tokio::spawn(async move {
+                let r = run_stdin_pump(socket, run_id, pump_chord, detach, stdin).await;
                 if matches!(&r, Ok(true)) {
                     let _ = pump_early_exit.send(());
                 }
                 r
             });
-            (Some(cancel), winsize, Some(stdin))
+            (Some(cancel), winsize, Some(stdin_task))
         }
         None => (None, None, None),
     };
@@ -738,6 +761,7 @@ async fn run_stdin_pump(
     run_id: String,
     detach_chord: Vec<u8>,
     detach: DetachBehaviour,
+    stdin: StdinForwarding,
 ) -> Result<bool> {
     let mut input = tokio::io::stdin();
     let mut buf = [0u8; 4096];
@@ -747,7 +771,7 @@ async fn run_stdin_pump(
             Ok(0) => {
                 if let Some(d) = detector.as_mut() {
                     let held = d.drain_for_eof();
-                    if !held.is_empty() {
+                    if !held.is_empty() && stdin == StdinForwarding::ToRun {
                         let _ = send_one_shot(
                             &socket,
                             &Request::RunStdin {
@@ -769,19 +793,21 @@ async fn run_stdin_pump(
         let chunk = &buf[..n];
         match detector.as_mut() {
             Some(d) => {
-                if !pump_with_detector(&socket, &run_id, chunk, d, detach).await? {
+                if !pump_with_detector(&socket, &run_id, chunk, d, detach, stdin).await? {
                     return Ok(true);
                 }
             }
             None => {
-                send_one_shot(
-                    &socket,
-                    &Request::RunStdin {
-                        run_id: run_id.clone(),
-                        bytes: chunk.to_vec(),
-                    },
-                )
-                .await?;
+                if stdin == StdinForwarding::ToRun {
+                    send_one_shot(
+                        &socket,
+                        &Request::RunStdin {
+                            run_id: run_id.clone(),
+                            bytes: chunk.to_vec(),
+                        },
+                    )
+                    .await?;
+                }
             }
         }
     }
@@ -793,10 +819,11 @@ async fn pump_with_detector(
     bytes: &[u8],
     detector: &mut DetachChordDetector,
     detach: DetachBehaviour,
+    stdin: StdinForwarding,
 ) -> Result<bool> {
     let mut pending: Vec<u8> = Vec::new();
     for &b in bytes {
-        let (requests, control) = plan_feed(detector.feed(b), run_id, &mut pending, detach);
+        let (requests, control) = plan_feed(detector.feed(b), run_id, &mut pending, detach, stdin);
         for request in &requests {
             send_one_shot(socket, request).await?;
         }
@@ -804,7 +831,9 @@ async fn pump_with_detector(
             return Ok(false);
         }
     }
-    if let Some(request) = drain_pending(run_id, &mut pending) {
+    if stdin == StdinForwarding::ToRun
+        && let Some(request) = drain_pending(run_id, &mut pending)
+    {
         send_one_shot(socket, &request).await?;
     }
     Ok(true)
@@ -831,36 +860,42 @@ fn plan_feed(
     run_id: &str,
     pending: &mut Vec<u8>,
     detach: DetachBehaviour,
+    stdin: StdinForwarding,
 ) -> (Vec<Request>, PumpControl) {
+    let stdin_requests = |bytes: Vec<u8>| match stdin {
+        StdinForwarding::ToRun => vec![Request::RunStdin {
+            run_id: run_id.to_string(),
+            bytes,
+        }],
+        StdinForwarding::Withheld => Vec::new(),
+    };
+    let drained = |pending: &mut Vec<u8>| match stdin {
+        StdinForwarding::ToRun => drain_pending(run_id, pending).into_iter().collect(),
+        StdinForwarding::Withheld => {
+            pending.clear();
+            Vec::<Request>::new()
+        }
+    };
     match action {
         FeedAction::Forward(byte) => {
             pending.push(byte);
             (Vec::new(), PumpControl::Continue)
         }
-        FeedAction::Hold => (
-            drain_pending(run_id, pending).into_iter().collect(),
-            PumpControl::Continue,
-        ),
+        FeedAction::Hold => (drained(pending), PumpControl::Continue),
         FeedAction::Flush(held) => {
-            let mut requests: Vec<Request> = drain_pending(run_id, pending).into_iter().collect();
-            requests.push(Request::RunStdin {
-                run_id: run_id.to_string(),
-                bytes: held,
-            });
+            let mut requests = drained(pending);
+            requests.extend(stdin_requests(held));
             (requests, PumpControl::Continue)
         }
         FeedAction::FlushAndForward(held, current) => {
-            let mut requests: Vec<Request> = drain_pending(run_id, pending).into_iter().collect();
+            let mut requests = drained(pending);
             let mut combined = held;
             combined.push(current);
-            requests.push(Request::RunStdin {
-                run_id: run_id.to_string(),
-                bytes: combined,
-            });
+            requests.extend(stdin_requests(combined));
             (requests, PumpControl::Continue)
         }
         FeedAction::Trigger => {
-            let mut requests: Vec<Request> = drain_pending(run_id, pending).into_iter().collect();
+            let mut requests = drained(pending);
             match detach {
                 DetachBehaviour::SignalAndDrain => requests.push(Request::RunSignal {
                     run_id: run_id.to_string(),
@@ -1202,6 +1237,7 @@ mod tests {
             Vec::new(),
             DetachBehaviour::SignalAndDrain,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("drive_attached_session");
@@ -1523,6 +1559,7 @@ mod tests {
             Vec::new(),
             DetachBehaviour::SignalAndDrain,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("a stray progress frame must not kill an attached session");
@@ -1547,6 +1584,7 @@ mod tests {
             Vec::new(),
             DetachBehaviour::SignalAndDrain,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect_err("daemon Error must surface as anyhow::Error");
@@ -1765,6 +1803,7 @@ mod tests {
             &mut captured,
             &mut status,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("drive");
@@ -1885,6 +1924,7 @@ mod tests {
             &mut captured,
             &mut status,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("drive");
@@ -1915,6 +1955,7 @@ mod tests {
             &mut captured,
             &mut status,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("drive");
@@ -1947,6 +1988,7 @@ mod tests {
             &mut captured,
             &mut status,
             false,
+            StdinForwarding::ToRun,
         )
         .await
         .expect("drive");
@@ -1963,6 +2005,50 @@ mod tests {
     }
 
     #[test]
+    fn a_session_opened_without_stdin_hands_the_run_nothing_it_typed() {
+        for action in [
+            FeedAction::Flush(b"echo pwned\n".to_vec()),
+            FeedAction::FlushAndForward(b"echo pwned".to_vec(), b'\n'),
+            FeedAction::Hold,
+        ] {
+            let mut pending = b"already typed".to_vec();
+            let (requests, control) = plan_feed(
+                action,
+                "1",
+                &mut pending,
+                DetachBehaviour::SignalAndDrain,
+                StdinForwarding::Withheld,
+            );
+            assert!(
+                requests.is_empty(),
+                "a non-interactive exec must not feed the run's own shell: {requests:?}"
+            );
+            assert!(matches!(control, PumpControl::Continue));
+        }
+    }
+
+    #[test]
+    fn a_session_opened_without_stdin_still_honours_the_detach_chord() {
+        let mut pending = b"already typed".to_vec();
+        let (requests, control) = plan_feed(
+            FeedAction::Trigger,
+            "9",
+            &mut pending,
+            DetachBehaviour::SignalAndDrain,
+            StdinForwarding::Withheld,
+        );
+        assert_eq!(
+            requests,
+            vec![Request::RunSignal {
+                run_id: "9".to_string(),
+                signal: SignalKind::Hup
+            }],
+            "the chord must still detach, and must not flush the withheld bytes on its way out"
+        );
+        assert!(matches!(control, PumpControl::Detach));
+    }
+
+    #[test]
     fn plan_feed_forward_accumulates_without_sending() {
         let mut pending = Vec::new();
         let (requests, control) = plan_feed(
@@ -1970,6 +2056,7 @@ mod tests {
             "1",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert!(requests.is_empty());
         assert!(matches!(control, PumpControl::Continue));
@@ -1984,6 +2071,7 @@ mod tests {
             "7",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,
@@ -2003,6 +2091,7 @@ mod tests {
             "7",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert!(requests.is_empty());
     }
@@ -2015,6 +2104,7 @@ mod tests {
             "3",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,
@@ -2040,6 +2130,7 @@ mod tests {
             "3",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,
@@ -2058,6 +2149,7 @@ mod tests {
             "9",
             &mut pending,
             DetachBehaviour::SignalAndDrain,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,
@@ -2084,6 +2176,7 @@ mod tests {
             "9",
             &mut pending,
             DetachBehaviour::LeaveRunning,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,
@@ -2105,6 +2198,7 @@ mod tests {
             "9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a",
             &mut pending,
             DetachBehaviour::DetachRun,
+            StdinForwarding::ToRun,
         );
         assert_eq!(
             requests,

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -26,6 +26,18 @@ Feature: managing running sandboxes from the CLI
     When I run "lns exec 3 -- echo hi"
     Then the exit code is 0
 
+  Scenario: exec refuses a session it cannot route input to, at parse time
+    When I run "lns exec -it 3 -- sh"
+    Then the command fails with an exit code other than 0
+    And the output contains "not yet supported"
+
+  Scenario: exec help stops offering a session it cannot open
+    When I run "lns sandbox exec --help"
+    Then the exit code is 0
+    And the output does not contain "--interactive"
+    And the output does not contain "--tty"
+    And the output does not contain "Open a new session"
+
   Scenario: sandbox kill sends the requested signal
     Given the service will answer Acknowledged
     When the user runs sandbox command "kill 3 --signal KILL"

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -617,6 +617,7 @@ async fn drive_attached_frames(world: &mut BehaviourWorld, frames: Vec<Vec<u8>>)
         &mut stdout,
         &mut status,
         false,
+        lns_cli::service::StdinForwarding::ToRun,
     )
     .await
     .expect("drive_attached_session_with_writers");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -169,7 +169,7 @@ interchangeable everywhere a run is addressed.
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
 | `ls`       | —              | List cached sandboxes (pulled or built) in the local store. Alias: `list`. |
-| `exec`     | `lns exec`     | Open a new session against a running run (`docker exec`-style). `-i`/`-t`, `--detach-keys`, and `-q` work as for `lns run`; detaching closes only the exec session. |
+| `exec`     | `lns exec`     | Run one non-interactive command against a running run (`docker exec`-style). `--detach-keys` and `-q` work as for `lns run`. `-i`/`-t` are refused: an exec session has no way to route your keystrokes to itself yet, so use `lns attach` to reach the run's own terminal. |
 | `kill`     | `lns kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -743,13 +743,17 @@ Every verb takes a run's **name** as readily as its numeric id — `lns stop
 reviewer` and `lns stop 7` are equivalent. `exec` is also reachable as the bare
 `lns exec`.
 
-### Exec — another session inside a run
+### Exec — another command inside a run
 
-`lns exec 7 -- bash` opens a second session, like `docker exec`. The run id is
-shown by `lns run -d` and `lns ps`. `-i`, `-t`, and `--detach-keys` work as they do
-for `lns run`; detaching from an exec session closes only that session — the run
-and any other sessions keep going. This is also how you open a debugging shell
-alongside a misbehaving workload without disturbing it.
+`lns exec 7 -- ls /workspace` runs one command in a second session, like
+`docker exec`. The run id is shown by `lns run -d` and `lns ps`. `--detach-keys`
+works as it does for `lns run`; detaching from an exec session closes only that
+session — the run and any other sessions keep going.
+
+The session is **non-interactive**: `-i` and `-t` are refused, because an exec
+session has no way yet to route your keystrokes to itself rather than to the run's
+own workload. So `lns exec 7 -- bash` gets you a shell with closed stdin, which
+exits at once. To reach a live terminal inside the run, use `lns attach`.
 
 ### Stopping vs killing
 


### PR DESCRIPTION
## Problem

`lns sandbox exec --help` documented both flags, defaulting to `true`:

```
-i, --interactive[=<INTERACTIVE>]  `-i` — keep stdin open. … [default: true]
-t, --tty[=<TTY>]                  Allocate a PTY for the exec session. … [default: true]
```

The daemon then refused exactly that:

```
Error: daemon error: lns exec -t/-i against run devprobe is not yet supported
(input routing for exec sessions awaits an IPC discriminator); for now lns exec
supports non-interactive commands only
```

## Worse than reported

Because both defaults were `true`, the CLI sent `stdin: true` for a **flagless** exec too — so `lns exec devprobe -- ls` was refused as well. The evidence was already in the tree: every e2e exec step has to pass `-i=false -t=false` explicitly (`crates/e2e-tests/tests/steps/microvm.rs:434,1428`). The only exec that worked was one no human would type.

## And the refusal was hiding a worse bug

`run_stdin_pump` spawned regardless of the `stdin` flag, and `Request::RunStdin` carries the **run id** — which for an exec is the primary run's id, because `crates/lns-service/src/ipc/adapter.rs` parks the exec session's `input_tx` as `input_keepalive` without registering it. So bytes piped into a non-interactive exec were delivered to the run's own workload:

> **Given** a running sandbox R whose primary session is an interactive shell,
> **When** the user runs `printf 'echo pwned\n' | lns exec R -- sleep 1`,
> **Then** R's shell must not receive `echo pwned` — today it does, and runs it.

Reachable before this PR only via `-i=false` (the e2e form). Making flagless exec work would have made it the default path, so it is fixed here rather than deferred.

## The change

**Flags.** `default_value_t = false`, `hide = true`, and a `value_parser` that accepts only `false` and otherwise refuses at parse time with a message pointing at `lns attach`. `require_equals` / `default_missing_value` are kept, so `-i=false` still parses and a bare `-i` hits the refusal. `RunArgs` (for `lns run`) is untouched — its `-i`/`-t` still default true.

**Stdin routing.** A new `StdinForwarding { ToRun, Withheld }` threads from `exec_image`/`run_image` down to `plan_feed`, the pure decision function where the six sibling behaviours already live. When withheld, no `RunStdin` is ever produced — including the no-detector fast path and the EOF drain — while `Trigger` still emits `RunSignal`/`RunDetach`, so `--detach-keys` keeps working and does not flush the withheld bytes on its way out. `lns run -i=false` stops forwarding too, which is what `-i=false` means. `attach` passes `ToRun`.

**What is deliberately NOT here.** `validate_exec` stays as the daemon-side backstop. The lns-ipc wire defaults stay `true` so an older CLI keeps its meaning. The real interactive-exec feature (an exec-session discriminator on `Request::RunStdin` plus a session registry) is its own slice.

## Tests

Red proven for every assertion, not assumed:

- `exec_interactive_and_tty_default_to_false` failed on `assertion failed: !args.interactive`.
- `exec_refuses_a_session_it_cannot_route_input_to` failed with `-i must be refused at parse time`.
- The help scenario's first version passed even with `hide` removed, so it was tightened to assert `--interactive`/`--tty` are absent, watched fail, then fixed.
- Both stdin-forwarding tests are **mutation-proven**: making the `Withheld` arm emit `RunStdin` reddens the first; making the drain flush under `Withheld` reddens the chord test.

The two `-it`-cluster tests were rewritten, not deleted: they now prove the cluster still expands into `-i -t` so the user reads our refusal instead of clap's `unexpected argument '-it'`.

## Docs

`docs/cli-reference.md` and the `docs/running-workloads.md` exec section both promised `-i`/`-t` work as for `lns run`. Both now say the session is non-interactive, why, that `lns exec 7 -- bash` therefore exits at once, and that `lns attach` is the way to a live terminal. The subcommand's `about` line stopped saying "Open a new session".

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-cli" make coverage` all green — 32 files at 100%, 0 failures. 808/808 lib tests, 372/372 scenarios.

Fixes item 5 of the devbox findings.