### PR TITLE
fix: keep the ps listing when one guest stops answering

### DIFF
--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -575,8 +575,8 @@ async fn ps<W: std::io::Write>(
             })
             .await?
         {
-            Response::RunStats { stats } => stats,
-            Response::Error { message } => bail!("daemon error: {message}"),
+            Response::RunStats { stats } => Some(stats),
+            Response::Error { .. } => None,
             other => bail!("unexpected response from daemon: {other:?}"),
         };
         rows.push(PsRow::new(run, stats));
@@ -594,13 +594,15 @@ struct PsRow {
     command: String,
     status: lns_ipc::RunStatus,
     started: String,
-    cpu_permille: u32,
-    mem_used_bytes: u64,
-    mem_total_bytes: u64,
+    cpu_permille: Option<u32>,
+    mem_used_bytes: Option<u64>,
+    mem_total_bytes: Option<u64>,
 }
 
+const NO_SAMPLE: &str = "-";
+
 impl PsRow {
-    fn new(run: &lns_ipc::RunSummary, stats: RunStatsInfo) -> Self {
+    fn new(run: &lns_ipc::RunSummary, stats: Option<RunStatsInfo>) -> Self {
         Self {
             id: run.id.clone(),
             name: run.name.clone(),
@@ -608,9 +610,18 @@ impl PsRow {
             command: run.command.clone(),
             status: run.status,
             started: run.started.clone(),
-            cpu_permille: stats.cpu_permille,
-            mem_used_bytes: stats.mem_used_bytes,
-            mem_total_bytes: stats.mem_total_bytes,
+            cpu_permille: stats.as_ref().map(|s| s.cpu_permille),
+            mem_used_bytes: stats.as_ref().map(|s| s.mem_used_bytes),
+            mem_total_bytes: stats.as_ref().map(|s| s.mem_total_bytes),
+        }
+    }
+
+    fn memory_cell(&self) -> String {
+        match (self.mem_used_bytes, self.mem_total_bytes) {
+            (Some(used), Some(total)) => {
+                format!("{} / {}", format_bytes(used), format_bytes(total))
+            }
+            _ => NO_SAMPLE.to_string(),
         }
     }
 }
@@ -623,12 +634,9 @@ impl crate::output::TableRow for PsRow {
             lns_ipc::short_run_id(&self.id).to_string(),
             self.name.clone(),
             self.image.clone(),
-            format_permille(self.cpu_permille),
-            format!(
-                "{} / {}",
-                format_bytes(self.mem_used_bytes),
-                format_bytes(self.mem_total_bytes)
-            ),
+            self.cpu_permille
+                .map_or_else(|| NO_SAMPLE.to_string(), format_permille),
+            self.memory_cell(),
         ]
     }
 }
