### PR TITLE
fix: transfer a volume's root to the run-as user on attach

### DIFF
--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -541,8 +541,30 @@ fn mount_volumes(
             false => MountFlags::none().nosuid().nodev(),
         };
         do_mount(sys, &vol.dev, &target, "ext4", flags, None)?;
+        if !vol.read_only {
+            reconcile_volume_owner(sys, &target, run_ids);
+        }
     }
     Ok(())
+}
+
+/// Runs after the mount, so it lands on the volume's own root inode rather than the ephemeral directory the mount covers.
+fn reconcile_volume_owner(sys: &dyn Syscalls, target: &str, run_ids: Option<(u32, u32)>) {
+    use std::os::unix::fs::MetadataExt;
+    let Some((uid, gid)) = run_ids else {
+        return;
+    };
+    // Root writes any path already, and rewriting here would clobber the ownership an image seeded.
+    if uid == 0 {
+        return;
+    }
+    let Ok(md) = std::fs::metadata(target) else {
+        return;
+    };
+    if (md.uid(), md.gid()) == (uid, gid) {
+        return;
+    }
+    lchown_logged(sys, target, uid, gid);
 }
 
 fn mount_binds(
@@ -2310,6 +2332,167 @@ mod tests {
             target: target.into(),
             read_only,
         }
+    }
+
+    /// A real directory to mount a volume over, plus the ids that own it, so a test can ask for a run-as identity that differs from the first attacher's.
+    fn volume_target(newroot: &tempfile::TempDir) -> (String, u32, u32) {
+        use std::os::unix::fs::MetadataExt;
+        let target = newroot.path().join("data");
+        std::fs::create_dir_all(&target).unwrap();
+        let md = std::fs::metadata(&target).unwrap();
+        (
+            newroot.path().to_string_lossy().into_owned(),
+            md.uid(),
+            md.gid(),
+        )
+    }
+
+    fn volume_chowns(calls: &[Call]) -> Vec<&Call> {
+        calls
+            .iter()
+            .filter(|c| matches!(c, Call::Lchown { .. }))
+            .collect()
+    }
+
+    #[test]
+    fn a_volume_root_owned_by_another_uid_is_transferred_to_the_run_as_user() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, uid, gid) = volume_target(&dir);
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(
+            &sys,
+            &[volume("/dev/vdc", "/data", false)],
+            &newroot,
+            Some((uid + 1, gid)),
+        )
+        .unwrap();
+
+        let calls = sys.calls();
+        let target = format!("{newroot}/data");
+        let chown = calls.iter().position(|c| {
+            matches!(c, Call::Lchown { path, uid: u, gid: g } if path == &target && *u == uid + 1 && *g == gid)
+        });
+        let mount = calls.iter().position(
+            |c| matches!(c, Call::Mount { target: t, fstype, .. } if t == &target && fstype == "ext4"),
+        );
+        assert!(
+            chown.is_some(),
+            "a volume attached under a different run-as identity leaves every file owned by the first attacher's uid: {calls:?}"
+        );
+        assert!(
+            chown > mount,
+            "the chown must land on the volume's own root inode, so it follows the mount: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_volume_root_already_owned_by_the_run_as_user_is_not_rewritten() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, uid, gid) = volume_target(&dir);
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(
+            &sys,
+            &[volume("/dev/vdc", "/data", false)],
+            &newroot,
+            Some((uid, gid)),
+        )
+        .unwrap();
+
+        assert!(
+            volume_chowns(&sys.calls()).is_empty(),
+            "the common path costs one stat and no write"
+        );
+    }
+
+    #[test]
+    fn a_root_run_as_leaves_an_image_seeded_volumes_ownership_alone() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, uid, gid) = volume_target(&dir);
+        assert_ne!(uid, 0, "the fixture must not already be root-owned");
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(
+            &sys,
+            &[volume("/dev/vdc", "/data", false)],
+            &newroot,
+            Some((0, gid)),
+        )
+        .unwrap();
+
+        assert!(
+            volume_chowns(&sys.calls()).is_empty(),
+            "root can write any path, and rewriting here would clobber an image's own ownership"
+        );
+    }
+
+    #[test]
+    fn a_read_only_volume_attach_never_writes_to_the_volume() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, uid, gid) = volume_target(&dir);
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(
+            &sys,
+            &[volume("/dev/vdc", "/data", true)],
+            &newroot,
+            Some((uid + 1, gid)),
+        )
+        .unwrap();
+
+        assert!(
+            volume_chowns(&sys.calls()).is_empty(),
+            "a chown on a read-only mount is EROFS, so every :ro attach would log a failure"
+        );
+    }
+
+    #[test]
+    fn a_volume_attach_without_a_resolved_run_as_user_chowns_nothing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, _uid, _gid) = volume_target(&dir);
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(&sys, &[volume("/dev/vdc", "/data", false)], &newroot, None).unwrap();
+
+        assert!(volume_chowns(&sys.calls()).is_empty());
+    }
+
+    #[test]
+    fn a_volume_target_that_cannot_be_stat_ed_is_skipped_without_failing_the_boot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_string_lossy().into_owned();
+        let sys = FakeSyscalls::new();
+
+        mount_volumes(
+            &sys,
+            &[volume("/dev/vdc", "/absent", false)],
+            &newroot,
+            Some((1000, 1000)),
+        )
+        .unwrap();
+
+        assert!(volume_chowns(&sys.calls()).is_empty());
+    }
+
+    #[test]
+    fn a_failed_volume_chown_does_not_abort_the_boot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (newroot, uid, gid) = volume_target(&dir);
+        let sys = FakeSyscalls::new().fail_when(|c| {
+            matches!(c, Call::Lchown { .. }).then_some(std::io::ErrorKind::PermissionDenied)
+        });
+
+        assert!(
+            mount_volumes(
+                &sys,
+                &[volume("/dev/vdc", "/data", false)],
+                &newroot,
+                Some((uid + 1, gid)),
+            )
+            .is_ok(),
+            "one ownership failure must warn, not strand the run"
+        );
     }
 
     #[test]

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -324,6 +324,13 @@ The format is `name:/absolute/path[:ro]`. The volume `name` may contain letters,
 digits, `_`, `.`, and `-`; the target must be an absolute path with no `.`/`..`
 segments. Volume contents are stored by the service and survive between runs.
 
