### PR TITLE
refactor: give the credential definition one home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ version = "0.0.0"
 dependencies = [
  "ipnet",
  "libc",
+ "lns-spec",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3440,6 +3441,14 @@ dependencies = [
  "libc",
  "lns-session",
  "tempfile",
+]
+
+[[package]]
+name = "lns-spec"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/lns-service",
     "crates/lns-session",
     "crates/lns-session-broker",
+    "crates/lns-spec",
     "crates/lns-supervisor",
     "crates/bump-kernel",
     "crates/bump-mise",
@@ -40,6 +41,7 @@ default-members = [
     "crates/lns-service",
     "crates/lns-session",
     "crates/lns-session-broker",
+    "crates/lns-spec",
 ]
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ COVERAGE_TARGET_DIR = $(WORKSPACE_ROOT)/target/llvm-cov-target
 # list above (`build-lns` / `build-lns-service`) — a crate can be in
 # this gate without producing a binary (e.g. `lns-ipc` is a pure
 # library).
-GATE_CRATES := lns-cli lns-service lns-ipc lns-audit lns-ocsf lns-policy lns-artifact
+GATE_CRATES := lns-cli lns-service lns-ipc lns-audit lns-ocsf lns-policy lns-artifact lns-spec
 
 # Every crate under crates/ EXCEPT e2e-tests. Used by `make coverage`
 # iteration. e2e-tests is excluded because Layer 1 tests don't

--- a/crates/lns-policy/Cargo.toml
+++ b/crates/lns-policy/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 doctest = false
 
 [dependencies]
+lns-spec   = { path = "../lns-spec" }
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -48,14 +48,7 @@ impl ConnectorRoute {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CredentialAuth {
-    pub env_var: String,
-    pub placeholder: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub injections: Vec<InjectionDef>,
-}
+pub use lns_spec::Credential as CredentialAuth;
 
 /// Which interactive sign-in an `oauth` connector uses: the RFC 8628 device flow (default) or the browser-redirect authorization-code + PKCE flow.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/lns-policy/src/providers.rs
+++ b/crates/lns-policy/src/providers.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+pub use lns_spec::{InjectionDef, InjectionKind, is_self_identifying};
+
+/// A catalog entry's credential, carrying the connector id the machine keys its value by; the injection contract itself is [`lns_spec::Credential`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderDef {
@@ -9,47 +12,9 @@ pub struct ProviderDef {
     pub injections: Vec<InjectionDef>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InjectionDef {
-    pub kind: InjectionKind,
-    pub domain: String,
-    /// Only `ApiKeyHeader` carries a header name (e.g. `x-api-key`); other kinds leave it `None`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub header: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum InjectionKind {
-    BearerHeader,
-    TokenHeader,
-    BasicXAccessToken,
-    ApiKeyHeader,
-    UriPlaceholder,
-}
-
-/// A placeholder must self-identify as fake so no real credential can leak into the shipped or declared provider set.
-pub fn is_self_identifying(placeholder: &str) -> bool {
-    let lower = placeholder.to_lowercase();
-    lower.contains("placeholder") || lower.contains("lns")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn is_self_identifying_accepts_placeholder_or_lns_markers() {
-        assert!(is_self_identifying("acme_LNSPLACEHOLDER0000"));
-        assert!(is_self_identifying("lns-fake-value"));
-        assert!(is_self_identifying("XPLACEHOLDERX"));
-    }
-
-    #[test]
-    fn is_self_identifying_rejects_a_real_looking_token() {
-        assert!(!is_self_identifying("acme_real_looking_token"));
-    }
 
     #[test]
     fn provider_def_round_trips_through_yaml_with_both_injection_kinds() {
@@ -79,20 +44,6 @@ mod tests {
             "headerless kinds omit header: {yaml}"
         );
         let parsed: ProviderDef = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(parsed, def);
-    }
-
-    #[test]
-    fn api_key_header_injection_round_trips_with_its_header_name() {
-        let def = InjectionDef {
-            kind: InjectionKind::ApiKeyHeader,
-            domain: "api.example.test".into(),
-            header: Some("x-api-key".into()),
-        };
-        let yaml = serde_yaml::to_string(&def).unwrap();
-        assert!(yaml.contains("kind: api_key_header"), "got: {yaml}");
-        assert!(yaml.contains("header: x-api-key"), "got: {yaml}");
-        let parsed: InjectionDef = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, def);
     }
 }

--- a/crates/lns-spec/Cargo.toml
+++ b/crates/lns-spec/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "lns-spec"
+version = "0.0.0"
+edition = "2024"
+description = "The lns.run/v1 document grammar — the shared definitions every kind is built from (docs/sandbox-spec.md)"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_yaml = "0.9"
+
+[lints.clippy]
+cognitive_complexity = { level = "deny", priority = 1 }

--- a/crates/lns-spec/src/credential.rs
+++ b/crates/lns-spec/src/credential.rs
@@ -1,0 +1,151 @@
+//! The credential definition — `docs/sandbox-spec.md` §4.1.
+
+use serde::{Deserialize, Serialize};
+
+/// The one injection contract: this placeholder, in this variable, replaced by the real value on a request to each declared domain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Credential {
+    pub env_var: String,
+    pub placeholder: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub injections: Vec<InjectionDef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InjectionDef {
+    pub kind: InjectionKind,
+    pub domain: String,
+    /// Only `ApiKeyHeader` carries a header name (e.g. `x-api-key`); other kinds leave it `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InjectionKind {
+    BearerHeader,
+    TokenHeader,
+    BasicXAccessToken,
+    ApiKeyHeader,
+    UriPlaceholder,
+}
+
+/// A placeholder must self-identify as fake so no real credential can leak into a document that gets published.
+pub fn is_self_identifying(placeholder: &str) -> bool {
+    let lower = placeholder.to_lowercase();
+    lower.contains("placeholder") || lower.contains("lns")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_self_identifying_accepts_placeholder_or_lns_markers() {
+        assert!(is_self_identifying("acme_LNSPLACEHOLDER0000"));
+        assert!(is_self_identifying("lns-fake-value"));
+        assert!(is_self_identifying("XPLACEHOLDERX"));
+    }
+
+    #[test]
+    fn is_self_identifying_rejects_a_real_looking_token() {
+        assert!(!is_self_identifying("acme_real_looking_token"));
+    }
+
+    #[test]
+    fn a_credential_reads_the_field_names_the_specification_uses() {
+        let credential: Credential = serde_yaml::from_str(
+            "envVar: SOME_TOKEN\n\
+             placeholder: some_LNSPLACEHOLDER0000000000\n\
+             injections:\n\
+             \x20 - kind: bearer_header\n\
+             \x20   domain: api.some-provider.example\n",
+        )
+        .expect("the §4.1 example shape parses");
+        assert_eq!(credential.env_var, "SOME_TOKEN");
+        assert_eq!(credential.placeholder, "some_LNSPLACEHOLDER0000000000");
+        assert_eq!(credential.injections[0].kind, InjectionKind::BearerHeader);
+        assert_eq!(credential.injections[0].domain, "api.some-provider.example");
+        assert_eq!(credential.injections[0].header, None);
+    }
+
+    #[test]
+    fn injections_default_to_none_declared() {
+        let credential: Credential =
+            serde_yaml::from_str("envVar: SOME_TOKEN\nplaceholder: lns-fake\n").unwrap();
+        assert!(credential.injections.is_empty());
+    }
+
+    #[test]
+    fn a_credential_round_trips_and_omits_what_it_does_not_carry() {
+        let credential = Credential {
+            env_var: "SOME_TOKEN".into(),
+            placeholder: "some_LNSPLACEHOLDER0000".into(),
+            injections: Vec::new(),
+        };
+        let yaml = serde_yaml::to_string(&credential).unwrap();
+        assert!(yaml.contains("envVar: SOME_TOKEN"), "got: {yaml}");
+        assert!(
+            !yaml.contains("injections"),
+            "an empty injection list is absent rather than written as [], so a hand-edited file stays as its author left it: {yaml}"
+        );
+        assert_eq!(
+            serde_yaml::from_str::<Credential>(&yaml).unwrap(),
+            credential
+        );
+    }
+
+    #[test]
+    fn every_injection_kind_round_trips_through_its_wire_name() {
+        for (kind, wire) in [
+            (InjectionKind::BearerHeader, "bearer_header"),
+            (InjectionKind::TokenHeader, "token_header"),
+            (InjectionKind::BasicXAccessToken, "basic_x_access_token"),
+            (InjectionKind::ApiKeyHeader, "api_key_header"),
+            (InjectionKind::UriPlaceholder, "uri_placeholder"),
+        ] {
+            let def = InjectionDef {
+                kind,
+                domain: "api.example.test".into(),
+                header: None,
+            };
+            let yaml = serde_yaml::to_string(&def).unwrap();
+            assert!(yaml.contains(&format!("kind: {wire}")), "got: {yaml}");
+            assert_eq!(serde_yaml::from_str::<InjectionDef>(&yaml).unwrap(), def);
+        }
+    }
+
+    #[test]
+    fn api_key_header_carries_its_header_name_and_others_omit_it() {
+        let named = InjectionDef {
+            kind: InjectionKind::ApiKeyHeader,
+            domain: "api.example.test".into(),
+            header: Some("x-api-key".into()),
+        };
+        let yaml = serde_yaml::to_string(&named).unwrap();
+        assert!(yaml.contains("header: x-api-key"), "got: {yaml}");
+        assert_eq!(serde_yaml::from_str::<InjectionDef>(&yaml).unwrap(), named);
+
+        let bare = InjectionDef {
+            header: None,
+            ..named
+        };
+        assert!(
+            !serde_yaml::to_string(&bare).unwrap().contains("header:"),
+            "a headerless kind must not write an empty header key"
+        );
+    }
+
+    #[test]
+    fn an_unknown_injection_kind_is_refused_rather_than_defaulted() {
+        let error =
+            serde_yaml::from_str::<InjectionDef>("kind: telepathy\ndomain: api.example.test\n")
+                .expect_err("an injection kind the proxy cannot perform must not load");
+        assert!(
+            error.to_string().contains("unknown variant"),
+            "got: {error}"
+        );
+    }
+}

--- a/crates/lns-spec/src/lib.rs
+++ b/crates/lns-spec/src/lib.rs
@@ -1,0 +1,8 @@
+//! The `lns.run/v1` document grammar, specified in `docs/sandbox-spec.md`.
+//!
+//! One definition per concept, below every crate that reads or writes one, so a
+//! sandbox, a connector and a mixin cannot drift apart in what they mean by it.
+
+pub mod credential;
+
+pub use credential::{Credential, InjectionDef, InjectionKind, is_self_identifying};


### PR DESCRIPTION
> Stacked on #210. Base is `docs/sandbox-spec`, so review that one first — this PR implements a piece of the specification it adds.

## Why

The specification's [§4.1](https://github.com/lensapp/lens-sandbox/blob/docs/sandbox-spec/docs/sandbox-spec.md#41-the-credential-definition) makes the credential definition — `envVar`, `placeholder`, `injections[]` — **one shape shared by all three kinds**. The interesting part is that we already implement it, twice, and both copies are correct: `CredentialAuth` in `lns-policy/src/connectors.rs` is field-for-field §4.1, and `InjectionDef` / `InjectionKind` / `is_self_identifying` are the injection half.

They just live inside the connector catalog. A sandbox or a mixin cannot reach them from there, and `lns-policy` can never depend on `lns-artifact` (the edge already runs the other way), so the shared definition has nowhere to live that both sides can read.

## What this does

Adds `crates/lns-spec` — a crate with **no workspace dependencies**, so it sits below both `lns-policy` and `lns-artifact` — and moves the definition into it. `lns-policy` consumes it and re-exports it under the names it used before, which is why no caller changes.

```
lns-spec  ←  lns-policy  ←  lns-artifact  ←  lns-service / lns-cli
```

## What this deliberately does not do

**No behaviour change and no format change.** Nothing new is accepted, nothing new is written, and no target-only shape is wired into a load path. The catalog's YAML is byte-identical in and out:

- same `rename_all = "camelCase"`, same `#[serde(default, skip_serializing_if = …)]` on `injections` and `header`
- still no `deny_unknown_fields` on any of it — the catalog is not strict today, and making it strict here would reject files that load now
- `pub use lns_spec::Credential as CredentialAuth;` keeps every construction site and every field access compiling

`git diff --stat` is the claim: the only files touched outside the new crate are `Cargo.toml`, `Cargo.lock`, the `Makefile`, and `lns-policy`'s two files. If a `lns-service` or `lns-cli` file had changed, the relocation would not have been pure.

## Verification

`make lint`, `make complexity` and `make coverage` all exit 0 from the workspace root. The whole existing suite passes untouched — that is the actual proof of purity, since every credential and connector behaviour in `lns-service` and `lns-cli` is exercised against the relocated types.

`crates/lns-spec/src/credential.rs` reports **100% region / function / line coverage** with no `IGNORES` entry, per the rule that a new side-effect-free module goes in at 100% from day one.

The 7 unit tests pin behaviour rather than lines: the §4.1 field names load as written, an absent `injections` list stays absent through a round trip (so a hand-edited catalog stays as its author left it), every injection kind round-trips through its wire name, `api_key_header` carries a header name while the others omit the key, and an injection kind the proxy cannot perform is refused rather than defaulted.

## Why this piece first

§4.2's egress definition is the other half of the specification's shared definitions, and it is the natural next move — but `RouteRule` / `TcpEgressRule` are mutually coupled with `lns-policy`'s 795-line `matching` module, so relocating them means splitting that module across a crate boundary. That deserves its own PR. §4.1 has no such coupling, which makes it the right place to prove the pattern: if a relocation of this shape can land with the gate green and nothing downstream touched, the rest follows mechanically.