@@ -1857,23 +1865,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ps_surfaces_a_stats_error_and_rejects_an_unrelated_stats_variant() {
-        let err = ps(
+    async fn ps_keeps_a_run_whose_guest_stopped_answering_the_stats_probe() {
+        let mut out = Vec::new();
+        let code = ps(
             &CannedService::with_stats(
                 Response::RunList {
                     runs: vec![running_run()],
                 },
                 Response::Error {
-                    message: "stats probe failed".into(),
+                    message: "sampling guest stats failed: connect_to_guest_port(1029) timed out"
+                        .into(),
                 },
             ),
             &ps_args(),
-            &mut Vec::new(),
+            &mut out,
         )
         .await
-        .unwrap_err();
-        assert!(format!("{err:#}").contains("stats probe failed"));
+        .expect("a dead guest must not fail the whole listing");
+        let text = String::from_utf8(out).expect("utf8");
+        assert_eq!(code, 0);
+        let row = text
+            .lines()
+            .find(|l| l.contains("reviewer"))
+            .unwrap_or_else(|| panic!("row lost: {text}"));
+        let cells: Vec<&str> = row.split_whitespace().collect();
+        assert_eq!(
+            &cells[cells.len() - 2..],
+            [NO_SAMPLE, NO_SAMPLE],
+            "an unsampled CPU and MEM must each render as a cell, or the trailing-empty-cell \
+             trim shortens the row and misaligns it under the header: {row}"
+        );
+        assert!(
+            !text.contains("sampling guest stats failed"),
+            "scripted cleanup must stay quiet: {text}"
+        );
+    }
 
+    #[tokio::test]
+    async fn ps_rejects_a_stats_variant_that_is_neither_a_sample_nor_an_error() {
         let err = ps(
             &CannedService::with_stats(
                 Response::RunList {

--- a/crates/lns-cli/tests/behaviours/machine_output.feature
+++ b/crates/lns-cli/tests/behaviours/machine_output.feature
@@ -22,6 +22,23 @@ Feature: machine-readable output from the list verbs
     And JSON row 0 has "id" set to "00000003000000000000000000000000"
     And the output does not contain "000000030000  "
 
+  Scenario: ps nulls the stats of a run whose guest stopped answering
+    Given the service reports one running sandbox whose stats probe fails
+    When the user runs sandbox command "ps --format json"
+    Then the exit code is 0
+    And the output is a JSON array of 1 rows
+    And JSON row 0 has "name" set to "reviewer"
+    And JSON row 0 has a null "cpuPermille"
+    And JSON row 0 has a null "memUsedBytes"
+    And JSON row 0 has a null "memTotalBytes"
+
+  Scenario: the human table keeps a run whose guest stopped answering
+    Given the service reports one running sandbox whose stats probe fails
+    When the user runs sandbox command "ps"
+    Then the exit code is 0
+    And the output contains "reviewer"
+    And the output does not contain "sampling guest stats failed"
+
   Scenario: ps with nothing running is an empty array, not absent output
     Given the service reports no runs
     When the user runs sandbox command "ps --format json"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -518,6 +518,16 @@ fn canned_running_with_stats(w: &mut BehaviourWorld, permille: u32, used: u64) {
     });
 }
 
+#[given(regex = r"^the service reports one running sandbox whose stats probe fails$")]
+fn canned_running_with_a_failing_stats_probe(w: &mut BehaviourWorld) {
+    canned_running_with_stats(w, 0, 0);
+    w.sandbox.stats_response = Some(Response::Error {
+        message: "sampling guest stats failed: opening capture vsock to broker: \
+                  connect_to_guest_port(1029) timed out after 10s"
+            .into(),
+    });
+}
+
 #[given(regex = r"^the service reports no runs$")]
 fn canned_no_runs(w: &mut BehaviourWorld) {
     w.sandbox.response = Some(Response::RunList { runs: Vec::new() });

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -794,6 +794,10 @@ flagging a permissive default policy.
 `lns ps` lists running sandboxes with their CPU share and memory — the microVM is
 the workload, so the numbers cover everything the run is doing.
 
+A run whose guest has stopped answering — one you just killed, for instance —
+still gets a row, with `-` in place of its CPU and memory (`null` under
+`--format json`). One unresponsive guest never costs you the rest of the listing.
+
 ## Cleaning up the cache
 
 Cached sandboxes accumulate as you pull and build. Remove one with `lns rm` (a


### PR DESCRIPTION
## Problem

```
$ lns kill devprobe && lns ps
Error: daemon error: sampling guest stats failed: opening capture vsock to broker:
connect_to_guest_port(1029) timed out after 10s … The virtual machine is no longer live.
```

The report called this cosmetic. It is worse than that: **one dead run loses the whole listing.** `ps` filters to running runs, probes each for stats, and the `Response::Error => bail!` arm aborted before `output::emit`, so zero rows printed and the exit code was non-zero.

## Why a killed run still reads Running

`crates/lns-service/src/run/orchestrator.rs` calls `set_exit_code` only after the session future returns `Ok`, and a SIGKILL tears the vsock down first — so `?` short-circuits and the fallback has to wait for the `RunExit` frame to drain through the IPC pump. That window is what the reporter hit.

There is no transitional state to filter on: `RunStatus` is only `Running | Exited { code }`. So "skip runs already transitioning out" is not expressible — the fix has to be to make the probe best-effort instead.

## The change

| | before | after |
|---|---|---|
| stats probe fails | whole listing aborts, exit ≠ 0 | row kept, exit 0 |
| table cells | — | `-` for CPU and MEM |
| `--format json` | — | `null` for `cpuPermille`, `memUsedBytes`, `memTotalBytes` |

The JSON nulls are not a new contract: `machine_output.feature`'s own header and `docs/cli-reference.md` both already promise "every key is present (null when there is no value)".

Two error paths are deliberately **kept** hard-failing:

- an unexpected response variant — that is a protocol violation, not a dead guest;
- a failure to list the runs at all — losing the listing itself is a real error.

A run that exits fully between `ListRuns` and its probe is absorbed by the same path, which is the right answer for that race too.

## What this does not fix

`ps` still blocks up to 10s per dead run on the hardcoded capture-connect timeout in `vm/session_client/real.rs`. You now get the complete table after that wait instead of an error. Shrinking a stats-specific timeout belongs in a follow-up: that file is in the coverage IGNORES table and cannot be driven at Layer 2/3, so it would land untested here.

Also worth naming: every stats `Response::Error` is now treated as "unavailable", so a genuine service-side bug (`parsing guest stats failed`) shows `-` with no reason. `ps` is the only `RunStats` consumer and the service does not log it either — the honest fix is to log where the error is produced, which is a separate change.

## Tests

Red proven first: both new Layer 2 scenarios failed with `expected exit code 0, got 1 (output: "daemon error: sampling guest stats failed: … timed out after 10s")`.

The `-` sentinel is **mutation-proven** — setting it to `""` reddens the unit test, which asserts the row's last two whitespace-separated cells are exactly `-`. That matters: `output::write_row` trims trailing empty cells, so an empty MEM cell would shorten the row and misalign it under the header.

The existing combined test was split rather than deleted: the error half now asserts the opposite (the row survives), and the `Response::Pong` half keeps its `unwrap_err` pin.

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-cli" make coverage` all green — 32 files at 100%, 0 failures. 805/805 lib tests, 372/372 scenarios.

Fixes item 6 of the devbox findings.