### PR TITLE
fix: report the resources a run will boot with, not the flags

### DIFF
--- a/crates/lns-artifact/src/lib.rs
+++ b/crates/lns-artifact/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod memory;
 pub mod registry;
+pub mod resources;
 pub mod sandbox;
 pub mod spec;
 pub mod tools;

--- a/crates/lns-artifact/src/resources.rs
+++ b/crates/lns-artifact/src/resources.rs
@@ -1,0 +1,353 @@
+use crate::spec::{Quantity, Resources};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmSize {
+    pub cpus: u8,
+    pub mem_mib: usize,
+}
+
+pub const DEFAULT_VM_SIZE: VmSize = VmSize {
+    cpus: 1,
+    mem_mib: 512,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResourceOverrides {
+    pub cpus: Option<u8>,
+    pub mem_mib: Option<usize>,
+}
+
+/// What a definition asked for, already read and range-checked — `None` where it asked for nothing the host can grant.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DeclaredSize {
+    pub cpus: Option<u8>,
+    pub mem_mib: Option<usize>,
+}
+
+/// The size a run boots with, from the same expression wherever it is asked — a flag beats the definition, which beats the built-in default.
+pub fn resolve_declared(
+    declared: DeclaredSize,
+    overrides: &ResourceOverrides,
+    defaults: VmSize,
+) -> VmSize {
+    VmSize {
+        cpus: overrides.cpus.or(declared.cpus).unwrap_or(defaults.cpus),
+        mem_mib: overrides
+            .mem_mib
+            .or(declared.mem_mib)
+            .unwrap_or(defaults.mem_mib),
+    }
+}
+
+impl DeclaredSize {
+    /// The `ignored` field names each request the host will not grant, so the caller that owns a log can say so.
+    pub fn from_resources(resources: Option<&Resources>) -> (Self, Vec<&'static str>) {
+        let mut ignored = Vec::new();
+        let cpus = read(resources.and_then(|r| r.cpu.as_ref()), quantity_to_cpus);
+        let mem_mib = read(resources.and_then(|r| r.memory.as_ref()), quantity_to_mib);
+        if cpus.asked_and_refused {
+            ignored.push("cpu");
+        }
+        if mem_mib.asked_and_refused {
+            ignored.push("memory");
+        }
+        (
+            Self {
+                cpus: cpus.value,
+                mem_mib: mem_mib.value,
+            },
+            ignored,
+        )
+    }
+}
+
+struct Read<T> {
+    value: Option<T>,
+    asked_and_refused: bool,
+}
+
+fn read<T>(quantity: Option<&Quantity>, parse: impl Fn(&Quantity) -> Option<T>) -> Read<T> {
+    match quantity {
+        None => Read {
+            value: None,
+            asked_and_refused: false,
+        },
+        Some(quantity) => {
+            let value = parse(quantity);
+            Read {
+                asked_and_refused: value.is_none(),
+                value,
+            }
+        }
+    }
+}
+
+fn quantity_to_cpus(quantity: &Quantity) -> Option<u8> {
+    let whole = match quantity {
+        Quantity::Int(n) => u32::try_from(*n).ok()?,
+        Quantity::Text(text) => parse_cpu_text(text)?,
+    };
+    (1..=u32::from(u8::MAX))
+        .contains(&whole)
+        .then_some(whole as u8)
+}
+
+fn parse_cpu_text(text: &str) -> Option<u32> {
+    let text = text.trim();
+    match text.strip_suffix('m') {
+        Some(millis) => millis.parse::<u32>().ok().map(|m| m.div_ceil(1000)),
+        None => text.parse::<u32>().ok(),
+    }
+}
+
+/// Ceiling on an artifact-declared VM memory size; a greedy or adversarial sandbox can't size the guest past this and starve the host (a user who genuinely needs more passes `-m` explicitly).
+pub const MAX_MEM_MIB: usize = 256 * 1024;
+
+fn quantity_to_mib(quantity: &Quantity) -> Option<usize> {
+    let mib = match quantity {
+        Quantity::Int(n) => usize::try_from(*n).ok(),
+        Quantity::Text(text) => crate::memory::parse_mib(text).ok(),
+    };
+    mib.filter(|mib| (1..=MAX_MEM_MIB).contains(mib))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolve(
+        resources: Option<&Resources>,
+        overrides: &ResourceOverrides,
+        defaults: VmSize,
+    ) -> VmSize {
+        let (declared, _) = DeclaredSize::from_resources(resources);
+        resolve_declared(declared, overrides, defaults)
+    }
+
+    #[test]
+    fn an_absent_sandbox_size_falls_back_to_defaults() {
+        let size = resolve(None, &ResourceOverrides::default(), DEFAULT_VM_SIZE);
+        assert_eq!(size, DEFAULT_VM_SIZE);
+    }
+
+    #[test]
+    fn a_flag_outranks_the_definition_which_outranks_the_default() {
+        let declared = DeclaredSize {
+            cpus: Some(3),
+            mem_mib: Some(6144),
+        };
+        assert_eq!(
+            resolve_declared(declared, &ResourceOverrides::default(), DEFAULT_VM_SIZE),
+            VmSize {
+                cpus: 3,
+                mem_mib: 6144
+            }
+        );
+        assert_eq!(
+            resolve_declared(
+                declared,
+                &ResourceOverrides {
+                    cpus: Some(2),
+                    mem_mib: None
+                },
+                DEFAULT_VM_SIZE
+            ),
+            VmSize {
+                cpus: 2,
+                mem_mib: 6144
+            },
+            "a flag must win without dragging the other field down to the default"
+        );
+        assert_eq!(
+            resolve_declared(
+                DeclaredSize::default(),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            ),
+            DEFAULT_VM_SIZE
+        );
+    }
+
+    #[test]
+    fn a_text_quantity_with_units_is_understood() {
+        let res = Resources {
+            cpu: Some(Quantity::Text("2".into())),
+            memory: Some(Quantity::Text("2Gi".into())),
+        };
+        let size = resolve(Some(&res), &ResourceOverrides::default(), DEFAULT_VM_SIZE);
+        assert_eq!(
+            size,
+            VmSize {
+                cpus: 2,
+                mem_mib: 2048
+            }
+        );
+    }
+
+    #[test]
+    fn millicore_cpu_rounds_up_and_units_or_plain_memory_are_mib() {
+        let res = Resources {
+            cpu: Some(Quantity::Text("1500m".into())),
+            memory: Some(Quantity::Text("768Mi".into())),
+        };
+        let size = resolve(Some(&res), &ResourceOverrides::default(), DEFAULT_VM_SIZE);
+        assert_eq!(
+            size,
+            VmSize {
+                cpus: 2,
+                mem_mib: 768
+            }
+        );
+
+        let plain = Resources {
+            cpu: None,
+            memory: Some(Quantity::Text("640".into())),
+        };
+        assert_eq!(
+            resolve(Some(&plain), &ResourceOverrides::default(), DEFAULT_VM_SIZE).mem_mib,
+            640
+        );
+    }
+
+    #[test]
+    fn a_definition_reads_every_size_the_mem_flag_accepts() {
+        for (text, mem_mib) in [
+            ("38Gi", 38912),
+            ("38gi", 38912),
+            ("38GiB", 38912),
+            ("2g", 2048),
+            ("2GB", 2048),
+            ("512m", 512),
+            ("768Mi", 768),
+            ("1024k", 1),
+            ("640", 640),
+        ] {
+            let res = Resources {
+                cpu: None,
+                memory: Some(Quantity::Text(text.into())),
+            };
+            assert_eq!(
+                resolve(Some(&res), &ResourceOverrides::default(), DEFAULT_VM_SIZE).mem_mib,
+                mem_mib,
+                "memory: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unparseable_or_out_of_range_quantity_falls_back_to_defaults() {
+        let res = Resources {
+            cpu: Some(Quantity::Int(0)),
+            memory: Some(Quantity::Text("lots".into())),
+        };
+        let size = resolve(Some(&res), &ResourceOverrides::default(), DEFAULT_VM_SIZE);
+        assert_eq!(size, DEFAULT_VM_SIZE);
+
+        let too_many = Resources {
+            cpu: Some(Quantity::Int(9000)),
+            memory: Some(Quantity::Int(-4)),
+        };
+        assert_eq!(
+            resolve(
+                Some(&too_many),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            ),
+            DEFAULT_VM_SIZE
+        );
+    }
+
+    #[test]
+    fn a_memory_request_over_the_ceiling_or_that_overflows_falls_back_to_defaults() {
+        let over_ceiling = Resources {
+            cpu: None,
+            memory: Some(Quantity::Text("999999Gi".into())),
+        };
+        assert_eq!(
+            resolve(
+                Some(&over_ceiling),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            )
+            .mem_mib,
+            DEFAULT_VM_SIZE.mem_mib,
+            "an artifact must not size the guest past the ceiling and starve the host"
+        );
+
+        let overflowing = Resources {
+            cpu: None,
+            memory: Some(Quantity::Text(format!("{}Gi", usize::MAX))),
+        };
+        assert_eq!(
+            resolve(
+                Some(&overflowing),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            )
+            .mem_mib,
+            DEFAULT_VM_SIZE.mem_mib,
+            "a Gi value whose *1024 overflows must fall back, not wrap to garbage"
+        );
+
+        let huge_int = Resources {
+            cpu: None,
+            memory: Some(Quantity::Int(i64::MAX)),
+        };
+        assert_eq!(
+            resolve(
+                Some(&huge_int),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            )
+            .mem_mib,
+            DEFAULT_VM_SIZE.mem_mib
+        );
+
+        let at_ceiling = Resources {
+            cpu: None,
+            memory: Some(Quantity::Int(MAX_MEM_MIB as i64)),
+        };
+        assert_eq!(
+            resolve(
+                Some(&at_ceiling),
+                &ResourceOverrides::default(),
+                DEFAULT_VM_SIZE
+            )
+            .mem_mib,
+            MAX_MEM_MIB,
+            "a request exactly at the ceiling is honored"
+        );
+    }
+
+    #[test]
+    fn a_request_the_host_will_not_grant_is_named_so_the_caller_can_say_so() {
+        let refused = Resources {
+            cpu: Some(Quantity::Int(9000)),
+            memory: Some(Quantity::Text("999999Gi".into())),
+        };
+        let (declared, ignored) = DeclaredSize::from_resources(Some(&refused));
+        assert_eq!(declared, DeclaredSize::default());
+        assert_eq!(ignored, vec!["cpu", "memory"]);
+
+        let honoured = Resources {
+            cpu: Some(Quantity::Int(2)),
+            memory: Some(Quantity::Text("2Gi".into())),
+        };
+        let (declared, ignored) = DeclaredSize::from_resources(Some(&honoured));
+        assert_eq!(
+            declared,
+            DeclaredSize {
+                cpus: Some(2),
+                mem_mib: Some(2048)
+            }
+        );
+        assert!(ignored.is_empty());
+
+        let (declared, ignored) = DeclaredSize::from_resources(None);
+        assert_eq!(declared, DeclaredSize::default());
+        assert!(
+            ignored.is_empty(),
+            "asking for nothing is not a refused request"
+        );
+    }
+}

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -247,16 +247,16 @@ pub struct RunArgs {
     pub cmd: Vec<String>,
 }
 
-pub const DEFAULT_CPUS: u8 = 1;
-pub const DEFAULT_MEM_MIB: usize = 512;
-
 impl RunArgs {
+    /// What the wire carries beside `cpus_explicit`; the summary prints the resolved size instead, which a definition can raise.
     pub fn effective_cpus(&self) -> u8 {
-        self.cpus.unwrap_or(DEFAULT_CPUS)
+        self.cpus
+            .unwrap_or(lns_artifact::resources::DEFAULT_VM_SIZE.cpus)
     }
 
     pub fn effective_mem(&self) -> usize {
-        self.mem.unwrap_or(DEFAULT_MEM_MIB)
+        self.mem
+            .unwrap_or(lns_artifact::resources::DEFAULT_VM_SIZE.mem_mib)
     }
 
     pub fn effective_sandbox_user(&self) -> Option<String> {
@@ -582,6 +582,21 @@ mod tests {
         let mut full = vec!["exec"];
         full.extend_from_slice(argv);
         ExecHarness::try_parse_from(full).map(|h| h.args)
+    }
+
+    #[test]
+    fn the_wire_size_is_the_flag_or_the_built_in_default() {
+        let flagless = parse_run(&["someimage"]).expect("defaults parse");
+        assert_eq!(flagless.effective_cpus(), 1);
+        assert_eq!(flagless.effective_mem(), 512);
+        assert!(
+            flagless.cpus.is_none() && flagless.mem.is_none(),
+            "the wire must stay able to say the user asked for nothing, or a definition can no longer outrank a flag"
+        );
+
+        let flagged = parse_run(&["--cpus", "4", "-m", "2g", "someimage"]).expect("flags parse");
+        assert_eq!(flagged.effective_cpus(), 4);
+        assert_eq!(flagged.effective_mem(), 2048);
     }
 
     #[test]

--- a/crates/lns-cli/src/run/declarative.rs
+++ b/crates/lns-cli/src/run/declarative.rs
@@ -23,11 +23,16 @@ pub struct Defaults {
     pub workdir: Option<String>,
     pub mounts: Vec<MountDefault>,
     pub ports: Vec<PortDefault>,
+    pub size: lns_artifact::resources::DeclaredSize,
 }
 
 impl Defaults {
     pub fn from_definition(definition: &lns_artifact::sandbox::Definition) -> Self {
+        let (size, _) = lns_artifact::resources::DeclaredSize::from_resources(
+            definition.spec.resources.as_ref(),
+        );
         Self {
+            size,
             workdir: definition.spec.workdir.clone(),
             mounts: definition
                 .spec
@@ -54,6 +59,10 @@ impl Defaults {
 
     pub fn from_view(view: &lns_ipc::SandboxView) -> Self {
         Self {
+            size: lns_artifact::resources::DeclaredSize {
+                cpus: view.cpus,
+                mem_mib: view.mem_mib,
+            },
             workdir: view.workdir.clone(),
             mounts: view
                 .mounts

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -52,21 +52,38 @@ pub fn resolve_policy(explicit: Option<&Path>, cwd: &Path) -> Result<(PathBuf, P
     }
 }
 
+/// The size the run will boot with: an explicit flag outranks what the definition declared, which outranks the built-in default.
+pub fn resolved_size(
+    declared: lns_artifact::resources::DeclaredSize,
+    args: &RunArgs,
+) -> lns_artifact::resources::VmSize {
+    lns_artifact::resources::resolve_declared(
+        declared,
+        &lns_artifact::resources::ResourceOverrides {
+            cpus: args.cpus,
+            mem_mib: args.mem,
+        },
+        lns_artifact::resources::DEFAULT_VM_SIZE,
+    )
+}
+
 pub fn print_run_summary(
     args: &RunArgs,
+    size: lns_artifact::resources::VmSize,
     cwd: &Path,
     writer: &mut impl io::Write,
 ) -> Result<PathBuf> {
     let (path, source) = resolve_policy(args.policy.as_deref(), cwd)?;
     let policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
-    let body = format_summary(args, &policy, &path, &source);
+    let body = format_summary(args, size, &policy, &path, &source);
     writer.write_all(body.as_bytes())?;
     Ok(path)
 }
 
 pub fn format_summary(
     args: &RunArgs,
+    size: lns_artifact::resources::VmSize,
     policy: &Policy,
     policy_path: &Path,
     source: &PolicySource,
@@ -90,13 +107,7 @@ pub fn format_summary(
     if let Some(dir) = &args.workdir {
         writeln!(s, "  Workdir:   {dir}").unwrap();
     }
-    writeln!(
-        s,
-        "  Resources: {} vCPU · {} MiB",
-        args.effective_cpus(),
-        args.effective_mem()
-    )
-    .unwrap();
+    writeln!(s, "  Resources: {} vCPU · {} MiB", size.cpus, size.mem_mib).unwrap();
     writeln!(s, "  Flags:     {}", flags_line(args)).unwrap();
     writeln!(s, "  Ports:     {}", ports_line(args)).unwrap();
     if !args.declared_unpublished.is_empty() {
@@ -313,7 +324,18 @@ fn source_line(source: &PolicySource) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lns_artifact::resources::{DEFAULT_VM_SIZE, VmSize};
     use lns_policy::{RouteRule, TcpEgressRule};
+
+    /// Most lines are indifferent to the size, so they read the built-in default; the resources line has its own tests.
+    fn summary_of(
+        args: &RunArgs,
+        policy: &Policy,
+        policy_path: &Path,
+        source: &PolicySource,
+    ) -> String {
+        format_summary(args, DEFAULT_VM_SIZE, policy, policy_path, source)
+    }
 
     fn run_args(image: Option<&str>) -> RunArgs {
         RunArgs {
@@ -361,7 +383,7 @@ mod tests {
     fn summary_with_publish(ports: Vec<lns_ipc::PortPublish>) -> String {
         let mut args = run_args(Some("prism"));
         args.publish = ports;
-        format_summary(
+        summary_of(
             &args,
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
@@ -443,6 +465,8 @@ mod tests {
             credentials: Vec::new(),
             tools: Vec::new(),
             policy_flags: Vec::new(),
+            cpus: None,
+            mem_mib: None,
         };
 
         assert_eq!(
@@ -469,7 +493,7 @@ mod tests {
     fn tools_line_lists_declared_tools_and_is_absent_without_them() {
         let mut args = run_args(Some("prism"));
         args.tools = vec!["node@22.11.0".into(), "python@3.12.6".into()];
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
@@ -525,7 +549,7 @@ mod tests {
     #[test]
     fn summary_lists_image_resources_flags_and_policy_block() {
         let args = run_args(Some("ubuntu"));
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/home/dev/my-app/lns-policy.yaml"),
@@ -552,7 +576,7 @@ mod tests {
                 read_only: true,
             }),
         ];
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -576,7 +600,7 @@ mod tests {
             target: "/work".into(),
             read_only: false,
         })];
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -596,7 +620,7 @@ mod tests {
             target: "/cfg".into(),
             read_only: true,
         })];
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -638,7 +662,7 @@ mod tests {
     fn summary_lists_the_requested_workdir() {
         let mut args = run_args(Some("ubuntu"));
         args.workdir = Some("/app".into());
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -649,7 +673,7 @@ mod tests {
 
     #[test]
     fn summary_omits_workdir_line_when_unset() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -660,7 +684,7 @@ mod tests {
 
     #[test]
     fn summary_omits_volume_line_when_none_attached() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -672,7 +696,7 @@ mod tests {
     #[test]
     fn image_field_shows_resolving_placeholder_until_service_confirms_digest() {
         let args = run_args(Some("ubuntu"));
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -684,7 +708,7 @@ mod tests {
     #[test]
     fn no_reference_run_shows_the_local_definition_as_the_image() {
         let args = run_args(None);
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -701,7 +725,7 @@ mod tests {
     fn a_file_selector_run_shows_the_selected_definition_as_the_image() {
         let mut args = run_args(None);
         args.file = Some(std::path::PathBuf::from("lns.dev.yaml"));
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -712,8 +736,8 @@ mod tests {
     }
 
     #[test]
-    fn resources_line_falls_back_to_one_vcpu_and_512_mib_when_nothing_is_requested() {
-        let s = format_summary(
+    fn resources_line_renders_the_size_the_run_will_boot_with() {
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -723,17 +747,23 @@ mod tests {
     }
 
     #[test]
-    fn resources_line_renders_cpu_and_memory_with_units() {
-        let mut args = run_args(Some("ubuntu"));
-        args.cpus = Some(4);
-        args.mem = Some(2048);
+    fn resources_line_reports_the_resolved_size_not_the_flags() {
+        let args = run_args(Some("ubuntu"));
+        assert!(
+            args.cpus.is_none() && args.mem.is_none(),
+            "the point of this test is that no flag was passed"
+        );
         let s = format_summary(
             &args,
+            VmSize {
+                cpus: 3,
+                mem_mib: 6144,
+            },
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
             &PolicySource::FoundInCwd,
         );
-        assert!(s.contains("4 vCPU · 2048 MiB"), "resources line wrong: {s}");
+        assert!(s.contains("3 vCPU · 6144 MiB"), "resources line wrong: {s}");
     }
 
     #[test]
@@ -742,7 +772,7 @@ mod tests {
         args.interactive = true;
         args.tty = true;
         args.detach = false;
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -757,7 +787,7 @@ mod tests {
         args.interactive = false;
         args.tty = false;
         args.detach = true;
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -770,7 +800,7 @@ mod tests {
     fn flags_line_includes_auto_remove_when_set() {
         let mut args = run_args(Some("ubuntu"));
         args.auto_remove = true;
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -785,7 +815,7 @@ mod tests {
         args.interactive = false;
         args.tty = false;
         args.detach = false;
-        let s = format_summary(
+        let s = summary_of(
             &args,
             &Policy::default(),
             Path::new("/x/lns-policy.yaml"),
@@ -801,7 +831,7 @@ mod tests {
         let mut policy = Policy::default();
         policy.add_rule(RouteRule::allow_host("api.example.test"));
         policy.add_rule(RouteRule::deny_host("*"));
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-policy.yaml"),
@@ -821,7 +851,7 @@ mod tests {
         policy.add_rule(RouteRule::allow_host("api.example.com"));
         policy.add_rule(RouteRule::allow_host("registry.npmjs.org"));
         policy.add_rule(RouteRule::deny_host("evil.example"));
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-policy.yaml"),
@@ -847,7 +877,7 @@ mod tests {
             .egress
             .tcp
             .push(TcpEgressRule::allow_destination("0.0.0.0/0:5432"));
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-policy.yaml"),
@@ -867,7 +897,7 @@ mod tests {
             .egress
             .tcp
             .push(TcpEgressRule::allow_destination("db.internal:5432"));
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-policy.yaml"),
@@ -881,7 +911,7 @@ mod tests {
 
     #[test]
     fn rules_line_says_none_defined_for_an_empty_route_list() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
@@ -898,7 +928,7 @@ mod tests {
         let mut policy = Policy::default();
         policy.add_rule(RouteRule::allow_host("api.linear.app"));
         policy.add_rule(RouteRule::deny_host("evil.example"));
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-policy.yaml"),
@@ -909,7 +939,7 @@ mod tests {
 
     #[test]
     fn source_line_for_found_in_cwd_reads_found_in_this_directory() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
@@ -920,7 +950,7 @@ mod tests {
 
     #[test]
     fn source_line_for_auto_created_calls_out_no_policy_in_directory() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
@@ -931,7 +961,7 @@ mod tests {
 
     #[test]
     fn source_line_for_explicit_flag_quotes_the_passed_path() {
-        let s = format_summary(
+        let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/home/ops/team-policy.yaml"),
@@ -1010,7 +1040,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let args = run_args(Some("ubuntu"));
         let mut buf = Vec::<u8>::new();
-        let path = print_run_summary(&args, dir.path(), &mut buf).unwrap();
+        let path = print_run_summary(
+            &args,
+            resolved_size(Default::default(), &args),
+            dir.path(),
+            &mut buf,
+        )
+        .unwrap();
         assert_eq!(path, dir.path().join(DEFAULT_POLICY_FILENAME));
         let text = String::from_utf8(buf).unwrap();
         assert!(text.contains("lns run"));

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -1249,6 +1249,8 @@ mod tests {
                 credentials: Vec::new(),
                 tools,
                 policy_flags: Vec::new(),
+                cpus: None,
+                mem_mib: None,
             })),
         }
     }
@@ -2000,6 +2002,8 @@ mod tests {
                     credentials: Vec::new(),
                     tools: vec!["node@22.11.0".into()],
                     policy_flags: Vec::new(),
+                    cpus: None,
+                    mem_mib: None,
                 })),
             },
         );

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -253,12 +253,14 @@ pub async fn run_image(
         (_, Some(published)) => published.tools.clone(),
         _ => Vec::new(),
     };
+    // The size travels as its own value: writing it back into args.cpus/args.mem would tell the service the user asked for it explicitly.
+    let size = crate::run::summary::resolved_size(defaults.size, &args);
     let quiet = args.quiet;
     let resolved_policy = if quiet {
         let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), &cwd)?;
         path
     } else {
-        print_run_summary(&args, &cwd, &mut std::io::stderr())?
+        print_run_summary(&args, size, &cwd, &mut std::io::stderr())?
     };
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
@@ -1150,6 +1152,8 @@ mod tests {
                 credentials: Vec::new(),
                 tools: Vec::new(),
                 policy_flags: Vec::new(),
+                cpus: None,
+                mem_mib: None,
             })),
         )
         .unwrap();
@@ -1202,6 +1206,8 @@ mod tests {
                 credentials: Vec::new(),
                 tools: Vec::new(),
                 policy_flags: Vec::new(),
+                cpus: None,
+                mem_mib: None,
             })),
         )
         .unwrap_err();

--- a/crates/lns-cli/tests/behaviours/run_resources.feature
+++ b/crates/lns-cli/tests/behaviours/run_resources.feature
@@ -2,7 +2,29 @@ Feature: lns run resource limits — vCPU count and memory size flags
   `lns run --cpus N` and `lns run -m SIZE` bound the microVM's resources,
   mirroring `docker run --cpus`/`-m`. Memory accepts Docker-style unit
   suffixes and zero-sized resources are rejected at the CLI boundary, so a
-  typo never boots an unbootable VM.
+  typo never boots an unbootable VM. A definition's `spec.resources` is the
+  other source, and the summary reports what the run will actually boot
+  with — not just what the flags said.
+
+  Scenario: The summary reports the definition's resources, not the flag fallback
+    Given an lns.yaml declaring 3 vCPU and 6Gi of memory
+    When the local run summary is composed with no resource flags
+    Then the run summary shows "Resources: 3 vCPU · 6144 MiB"
+
+  Scenario: An explicit flag outranks the definition in the summary
+    Given an lns.yaml declaring 3 vCPU and 6Gi of memory
+    When the local run summary is composed with "--cpus 2"
+    Then the run summary shows "Resources: 2 vCPU · 6144 MiB"
+
+  Scenario: A published sandbox's declared resources reach the summary
+    Given an lns.yaml declaring 3 vCPU and 6Gi of memory
+    When the published run summary is composed with no resource flags
+    Then the run summary shows "Resources: 3 vCPU · 6144 MiB"
+
+  Scenario: A definition that declares no resources still shows the built-in default
+    Given an lns.yaml declaring no resources
+    When the local run summary is composed with no resource flags
+    Then the run summary shows "Resources: 1 vCPU · 512 MiB"
 
   Scenario: Zero vCPUs is rejected before the run starts
     When the user runs `lns run --cpus 0 someimage`

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -74,7 +74,13 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
     }
     let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut buf).expect("print_run_summary");
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut buf,
+    )
+    .expect("print_run_summary");
     world.summary_output = String::from_utf8(buf).expect("non-utf8 summary output");
 }
 
@@ -101,6 +107,8 @@ fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     });
 }
 
@@ -127,6 +135,8 @@ fn pulled_view_with_inline_fileset(world: &mut BehaviourWorld, mount: String) {
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     });
 }
 
@@ -141,7 +151,13 @@ fn pulled_run_prepared(world: &mut BehaviourWorld) {
     }
     let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut buf).expect("print_run_summary");
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut buf,
+    )
+    .expect("print_run_summary");
     world.summary_output = String::from_utf8(buf).expect("non-utf8 summary output");
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -57,6 +57,8 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }
 }
 
@@ -80,7 +82,13 @@ fn summarize(world: &mut BehaviourWorld, defaults: &Defaults, flags: &str, local
     }
     let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut buf).expect("print_run_summary");
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut buf,
+    )
+    .expect("print_run_summary");
     world.summary_output = String::from_utf8(buf).expect("non-utf8 summary output");
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -84,6 +84,60 @@ fn resolve_defaults(world: &mut BehaviourWorld, defaults: &Defaults, project: &P
     });
 }
 
+#[given(regex = r"^an lns.yaml declaring 3 vCPU and 6Gi of memory$")]
+fn declares_resources(world: &mut BehaviourWorld) {
+    install_definition(world, "  resources:\n    cpu: 3\n    memory: 6Gi\n");
+}
+
+#[given(regex = r"^an lns.yaml declaring no resources$")]
+fn declares_no_resources(world: &mut BehaviourWorld) {
+    install_definition(world, "");
+}
+
+fn install_definition(world: &mut BehaviourWorld, extra_spec: &str) {
+    world.author_files.insert(
+        Path::new("/work/lns.yaml").to_path_buf(),
+        format!(
+            "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: some-sandbox\nspec:\n  image: example.test/runtime:1\n{extra_spec}"
+        ),
+    );
+}
+
+#[when(regex = r"^the local run summary is composed with no resource flags$")]
+fn compose_local_summary(world: &mut BehaviourWorld) {
+    let defaults = Defaults::from_definition(&definition(world));
+    compose_summary(world, defaults, "");
+}
+
+#[when(regex = r#"^the local run summary is composed with "([^"]+)"$"#)]
+fn compose_local_summary_with(world: &mut BehaviourWorld, flags: String) {
+    let defaults = Defaults::from_definition(&definition(world));
+    compose_summary(world, defaults, &flags);
+}
+
+#[when(regex = r"^the published run summary is composed with no resource flags$")]
+fn compose_published_summary(world: &mut BehaviourWorld) {
+    let defaults = Defaults::from_view(&published_view(&definition(world)));
+    compose_summary(world, defaults, "");
+}
+
+fn compose_summary(world: &mut BehaviourWorld, defaults: Defaults, flags: &str) {
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    let args: RunArgs = parse_args(&argv).expect("override flags must parse");
+    let size = lns_cli::run::summary::resolved_size(defaults.size, &args);
+    world.resolved_run = Some(ResolvedRunView {
+        summary: lns_cli::run::summary::format_summary(
+            &args,
+            size,
+            &lns_policy::Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &lns_cli::run::summary::PolicySource::FoundInCwd,
+        ),
+        ..Default::default()
+    });
+}
+
 #[when("the local sandbox launch settings are resolved with no overrides")]
 fn resolve_local_without_overrides(world: &mut BehaviourWorld) {
     let defaults = Defaults::from_definition(&definition(world));
@@ -98,8 +152,15 @@ fn resolve_local_with_overrides(world: &mut BehaviourWorld, flags: String) {
 
 #[when(regex = r#"^the published sandbox launch settings are resolved from "([^"]+)"$"#)]
 fn resolve_published(world: &mut BehaviourWorld, project: String) {
-    let def = definition(world);
-    let view = lns_ipc::SandboxView {
+    let view = published_view(&definition(world));
+    resolve_defaults(world, &Defaults::from_view(&view), Path::new(&project), "");
+}
+
+/// The view the service projects for a pulled sandbox, so a published run's defaults come from the same shape a real preflight returns.
+fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxView {
+    let (declared, _) =
+        lns_artifact::resources::DeclaredSize::from_resources(def.spec.resources.as_ref());
+    lns_ipc::SandboxView {
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),
@@ -126,8 +187,9 @@ fn resolve_published(world: &mut BehaviourWorld, project: String) {
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
-    };
-    resolve_defaults(world, &Defaults::from_view(&view), Path::new(&project), "");
+        cpus: declared.cpus,
+        mem_mib: declared.mem_mib,
+    }
 }
 
 struct FakeDir {

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -78,6 +78,8 @@ fn published_sandbox_declaring_tools(w: &mut BehaviourWorld) {
         credentials: Vec::new(),
         tools: PINNED_TOOLS.iter().map(ToString::to_string).collect(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     };
     w.sandbox.response = Some(Response::Error {
         message: format!("no active run with id {TOOLS_REFERENCE}"),
@@ -141,7 +143,13 @@ fn run_summary_discloses_tools(w: &mut BehaviourWorld) -> Result<(), String> {
     }
     let cwd = w.cwd.as_ref().ok_or("cwd")?.path().to_path_buf();
     let mut buf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut buf).map_err(|e| format!("{e:#}"))?;
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut buf,
+    )
+    .map_err(|e| format!("{e:#}"))?;
     let summary = String::from_utf8_lossy(&buf).into_owned();
     let expected = format!("Tools:     {}", PINNED_TOOLS.join(", "));
     if summary.contains(&expected) {

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -137,6 +137,7 @@ fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
             let args: RunArgs = parse_args(&argv).expect("argv must parse");
             let mut text = format_summary(
                 &args,
+                lns_cli::run::summary::resolved_size(Default::default(), &args),
                 &Policy::default(),
                 Path::new("./lns-policy.yaml"),
                 &PolicySource::FoundInCwd,

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -201,7 +201,13 @@ async fn the_run_starts(world: &mut BehaviourWorld) {
     let cwd = require_cwd(world).to_path_buf();
     let args = parse_argv(&world.argv);
     let mut buf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut buf).expect("print_run_summary");
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut buf,
+    )
+    .expect("print_run_summary");
     world.summary_output = String::from_utf8(buf).expect("non-utf8 summary output");
 
     drive_canned_sequence(world).await;
@@ -491,7 +497,13 @@ async fn resolution_fails(world: &mut BehaviourWorld) {
     let cwd = require_cwd(world).to_path_buf();
     let args = parse_argv(&world.argv);
     let mut sbuf = Vec::<u8>::new();
-    print_run_summary(&args, &cwd, &mut sbuf).expect("print_run_summary");
+    print_run_summary(
+        &args,
+        lns_cli::run::summary::resolved_size(Default::default(), &args),
+        &cwd,
+        &mut sbuf,
+    )
+    .expect("print_run_summary");
     world.summary_output = String::from_utf8(sbuf).expect("non-utf8 summary");
 
     let err_frame = encode_frame(&Response::RunLog {

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -25,6 +25,7 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
     world.resolved_run = Some(ResolvedRunView {
         summary: format_summary(
             &resolved,
+            lns_cli::run::summary::resolved_size(Default::default(), &resolved),
             &Policy::default(),
             Path::new("./lns-policy.yaml"),
             &PolicySource::FoundInCwd,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -57,6 +57,8 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }
@@ -87,6 +89,8 @@ fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }
@@ -117,6 +121,8 @@ fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, moun
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }
@@ -169,6 +175,8 @@ fn inspects_sandbox_credential_with_requirement(
         }],
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }
@@ -192,6 +200,8 @@ fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: Str
         policy_flags: vec![
             "wildcard allow — a catch-all or whole-suffix host pattern is permitted".into(),
         ],
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }
@@ -211,6 +221,8 @@ fn inspects_sandbox_env(world: &mut BehaviourWorld, reference: String, entry: St
         credentials: Vec::new(),
         tools: Vec::new(),
         policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
     }));
     cached_artifact(world, &reference, inspection);
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -46,6 +46,8 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
             credentials: Vec::new(),
             tools: Vec::new(),
             policy_flags: Vec::new(),
+            cpus: None,
+            mem_mib: None,
         })),
     });
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -75,6 +75,8 @@ fn registry_serves_sandbox(w: &mut BehaviourWorld, reference: String) {
             credentials: Vec::new(),
             tools: Vec::new(),
             policy_flags: Vec::new(),
+            cpus: None,
+            mem_mib: None,
         })),
     });
 }
@@ -151,6 +153,7 @@ fn run_resolved(w: &mut BehaviourWorld, args: RunArgs, target: &RunTarget, cwd: 
     if let Some(policy) = args.policy.as_deref() {
         w.summary_output = format_summary(
             &args,
+            lns_cli::run::summary::resolved_size(Default::default(), &args),
             &Policy::default(),
             &cwd.join(policy),
             &PolicySource::Explicit(policy.to_path_buf()),

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -289,6 +289,11 @@ pub struct SandboxView {
     pub tools: Vec<String>,
     #[serde(default)]
     pub policy_flags: Vec<String>,
+    /// What the sandbox declared, not what it resolves to — `None` must stay distinguishable from "declared exactly the default", or a flag can no longer outrank a declaration.
+    #[serde(default)]
+    pub cpus: Option<u8>,
+    #[serde(default)]
+    pub mem_mib: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1383,6 +1388,8 @@ mod tests {
             }],
             tools: vec!["node@22.11.0".into()],
             policy_flags: Vec::new(),
+            cpus: Some(3),
+            mem_mib: Some(6144),
         };
         let response = Response::ImageInspected {
             inspection: ArtifactInspection::Sandbox(Box::new(view)),

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -37,10 +37,14 @@ pub(crate) fn project_inspection(
             let def = lns_artifact::sandbox::parse(config_json.as_bytes())
                 .with_context(|| format!("inspecting sandbox {image_ref}"))?;
             let resolved = resolved_from_sandbox(&def);
+            let (declared_size, _) =
+                lns_artifact::resources::DeclaredSize::from_resources(def.spec.resources.as_ref());
             Ok(ArtifactInspection::Sandbox(Box::new(
                 lns_ipc::SandboxView {
                     reference: image_ref.to_string(),
                     digest,
+                    cpus: declared_size.cpus,
+                    mem_mib: declared_size.mem_mib,
                     image: resolved.base_image,
                     workdir: def.spec.workdir.clone(),
                     mounts: def
@@ -179,6 +183,50 @@ mod tests {
         );
     }
 
+    /// The projection of a bare sandbox that declares nothing but an image, so a test can vary one field and compare whole values.
+    fn bare_sandbox_view(cpus: Option<u8>, mem_mib: Option<usize>) -> ArtifactInspection {
+        ArtifactInspection::Sandbox(Box::new(SandboxView {
+            reference: "registry.example.test/team/sandbox:latest".into(),
+            digest: digest(),
+            image: "registry.example.test/runtime:1".into(),
+            workdir: None,
+            mounts: Vec::new(),
+            ports: Vec::new(),
+            filesets: Vec::new(),
+            connectors: Vec::new(),
+            env: Vec::new(),
+            credentials: Vec::new(),
+            tools: Vec::new(),
+            policy_flags: Vec::new(),
+            cpus,
+            mem_mib,
+        }))
+    }
+
+    #[test]
+    fn a_sandbox_projects_the_size_it_declared_so_a_pulled_run_can_report_it() {
+        assert_eq!(
+            project_sandbox(
+                r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","resources":{"cpu":3,"memory":"6Gi"}}}"#
+            )
+            .unwrap(),
+            bare_sandbox_view(Some(3), Some(6144)),
+            "without this the summary of a pulled run falls back to the default size"
+        );
+    }
+
+    #[test]
+    fn a_sandbox_that_declares_no_size_projects_none_not_the_default() {
+        assert_eq!(
+            project_sandbox(
+                r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1"}}"#
+            )
+            .unwrap(),
+            bare_sandbox_view(None, None),
+            "None must stay distinguishable from a declared default, or a flag can no longer outrank a declaration"
+        );
+    }
+
     #[test]
     fn a_sandbox_projects_its_volumes_ports_filesets_and_over_broad_policy_flag() {
         let config = r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","workdir":"/work","volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","name":"cache","target":"/root/.cache","readOnly":true}],"ports":[{"container":8080},{"host":9090,"container":3000}],"filesets":[{"ref":"registry.example.test/team/skills@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mountPath":"/root/.agent/skills"},{"inline":{"settings.json":"do-not-print"},"mountPath":"/etc/agent","owner":"root"}],"policy":{"egress":{"http":[{"match":"*","verdict":"allow"}]}}}}"#;
@@ -242,6 +290,8 @@ mod tests {
                 policy_flags: vec![
                     "wildcard allow — a catch-all or whole-suffix host pattern is permitted".into()
                 ],
+                cpus: None,
+                mem_mib: None,
             }))
         );
     }
@@ -271,6 +321,8 @@ mod tests {
                 }],
                 tools: vec![],
                 policy_flags: vec![],
+                cpus: None,
+                mem_mib: None,
             }))
         );
     }
@@ -296,6 +348,8 @@ mod tests {
                 credentials: vec![],
                 tools: vec!["node@22.11.0".into(), "python@3.12.6".into()],
                 policy_flags: vec![],
+                cpus: None,
+                mem_mib: None,
             }))
         );
     }
@@ -321,6 +375,8 @@ mod tests {
                 credentials: vec![],
                 tools: vec![],
                 policy_flags: vec![],
+                cpus: None,
+                mem_mib: None,
             }))
         );
     }