+A volume outlives the identity that wrote it, so its **root directory** is
+transferred to the run-as user on each writable attach. That is what lets a
+volume first written under one `-u` still be written under another. Files already
+inside it keep the owner they had — a volume written as root and then attached
+unprivileged still holds root-owned files, and a tool that checks ownership (git's
+`safe.directory`, for one) will say so.
+
 Manage the store with `lns volume`:
 
 ```bash


### PR DESCRIPTION
## Problem

A volume first written by the default unprivileged user (uid 65534), later attached under `-u root`:

```
fatal: detected dubious ownership in repository at '/root/dev/zsh-profile'
drwxr-xr-x 7 nobody nogroup 4096 … zsh-profile
```

The workaround was a marker-guarded `chown -R "$(id -u):$(id -g)" "$HOME/dev"` in the boot script plus `git config --global safe.directory '*'`. The marker existed because `chown -R` reaches the top directory last, so an owner-based guard would skip forever after an interrupted walk.

## Root cause

Nothing reconciles a volume's ownership on attach. `mount_volumes` mkdir's the target and mounts ext4, then stops. The only ownership work is `seed_volume_if_pristine`, which returns early once the volume has content — so a second attach performs zero chown, and even the first only chowns when the image ships nothing at the mount path. The volume keeps the uid of whoever first attached it.

## The change

A writable attach whose root owner differs transfers the volume's **root directory** to the run-as user. It runs **after the mount**, so it lands on the volume's own root inode rather than the ephemeral directory the mount covers.

Two deliberate skips:

- **A root run-as is skipped.** Root writes any path already, and rewriting there would clobber the ownership an image seeded — the exact bug commit 31134e90 ("preserve image ownership when seeding a pristine volume") fixed. Its test only covers a *first* attach, so a blanket reconcile would have re-opened it silently on the second. `a_root_run_as_leaves_an_image_seeded_volumes_ownership_alone` is the guard.
- **A read-only attach is skipped**, where a chown is EROFS and would log a failure on every `:ro` volume.

A failed chown warns and the boot continues, matching the sibling tool-tree walk.

## What this does not fix

**It is not recursive.** The error in the report is about `/root/dev/zsh-profile` — a *subdirectory* of the volume — so a file already inside the volume keeps its owner and git will still object to it. This change is enough for the workload to create entries at the volume root again, which is the breakage that has no workaround; it is not enough to clear that message. The docs now say exactly that.

The recursive variant was considered and rejected for now: it rewrites every inode in the user's one persistent store without asking, and it re-opens 31134e90 on the second attach of any image-seeded volume.

## Tests

Red proven first: the transfer test failed with no `Call::Lchown` recorded at all, while the six guard siblings passed vacuously. The transfer test also asserts the chown's call index is **after** the mount's, which is the invariant that keeps it on the right inode.

The guards pin each early return, so the file stays at 100% without any of them being coverage padding: owner already matches, run-as is root, read-only attach, no resolved run-as, un-stat-able target, and a failing chown that must not abort the boot.

## Gate

`make lint`, `make complexity`, `COVERAGE_CRATES="lns-init" make coverage` all green (4 files at 100%, 0 failures), plus `cargo clippy -p lns-init --target aarch64-unknown-linux-musl --all-targets -- -D warnings` — the guest crate's real target, which a macOS-only lint does not cover. 141/141 lns-init tests.

Fixes item 4 of the devbox findings.