### PR TITLE
fix: let an exec session join the run it names

### DIFF
--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -561,7 +561,7 @@ async fn handle_run(mut stream: UnixStream, args: lns_ipc::RunImageArgs) -> anyh
             status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
             logs,
             config,
-            tools: Default::default(),
+            exec_environment: Default::default(),
         },
     );
     drop(runtime_cache_registration);

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -477,13 +477,12 @@ pub(super) fn build_session_params(
     args: lns_ipc::ExecImageArgs,
     run_id: &str,
 ) -> crate::vm::session_client::SessionParams {
-    let mut env = args.env;
-    // The run's declared tools reach exec through the same rule the workload's PATH was built with; the image's own PATH additions are not part of an exec session, which inherits the guest default.
-    crate::workload_env::compose_guest_tool_env(&mut env, &crate::run_registry::tools(run_id));
+    let exec_environment = crate::run_registry::exec_environment(run_id);
+    let env = crate::workload_env::exec_session_env(&exec_environment, &args.env);
     crate::vm::session_client::SessionParams {
         argv: args.argv,
         env,
-        cwd: None,
+        cwd: exec_environment.workdir,
         hostname: None,
         tty: args.tty,
         stdin: args.stdin,
@@ -930,7 +929,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tools: Default::default(),
+                exec_environment: Default::default(),
             },
         );
 
@@ -1290,7 +1289,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tools: Default::default(),
+            exec_environment: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
         let resp = handle_request(
@@ -1325,7 +1324,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tools: Default::default(),
+            exec_environment: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
 
@@ -1381,7 +1380,7 @@ mod tests {
             status: Mutex::new(lns_ipc::RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tools: Default::default(),
+            exec_environment: Default::default(),
         };
         crate::run_registry::register(run_id.clone(), handle);
 
@@ -1470,7 +1469,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tools: Default::default(),
+                exec_environment: Default::default(),
             },
         );
     }
@@ -1818,7 +1817,7 @@ mod tests {
                 status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
                 logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
                 config: lns_ipc::RunConfig::default(),
-                tools: Default::default(),
+                exec_environment: Default::default(),
             },
         );
 
@@ -1891,10 +1890,10 @@ mod tests {
         };
         let params = build_session_params(args, "1");
         assert_eq!(params.argv, vec!["echo".to_string()]);
-        assert_eq!(params.env, vec!["A=B".to_string()]);
+        assert!(params.env.contains(&"A=B".to_string()));
         assert_eq!(
             params.cwd, None,
-            "exec sessions run in the broker's default cwd"
+            "a run with no stored environment forces no working directory"
         );
         let ws = params.initial_winsize.expect("winsize should be mapped");
         assert_eq!((ws.rows, ws.cols), (24, 80));