--- a/crates/lns-service/src/artifact/resources.rs
+++ b/crates/lns-service/src/artifact/resources.rs
@@ -1,129 +1,25 @@
-use lns_artifact::spec::{Quantity, Resources};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct VmSize {
-    pub cpus: u8,
-    pub mem_mib: usize,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ResourceOverrides {
-    pub cpus: Option<u8>,
-    pub mem_mib: Option<usize>,
-}
+use lns_artifact::resources::{DeclaredSize, ResourceOverrides, VmSize, resolve_declared};
+use lns_artifact::spec::Resources;
 
 pub fn resolve_size(
     sandbox: Option<&Resources>,
     overrides: &ResourceOverrides,
     defaults: VmSize,
 ) -> VmSize {
-    let sandbox_cpus = sandbox
-        .and_then(|r| r.cpu.as_ref())
-        .and_then(quantity_to_cpus);
-    let sandbox_mem = sandbox
-        .and_then(|r| r.memory.as_ref())
-        .and_then(quantity_to_mib);
-    VmSize {
-        cpus: overrides.cpus.or(sandbox_cpus).unwrap_or(defaults.cpus),
-        mem_mib: overrides
-            .mem_mib
-            .or(sandbox_mem)
-            .unwrap_or(defaults.mem_mib),
+    let (declared, ignored) = DeclaredSize::from_resources(sandbox);
+    for field in ignored {
+        crate::log::warn!(
+            "resources.{field} is not a size this host will grant; using the default instead"
+        );
     }
-}
-
-fn quantity_to_cpus(quantity: &Quantity) -> Option<u8> {
-    let whole = match quantity {
-        Quantity::Int(n) => u32::try_from(*n).ok()?,
-        Quantity::Text(text) => parse_cpu_text(text)?,
-    };
-    (1..=u32::from(u8::MAX))
-        .contains(&whole)
-        .then_some(whole as u8)
-}
-
-fn parse_cpu_text(text: &str) -> Option<u32> {
-    let text = text.trim();
-    match text.strip_suffix('m') {
-        Some(millis) => millis.parse::<u32>().ok().map(|m| m.div_ceil(1000)),
-        None => text.parse::<u32>().ok(),
-    }
-}
-
-/// Ceiling on an artifact-declared VM memory size; a greedy or adversarial sandbox can't size the guest past this and starve the host (a user who genuinely needs more passes `-m` explicitly).
-const MAX_MEM_MIB: usize = 256 * 1024;
-
-fn quantity_to_mib(quantity: &Quantity) -> Option<usize> {
-    let mib = match quantity {
-        Quantity::Int(n) => usize::try_from(*n).ok(),
-        Quantity::Text(text) => lns_artifact::memory::parse_mib(text).ok(),
-    };
-    match mib {
-        Some(mib) if (1..=MAX_MEM_MIB).contains(&mib) => Some(mib),
-        _ => {
-            crate::log::warn!(
-                "memory request {quantity:?} is not a size this host will grant; using the default instead"
-            );
-            None
-        }
-    }
+    resolve_declared(declared, overrides, defaults)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const DEFAULTS: VmSize = VmSize {
-        cpus: 1,
-        mem_mib: 512,
-    };
-
-    #[test]
-    fn an_absent_sandbox_size_falls_back_to_defaults() {
-        let size = resolve_size(None, &ResourceOverrides::default(), DEFAULTS);
-        assert_eq!(size, DEFAULTS);
-    }
-
-    #[test]
-    fn a_text_quantity_with_units_is_understood() {
-        let res = Resources {
-            cpu: Some(Quantity::Text("2".into())),
-            memory: Some(Quantity::Text("2Gi".into())),
-        };
-        let size = resolve_size(Some(&res), &ResourceOverrides::default(), DEFAULTS);
-        assert_eq!(
-            size,
-            VmSize {
-                cpus: 2,
-                mem_mib: 2048
-            }
-        );
-    }
-
-    #[test]
-    fn millicore_cpu_rounds_up_and_units_or_plain_memory_are_mib() {
-        let res = Resources {
-            cpu: Some(Quantity::Text("1500m".into())),
-            memory: Some(Quantity::Text("768Mi".into())),
-        };
-        let size = resolve_size(Some(&res), &ResourceOverrides::default(), DEFAULTS);
-        assert_eq!(
-            size,
-            VmSize {
-                cpus: 2,
-                mem_mib: 768
-            }
-        );
-
-        let plain = Resources {
-            cpu: None,
-            memory: Some(Quantity::Text("640".into())),
-        };
-        assert_eq!(
-            resolve_size(Some(&plain), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-            640
-        );
-    }
+    use lns_artifact::resources::DEFAULT_VM_SIZE;
+    use lns_artifact::spec::Quantity;
 
     #[derive(Default)]
     struct MessageCapture(std::sync::Mutex<Vec<String>>);
@@ -164,108 +60,50 @@ mod tests {
     }
 
     #[test]
-    fn a_memory_request_this_host_will_not_grant_is_said_out_loud() {
+    fn a_request_this_host_will_not_grant_is_said_out_loud_per_field() {
         let over_ceiling = Resources {
-            cpu: None,
+            cpu: Some(Quantity::Int(9000)),
             memory: Some(Quantity::Text("999999Gi".into())),
         };
         let messages = captured_messages(|| {
             assert_eq!(
-                resolve_size(Some(&over_ceiling), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-                DEFAULTS.mem_mib
+                resolve_size(
+                    Some(&over_ceiling),
+                    &ResourceOverrides::default(),
+                    DEFAULT_VM_SIZE
+                ),
+                DEFAULT_VM_SIZE
             );
         });
-        assert!(
-            messages
-                .iter()
-                .any(|m| m.contains("not a size this host will grant")),
-            "an ignored memory request must not be silent; got: {messages:?}"
-        );
-    }
-
-    #[test]
-    fn a_definition_reads_every_size_the_mem_flag_accepts() {
-        for (text, mem_mib) in [
-            ("38Gi", 38912),
-            ("38gi", 38912),
-            ("38GiB", 38912),
-            ("2g", 2048),
-            ("2GB", 2048),
-            ("512m", 512),
-            ("768Mi", 768),
-            ("1024k", 1),
-            ("640", 640),
-        ] {
-            let res = Resources {
-                cpu: None,
-                memory: Some(Quantity::Text(text.into())),
-            };
-            assert_eq!(
-                resolve_size(Some(&res), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-                mem_mib,
-                "memory: {text}"
+        for field in ["resources.cpu", "resources.memory"] {
+            assert!(
+                messages
+                    .iter()
+                    .any(|m| m.contains(&format!("{field} is not a size this host will grant"))),
+                "an ignored {field} must not be silent; got: {messages:?}"
             );
         }
     }
 
     #[test]
-    fn an_unparseable_or_out_of_range_quantity_falls_back_to_defaults() {
-        let res = Resources {
-            cpu: Some(Quantity::Int(0)),
-            memory: Some(Quantity::Text("lots".into())),
+    fn a_size_the_host_grants_says_nothing() {
+        let honoured = Resources {
+            cpu: Some(Quantity::Int(3)),
+            memory: Some(Quantity::Text("6Gi".into())),
         };
-        let size = resolve_size(Some(&res), &ResourceOverrides::default(), DEFAULTS);
-        assert_eq!(size, DEFAULTS);
-
-        let too_many = Resources {
-            cpu: Some(Quantity::Int(9000)),
-            memory: Some(Quantity::Int(-4)),
-        };
-        assert_eq!(
-            resolve_size(Some(&too_many), &ResourceOverrides::default(), DEFAULTS),
-            DEFAULTS
-        );
-    }
-
-    #[test]
-    fn a_memory_request_over_the_ceiling_or_that_overflows_falls_back_to_defaults() {
-        let over_ceiling = Resources {
-            cpu: None,
-            memory: Some(Quantity::Text("999999Gi".into())),
-        };
-        assert_eq!(
-            resolve_size(Some(&over_ceiling), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-            DEFAULTS.mem_mib,
-            "an artifact must not size the guest past the ceiling and starve the host"
-        );
-
-        let overflowing = Resources {
-            cpu: None,
-            memory: Some(Quantity::Text(format!("{}Gi", usize::MAX))),
-        };
-        assert_eq!(
-            resolve_size(Some(&overflowing), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-            DEFAULTS.mem_mib,
-            "a Gi value whose *1024 overflows must fall back, not wrap to garbage"
-        );
-
-        let huge_int = Resources {
-            cpu: None,
-            memory: Some(Quantity::Int(i64::MAX)),
-        };
-        assert_eq!(
-            resolve_size(Some(&huge_int), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-            DEFAULTS.mem_mib
-        );
-
-        let at_ceiling = Resources {
-            cpu: None,
-            memory: Some(Quantity::Int(MAX_MEM_MIB as i64)),
-        };
-        assert_eq!(
-            resolve_size(Some(&at_ceiling), &ResourceOverrides::default(), DEFAULTS).mem_mib,
-            MAX_MEM_MIB,
-            "a request exactly at the ceiling is honored"
-        );
+        let messages = captured_messages(|| {
+            assert_eq!(
+                resolve_size(
+                    Some(&honoured),
+                    &ResourceOverrides::default(),
+                    DEFAULT_VM_SIZE
+                ),
+                VmSize {
+                    cpus: 3,
+                    mem_mib: 6144
+                }
+            );
+        });
+        assert!(messages.is_empty(), "got: {messages:?}");
     }
 }

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -106,21 +106,13 @@ pub(super) fn sandbox_vm_size(
     requested_mem_mib: usize,
     mem_explicit: bool,
 ) -> (u8, usize) {
-    use crate::artifact::resources::{ResourceOverrides, VmSize, resolve_size};
-    const DEFAULT_CPUS: u8 = 1;
-    const DEFAULT_MEM_MIB: usize = 512;
+    use crate::artifact::resources::resolve_size;
+    use lns_artifact::resources::{DEFAULT_VM_SIZE, ResourceOverrides};
     let overrides = ResourceOverrides {
         cpus: cpus_explicit.then_some(requested_cpus),
         mem_mib: mem_explicit.then_some(requested_mem_mib),
     };
-    let size = resolve_size(
-        resources,
-        &overrides,
-        VmSize {
-            cpus: DEFAULT_CPUS,
-            mem_mib: DEFAULT_MEM_MIB,
-        },
-    );
+    let size = resolve_size(resources, &overrides, DEFAULT_VM_SIZE);
     (size.cpus, size.mem_mib)
 }
 


### PR DESCRIPTION
## Problem

A definition asking for 3 vCPU / 6 GiB displays:

```
  Resources: 1 vCPU · 512 MiB
```

while `lns inspect` on the same run correctly reports `cpus: 3, memMib: 6144`. From the report: *"I chased this as a bug in resource resolution before checking `inspect`."*

## Root cause

`summary.rs` called `args.effective_cpus()` / `args.effective_mem()`, which know only the CLI Options. Resolution happens **service-side, strictly after the summary is printed** — the CLI sends the raw flags plus an explicitness bit, the service resolves `flag > spec.resources > default`, and records the pair for `lns inspect`. `Defaults::from_definition` dropped `spec.resources` on the floor, so the CLI never had the number.

I checked every other summary line: `Resources` is the only one with this bug. Workdir, volumes, binds, ports, filesets and tools are all resolved *before* the summary. Env and user print no line at all, so they claim nothing.

## The change

Giving the CLI its own copy of the precedence is how this class of bug recurs, so instead there is **one resolver with three callers**.

- New `crates/lns-artifact/src/resources.rs` owns `VmSize`, `DEFAULT_VM_SIZE`, `ResourceOverrides`, `DeclaredSize::from_resources`, `resolve_declared`, the cpu/memory quantity parsing and `MAX_MEM_MIB`.
- The service's `artifact/resources.rs` shrinks to a wrapper that keeps the host-ceiling **warning** — logging goes through `crate::log`, which is not lns-artifact's business — and delegates the precedence. `from_resources` returns the fields it refused so the caller that owns a log can say so, and the CLI can stay silent.
- `SandboxView` gains `cpus`/`mem_mib` as `Option`, filled by `project_inspection`, so a **published** sandbox's declared size reaches the CLI too. `Option` is load-bearing: `None` must stay distinguishable from "declared exactly the default".
- `summary::resolved_size(declared, args)` is the single place the precedence is applied, used by production and by every test step.

### The trap this deliberately avoids

The tempting minimal fix is to write the resolved numbers into `args.cpus` / `args.mem` before the summary, mirroring how `args.workdir` and `args.mounts` are already overwritten. That is wrong: `cpus_explicit` / `mem_explicit` are derived from those same Options, so a definition-derived value would reach the service labelled *"the user asked for this explicitly"*. The numbers happen to match today, so **no test would catch it.** The size travels as its own value; the wire is untouched.

## Behaviour change worth knowing

The wrapper now also warns when a **cpu** request is refused, where before only memory did. Both are pinned.

## Tests

Both halves of the fix are mutation-proven, because I wrote the scenarios and the change together rather than red-first:

- mutating `Defaults::from_definition` to stop reading `spec.resources` reddens the two definition-driven scenarios (`got Resources: 1 vCPU · 512 MiB`);
- mutating `project_inspection` to emit `None`/`None` reddens the new inspect test — the review caught that this second half originally survived every test, which would have left half the bug unpinned.

`effective_cpus`/`effective_mem` kept a test of their own, since they still serve the wire: it also pins that a flagless parse leaves `None`, which is what keeps a flag able to outrank a declaration.

## Known gap, not fixed here

The CLI discards the refused-field list, so a definition asking for `999999Gi` shows the default in the summary with no explanation — only the service log says why. Worth a follow-up.

## Gate

`make lint`, `make complexity`, and **full** `make coverage` all green — every one of the 14 crates at 100% with 0 failures. 378/378 CLI scenarios plus the whole workspace suite.

Fixes item 8 of the devbox findings.