### PR TITLE
fix: let a definition's HOME survive the run-as user

### DIFF
--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -36,7 +36,7 @@ pub fn compose_workload_env(
     let mut entries: Vec<(String, String)> = Vec::new();
     if let Some(image) = image_env {
         for kv in image {
-            if let Some((k, v)) = kv.split_once('=') {
+            if let Some((k, v)) = kv.split_once('=').filter(|(k, _)| !is_internal(k)) {
                 upsert(&mut entries, k, v);
             }
         }
@@ -46,6 +46,9 @@ pub fn compose_workload_env(
         let Some((k, v)) = kv.split_once('=') else {
             continue;
         };
+        if is_internal(k) {
+            continue;
+        }
         if is_run_managed(k, extra_managed) {
             refused.push(k.to_string());
             continue;
@@ -159,8 +162,29 @@ pub fn run_workload_env(
         composed
             .env
             .push(format!("TERM={SUPERVISOR_PTY_OPT_IN_TERM}"));
+        // Only what the author declared: an image's own ENV HOME must not outrank the run-as identity, or an unprivileged workload inherits a home it cannot write.
+        for key in ["HOME", "USER"] {
+            if let Some(value) = declared(user_env, key) {
+                composed
+                    .env
+                    .push(format!("LENS_SANDBOX_WORKLOAD_{key}={value}"));
+            }
+        }
     }
     composed
+}
+
+/// The supervisor reads its own instructions out of this prefix, so no image or `-e` may write one.
+fn is_internal(key: &str) -> bool {
+    key.starts_with("LENS_SANDBOX_")
+}
+
+fn declared<'a>(user_env: &'a [String], key: &str) -> Option<&'a str> {
+    let prefix = format!("{key}=");
+    user_env
+        .iter()
+        .rev()
+        .find_map(|entry| entry.strip_prefix(&prefix))
 }
 
 pub fn refusal_warning(key: &str) -> String {

--- a/crates/lns-service/tests/behaviours/run_as_env.feature
+++ b/crates/lns-service/tests/behaviours/run_as_env.feature
@@ -31,6 +31,10 @@ Feature: HOME and USER when the run-as user is not the author's user
     When the user runs `lns run someimage` under a policy
     Then the supervised workload env pins no declared HOME
 
+  Scenario: -e cannot forge the declaration either
+    When the user runs `lns run -e LENS_SANDBOX_WORKLOAD_HOME=/root someimage` under a policy
+    Then the supervised workload env pins no declared HOME
+
   Scenario: A run that declares nothing keeps the run-as user's own home
     When the user runs `lns run someimage` under a policy
     Then the supervised workload env pins no declared HOME

--- a/crates/lns-service/tests/behaviours/run_as_env.feature
+++ b/crates/lns-service/tests/behaviours/run_as_env.feature
@@ -1,0 +1,41 @@
+Feature: HOME and USER when the run-as user is not the author's user
+  A workload's HOME and USER come from the run-as user's guest passwd
+  entry. That is the right default, but it silently outranked what the
+  author declared: a definition setting HOME=/home/sandbox, run with
+  `-u root`, gave the workload HOME=/root and said nothing. What the
+  author declares now wins, and an image's own ENV HOME does not — an
+  image shipping ENV HOME=/root must never hand an unprivileged
+  workload a home it cannot write.
+
+  Scenario: A declared HOME is pinned through the supervised workload env
+    Given the definition declares env "HOME=/home/sandbox"
+    When the user runs `lns run someimage` under a policy
+    Then the supervised workload env pins the declared HOME to "/home/sandbox"
+
+  Scenario: -e declares a HOME just as the definition does
+    When the user runs `lns run -e HOME=/home/sandbox someimage` under a policy
+    Then the supervised workload env pins the declared HOME to "/home/sandbox"
+
+  Scenario: A declared USER is pinned the same way
+    Given the definition declares env "USER=builder"
+    When the user runs `lns run someimage` under a policy
+    Then the supervised workload env pins the declared USER to "builder"
+
+  Scenario: An image's ENV HOME is not a declaration and stays subordinate
+    Given the image declares ENV HOME=/root
+    When the user runs `lns run someimage` under a policy
+    Then the supervised workload env pins no declared HOME
+
+  Scenario: An image cannot forge the declaration itself
+    Given the image declares ENV LENS_SANDBOX_WORKLOAD_HOME=/root
+    When the user runs `lns run someimage` under a policy
+    Then the supervised workload env pins no declared HOME
+
+  Scenario: A run that declares nothing keeps the run-as user's own home
+    When the user runs `lns run someimage` under a policy
+    Then the supervised workload env pins no declared HOME
+
+  Scenario: An unsupervised run needs no marker, because nothing rewrites its HOME
+    Given the definition declares env "HOME=/home/sandbox"
+    When the user runs `lns run someimage` without a policy
+    Then the supervised workload env pins no declared HOME

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -12,6 +12,7 @@ pub mod ipc;
 pub mod oauth_connector;
 pub mod pkce_connector;
 pub mod policy_guardrail;
+pub mod run_as_env;
 pub mod run_lifecycle;
 pub mod run_naming;
 pub mod sandbox_filesets;

--- a/crates/lns-service/tests/behaviours/steps/run_as_env.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_as_env.rs
@@ -1,0 +1,38 @@
+use crate::world::BehaviourWorld;
+use cucumber::{given, then};
+
+#[given(regex = r#"^the definition declares env "([^=]+)=([^"]*)"$"#)]
+fn definition_declares_env(world: &mut BehaviourWorld, key: String, value: String) {
+    world.definition_env.push(format!("{key}={value}"));
+}
+
+#[then(regex = r#"^the supervised workload env pins the declared (HOME|USER) to "([^"]*)"$"#)]
+fn pins_declared(world: &mut BehaviourWorld, key: String, value: String) -> Result<(), String> {
+    let entry = format!("LENS_SANDBOX_WORKLOAD_{key}={value}");
+    let env = composed(world)?;
+    if env.contains(&entry) {
+        Ok(())
+    } else {
+        Err(format!("expected {entry:?} in {env:?}"))
+    }
+}
+
+#[then(regex = r"^the supervised workload env pins no declared HOME$")]
+fn pins_no_declared_home(world: &mut BehaviourWorld) -> Result<(), String> {
+    let env = composed(world)?;
+    match env
+        .iter()
+        .find(|e| e.starts_with("LENS_SANDBOX_WORKLOAD_HOME="))
+    {
+        Some(entry) => Err(format!("unexpected {entry:?} in {env:?}")),
+        None => Ok(()),
+    }
+}
+
+fn composed(world: &BehaviourWorld) -> Result<&Vec<String>, String> {
+    world
+        .composed_env
+        .as_ref()
+        .map(|c| &c.env)
+        .ok_or_else(|| "no workload env was composed".to_string())
+}

--- a/crates/lns-service/tests/behaviours/steps/workdir.rs
+++ b/crates/lns-service/tests/behaviours/steps/workdir.rs
@@ -46,7 +46,8 @@ fn user_runs_unsupervised(world: &mut BehaviourWorld, cmd: String) {
 }
 
 fn compose_run_env(world: &mut BehaviourWorld, cmd: &str, agent_command: Option<&str>) {
-    let user_env = flag_values(cmd, &["-e", "--env"]);
+    let mut user_env = world.definition_env.clone();
+    user_env.extend(flag_values(cmd, &["-e", "--env"]));
     let workdir =
         workload_cwd::resolve(cli_workdir(cmd).as_deref(), world.image_workdir.as_deref());
     world.composed_env = Some(run_workload_env(

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -38,6 +38,8 @@ pub struct BehaviourWorld {
     pub composed_env: Option<lns_service::workload_env::WorkloadEnv>,
     pub resolved_workdir: Option<Option<String>>,
     pub user_env: Vec<String>,
+    /// `spec.env` entries, merged ahead of `-e` exactly as `sandbox_launch` merges them.
+    pub definition_env: Vec<String>,
     /// Env vars a connected connector manages for the run; `-e` overrides of these are refused.
     pub managed_vars: Vec<String>,
 

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -205,15 +205,40 @@ fn build_agent_env(
         full_env.insert("http_proxy".into(), local_proxy);
     }
 
-    if let Some(creds) = creds {
-        full_env.insert("HOME".into(), creds.home().into());
-        full_env.insert("USER".into(), creds.user().into());
+    if let Some(home) = effective_home(env, creds) {
+        full_env.insert("HOME".into(), home);
+    }
+    if let Some(user) = effective_value(env, DECLARED_USER, creds.map(SandboxCredentials::user)) {
+        full_env.insert("USER".into(), user);
     }
 
     // Scrub after all layering so no source can reintroduce internal vars
     lens_sandbox_core::privilege::scrub_internal_vars(&mut full_env);
 
     full_env
+}
+
+const DECLARED_HOME: &str = "LENS_SANDBOX_WORKLOAD_HOME";
+const DECLARED_USER: &str = "LENS_SANDBOX_WORKLOAD_USER";
+
+fn effective_home(
+    env: &HashMap<String, String>,
+    creds: Option<&SandboxCredentials>,
+) -> Option<String> {
+    effective_value(env, DECLARED_HOME, creds.map(SandboxCredentials::home))
+}
+
+/// The service delivers the marker through the process env the broker execs us with, not the policy frame, so both sources are read before the scrub drops the prefix.
+fn effective_value(
+    env: &HashMap<String, String>,
+    declared_key: &str,
+    from_creds: Option<&str>,
+) -> Option<String> {
+    env.get(declared_key)
+        .cloned()
+        .or_else(|| std::env::var(declared_key).ok())
+        .filter(|declared| !declared.is_empty())
+        .or_else(|| from_creds.map(str::to_string))
 }
 
 /// Resolve the agent cwd: explicit `WORKSPACE_PATH`, else the post-setuid home, else ".".
@@ -237,7 +262,7 @@ pub(crate) fn agent_child_spec(
         argv: vec!["sh".into(), "-c".into(), config.agent_command.clone()],
         cwd: Some(resolve_cwd(
             config.workspace_path.as_deref(),
-            creds.map(|c| c.home()),
+            effective_home(env, creds).as_deref(),
         )),
         env: build_agent_env(config, creds, env),
         creds: crate::run_as::setuid_creds(creds),
@@ -382,6 +407,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn build_agent_env_inserts_home_and_user_from_creds() {
         // The Some(creds) arm must layer HOME/USER and survive the post-layering scrub.
         let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
@@ -392,6 +418,87 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
+    fn a_declared_home_outranks_the_run_as_users_passwd_home() {
+        let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
+        let config = make_agent_config();
+        let declared = HashMap::from([
+            (
+                "LENS_SANDBOX_WORKLOAD_HOME".to_string(),
+                "/home/sandbox".to_string(),
+            ),
+            (
+                "LENS_SANDBOX_WORKLOAD_USER".to_string(),
+                "builder".to_string(),
+            ),
+        ]);
+
+        let env = build_agent_env(&config, Some(&creds), &declared);
+
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/home/sandbox"));
+        assert_eq!(env.get("USER").map(String::as_str), Some("builder"));
+        assert!(
+            !env.keys().any(|k| k.starts_with("LENS_SANDBOX_")),
+            "the marker must never reach the workload"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn a_declared_home_is_also_the_agent_cwd_fallback() {
+        let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
+        let mut config = make_agent_config();
+        config.workspace_path = None;
+        let declared = HashMap::from([(
+            "LENS_SANDBOX_WORKLOAD_HOME".to_string(),
+            "/home/sandbox".to_string(),
+        )]);
+
+        let spec = agent_child_spec(&config, Some(&creds), &declared);
+
+        assert_eq!(spec.cwd.as_deref(), Some("/home/sandbox"));
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn the_marker_is_read_from_the_env_the_broker_execs_us_with() {
+        // SAFETY: serialized via #[serial(env)]; no other thread reads env during this body.
+        unsafe {
+            std::env::set_var("LENS_SANDBOX_WORKLOAD_HOME", "/home/sandbox");
+        }
+        let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
+        let mut config = make_agent_config();
+        config.workspace_path = None;
+
+        let spec = agent_child_spec(&config, Some(&creds), &HashMap::new());
+
+        // SAFETY: serialized via #[serial(env)]; no other thread reads env during this body.
+        unsafe {
+            std::env::remove_var("LENS_SANDBOX_WORKLOAD_HOME");
+        }
+        assert_eq!(
+            spec.env.get("HOME").map(String::as_str),
+            Some("/home/sandbox"),
+            "the policy frame carries no env, so the inherited env is the only place the marker arrives"
+        );
+        assert_eq!(spec.cwd.as_deref(), Some("/home/sandbox"));
+        assert!(!spec.env.keys().any(|k| k.starts_with("LENS_SANDBOX_")));
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn the_run_as_users_home_still_fills_an_undeclared_home() {
+        let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
+        let config = make_agent_config();
+
+        let env = build_agent_env(&config, Some(&creds), &HashMap::new());
+
+        assert_eq!(env.get("HOME").map(String::as_str), Some(creds.home()));
+        assert_eq!(env.get("USER").map(String::as_str), Some(creds.user()));
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
     fn a_root_run_as_keeps_its_identity_but_not_its_setuid() {
         let creds = SandboxCredentials::resolve_by_uid(0, 0).expect("uid 0 resolves on host");
         let mut config = make_agent_config();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -112,7 +112,7 @@ the `./lns.yaml` definition with its command overridden.
 | `-d`, `--detach`             | `false`          | Return immediately; the run continues in the service. Conflicts with `-i`/`-t`. |
 | `--rm`                       | `false`          | Remove the run record once the workload exits (Docker-style `--rm`).    |
 | `--detach-keys <CHORD>`      | `ctrl-p,ctrl-q`  | Detach chord (single chars or `ctrl-X`, comma-separated). On match `lns` returns `0` and leaves the run executing in the background — re-join with `lns attach`; no signal is sent. Killing `lns` without the chord cancels the run. |
-| `-u`, `--user <USER[:GROUP]>`|                  | Run-as user or uid inside the sandbox. Alias for `--sandbox-user` / `--sandbox-uid`; a numeric segment is used as the uid. |
+| `-u`, `--user <USER[:GROUP]>`|                  | Run-as user or uid inside the sandbox. Alias for `--sandbox-user` / `--sandbox-uid`; a numeric segment is used as the uid. `HOME` and `USER` follow that user's guest passwd entry unless the definition's `env:` or a `-e` declares them, which wins; an image's `ENV HOME` does not. |
 | `--sandbox-user <NAME>`      | image `USER`     | Username the workload runs as inside the guest (the unprivileged `sandbox` user when the image sets none). |
 | `--sandbox-uid <UID>`        | image `USER` uid | UID the workload runs as inside the guest. |
 | `--entrypoint <COMMAND>`     | image `ENTRYPOINT` | Override the image `ENTRYPOINT`; the `COMMAND` after the reference is kept as its arguments. Pass `--entrypoint ""` to clear the image entrypoint. |

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -206,6 +206,18 @@ segment is used as the uid), and `-h`/`--hostname` sets the guest hostname:
 lns run -u 1000:1000 -h build-box ghcr.io/acme/agent:1.0.0
 ```
 
+`HOME` and `USER` come from that user's guest passwd entry, so `-u root` normally
+gives the workload `HOME=/root`. A definition's `env:` or a `-e` on the command
+line overrides both — what you declare wins, and nothing rewrites it behind you.
+An image's own `ENV HOME` does not: an image shipping `ENV HOME=/root` must never
+hand an unprivileged workload a home it cannot write.
+
+```yaml
+spec:
+  env:
+    HOME: /home/sandbox     # kept, even under `lns run -u root`
+```
+
 ### Resources
 
 | Flag                          | Default | Meaning            |


### PR DESCRIPTION
## Problem

A definition declaring `HOME=/home/sandbox`, run with `-u root`, gives the workload `HOME=/root`. No warning, and `lns inspect` still reports `/home/sandbox`.

How it surfaced in the report: the definition mounted a work volume at `/home/sandbox/dev` and the boot script wrote `"$HOME/.zshrc"`. Because `$HOME` was `/root`, the rc landed at `/root/.zshrc` while the volume sat at `/home/sandbox/dev`, so its `source "$HOME/dev/zsh-profile/init.zsh"` pointed at nothing. The box came up fine and the profile just never loaded — **the failure was three steps from the cause.**

## Root cause

`build_agent_env` in the supervisor rebuilds the agent env from scratch and inserts

```rust
full_env.insert("HOME", creds.home());   // the run-as user's guest passwd entry
full_env.insert("USER", creds.user());
```

**last and unconditionally.** Nothing consulted what the author declared, so the run-as identity beat every env source.

Worth naming: the two paths disagreed. An **unsupervised** run already kept the declared HOME (nothing overrides the broker's putenv), a **supervised** one did not — so merely adding a policy silently changed HOME. Only HOME, USER and the agent's cwd fallback are derived this way; there is no `SHELL`/`LOGNAME` anywhere in the tree.

## Decision

Of the three options (declared wins silently / `-u` wins with a warning / refuse the run), the choice was **declared wins, silently** — it is the only one that also makes the supervised and unsupervised paths agree, so there is no surprise left to report.

## The change

The service marks what the author declared; the supervisor prefers that mark over the passwd entry, for HOME, USER, and `agent_child_spec`'s cwd fallback. A run that declares nothing is unchanged.

Two things the design is deliberately careful about:

- **Only `spec.env` and `-e` count as a declaration.** An image's `ENV HOME` does not: an image shipping `ENV HOME=/root` must never hand an unprivileged `-u sandbox` workload a home it cannot write. That asymmetry carries the diff's one comment, and a scenario exists purely to stop a future reader "simplifying" it.
- **No image or `-e` may forge the marker.** The composer drops the whole `LENS_SANDBOX_` prefix from both image env and user env before the service appends its own, so an image cannot write `LENS_SANDBOX_WORKLOAD_HOME=/root` and drive the agent's home. The prefix is also what keeps the marker out of every workload: core scrubs it from the agent env and the broker scrubs it from every confined session.

## The review caught two things worth reporting

1. **My first version was inert.** The supervisor read the marker from its `env` parameter — which in production is the policy-frame env, and `PolicyMessage` has no env field at all. The marker actually arrives in the **inherited process env** the broker execs the supervisor with. My unit tests passed only because they injected it where it never lives. The fix reads both sources; the new test uses an *empty* policy map and the real process env, and asserts the scrub still holds.

2. That fix immediately reddened the undeclared-HOME test through cross-test env leakage, so the five tests that depend on the marker's presence or absence now carry `#[serial(env)]`.

## Tests

Red proven first at both layers: the supervisor tests failed with `left: Some("/var/root") right: Some("/home/sandbox")`, and the Layer 2 scenarios with `expected "LENS_SANDBOX_WORKLOAD_HOME=/home/sandbox" in ["HOME=/home/sandbox", ...]`. The forgery scenario failed with `unexpected "LENS_SANDBOX_WORKLOAD_HOME=/root"`.

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-service lns-supervisor" make coverage` all green (lns-service 104 files at 100%, lns-supervisor 3 at 100%), plus `cargo clippy -p lns-supervisor --target aarch64-unknown-linux-musl --all-targets -- -D warnings` — the guest crate's real target, which a macOS-only lint does not cover. 193/193 scenarios, 2084/2084 service lib tests, 43/43 supervisor tests.

Fixes item 3 of the devbox findings. Item 9 (exec sessions get none of `spec.env`) is separate and still open: an exec is confined and inherits the broker's env, so it still sees `HOME=/`.