@@ -1947,7 +1946,7 @@ mod tests {
 
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tools = tools.clone();
+        handle.exec_environment.tools = tools.clone();
         crate::run_registry::register_named(run_id.clone(), None, handle).expect("register");
         let mut args = exec_args(vec!["node".into()], false, false);
         args.env = vec!["PATH=/usr/bin".into()];
@@ -1971,6 +1970,58 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
+    async fn an_exec_session_joins_the_runs_own_environment() {
+        let run_id = crate::run_registry::allocate_run_id();
+        let (mut handle, _cancel) = crate::run_registry::test_handle();
+        handle.exec_environment = crate::run_registry::ExecEnvironment {
+            session_env: vec![
+                "HOME=/workspace".into(),
+                "SHELL=/bin/bash".into(),
+                "SOME_TOOL_HOME=/workspace/mine".into(),
+            ],
+            workdir: Some("/workspace".into()),
+            tools: crate::workload_env::ToolRuntime {
+                bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
+                env: vec![(
+                    "SOME_TOOL_HOME".into(),
+                    "/.lens/tools/some-tool/1.2.3/home".into(),
+                )],
+            },
+            ..Default::default()
+        };
+        crate::run_registry::register_named(run_id.clone(), None, handle).expect("register");
+
+        let args = exec_args(vec!["printenv".into()], false, false);
+        assert!(args.env.is_empty(), "the CLI sends no env for an exec");
+        let params = build_session_params(args, &run_id);
+        crate::run_registry::deregister(&run_id);
+
+        assert!(
+            params.env.contains(&"HOME=/workspace".to_string()),
+            "a diagnostic command that has to re-export HOME is not in the same sandbox: {:?}",
+            params.env
+        );
+        assert!(
+            params.env.contains(&"SHELL=/bin/bash".to_string()),
+            "got: {:?}",
+            params.env
+        );
+        assert!(
+            params
+                .env
+                .contains(&"SOME_TOOL_HOME=/workspace/mine".to_string()),
+            "the definition's own value must win over the tool tree's: {:?}",
+            params.env
+        );
+        assert_eq!(
+            params.cwd.as_deref(),
+            Some("/workspace"),
+            "an exec starting in / makes `sh -lc` write to the wrong place"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(global_runs)]
     async fn an_exec_carrying_no_env_still_puts_the_runs_tool_dirs_first() {
         // What `lns exec` actually sends is an empty env, so the composed PATH has to hold up on that input and not just on a hand-supplied one.
         let tools = crate::workload_env::ToolRuntime {
@@ -1979,7 +2030,7 @@ mod tests {
         };
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tools = tools.clone();
+        handle.exec_environment.tools = tools.clone();
         crate::run_registry::register_named(run_id.clone(), None, handle).expect("register");
         let args = exec_args(vec!["node".into()], false, false);
         assert!(args.env.is_empty(), "the CLI sends no env for exec");
@@ -2003,7 +2054,7 @@ mod tests {
         // `lns ps` shows names and the docs use them, so a name that loses the tool PATH is the common path, not the edge case.
         let run_id = crate::run_registry::allocate_run_id();
         let (mut handle, _cancel) = crate::run_registry::test_handle();
-        handle.tools = crate::workload_env::ToolRuntime {
+        handle.exec_environment.tools = crate::workload_env::ToolRuntime {
             bin_paths: vec!["/.lens/tools/node/22.11.0/bin".to_string()],
             env: Vec::new(),
         };

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -453,8 +453,15 @@ async fn orchestrate(
             }))
             .await;
     }
-    // What an `lns exec` into this run may re-apply: a var the definition already owns kept its own value here, and exec composes against an empty env, so only what took effect travels.
-    let applied_tools = tool_runtime.as_applied(&composed.env);
+    let exec_environment = crate::run_registry::ExecEnvironment {
+        session_env: composed.env.clone(),
+        tools: tool_runtime,
+        placeholders: session
+            .as_ref()
+            .map(|s| s.placeholder_env.clone())
+            .unwrap_or_default(),
+        workdir: workdir.clone(),
+    };
     let env: Vec<String> = composed.env;
 
     let params = vm::session_client::SessionParams {
@@ -502,10 +509,10 @@ async fn orchestrate(
         "microVM   ({:.2}s)",
         boot_start.elapsed().as_secs_f64()
     );
-    crate::run_registry::set_connector_with_tools(
+    crate::run_registry::set_connector_with_environment(
         &run_id,
         connector.clone(),
-        applied_tools.clone(),
+        exec_environment,
     );
     let _vm_stop_guard = vm::VmStopGuard::new(connector.clone());
 

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -30,8 +30,20 @@ pub struct RunHandle {
     pub status: std::sync::Mutex<RunStatus>,
     pub logs: std::sync::Arc<crate::run_log::RunLogBuffer>,
     pub config: lns_ipc::RunConfig,
-    /// What this run's declared tools contribute to its guest environment, so `lns exec` into the same guest resolves them the way the workload does.
+    /// Everything an `lns exec` into this run needs to land in the same sandbox the workload is in.
+    pub exec_environment: ExecEnvironment,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExecEnvironment {
+    /// The run's resolved workload env, so a diagnostic command does not have to re-export it by hand.
+    pub session_env: Vec<String>,
+    /// What this run's declared tools contribute, so `lns exec` resolves them the way the workload does.
     pub tools: crate::workload_env::ToolRuntime,
+    /// `env_var=placeholder` for each connector that seeds one, so an exec can exercise a token path the workload uses without ever holding the real value.
+    pub placeholders: Vec<(String, String)>,
+    /// The workload's working directory; `docker exec` inherits it, and an exec in `/` makes `sh -lc` write to the wrong place.
+    pub workdir: Option<String>,
 }
 
 pub fn allocate_run_id() -> String {
@@ -198,11 +210,11 @@ pub fn connector(run_id: &str) -> Option<std::sync::Arc<dyn GuestTransport>> {
         .and_then(|h| h.connector.clone())
 }
 
-pub fn tools(run_id: &str) -> crate::workload_env::ToolRuntime {
+pub fn exec_environment(run_id: &str) -> ExecEnvironment {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     g.as_ref()
         .and_then(|m| m.get(run_id))
-        .map(|h| h.tools.clone())
+        .map(|h| h.exec_environment.clone())
         .unwrap_or_default()
 }
 
@@ -213,15 +225,15 @@ pub fn set_connector(run_id: &str, connector: std::sync::Arc<dyn GuestTransport>
     }
 }
 
-/// The connector is what makes a run exec-able, so a run that has declared tools publishes both in one mutation — an exec that saw the gate open but not the tools would run without them and with no error.
-pub fn set_connector_with_tools(
+/// The connector is what makes a run exec-able, so both publish in one mutation — an exec that saw the gate open but not the environment would run without it and with no error.
+pub fn set_connector_with_environment(
     run_id: &str,
     connector: std::sync::Arc<dyn GuestTransport>,
-    tools: crate::workload_env::ToolRuntime,
+    exec_environment: ExecEnvironment,
 ) {
     let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
     if let Some(h) = g.as_mut().and_then(|m| m.get_mut(run_id)) {
-        h.tools = tools;
+        h.exec_environment = exec_environment;
         h.connector = Some(connector);
     }
 }
@@ -410,7 +422,7 @@ pub(crate) fn test_handle() -> (RunHandle, oneshot::Receiver<i32>) {
             status: std::sync::Mutex::new(RunStatus::Running),
             logs: std::sync::Arc::new(crate::run_log::RunLogBuffer::default()),
             config: lns_ipc::RunConfig::default(),
-            tools: Default::default(),
+            exec_environment: Default::default(),
         },
         cancel_rx,
     )
@@ -647,16 +659,28 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
-    async fn a_runs_tool_environment_is_readable_for_the_life_of_the_run() {
-        // `lns exec` enters the same guest later and has to compose the same PATH and the same tool vars.
+    async fn a_runs_exec_environment_is_readable_for_the_life_of_the_run() {
+        // `lns exec` enters the same guest later and has to compose the same env, the same PATH and the same tool vars.
         let id = allocate_run_id();
         let (mut h, _rx) = make_handle();
-        h.tools = tool_runtime();
+        h.exec_environment = exec_environment_fixture();
         register_named(id.clone(), None, h).unwrap();
-        assert_eq!(tools(&id), tool_runtime());
-        assert_eq!(tools("ghost"), Default::default());
+        assert_eq!(exec_environment(&id), exec_environment_fixture());
+        assert_eq!(exec_environment("ghost"), Default::default());
         deregister(&id);
-        assert_eq!(tools(&id), Default::default());
+        assert_eq!(exec_environment(&id), Default::default());
+    }
+
+    fn exec_environment_fixture() -> ExecEnvironment {
+        ExecEnvironment {
+            session_env: vec!["HOME=/workspace".to_string()],
+            tools: tool_runtime(),
+            placeholders: vec![(
+                "SOME_TOKEN".to_string(),
+                "some-provider_LNSPLACEHOLDER0000".to_string(),
+            )],
+            workdir: Some("/workspace".to_string()),
+        }
     }
 
     fn tool_runtime() -> crate::workload_env::ToolRuntime {
@@ -671,14 +695,18 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(global_runs)]
-    async fn a_run_never_becomes_exec_able_before_its_tool_environment_is_readable() {
-        // The connector is the gate `lns exec` passes; publishing it a moment before the tools would let an exec in that window run without them and with no error.
+    async fn a_run_never_becomes_exec_able_before_its_environment_is_readable() {
+        // The connector is the gate `lns exec` passes; publishing it a moment before the environment would let an exec in that window run without it and with no error.
         let id = allocate_run_id();
         let (h, _rx) = make_handle();
         register_named(id.clone(), None, h).unwrap();
-        set_connector_with_tools(&id, std::sync::Arc::new(StubTransport), tool_runtime());
+        set_connector_with_environment(
+            &id,
+            std::sync::Arc::new(StubTransport),
+            exec_environment_fixture(),
+        );
         assert!(connector(&id).is_some());
-        assert_eq!(tools(&id), tool_runtime());
+        assert_eq!(exec_environment(&id), exec_environment_fixture());
         deregister(&id);
     }
 

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -336,6 +336,15 @@ fn collect_managed_env_vars(providers: &[DefProvider]) -> Vec<String> {
     providers.iter().map(|p| p.env_var().to_string()).collect()
 }
 
+/// Only what the guest seeds into the workload env, and only the placeholder — this function is never handed a credential value, so an exec session cannot carry a real token.
+fn collect_placeholder_env(providers: &[DefProvider]) -> Vec<(String, String)> {
+    providers
+        .iter()
+        .filter(|p| p.seeds_env())
+        .map(|p| (p.env_var().to_string(), p.placeholder().to_string()))
+        .collect()
+}
+
 /// `Weak` so the closure doesn't keep the credential session alive past the run; a dropped session yields an empty list.
 fn make_credentials_provider(
     credential_session: &Arc<CredentialSession>,
@@ -692,6 +701,7 @@ pub(super) async fn start(
         .collect();
     let custom_providers = Arc::new(run.providers);
     let managed_env_vars = collect_managed_env_vars(&custom_providers);
+    let placeholder_env = collect_placeholder_env(&custom_providers);
 
     let store = Arc::new(FilePolicyStore::new(policy_path.to_path_buf()));
     let (frame_tx, frame_rx) = tokio::sync::mpsc::unbounded_channel::<HostFrame>();
@@ -798,6 +808,7 @@ pub(super) async fn start(
         watcher: Some(watcher),
         credential_watcher: Some(credential_watcher),
         managed_env_vars,
+        placeholder_env,
     })
 }
 
@@ -1825,6 +1836,25 @@ mod tests {
     #[test]
     fn collect_managed_env_vars_lists_each_run_providers_env_var() {
         assert_eq!(collect_managed_env_vars(&acme_custom()), ["ACME_API_KEY"]);
+    }
+
+    #[test]
+    fn a_seeding_connector_contributes_its_env_var_and_placeholder_pair() {
+        let pairs = collect_placeholder_env(&acme_custom());
+
+        assert_eq!(
+            pairs,
+            vec![(
+                "ACME_API_KEY".to_string(),
+                "acme_LNSPLACEHOLDER".to_string()
+            )]
+        );
+        for (_, value) in &pairs {
+            assert!(
+                value.contains("LNSPLACEHOLDER"),
+                "an exec session must never be handed anything but a self-identifying placeholder: {value}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -68,6 +68,8 @@ pub struct SupervisorSession {
     pub credential_watcher: Option<crate::credential_flow::watcher::CredentialWatcher>,
     // Env vars of the run's custom providers + connected connectors, stripped from `-e` so a real secret can't bypass the placeholder.
     pub managed_env_vars: Vec<String>,
+    // `env_var=placeholder` for each provider that seeds one, captured at boot exactly as the workload's own set is, so an `lns exec` sees the same token path.
+    pub placeholder_env: Vec<(String, String)>,
 }
 
 /// The run's consent inputs: the definition's credential slots, the identity its grants key against, the slot ids whose boot-gate sign-in the user completed this launch, and each connector's forget count as the gate found it.

--- a/crates/lns-service/src/vm/mod.rs
+++ b/crates/lns-service/src/vm/mod.rs
@@ -765,6 +765,7 @@ mod tests {
             watcher: None,
             credential_watcher: None,
             managed_env_vars: Vec::new(),
+            placeholder_env: Vec::new(),
         }
     }
 

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -75,22 +75,65 @@ pub struct ToolRuntime {
     pub env: Vec<(String, String)>,
 }
 
-impl ToolRuntime {
-    /// The contribution that actually took effect on a composed workload env. `lns exec` composes against its own env — nearly always empty — so a var the image or `-e` already owns has to be dropped here or the exec session gets the tool's value where the workload got the definition's.
-    pub fn as_applied(&self, composed_env: &[String]) -> ToolRuntime {
-        ToolRuntime {
-            bin_paths: self.bin_paths.clone(),
-            env: self
-                .env
-                .iter()
-                .filter(|(name, value)| {
-                    composed_env
-                        .iter()
-                        .any(|kv| kv == &format!("{name}={value}"))
-                })
-                .cloned()
-                .collect(),
-        }
+pub const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
+
+/// The vars the supervisor handshake owns; they describe the workload's own session, so replaying them into an exec would tell a piped command it has a colour terminal and hand it the workload's command line.
+fn is_session_only(entry: &str) -> bool {
+    let (key, value) = entry.split_once('=').unwrap_or((entry, ""));
+    match key {
+        "AGENT_COMMAND" | "WORKSPACE_PATH" => true,
+        // Only the value we injected: a workload that declares its own TERM meant it.
+        "TERM" => value == SUPERVISOR_PTY_OPT_IN_TERM,
+        _ => key.starts_with("LENS_SANDBOX_"),
+    }
+}
+
+/// The CA bundle paths a workload's runtimes are given, so a curl, git, python or node command in an exec trusts the proxy the way the workload does.
+fn ca_bundle_env() -> [(&'static str, &'static str); 5] {
+    [
+        ("SSL_CERT_FILE", lns_session::SYSTEM_CA_BUNDLE_PATH),
+        ("REQUESTS_CA_BUNDLE", lns_session::SYSTEM_CA_BUNDLE_PATH),
+        ("NODE_EXTRA_CA_CERTS", lns_session::SYSTEM_CA_BUNDLE_PATH),
+        ("CURL_CA_BUNDLE", lns_session::SYSTEM_CA_BUNDLE_PATH),
+        ("GIT_SSL_CAINFO", lns_session::SYSTEM_CA_BUNDLE_PATH),
+    ]
+}
+
+/// What an `lns exec` into a live run joins: the run's own resolved environment, then the caller's additions, its declared tools, the CA bundle the workload trusts, and last the credential placeholders — which override, because the workload's real env carries the placeholder for those vars too.
+pub fn exec_session_env(
+    exec_environment: &crate::run_registry::ExecEnvironment,
+    exec_env: &[String],
+) -> Vec<String> {
+    let joined: Vec<String> = exec_environment
+        .session_env
+        .iter()
+        .filter(|entry| !is_session_only(entry))
+        .cloned()
+        .collect();
+    let caller: Vec<String> = exec_env
+        .iter()
+        .filter(|entry| !is_session_only(entry))
+        .cloned()
+        .collect();
+    let mut env = compose_workload_env(Some(&joined), &caller, &[]).env;
+    compose_guest_tool_env(&mut env, &exec_environment.tools);
+    for (key, value) in ca_bundle_env() {
+        overwrite(&mut env, key, value);
+    }
+    for (key, value) in &exec_environment.placeholders {
+        overwrite(&mut env, key, value);
+    }
+    env
+}
+
+fn overwrite(env: &mut Vec<String>, key: &str, value: &str) {
+    let entry = format!("{key}={value}");
+    match env
+        .iter_mut()
+        .find(|kv| kv.split_once('=').is_some_and(|(k, _)| k == key))
+    {
+        Some(slot) => *slot = entry,
+        None => env.push(entry),
     }
 }
 
@@ -148,7 +191,6 @@ pub fn run_workload_env(
     extra_managed: &[String],
     tools: &ToolRuntime,
 ) -> WorkloadEnv {
-    const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
     let mut composed = compose_workload_env(image_env, user_env, extra_managed);
     // The broker's last-wins putenv would otherwise let the image PATH shadow the tool dirs.
     compose_guest_tool_env(&mut composed.env, tools);
@@ -440,48 +482,144 @@ mod tests {
     }
 
     #[test]
-    fn only_the_tool_vars_that_took_effect_travel_to_an_exec_session() {
-        // `lns exec` composes against its own (usually empty) env, so a var the definition already set would come back as the tool's value there — one sandbox, two CARGO_HOMEs, no warning.
-        let tools = ToolRuntime {
-            bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
-            env: vec![
-                (
-                    "SOME_TOOL_CACHE".to_string(),
-                    "/.lens/tools/some-tool/1.2.3/home/.cache".to_string(),
-                ),
-                (
-                    "SOME_TOOL_HOME".to_string(),
-                    "/.lens/tools/some-tool/1.2.3/home".to_string(),
-                ),
+    fn an_exec_session_joins_the_runs_environment_and_keeps_the_definitions_own_values() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec![
+                "HOME=/workspace".into(),
+                "SOME_TOOL_CACHE=/workspace/mine".into(),
             ],
+            tools: ToolRuntime {
+                bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
+                env: vec![
+                    (
+                        "SOME_TOOL_CACHE".to_string(),
+                        "/.lens/tools/some-tool/1.2.3/home/.cache".to_string(),
+                    ),
+                    (
+                        "SOME_TOOL_HOME".to_string(),
+                        "/.lens/tools/some-tool/1.2.3/home".to_string(),
+                    ),
+                ],
+            },
+            ..Default::default()
         };
-        let composed = run_workload_env(
-            Some(&["SOME_TOOL_CACHE=/workspace/mine".into()]),
-            &[],
-            None,
-            None,
-            &[],
-            &tools,
+
+        let env = exec_session_env(&run, &[]);
+
+        assert!(env.contains(&"HOME=/workspace".to_string()), "got: {env:?}");
+        assert!(
+            env.contains(&"SOME_TOOL_CACHE=/workspace/mine".to_string()),
+            "the var the definition owns keeps the definition's value, not the tool tree's: {env:?}"
         );
-        let applied = tools.as_applied(&composed.env);
-        assert_eq!(
-            applied.env,
-            vec![(
-                "SOME_TOOL_HOME".to_string(),
-                "/.lens/tools/some-tool/1.2.3/home".to_string()
-            )],
-            "the var the definition owns must not reach exec as the tool's"
+        assert!(
+            env.contains(&"SOME_TOOL_HOME=/.lens/tools/some-tool/1.2.3/home".to_string()),
+            "a tool var nothing else set still arrives: {env:?}"
         );
         assert_eq!(
-            applied.bin_paths, tools.bin_paths,
-            "the PATH rule is unchanged"
+            env.iter().find(|kv| kv.starts_with("PATH=")),
+            Some(&format!(
+                "PATH=/.lens/tools/some-tool/1.2.3/bin:{GUEST_DEFAULT_PATH}"
+            )),
+            "the run's tool dirs still come first: {env:?}"
+        );
+    }
+
+    #[test]
+    fn the_supervisors_own_handshake_does_not_travel_into_an_exec_session() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec![
+                "AGENT_COMMAND=agent --serve".into(),
+                "WORKSPACE_PATH=/workspace".into(),
+                format!("TERM={SUPERVISOR_PTY_OPT_IN_TERM}"),
+                "LENS_SANDBOX_TOKEN=a-relay-token".into(),
+                // A malformed entry still names an internal var, so the prefix decides, not the shape.
+                "LENS_SANDBOX_BARE".into(),
+                "MODE=research".into(),
+            ],
+            ..Default::default()
+        };
+
+        let env = exec_session_env(&run, &[]);
+
+        for leaked in [
+            "AGENT_COMMAND=",
+            "WORKSPACE_PATH=",
+            "TERM=",
+            "LENS_SANDBOX_",
+            "LENS_SANDBOX_BARE",
+        ] {
+            assert!(
+                !env.iter().any(|kv| kv.starts_with(leaked)),
+                "{leaked} must not reach an exec session: {env:?}"
+            );
+        }
+        assert!(env.contains(&"MODE=research".to_string()), "got: {env:?}");
+    }
+
+    #[test]
+    fn the_caller_of_an_exec_cannot_smuggle_an_internal_var_in_either() {
+        let env = exec_session_env(
+            &Default::default(),
+            &["LENS_SANDBOX_TOKEN=a-forged-token".to_string()],
         );
 
-        let mut exec_env = Vec::new();
-        compose_guest_tool_env(&mut exec_env, &applied);
         assert!(
-            !exec_env.iter().any(|kv| kv.starts_with("SOME_TOOL_CACHE=")),
-            "got: {exec_env:?}"
+            !env.iter().any(|kv| kv.starts_with("LENS_SANDBOX_")),
+            "got: {env:?}"
+        );
+    }
+
+    #[test]
+    fn a_workloads_own_term_is_a_declaration_and_survives() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec!["TERM=dumb".into()],
+            ..Default::default()
+        };
+
+        assert!(
+            exec_session_env(&run, &[]).contains(&"TERM=dumb".to_string()),
+            "only the value the supervisor injected is internal"
+        );
+    }
+
+    #[test]
+    fn an_exec_session_trusts_the_same_ca_bundle_the_workload_does() {
+        let env = exec_session_env(&Default::default(), &[]);
+
+        for key in [
+            "SSL_CERT_FILE",
+            "REQUESTS_CA_BUNDLE",
+            "NODE_EXTRA_CA_CERTS",
+            "CURL_CA_BUNDLE",
+            "GIT_SSL_CAINFO",
+        ] {
+            assert!(
+                env.contains(&format!("{key}={}", lns_session::SYSTEM_CA_BUNDLE_PATH)),
+                "a python or node command in an exec fails TLS without {key}: {env:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_credential_placeholder_overrides_whatever_the_run_env_holds_for_that_var() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec!["SOME_TOKEN=an-image-baked-value".into()],
+            placeholders: vec![(
+                "SOME_TOKEN".to_string(),
+                "some-provider_LNSPLACEHOLDER0000".to_string(),
+            )],
+            ..Default::default()
+        };
+
+        let env = exec_session_env(&run, &[]);
+
+        assert!(
+            env.contains(&"SOME_TOKEN=some-provider_LNSPLACEHOLDER0000".to_string()),
+            "the workload's own env carries the placeholder for a managed var, so an exec must match: {env:?}"
+        );
+        assert!(
+            !env.iter().any(|kv| kv.contains("an-image-baked-value")),
+            "got: {env:?}"
         );
     }
 

--- a/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
@@ -26,7 +26,7 @@ pub fn fresh_handle(
         status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
         logs: std::sync::Arc::new(lns_service::run_log::RunLogBuffer::default()),
         config,
-        tools: Default::default(),
+        exec_environment: Default::default(),
     }
 }
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -767,6 +767,17 @@ session has no way yet to route your keystrokes to itself rather than to the run
 own workload. So `lns exec 7 -- bash` gets you a shell with closed stdin, which
 exits at once. To reach a live terminal inside the run, use `lns attach`.
 
+An exec **joins the run it names**, so a diagnostic command sees the same sandbox
+the workload does: the run's resolved environment (base image `ENV`, `spec.env`,
+`-e`, and its declared tools on `PATH`), its working directory, the CA bundle its
+runtimes trust, and the credential placeholders — so a request you make from an
+exec goes through the same policy and the same credential swap. You never have to
+re-export the environment by hand, and `~` means what it means to the workload.
+
+The supervisor's own handshake variables stay out, so a piped exec is not told it
+has a colour terminal. Real credential values stay out too: an exec is handed the
+same placeholder the workload holds, never the secret behind it.
+
 ### Stopping vs killing
 
 `lns kill` sends one signal (case-insensitive, bare or `SIG`-prefixed: `TERM`,


### PR DESCRIPTION
## Problem

```
$ lns exec devprobe -- printenv HOME
/
```

`SHELL`, `CARGO_HOME` and everything from `spec.env` are unset too. The workload gets them correctly. So every diagnostic command has to re-export the environment by hand, and `sh -lc` in an exec expands `~` to `/` — silently writing to the wrong place.

## Root cause

The run's resolved env was never stored for the life of the run, and the exec path never asked for it. The CLI sends `env: Vec::new()` for an exec; `build_session_params` composed from that empty vec plus the tool contribution, with `cwd: None`. Nothing else supplies HOME, so PID 1's kernel-supplied `HOME=/` survived into every exec session.

## Decision

The chosen option was **the run's declared environment plus the connector credential placeholders**, and **yes** to inheriting the working directory.

Before implementing the placeholder half I had it verified, because a placeholder is only worth having if the exec's traffic gets it swapped — otherwise it is a footgun that sends a fake token to a real service. It does get swapped: the nftables cage is **netns-scoped**, not process-scoped (`meta mark != {mark} … redirect to :{transparent}` catches every process in the guest), and the MITM CA is appended to the system bundle the broker seeds. An exec's `curl` is intercepted and resigned exactly as the workload's is.

## The change

`RunHandle.tools` becomes `RunHandle.exec_environment: ExecEnvironment { session_env, tools, placeholders, workdir }`, published by `set_connector_with_environment` — keeping the existing **one-mutation** contract, so an exec can never see the gate open without the environment behind it.

`workload_env::exec_session_env` composes, in order:

1. the run's resolved env, minus the session-only vars;
2. the caller's own env, minus the same;
3. the declared tools — filling only what nothing else set, so a definition's own `CARGO_HOME` wins over the tool tree's;
4. the 5 CA bundle vars (override);
5. the credential placeholders (override).

Steps 4 and 5 override because the workload's env has them overridden too: core's `handle_policy` extends the spec env with the `env_var → placeholder` map, and `apply_ca_env` sets the CA vars at the Command level. Step 4 is why the CA vars are here at all — without them a python or node command in an exec fails TLS against the MITM while the same command in the workload succeeds.

`ToolRuntime::as_applied` is **deleted**. It existed only because exec composed against an empty env; with the run env replayed it would remove information rather than protect it.

## Nothing real travels

- The placeholder pairs come from `&[DefProvider]` alone — no credential store, no armed set — so this path cannot carry a real token **by signature**. They are captured at boot, which matches the workload: `on_policy` seeds the workload env exactly once, so a live read would give an exec a var the workload does not have.
- The relay token and URL travel only on the kernel cmdline, never in the composed session env.
- The supervisor's handshake vars are stripped, so a piped exec is not told it has a colour terminal and `AGENT_COMMAND` does not leak the workload's command line. `TERM` is stripped only when it equals the value we injected — a workload that declares its own `TERM` meant it.
- Neither the replayed run env nor the caller's env may carry the internal `LENS_SANDBOX_` prefix.

## Known gaps, named not fixed

- `exec_session_env` passes no managed-var list, so an `ExecImageArgs.env` entry for a managed var is not refused the way `-e` is on the run path. Unreachable through the shipping CLI (it sends an empty env); it needs the same plumbing `lns exec -e` would, so it belongs with that.
- An exec into an *unsupervised* run whose image sets a custom `SSL_CERT_FILE` now gets the canonical path instead. Needs supervision captured in `ExecEnvironment`.

## Tests

Red proven first for the headline: `an_exec_session_joins_the_runs_own_environment` failed because `build_session_params` started from the empty `args.env`. Seven more pin the composition rules, the strip list, the CA vars, the placeholder override, and that neither an image nor a caller can forge the internal prefix.

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-service" make coverage` all green — 104 files at 100%, 0 failures. 2091/2091 lib tests, 186/186 scenarios.

Fixes item 9 of the devbox findings.