### PR TITLE
fix: give volume images a journal so an unclean shutdown cannot corrupt them

### DIFF
--- a/crates/e2e-tests/features/volume_management.feature
+++ b/crates/e2e-tests/features/volume_management.feature
@@ -23,9 +23,6 @@ Feature: volume lifecycle management end to end
     When I run "lns volume ls"
     Then the output does not contain "prism-data"
 
-  # The service's own writer is the only thing that puts a journal in the
-  # image, and the superblock is readable without booting a guest, so this
-  # runs in `make e2e` rather than behind @microvm.
   Scenario: a created volume image carries an internal journal
     When I run "lns volume create prism-data"
     Then the exit code is 0

--- a/crates/e2e-tests/features/volume_management.feature
+++ b/crates/e2e-tests/features/volume_management.feature
@@ -23,6 +23,14 @@ Feature: volume lifecycle management end to end
     When I run "lns volume ls"
     Then the output does not contain "prism-data"
 
+  # The service's own writer is the only thing that puts a journal in the
+  # image, and the superblock is readable without booting a guest, so this
+  # runs in `make e2e` rather than behind @microvm.
+  Scenario: a created volume image carries an internal journal
+    When I run "lns volume create prism-data"
+    Then the exit code is 0
+    And the backing image for volume "prism-data" declares an internal journal
+
   Scenario: prune reclaims every idle volume
     When I run "lns volume create prism-data"
     And I run "lns volume create scratch"

--- a/crates/e2e-tests/features/volumes.feature
+++ b/crates/e2e-tests/features/volumes.feature
@@ -69,14 +69,7 @@ Feature: named volumes persist workload state across runs
     Then the exit code is non-zero
     And the output contains "in use"
 
-  # NOT a journal test, and no scenario here is one. `lns kill` signals the
-  # workload, not the guest: the broker still unmounts every volume and calls
-  # sync() before poweroff, so the next attach never has anything to replay.
-  # The workload deliberately does not sync — what this pins is that the
-  # release path flushes the workload's unsynced write. Journal recovery would
-  # need a scenario that terminates the VM outright, which this harness has no
-  # step for; the journal's presence is pinned in volume_management.feature.
-  Scenario: a killed workload's unsynced write is still on the volume
+  Scenario: releasing a killed workload's volume flushes its unsynced write
     Given the Lens Sandbox service is running
     When the user starts a detached microVM command "/bin/sh -c 'echo survived > /data/marker; echo wrote=$?; /.lens/guest-tools/bin/busybox sleep 60'" with volume "e2e-vol-killed" at "/data"
     Then the exit code is 0

--- a/crates/e2e-tests/features/volumes.feature
+++ b/crates/e2e-tests/features/volumes.feature
@@ -69,6 +69,25 @@ Feature: named volumes persist workload state across runs
     Then the exit code is non-zero
     And the output contains "in use"
 
+  # NOT a journal test, and no scenario here is one. `lns kill` signals the
+  # workload, not the guest: the broker still unmounts every volume and calls
+  # sync() before poweroff, so the next attach never has anything to replay.
+  # The workload deliberately does not sync — what this pins is that the
+  # release path flushes the workload's unsynced write. Journal recovery would
+  # need a scenario that terminates the VM outright, which this harness has no
+  # step for; the journal's presence is pinned in volume_management.feature.
+  Scenario: a killed workload's unsynced write is still on the volume
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c 'echo survived > /data/marker; echo wrote=$?; /.lens/guest-tools/bin/busybox sleep 60'" with volume "e2e-vol-killed" at "/data"
+    Then the exit code is 0
+    When the user prints that run's logs until they contain "wrote=0"
+    Then the exit code is 0
+    When the user kills that run
+    Then volume "e2e-vol-killed" is released
+    When the user runs a microVM command "/bin/sh -c 'read v < /data/marker; echo got=$v'" with volume "e2e-vol-killed" at "/data"
+    Then the exit code is 0
+    And the output contains "got=survived"
+
   Scenario: a volume the run finished with is left marked clean
     Given the Lens Sandbox service is running
     When the user runs a microVM command "/bin/sh -c 'echo persisted > /data/marker'" with volume "e2e-vol-clean" at "/data"

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -1560,14 +1560,9 @@ fn policy_deny_all(world: &mut E2eWorld) {
     );
 }
 
-/// The ext4 superblock's `s_state`: the kernel clears bit 0 at read-write mount and sets it back only when the filesystem is put away, so this byte is what tells a later mount whether to warn that the image is unchecked.
-#[then(regex = r#"^the backing image for volume "([^"]+)" is marked clean$"#)]
-fn volume_image_marked_clean(world: &mut E2eWorld, name: String) -> Result<(), String> {
-    const SUPERBLOCK_OFFSET: u64 = 1024;
-    const S_MAGIC_OFFSET: u64 = 0x38;
-    const EXT4_SUPER_MAGIC: u16 = 0xEF53;
-    const EXT4_VALID_FS: u16 = 0x0001;
+const SUPERBLOCK_OFFSET: u64 = 1024;
 
+fn volume_image_path(world: &E2eWorld, name: &str) -> Result<std::path::PathBuf, String> {
     let home = world
         .home
         .as_ref()
@@ -1578,18 +1573,59 @@ fn volume_image_marked_clean(world: &mut E2eWorld, name: String) -> Result<(), S
     } else {
         home.join(".cache")
     };
-    let image = cache_root
+    Ok(cache_root
         .join("lns")
         .join("volumes")
-        .join(format!("{name}.img"));
+        .join(format!("{name}.img")))
+}
 
+fn read_superblock_field(image: &std::path::Path, offset: u64) -> Result<[u8; 4], String> {
     use std::io::{Read, Seek, SeekFrom};
-    let mut file = std::fs::File::open(&image).map_err(|e| format!("{}: {e}", image.display()))?;
-    file.seek(SeekFrom::Start(SUPERBLOCK_OFFSET + S_MAGIC_OFFSET))
+    let mut file = std::fs::File::open(image).map_err(|e| format!("{}: {e}", image.display()))?;
+    file.seek(SeekFrom::Start(SUPERBLOCK_OFFSET + offset))
         .map_err(|e| e.to_string())?;
-    // s_magic then s_state, adjacent — reading both proves the offsets land on a real superblock rather than garbage.
     let mut bytes = [0u8; 4];
     file.read_exact(&mut bytes).map_err(|e| e.to_string())?;
+    Ok(bytes)
+}
+
+/// A journal the kernel can replay is what keeps a volume the guest never unmounted mountable and consistent.
+#[then(regex = r#"^the backing image for volume "([^"]+)" declares an internal journal$"#)]
+fn volume_image_declares_journal(world: &mut E2eWorld, name: String) -> Result<(), String> {
+    const S_FEATURE_COMPAT_OFFSET: u64 = 0x5C;
+    const S_JOURNAL_INUM_OFFSET: u64 = 0xE0;
+    const FEATURE_COMPAT_HAS_JOURNAL: u32 = 0x0004;
+    const JOURNAL_INO: u32 = 8;
+
+    let image = volume_image_path(world, &name)?;
+    let compat = u32::from_le_bytes(read_superblock_field(&image, S_FEATURE_COMPAT_OFFSET)?);
+    let inum = u32::from_le_bytes(read_superblock_field(&image, S_JOURNAL_INUM_OFFSET)?);
+
+    if compat & FEATURE_COMPAT_HAS_JOURNAL == 0 {
+        return Err(format!(
+            "{} carries no journal (s_feature_compat={compat:#010x}); a volume the guest never unmounted has nothing to replay",
+            image.display()
+        ));
+    }
+    if inum != JOURNAL_INO {
+        return Err(format!(
+            "{} advertises a journal on inode {inum}, not {JOURNAL_INO}",
+            image.display()
+        ));
+    }
+    Ok(())
+}
+
+/// The ext4 superblock's `s_state`: the kernel clears bit 0 at read-write mount and sets it back only when the filesystem is put away, so this byte is what tells a later mount whether to warn that the image is unchecked.
+#[then(regex = r#"^the backing image for volume "([^"]+)" is marked clean$"#)]
+fn volume_image_marked_clean(world: &mut E2eWorld, name: String) -> Result<(), String> {
+    const S_MAGIC_OFFSET: u64 = 0x38;
+    const EXT4_SUPER_MAGIC: u16 = 0xEF53;
+    const EXT4_VALID_FS: u16 = 0x0001;
+
+    let image = volume_image_path(world, &name)?;
+    // s_magic then s_state, adjacent — reading both proves the offsets land on a real superblock rather than garbage.
+    let bytes = read_superblock_field(&image, S_MAGIC_OFFSET)?;
     let magic = u16::from_le_bytes([bytes[0], bytes[1]]);
     let state = u16::from_le_bytes([bytes[2], bytes[3]]);
 

--- a/crates/e2e-tests/tests/upperfs_oracle.rs
+++ b/crates/e2e-tests/tests/upperfs_oracle.rs
@@ -33,12 +33,12 @@ mod host_validation {
         None
     }
 
-    fn produce_image(size_bytes: u64) -> (tempfile::TempDir, PathBuf) {
+    fn produce_image(size_bytes: u64) -> (tempfile::TempDir, PathBuf, Plan) {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join("upper.img");
-        let plan = Plan::new(size_bytes, [0xAA; 16], "lns-upper", 0x12345678);
+        let plan = Plan::new(size_bytes, [0xAA; 16], "lns-upper", 0x12345678).expect("plan");
         write_ext4(&plan, &path).expect("write_ext4");
-        (dir, path)
+        (dir, path, plan)
     }
 
     fn parse_field(out: &str, key: &str) -> Option<String> {
@@ -60,7 +60,7 @@ mod host_validation {
             eprintln!("SKIP: e2fsck not found on host");
             return;
         };
-        let (_dir, path) = produce_image(32 * 1024 * 1024);
+        let (_dir, path, _plan) = produce_image(32 * 1024 * 1024);
         let out = Command::new(&e2fsck)
             .args(["-f", "-n", "-v"])
             .arg(&path)
@@ -86,7 +86,7 @@ mod host_validation {
             eprintln!("SKIP: e2fsck not found on host");
             return;
         };
-        let (_dir, path) = produce_image(10 * 1024 * 1024 * 1024);
+        let (_dir, path, _plan) = produce_image(10 * 1024 * 1024 * 1024);
         let out = Command::new(&e2fsck)
             .args(["-f", "-n"])
             .arg(&path)
@@ -108,7 +108,7 @@ mod host_validation {
             eprintln!("SKIP: tune2fs not found on host");
             return;
         };
-        let (_dir, path) = produce_image(32 * 1024 * 1024);
+        let (_dir, path, _plan) = produce_image(32 * 1024 * 1024);
         let out = Command::new(&tune2fs)
             .arg("-l")
             .arg(&path)
@@ -127,6 +127,7 @@ mod host_validation {
         let feat_set: Vec<&str> = features.split_whitespace().collect();
 
         for required in [
+            "has_journal",
             "ext_attr",
             "filetype",
             "extent",
@@ -139,7 +140,6 @@ mod host_validation {
             );
         }
         for forbidden in [
-            "has_journal",
             "64bit",
             "metadata_csum",
             "huge_file",
@@ -163,7 +163,7 @@ mod host_validation {
             eprintln!("SKIP: dumpe2fs not found on host");
             return;
         };
-        let (_dir, path) = produce_image(32 * 1024 * 1024);
+        let (_dir, path, _plan) = produce_image(32 * 1024 * 1024);
         let out = Command::new(&dumpe2fs)
             .arg("-h")
             .arg(&path)
@@ -193,6 +193,41 @@ mod host_validation {
 
     #[test]
     #[ignore]
+    fn dumpe2fs_reports_a_journal_of_the_planned_size() {
+        let Some(dumpe2fs) = find_tool("dumpe2fs") else {
+            eprintln!("SKIP: dumpe2fs not found on host");
+            return;
+        };
+        let (_dir, path, plan) = produce_image(32 * 1024 * 1024);
+        let out = Command::new(&dumpe2fs)
+            .arg("-h")
+            .arg(&path)
+            .output()
+            .expect("run dumpe2fs");
+        assert!(out.status.success(), "dumpe2fs failed");
+        let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+        eprintln!("dumpe2fs -h output:\n{stdout}");
+
+        assert_eq!(parse_field(&stdout, "Journal inode").as_deref(), Some("8"));
+        assert_eq!(
+            parse_field(&stdout, "Total journal blocks").as_deref(),
+            Some(plan.journal_blocks().to_string().as_str()),
+            "dumpe2fs only reports this after it parses our big-endian JBD2 superblock"
+        );
+        assert_eq!(
+            parse_field(&stdout, "Journal sequence").as_deref(),
+            Some("0x00000001")
+        );
+        assert_eq!(parse_field(&stdout, "Journal start").as_deref(), Some("0"));
+        assert_eq!(
+            parse_field(&stdout, "Journal features").as_deref(),
+            Some("(none)"),
+            "a journal with no optional features is recoverable by any kernel"
+        );
+    }
+
+    #[test]
+    #[ignore]
     fn compare_with_mke2fs_reference_image() {
         let Some(mke2fs) = find_tool("mke2fs") else {
             eprintln!("SKIP: mke2fs not found on host");
@@ -207,7 +242,7 @@ mod host_validation {
         let ours = dir.path().join("ours.img");
         let theirs = dir.path().join("theirs.img");
 
-        let plan = Plan::new(32 * 1024 * 1024, [0xAA; 16], "lns-upper", 0);
+        let plan = Plan::new(32 * 1024 * 1024, [0xAA; 16], "lns-upper", 0).expect("plan");
         write_ext4(&plan, &ours).expect("write ours");
 
         let theirs_file = std::fs::File::create(&theirs).expect("create theirs");
@@ -228,9 +263,11 @@ mod host_validation {
                 "-I",
                 "256",
                 "-O",
-                "sparse_super,filetype,extents,ext_attr,large_file,\
-                 ^has_journal,^64bit,^huge_file,^flex_bg,^metadata_csum,\
+                "sparse_super,filetype,extents,ext_attr,large_file,has_journal,\
+                 ^64bit,^huge_file,^flex_bg,^metadata_csum,\
                  ^dir_index,^resize_inode,^inline_data,^extra_isize",
+                "-J",
+                "size=4",
                 "-U",
                 "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 "-L",
@@ -334,7 +371,7 @@ mod overlayfs_validation {
         std::fs::create_dir_all(&parent).expect("create parent tempdir");
         let dir = tempfile::TempDir::new_in(&parent).expect("tempdir");
         let path = dir.path().join("upper.img");
-        let plan = Plan::new(32 * 1024 * 1024, [0xBB; 16], "lns-upper", 0);
+        let plan = Plan::new(32 * 1024 * 1024, [0xBB; 16], "lns-upper", 0).expect("plan");
         write_ext4(&plan, &path).expect("write_ext4");
         (dir, path)
     }

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -25,6 +25,7 @@ const UPPER_MOUNTPOINT: &str = "/mnt/upper";
 const NEWROOT: &str = "/newroot";
 const INIT_BROKER_PATH: &str = "/init-broker";
 const VOLUME_SEED_MOUNT: &str = "/mnt/vol-seed";
+const VOLUME_MOUNT_OPTS: &str = "errors=remount-ro";
 const PROC_CMDLINE: &str = "/proc/cmdline";
 const CMDLINE_MASK_FILE: &str = "/.lens/.cmdline";
 const DEV_FD_LINKS: &[(&str, &str)] = &[
@@ -543,7 +544,14 @@ fn mount_volumes(
             true => MountFlags::read_only().nosuid().nodev(),
             false => MountFlags::none().nosuid().nodev(),
         };
-        do_mount(sys, &vol.dev, &target, "ext4", flags, None)?;
+        do_mount(
+            sys,
+            &vol.dev,
+            &target,
+            "ext4",
+            flags,
+            Some(VOLUME_MOUNT_OPTS),
+        )?;
         if !vol.read_only {
             reconcile_volume_owner(sys, &target, run_ids);
         }
@@ -655,7 +663,7 @@ fn seed_volume_if_pristine(
         VOLUME_SEED_MOUNT,
         "ext4",
         MountFlags::none().nosuid().nodev(),
-        None,
+        Some(VOLUME_MOUNT_OPTS),
     )?;
     let (uid, gid) = run_ids.unwrap_or((0, 0));
     let result = sys.seed_pristine_volume(VOLUME_SEED_MOUNT, image_target, uid, gid);
@@ -807,7 +815,7 @@ fn mount_composefs_and_exec_broker_inner(
         UPPER_MOUNTPOINT,
         "ext4",
         MountFlags::none().nosuid().nodev(),
-        None,
+        Some(VOLUME_MOUNT_OPTS),
     )?;
 
     let upper_upper = format!("{UPPER_MOUNTPOINT}/upper");
@@ -2590,6 +2598,69 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, Call::Mount { target, flags, .. }
             if target == "/newroot/cache" && *flags == MountFlags::read_only().nosuid().nodev()))
+        );
+    }
+
+    #[test]
+    fn the_upper_mount_also_remounts_read_only_on_error() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+
+        let upper = sys
+            .calls()
+            .into_iter()
+            .find(
+                |c| matches!(c, Call::Mount { target, fstype, .. } if fstype == "ext4" && target == UPPER_MOUNTPOINT),
+            )
+            .expect("the upper image is mounted as ext4");
+        assert!(
+            matches!(&upper, Call::Mount { data, .. } if data.as_deref() == Some(VOLUME_MOUNT_OPTS)),
+            "the upper carries a journal like every other image we write, so it takes the same errors= treatment: {upper:?}"
+        );
+    }
+
+    #[test]
+    fn volume_mounts_ask_the_kernel_to_remount_read_only_on_error() {
+        let sys = FakeSyscalls::new();
+        let volumes = vec![
+            volume("/dev/vdc", "/data", false),
+            volume("/dev/vdd", "/cache", true),
+        ];
+        mount_volumes(&sys, &volumes, "/newroot", None).unwrap();
+
+        let ext4: Vec<_> = sys
+            .calls()
+            .into_iter()
+            .filter(|c| matches!(c, Call::Mount { target, fstype, .. } if fstype == "ext4" && target.starts_with("/newroot")))
+            .collect();
+        assert_eq!(ext4.len(), 2, "one mount per volume: {ext4:?}");
+        for call in &ext4 {
+            assert!(
+                matches!(call, Call::Mount { data, .. } if data.as_deref() == Some(VOLUME_MOUNT_OPTS)),
+                "a volume left inconsistent by a killed run keeps taking writes without errors=remount-ro: {call:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_seed_mount_also_remounts_read_only_on_error() {
+        let sys = FakeSyscalls::new();
+        seed_volume_if_pristine(&sys, "/dev/vdc", "/newroot/data", None).unwrap();
+
+        let seed = sys
+            .calls()
+            .into_iter()
+            .find(|c| matches!(c, Call::Mount { target, .. } if target == VOLUME_SEED_MOUNT))
+            .expect("the seed staging mount happens");
+        assert!(
+            matches!(&seed, Call::Mount { data, .. } if data.as_deref() == Some(VOLUME_MOUNT_OPTS)),
+            "seeding writes to the volume too, so it needs the same protection: {seed:?}"
         );
     }
 

--- a/crates/lns-service/src/upperfs/constants.rs
+++ b/crates/lns-service/src/upperfs/constants.rs
@@ -21,6 +21,23 @@ pub const LOST_FOUND_INO: u32 = 11;
 
 pub const LOST_FOUND_BLOCKS: u32 = 4;
 
+pub const JOURNAL_INO: u32 = 8;
+
+// JBD2 refuses to recover a journal shorter than 1024 blocks.
+pub const JBD2_MIN_JOURNAL_BLOCKS: u32 = 1024;
+
+pub const JOURNAL_TARGET_BLOCKS: u32 = 4096;
+
+// Every JBD2 field is big-endian, unlike every other structure in this image.
+pub const JBD2_MAGIC: u32 = 0xC03B_3998;
+pub const JBD2_SUPERBLOCK_V2: u32 = 4;
+pub const JBD2_FIRST_LOG_BLOCK: u32 = 1;
+pub const JBD2_FIRST_SEQUENCE: u32 = 1;
+pub const JBD2_SINGLE_USER: u32 = 1;
+
+// `COMPAT_HAS_JOURNAL` MUST NOT be set without a valid JBD2 block at the reserved run — the kernel then refuses the rw mount outright.
+pub const FEATURE_COMPAT_HAS_JOURNAL: u32 = 0x0004;
+
 // `COMPAT_EXT_ATTR` MUST be set — without it fsck rejects `trusted.overlay.*` xattrs that overlayfs writes to the upper.
 pub const FEATURE_COMPAT_EXT_ATTR: u32 = 0x0008;
 
@@ -34,7 +51,7 @@ pub const FEATURE_RO_COMPAT_SPARSE_SUPER: u32 = 0x0001;
 
 pub const FEATURE_RO_COMPAT_LARGE_FILE: u32 = 0x0002;
 
-pub const SB_FEATURE_COMPAT: u32 = FEATURE_COMPAT_EXT_ATTR;
+pub const SB_FEATURE_COMPAT: u32 = FEATURE_COMPAT_EXT_ATTR | FEATURE_COMPAT_HAS_JOURNAL;
 pub const SB_FEATURE_INCOMPAT: u32 = FEATURE_INCOMPAT_FILETYPE | FEATURE_INCOMPAT_EXTENTS;
 pub const SB_FEATURE_RO_COMPAT: u32 = FEATURE_RO_COMPAT_SPARSE_SUPER | FEATURE_RO_COMPAT_LARGE_FILE;
 
@@ -51,3 +68,4 @@ pub const EXT2_DYNAMIC_REV: u32 = 1;
 
 pub const FT_DIR: u8 = 2;
 pub const S_IFDIR: u16 = 0o0040000;
+pub const S_IFREG: u16 = 0o0100000;

--- a/crates/lns-service/src/upperfs/format.rs
+++ b/crates/lns-service/src/upperfs/format.rs
@@ -40,6 +40,7 @@ pub struct Superblock {
     pub volume_name: [u8; 16],
     // reserved_gdt_blocks MUST be 0 when COMPAT_RESIZE_INODE is clear — e2fsprogs warns on any non-zero value without the matching feature.
     pub reserved_gdt_blocks: u16,
+    pub journal_inum: u32,
     pub mkfs_time: u32,
 }
 
@@ -85,6 +86,7 @@ impl Superblock {
             uuid,
             volume_name: pad_name::<16>(volume_name),
             reserved_gdt_blocks: 0,
+            journal_inum: JOURNAL_INO,
             mkfs_time,
         }
     }
@@ -125,7 +127,8 @@ impl Superblock {
         b[0x68..0x78].copy_from_slice(&self.uuid);
         b[0x78..0x88].copy_from_slice(&self.volume_name);
         b[0xCE..0xD0].copy_from_slice(&self.reserved_gdt_blocks.to_le_bytes());
-        // 0xD0..0x108: journal fields all zero because HAS_JOURNAL is clear.
+        b[0xE0..0xE4].copy_from_slice(&self.journal_inum.to_le_bytes());
+        // 0xD0..0xE0 (s_journal_uuid) and 0xE4..0xE8 (s_journal_dev) MUST stay zero — a non-zero value there means the journal lives on an external device.
         // 0xFE..0x100: s_desc_size MUST be 0 when INCOMPAT_64BIT is clear — e2fsprogs treats non-zero as "64bit implied" and errors.
         b[0x108..0x10C].copy_from_slice(&self.mkfs_time.to_le_bytes());
         b
@@ -261,6 +264,30 @@ impl Inode {
         }
     }
 
+    pub fn journal(time: u32, first_block: u32, journal_blocks: u32) -> Self {
+        let i_block = encode_inline_leaf(&[ExtentLeaf {
+            logical_block: 0,
+            length: u16::try_from(journal_blocks).expect("journal_blocks fits one extent record"),
+            physical_block: first_block as u64,
+        }]);
+        Self {
+            mode: S_IFREG | 0o600,
+            uid: 0,
+            size: journal_blocks * BLOCK_SIZE,
+            atime: time,
+            ctime: time,
+            mtime: time,
+            dtime: 0,
+            gid: 0,
+            links_count: 1,
+            blocks: journal_blocks * (BLOCK_SIZE / 512),
+            flags: EXT4_EXTENTS_FL,
+            i_block,
+            generation: 0,
+            file_acl: 0,
+        }
+    }
+
     pub fn to_bytes(&self) -> [u8; INODE_SIZE as usize] {
         let mut b = [0u8; INODE_SIZE as usize];
         b[0x00..0x02].copy_from_slice(&self.mode.to_le_bytes());
@@ -309,7 +336,7 @@ mod tests {
         let compat = u32::from_le_bytes([b[0x5C], b[0x5D], b[0x5E], b[0x5F]]);
         let incompat = u32::from_le_bytes([b[0x60], b[0x61], b[0x62], b[0x63]]);
         let ro_compat = u32::from_le_bytes([b[0x64], b[0x65], b[0x66], b[0x67]]);
-        assert_eq!(compat, 0x0000_0008, "EXT_ATTR only");
+        assert_eq!(compat, 0x0000_000C, "EXT_ATTR | HAS_JOURNAL");
         assert_eq!(incompat, 0x0000_0042, "FILETYPE | EXTENTS");
         assert_eq!(ro_compat, 0x0000_0003, "SPARSE_SUPER | LARGE_FILE");
     }
@@ -399,13 +426,42 @@ mod tests {
     }
 
     #[test]
-    fn superblock_journal_area_is_zero() {
+    fn superblock_journal_area_is_zero_apart_from_the_inode_number() {
         let sb = Superblock::for_fresh_image(&small_layout(), [0; 16], "test", 0);
         let b = sb.to_bytes();
         for (off, byte) in b[0xD0..0x108].iter().enumerate() {
             let abs = 0xD0 + off;
+            if (0xE0..0xE4).contains(&abs) {
+                continue;
+            }
             assert_eq!(*byte, 0, "journal area byte 0x{abs:X} must be zero");
         }
+    }
+
+    #[test]
+    fn the_superblock_advertises_an_internal_journal_on_inode_8() {
+        let sb = Superblock::for_fresh_image(&small_layout(), [0; 16], "test", 0);
+        let b = sb.to_bytes();
+        let compat = u32::from_le_bytes([b[0x5C], b[0x5D], b[0x5E], b[0x5F]]);
+        assert_eq!(
+            compat & FEATURE_COMPAT_HAS_JOURNAL,
+            FEATURE_COMPAT_HAS_JOURNAL
+        );
+        assert_eq!(
+            u32::from_le_bytes([b[0xE0], b[0xE1], b[0xE2], b[0xE3]]),
+            JOURNAL_INO,
+            "s_journal_inum"
+        );
+        assert_eq!(
+            &b[0xD0..0xE0],
+            &[0u8; 16],
+            "s_journal_uuid stays zero for an internal journal"
+        );
+        assert_eq!(
+            &b[0xE4..0xE8],
+            &[0u8; 4],
+            "s_journal_dev stays zero for an internal journal"
+        );
     }
 
     #[test]
@@ -544,6 +600,39 @@ mod tests {
         assert_eq!(logical, 0);
         assert_eq!(length, 4);
         assert_eq!(physical, 517);
+    }
+
+    #[test]
+    fn the_journal_inode_is_a_regular_root_owned_file_the_workload_cannot_see() {
+        let j = Inode::journal(0, 521, 4096);
+        assert_eq!(j.mode, S_IFREG | 0o600, "mode = 0100600");
+        assert_eq!(j.links_count, 1, "reachable only from the superblock");
+        assert_eq!(j.uid, 0);
+        assert_eq!(j.gid, 0);
+        assert_eq!(j.flags, EXT4_EXTENTS_FL);
+    }
+
+    #[test]
+    fn the_journal_inode_maps_the_reserved_range_as_one_extent() {
+        let j = Inode::journal(0, 521, 4096);
+        let (magic, entries, _, depth) = extent_header(&j.i_block);
+        assert_eq!(magic, EXT4_EXTENT_MAGIC);
+        assert_eq!(
+            entries, 1,
+            "the journal must stay contiguous: encode_inline_leaf holds at most 4 records"
+        );
+        assert_eq!(depth, 0);
+        let (logical, length, physical) = extent_record(&j.i_block, 0);
+        assert_eq!(logical, 0);
+        assert_eq!(length, 4096);
+        assert_eq!(physical, 521);
+    }
+
+    #[test]
+    fn the_journal_inode_size_and_block_count_match_the_reservation() {
+        let j = Inode::journal(0, 521, 4096);
+        assert_eq!(j.size, 4096 * BLOCK_SIZE, "16 MiB still fits u32");
+        assert_eq!(j.blocks, 4096 * (BLOCK_SIZE / 512));
     }
 
     #[test]

--- a/crates/lns-service/src/upperfs/journal.rs
+++ b/crates/lns-service/src/upperfs/journal.rs
@@ -1,0 +1,95 @@
+use crate::upperfs::constants::*;
+
+pub fn superblock_block(journal_blocks: u32, uuid: [u8; 16]) -> Vec<u8> {
+    let mut b = vec![0u8; BLOCK_SIZE as usize];
+    b[0x00..0x04].copy_from_slice(&JBD2_MAGIC.to_be_bytes());
+    b[0x04..0x08].copy_from_slice(&JBD2_SUPERBLOCK_V2.to_be_bytes());
+    b[0x0C..0x10].copy_from_slice(&BLOCK_SIZE.to_be_bytes());
+    b[0x10..0x14].copy_from_slice(&journal_blocks.to_be_bytes());
+    b[0x14..0x18].copy_from_slice(&JBD2_FIRST_LOG_BLOCK.to_be_bytes());
+    b[0x18..0x1C].copy_from_slice(&JBD2_FIRST_SEQUENCE.to_be_bytes());
+    b[0x30..0x40].copy_from_slice(&uuid);
+    b[0x40..0x44].copy_from_slice(&JBD2_SINGLE_USER.to_be_bytes());
+    b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_be32(b: &[u8], off: usize) -> u32 {
+        u32::from_be_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+    }
+
+    #[test]
+    fn journal_superblock_header_is_big_endian_magic_and_v2_blocktype() {
+        let b = superblock_block(1024, [0; 16]);
+        assert_eq!(
+            &b[0x00..0x04],
+            &[0xC0, 0x3B, 0x39, 0x98],
+            "JBD2 is the one big-endian structure in this image; a little-endian magic is unrecoverable"
+        );
+        assert_eq!(read_be32(&b, 0x04), JBD2_SUPERBLOCK_V2);
+        assert_eq!(
+            read_be32(&b, 0x08),
+            0,
+            "h_sequence is unused in a superblock"
+        );
+    }
+
+    #[test]
+    fn journal_superblock_describes_the_reserved_extent() {
+        let b = superblock_block(4096, [0; 16]);
+        assert_eq!(read_be32(&b, 0x0C), BLOCK_SIZE, "s_blocksize");
+        assert_eq!(read_be32(&b, 0x10), 4096, "s_maxlen");
+        assert_eq!(
+            read_be32(&b, 0x14),
+            1,
+            "s_first: block 0 is this superblock"
+        );
+        assert_eq!(
+            read_be32(&b, 0x18),
+            1,
+            "s_sequence: first commit id expected"
+        );
+        assert_eq!(
+            read_be32(&b, 0x1C),
+            0,
+            "s_start: an empty journal has no log"
+        );
+        assert_eq!(read_be32(&b, 0x40), 1, "s_nr_users: one filesystem");
+    }
+
+    #[test]
+    fn journal_superblock_carries_the_filesystem_uuid_for_its_single_user() {
+        let uuid = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x10, 0x32, 0x54, 0x76, 0x98, 0xBA,
+            0xDC, 0xFE,
+        ];
+        let b = superblock_block(1024, uuid);
+        assert_eq!(&b[0x30..0x40], &uuid);
+    }
+
+    #[test]
+    fn journal_superblock_declares_no_features_so_any_kernel_can_recover_it() {
+        let b = superblock_block(1024, [0xAA; 16]);
+        assert_eq!(read_be32(&b, 0x24), 0, "s_feature_compat");
+        assert_eq!(read_be32(&b, 0x28), 0, "s_feature_incompat");
+        assert_eq!(read_be32(&b, 0x2C), 0, "s_feature_ro_compat");
+        assert_eq!(b[0x50], 0, "s_checksum_type");
+        assert_eq!(read_be32(&b, 0xFC), 0, "s_checksum");
+    }
+
+    #[test]
+    fn journal_superblock_is_exactly_one_block_and_otherwise_zero() {
+        let b = superblock_block(4096, [0xAA; 16]);
+        assert_eq!(b.len(), BLOCK_SIZE as usize);
+        let set: Vec<usize> = (0..b.len())
+            .filter(|&i| b[i] != 0)
+            .filter(|i| !(0x00..0x08).contains(i))
+            .filter(|i| !(0x0C..0x20).contains(i))
+            .filter(|i| !(0x30..0x44).contains(i))
+            .collect();
+        assert!(set.is_empty(), "unexpected non-zero bytes at {set:?}");
+    }
+}

--- a/crates/lns-service/src/upperfs/mod.rs
+++ b/crates/lns-service/src/upperfs/mod.rs
@@ -2,6 +2,7 @@ mod constants;
 mod dir;
 mod extents;
 mod format;
+mod journal;
 mod layout;
 mod plan;
 mod writer;
@@ -23,7 +24,7 @@ fn provision_image(
     let run_dir = root.join("runs").join(run_id);
     std::fs::create_dir_all(&run_dir)?;
     let path = run_dir.join("upper.img");
-    let plan = Plan::new(DEFAULT_SIZE_BYTES, uuid, "lns-upper", mkfs_time);
+    let plan = Plan::new(DEFAULT_SIZE_BYTES, uuid, "lns-upper", mkfs_time)?;
     write(&plan, &path)?;
     Ok(path)
 }

--- a/crates/lns-service/src/upperfs/plan.rs
+++ b/crates/lns-service/src/upperfs/plan.rs
@@ -83,6 +83,10 @@ pub fn block_bitmap(layout: &Layout, g: u32) -> Vec<u8> {
         for i in 0..LOST_FOUND_BLOCKS {
             mark(&mut bm, gbl.data_first_block + 1 + i);
         }
+        let journal_first = journal_first_block(layout);
+        for i in 0..journal_blocks(layout) {
+            mark(&mut bm, journal_first + i);
+        }
     }
 
     let real_blocks = layout.blocks_in_group(g) as usize;
@@ -92,6 +96,25 @@ pub fn block_bitmap(layout: &Layout, g: u32) -> Vec<u8> {
     }
 
     bm
+}
+
+pub fn journal_first_block(layout: &Layout) -> u32 {
+    group_block_layout(layout, 0).data_first_block + 1 + LOST_FOUND_BLOCKS
+}
+
+fn group_zero_free_blocks(layout: &Layout) -> u32 {
+    let gbl = group_block_layout(layout, 0);
+    layout
+        .blocks_in_group(0)
+        .saturating_sub(gbl.data_first_block + 1 + LOST_FOUND_BLOCKS)
+}
+
+pub fn journal_blocks(layout: &Layout) -> u32 {
+    if group_zero_free_blocks(layout) >= JOURNAL_TARGET_BLOCKS * 4 {
+        JOURNAL_TARGET_BLOCKS
+    } else {
+        JBD2_MIN_JOURNAL_BLOCKS
+    }
 }
 
 pub fn inode_bitmap(layout: &Layout, g: u32) -> Vec<u8> {
@@ -143,19 +166,40 @@ pub struct Plan {
     pub superblock: Superblock,
     pub root_inode: Inode,
     pub lost_found_inode: Inode,
+    pub journal_inode: Inode,
     pub root_dir_block: Vec<u8>,
     pub lost_found_blocks: Vec<Vec<u8>>,
 }
 
 impl Plan {
-    pub fn new(image_size_bytes: u64, uuid: [u8; 16], volume_name: &str, mkfs_time: u32) -> Self {
+    pub fn new(
+        image_size_bytes: u64,
+        uuid: [u8; 16],
+        volume_name: &str,
+        mkfs_time: u32,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            image_size_bytes >= BLOCK_SIZE as u64,
+            "an image of {image_size_bytes} bytes is too small for a journalled volume: it holds no whole {BLOCK_SIZE}-byte block"
+        );
         let layout = Layout::from_image_size(image_size_bytes);
+        let free = group_zero_free_blocks(&layout);
+        anyhow::ensure!(
+            free >= JBD2_MIN_JOURNAL_BLOCKS * 4,
+            "an image of {image_size_bytes} bytes is too small for a journalled volume: group 0 has {free} free blocks, and the smallest recoverable journal needs {}",
+            JBD2_MIN_JOURNAL_BLOCKS * 4
+        );
 
         let root_data_block = group_block_layout(&layout, 0).data_first_block;
         let lost_found_first_block = root_data_block + 1;
 
         let root_inode = Inode::root_directory(mkfs_time, root_data_block);
         let lost_found_inode = Inode::lost_found_directory(mkfs_time, lost_found_first_block);
+        let journal_inode = Inode::journal(
+            mkfs_time,
+            journal_first_block(&layout),
+            journal_blocks(&layout),
+        );
 
         let mut root_dir = DirBlock::new();
         root_dir.push(DirEntry::new(ROOT_INO, FT_DIR, "."));
@@ -177,14 +221,15 @@ impl Plan {
         superblock.free_blocks_count = free_blocks;
         superblock.free_inodes_count = free_inodes;
 
-        Self {
+        Ok(Self {
             layout,
             superblock,
             root_inode,
             lost_found_inode,
+            journal_inode,
             root_dir_block,
             lost_found_blocks,
-        }
+        })
     }
 
     pub fn root_data_block(&self) -> u32 {
@@ -193,6 +238,14 @@ impl Plan {
 
     pub fn lost_found_first_block(&self) -> u32 {
         self.root_data_block() + 1
+    }
+
+    pub fn journal_first_block(&self) -> u32 {
+        journal_first_block(&self.layout)
+    }
+
+    pub fn journal_blocks(&self) -> u32 {
+        journal_blocks(&self.layout)
     }
 }
 
@@ -295,7 +348,10 @@ mod tests {
         for bit in 516..=520 {
             assert!(get_bit(&bm, bit), "bit {bit} should be set (root/l+f)");
         }
-        for bit in 521..32768 {
+        for bit in 521..=4616 {
+            assert!(get_bit(&bm, bit), "bit {bit} should be set (journal)");
+        }
+        for bit in 4617..32768 {
             assert!(!get_bit(&bm, bit), "bit {bit} should be clear (free)");
         }
     }
@@ -366,10 +422,119 @@ mod tests {
     }
 
     #[test]
+    fn a_ten_gib_image_gets_the_full_journal_target() {
+        let l = ten_gib();
+        let blocks = journal_blocks(&l);
+        assert_eq!(blocks, JOURNAL_TARGET_BLOCKS);
+        assert!(
+            blocks < group_zero_free_blocks(&l),
+            "the journal has to fit group 0's free space alongside root and lost+found"
+        );
+        assert!(
+            blocks <= 32768,
+            "one initialised extent record caps at 32768 blocks, and the journal must stay a single extent"
+        );
+    }
+
+    #[test]
+    fn a_thirty_two_mib_image_falls_back_to_the_jbd2_minimum() {
+        let l = small();
+        assert_eq!(journal_blocks(&l), JBD2_MIN_JOURNAL_BLOCKS);
+    }
+
+    #[test]
+    fn an_image_too_small_to_hold_the_minimum_journal_is_refused() {
+        let err = Plan::new(4 * 1024 * 1024, [0; 16], "test", 0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("too small for a journalled volume"),
+            "volume provisioning runs Plan::new on a service worker, so an unformattable size has to come back as an error: {err}"
+        );
+    }
+
+    #[test]
+    fn the_guard_sits_on_the_real_boundary_rather_than_a_threshold_above_it() {
+        let smallest_accepted = (4..=64u64)
+            .map(|mib| mib * 1024 * 1024)
+            .find(|size| Plan::new(*size, [0; 16], "test", 0).is_ok())
+            .expect("some size in 4..=64 MiB is formattable");
+        assert!(
+            Plan::new(smallest_accepted - 1024 * 1024, [0; 16], "test", 0).is_err(),
+            "one MiB below the smallest accepted size must still be refused"
+        );
+    }
+
+    #[test]
+    fn the_journal_never_exceeds_a_quarter_of_group_zeros_free_space() {
+        for size in (4 * 1024 * 1024..=10 * 1024 * 1024 * 1024u64).step_by(7 * 1024 * 1024) {
+            let layout = Layout::from_image_size(size);
+            let free = group_zero_free_blocks(&layout);
+            if free < JBD2_MIN_JOURNAL_BLOCKS * 4 {
+                continue;
+            }
+            assert!(
+                journal_blocks(&layout) * 4 <= free,
+                "{size} bytes: journal_blocks answers unconditionally, so everything the guard admits must have the room"
+            );
+        }
+    }
+
+    #[test]
+    fn the_journal_sits_immediately_after_lost_and_found() {
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
+        assert_eq!(
+            p.journal_first_block(),
+            p.lost_found_first_block() + LOST_FOUND_BLOCKS
+        );
+    }
+
+    #[test]
+    fn group_zero_block_bitmap_marks_every_journal_block_and_no_more() {
+        let l = ten_gib();
+        let bm = block_bitmap(&l, 0);
+        let first = journal_first_block(&l) as usize;
+        let len = journal_blocks(&l) as usize;
+        for bit in first..first + len {
+            assert!(get_bit(&bm, bit), "journal bit {bit} should be set");
+        }
+        assert!(
+            !get_bit(&bm, first + len),
+            "a journal that runs past its reservation would be overwritten by the first file written"
+        );
+    }
+
+    #[test]
+    fn an_image_smaller_than_group_zeros_own_metadata_is_refused_not_wrapped() {
+        for bytes in [1024u64, 3072, 32 * 1024, 16 * 1024 * 1024] {
+            let err = Plan::new(bytes, [0; 16], "test", 0)
+                .expect_err("an image this small cannot hold a journalled filesystem");
+            assert!(
+                format!("{err:#}").contains("too small for a journalled volume"),
+                "group 0's metadata outgrows its block count here, so an unguarded subtraction \
+                 would wrap to a huge free count and admit the image: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn group_zero_free_blocks_drop_by_exactly_the_journal_size() {
+        let l = ten_gib();
+        let gd = group_descriptor(&l, 0);
+        assert_eq!(gd.free_blocks_count, 32247 - 4096);
+    }
+
+    #[test]
+    fn the_journal_does_not_move_the_root_or_lost_and_found_data_blocks() {
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
+        assert_eq!(p.root_data_block(), 516);
+        assert_eq!(p.lost_found_first_block(), 517);
+    }
+
+    #[test]
     fn group_descriptor_group_0_10_gib() {
         let l = ten_gib();
         let gd = group_descriptor(&l, 0);
-        assert_eq!(gd.free_blocks_count, 32247);
+        assert_eq!(gd.free_blocks_count, 28151);
         assert_eq!(gd.free_inodes_count, 8181);
         assert_eq!(gd.used_dirs_count, 2);
         assert_eq!(gd.block_bitmap, 2);
@@ -397,17 +562,24 @@ mod tests {
 
     #[test]
     fn plan_32_mib_total_free_blocks() {
-        let p = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0);
-        assert_eq!(p.superblock.free_blocks_count, 8055);
+        let p = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0).unwrap();
+        assert_eq!(
+            p.superblock.free_blocks_count,
+            8055 - JBD2_MIN_JOURNAL_BLOCKS
+        );
         assert_eq!(p.superblock.free_inodes_count, 2048 - 11);
     }
 
     #[test]
     fn plan_10_gib_total_free_counts() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         let backup_groups = 9u32;
         let other_groups = 80 - 9;
-        let expected_metadata = backup_groups * 516 + other_groups * 514 + 1 /*root dir*/ + 4 /*l+f*/;
+        let expected_metadata = backup_groups * 516
+            + other_groups * 514
+            + 1 /*root dir*/
+            + 4 /*l+f*/
+            + JOURNAL_TARGET_BLOCKS;
         let expected_free = 2_621_440 - expected_metadata;
         assert_eq!(p.superblock.free_blocks_count, expected_free);
         assert_eq!(p.superblock.free_inodes_count, 655_360 - 11);
@@ -424,7 +596,7 @@ mod tests {
 
     #[test]
     fn plan_root_inode_points_to_correct_block() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         assert_eq!(p.root_data_block(), 516);
         let (logical, length, physical) = first_extent(&p.root_inode);
         assert_eq!(logical, 0);
@@ -434,7 +606,7 @@ mod tests {
 
     #[test]
     fn plan_lost_found_inode_points_to_4_consecutive_blocks() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         assert_eq!(p.lost_found_first_block(), 517);
         let (logical, length, physical) = first_extent(&p.lost_found_inode);
         assert_eq!(logical, 0);
@@ -443,8 +615,17 @@ mod tests {
     }
 
     #[test]
+    fn plan_journal_inode_covers_exactly_the_reserved_run() {
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
+        let (logical, length, physical) = first_extent(&p.journal_inode);
+        assert_eq!(logical, 0);
+        assert_eq!(length as u32, p.journal_blocks());
+        assert_eq!(physical as u32, p.journal_first_block());
+    }
+
+    #[test]
     fn plan_lost_found_blocks_count_matches_constant() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         assert_eq!(p.lost_found_blocks.len(), LOST_FOUND_BLOCKS as usize);
         for block in &p.lost_found_blocks {
             assert_eq!(block.len(), BLOCK_SIZE as usize);
@@ -453,7 +634,7 @@ mod tests {
 
     #[test]
     fn plan_root_dir_block_has_three_entries() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         let b = &p.root_dir_block;
         assert_eq!(u32::from_le_bytes([b[0], b[1], b[2], b[3]]), ROOT_INO);
         assert_eq!(u16::from_le_bytes([b[4], b[5]]), 12);
@@ -471,7 +652,7 @@ mod tests {
 
     #[test]
     fn plan_lost_found_first_block_has_dot_and_dotdot() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         let b = &p.lost_found_blocks[0];
         assert_eq!(u32::from_le_bytes([b[0], b[1], b[2], b[3]]), LOST_FOUND_INO);
         assert_eq!(u32::from_le_bytes([b[12], b[13], b[14], b[15]]), ROOT_INO);
@@ -480,7 +661,7 @@ mod tests {
 
     #[test]
     fn plan_lost_found_trailing_blocks_are_sentinels() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         for i in 1..LOST_FOUND_BLOCKS as usize {
             let b = &p.lost_found_blocks[i];
             assert_eq!(u32::from_le_bytes([b[0], b[1], b[2], b[3]]), 0);
@@ -490,7 +671,7 @@ mod tests {
 
     #[test]
     fn plan_layout_geometry_propagates_to_superblock() {
-        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0);
+        let p = Plan::new(10 * 1024 * 1024 * 1024, [0; 16], "test", 0).unwrap();
         assert_eq!(p.superblock.blocks_count, p.layout.block_count);
         assert_eq!(p.superblock.inodes_count, p.layout.inodes_count);
         assert_eq!(p.superblock.blocks_per_group, p.layout.blocks_per_group);

--- a/crates/lns-service/src/upperfs/writer.rs
+++ b/crates/lns-service/src/upperfs/writer.rs
@@ -4,6 +4,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use crate::upperfs::constants::*;
+use crate::upperfs::journal;
 use crate::upperfs::plan::{
     Plan, block_bitmap, group_block_layout, group_descriptor, inode_bitmap,
 };
@@ -81,8 +82,19 @@ fn write_metadata(f: &mut File, plan: &Plan) -> Result<()> {
                 itab_off + (LOST_FOUND_INO as u64 - 1) * INODE_SIZE as u64,
                 &plan.lost_found_inode.to_bytes(),
             )?;
+            write_at(
+                f,
+                itab_off + (JOURNAL_INO as u64 - 1) * INODE_SIZE as u64,
+                &plan.journal_inode.to_bytes(),
+            )?;
         }
     }
+
+    write_at(
+        f,
+        plan.journal_first_block() as u64 * BLOCK_SIZE as u64,
+        &journal::superblock_block(plan.journal_blocks(), plan.superblock.uuid),
+    )?;
 
     write_at(
         f,
@@ -128,7 +140,7 @@ mod tests {
     fn build_and_read(image_size: u64) -> (tempfile::TempDir, Plan, Vec<u8>) {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join("upper.img");
-        let plan = Plan::new(image_size, [0xAA; 16], "lns-upper", 0x12345678);
+        let plan = Plan::new(image_size, [0xAA; 16], "lns-upper", 0x12345678).expect("plan");
         write_ext4(&plan, &path).expect("write_ext4");
         let mut buf = Vec::new();
         File::open(&path)
@@ -191,13 +203,13 @@ mod tests {
     fn block_bitmap_at_block_2_for_group_0() {
         let (_d, _p, bytes) = build_and_read(32 * 1024 * 1024);
         let bbmp = &bytes[4096 * 2..4096 * 3];
-        for bit in 0..=136 {
+        for bit in 0..=1160 {
             let set = (bbmp[bit / 8] >> (bit % 8)) & 1 == 1;
             assert!(set, "block bitmap bit {bit} should be set");
         }
-        let bit = 137;
+        let bit = 1161;
         let set = (bbmp[bit / 8] >> (bit % 8)) & 1 == 1;
-        assert!(!set, "bit 137 should be clear (first free block)");
+        assert!(!set, "bit 1161 should be clear (first free block)");
     }
 
     #[test]
@@ -243,6 +255,55 @@ mod tests {
         assert_eq!(read_u32(&bytes, off + 0x34), 0, "ee_block");
         assert_eq!(read_u16(&bytes, off + 0x38), 4, "ee_len");
         assert_eq!(read_u32(&bytes, off + 0x3C), 133, "ee_start_lo");
+    }
+
+    fn inode_table_offset(plan: &Plan) -> usize {
+        group_block_layout(&plan.layout, 0).itab_first_block as usize * BLOCK_SIZE as usize
+    }
+
+    #[test]
+    fn the_written_image_contains_the_journal_inode_in_group_zero() {
+        let (_d, plan, bytes) = build_and_read(32 * 1024 * 1024);
+        let off = inode_table_offset(&plan) + (JOURNAL_INO as usize - 1) * INODE_SIZE as usize;
+        assert_eq!(
+            &bytes[off..off + INODE_SIZE as usize],
+            &plan.journal_inode.to_bytes()
+        );
+    }
+
+    #[test]
+    fn the_written_image_starts_the_journal_with_a_valid_jbd2_superblock() {
+        let (_d, plan, bytes) = build_and_read(32 * 1024 * 1024);
+        let off = plan.journal_first_block() as usize * BLOCK_SIZE as usize;
+        assert_eq!(&bytes[off..off + 4], &JBD2_MAGIC.to_be_bytes());
+        assert_eq!(
+            u32::from_be_bytes([
+                bytes[off + 0x10],
+                bytes[off + 0x11],
+                bytes[off + 0x12],
+                bytes[off + 0x13]
+            ]),
+            plan.journal_blocks(),
+            "s_maxlen must match the extent the inode reserved"
+        );
+    }
+
+    #[test]
+    fn the_journal_flag_and_the_jbd2_block_come_from_one_plan() {
+        let (_d, plan, bytes) = build_and_read(32 * 1024 * 1024);
+        assert_eq!(
+            read_u32(&bytes, 1024 + 0x5C) & FEATURE_COMPAT_HAS_JOURNAL,
+            FEATURE_COMPAT_HAS_JOURNAL,
+            "a flag with no journal behind it makes the kernel refuse the rw mount outright"
+        );
+        let inum = read_u32(&bytes, 1024 + 0xE0);
+        let inode_off = inode_table_offset(&plan) + (inum as usize - 1) * INODE_SIZE as usize;
+        let first_block = read_u32(&bytes, inode_off + 0x3C) as usize;
+        assert_eq!(
+            &bytes[first_block * BLOCK_SIZE as usize..first_block * BLOCK_SIZE as usize + 4],
+            &JBD2_MAGIC.to_be_bytes(),
+            "the block the advertised inode points at must hold the JBD2 superblock"
+        );
     }
 
     #[test]
@@ -293,7 +354,7 @@ mod tests {
     fn no_tmp_file_left_after_success() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join("upper.img");
-        let plan = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0);
+        let plan = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0).expect("plan");
         write_ext4(&plan, &path).expect("write");
         assert!(path.exists(), "image exists");
         let tmp = tmp_path(&path);
@@ -306,7 +367,7 @@ mod tests {
         let path = dir.path().join("upper.img");
         let tmp = tmp_path(&path);
         std::fs::write(&tmp, b"stale junk").expect("seed stale tmp");
-        let plan = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0);
+        let plan = Plan::new(32 * 1024 * 1024, [0; 16], "test", 0).expect("plan");
         write_ext4(&plan, &path).expect("write should succeed despite stale tmp");
         assert!(path.exists());
         assert!(!tmp.exists());

--- a/crates/lns-service/src/volume_store/real.rs
+++ b/crates/lns-service/src/volume_store/real.rs
@@ -54,7 +54,7 @@ impl Fs for RealFs {
             .unwrap_or(0);
         let path = p.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            let plan = Plan::new(size_bytes, uuid, "lns-vol", mkfs_time);
+            let plan = Plan::new(size_bytes, uuid, "lns-vol", mkfs_time)?;
             write_ext4(&plan, &path)
         })
         .await

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -384,8 +384,14 @@ removing one is permanent.
 A run that finishes, or that you `lns stop`, **releases** each volume before the
 guest powers off, so the image is left marked clean. A run the host cannot ask to
 stop — `lns kill`, or a service killed outright — cannot do that, and leaves its
-volumes dirty. The images carry no journal yet, so nothing replays on the next
-mount: prefer `lns stop` over `lns kill` when a volume holds work you care about.
+volumes dirty.
+
+A volume image carries an internal journal, so an interrupted run leaves it
+mountable and consistent — the kernel replays the journal at the next attach. A
+volume created by an older build has no journal, and gains one only when you
+recreate it (`lns volume rm`, then the next run). Every volume also mounts with
+`errors=remount-ro`, so an image the kernel does find inconsistent stops taking
+writes instead of compounding the damage.
 
 Once an image has been left dirty, it stays dirty. The kernel restores the state
 it found at mount, so a later clean run does not clear the mark, and there is no


### PR DESCRIPTION
## The problem

`crates/lns-service/src/upperfs/` writes our ext4 images from scratch, and it sets `SB_FEATURE_COMPAT = FEATURE_COMPAT_EXT_ATTR` only — no `HAS_JOURNAL`. So every named volume is journal-less ext4, mounted read-write, never checked. The guest kernel says so on each mount:

```
EXT4-fs (vdc): warning: mounting unchecked fs, running e2fsck is recommended
EXT4-fs (vdc): mounted filesystem … r/w without journal
```

Nothing acts on that warning, and we ship no `e2fsck` in the guest. When a run ends without the guest completing its shutdown, the filesystem is left mid-write with no way to recover, and later reads fail with `EUCLEAN`:

```
$ ls …/toolchains/1.95.0-aarch64-unknown-linux-gnu/bin/
cargo                         # rustc absent
$ du -sh …/toolchains/*
du: cannot access '…/lib/rustlib/etc': Structure needs cleaning
```

That is metadata corruption, not a missing file. Since a named volume is where a workload keeps state worth keeping, this is a data-loss bug.

## Which shutdowns are actually at risk

Worth being precise, because it is easy to assume `lns kill` is one of them. It is not. `kill_resolved` sends a signal down the session channel to the workload fork only; the workload dies, `run()` returns, and `main()` then runs `release_volumes()` → `sync()` → `reboot(RB_POWER_OFF)` on **every** exit path. The volume is unmounted cleanly.

What stays unprotected:

- `SIGKILL` of `lns-service`, which takes its VMs with it
- host power loss
- a guest that does not finish release+sync inside the host's 2-second grace before `VmStopGuard::drop` force-stops the VM

## The fix

Every image the writer produces now carries an internal JBD2 journal, so the kernel replays it at the next read-write mount and no external tool is needed.

- **One source of truth.** The group-0 block bitmap, inode 8's single extent, and the on-disk JBD2 superblock all derive from the same two functions (`journal_first_block`, `journal_blocks`), so no parallel arithmetic can drift. Free counts self-correct: `group_descriptor` counts set bitmap bits, and `total_free_counts` sums descriptors.
- **The flag and the block are inseparable.** `FEATURE_COMPAT_HAS_JOURNAL` is OR'd into the shared `SB_FEATURE_COMPAT` constant, and the JBD2 block is written inside the same `write_metadata` that writes that superblock. There is no code path producing one without the other — which matters, because a flag set with no valid journal block makes the kernel refuse the read-write mount outright.
- **Big-endian, pinned deliberately.** JBD2 is the only big-endian structure in this writer. The magic is asserted as a literal `[0xC0, 0x3B, 0x39, 0x98]`, so a `to_le_bytes` slip cannot pass.
- **Journal size is a pure function of the layout** — the full target when group 0 has room, the JBD2 minimum otherwise. Two branches, both tested. No size ladder, because every shipped volume is `VOLUME_DEFAULT_SIZE_BYTES` and the only other size in the tree is the 32 MiB oracle image.
- **`errors=remount-ro` on every ext4 mount we make** — both volumes and the per-run overlay upper. A damaged filesystem stops taking writes instead of compounding the damage. This is also the only protection an image written by an older build ever gets.
- **`Plan::new` returns `Result`** instead of asserting, and refuses an image too small to hold one block before any layout arithmetic runs. (`Layout::from_image_size` underflows below 4096 bytes; unreachable today, reachable the moment volume size becomes user-settable.)

The overlay upper is journalled too, deliberately. It is discarded each run and gains nothing, but a second unjournalled format path would double the encoder surface and need its own e2fsprogs oracle.

## Existing expectations that moved

`plan.rs`'s pinned bitmap ranges and free counts change, because group 0 now reserves the journal. Each was corrected individually rather than blanket-updated — e.g. group 0 free blocks go `32247 → 28151` on a 10 GiB image, exactly the 4096-block reservation, and `the_journal_does_not_move_the_root_or_lost_and_found_data_blocks` pins that the change is append-only.

## Verification

- `make lint`, `make complexity`, `make coverage` — all exit 0. Every touched file at 100%; no `IGNORES` entry added.
- `cargo clippy -p lns-init --target aarch64-unknown-linux-musl --all-targets -- -D warnings` — exit 0. `mount.rs` is `#[cfg(target_os = "linux")]`, so a macOS `make lint` does not see it.
- **Validated by e2fsprogs 1.47.4, not only by our own encoder**: `e2fsck` reports both the 32 MiB and 10 GiB images clean, `dumpe2fs` reports journal inode/size/sequence — which it can only do by parsing our big-endian superblock correctly — and the image is compared against a real `mke2fs -J size=4` reference. Removing the JBD2 block write turns 4 of these red.

## Testing notes for the reviewer

There is no journal-replay scenario, and `volumes.feature` now carries a comment saying so rather than implying otherwise. The reason is the shutdown analysis above: this harness has no step that produces an unclean unmount, because the broker always releases and syncs. A test that kills a run and reads the data back is green on `main` today — it proves the release path, not the journal.

The deterministic proof is instead `volume_management.feature`: `lns volume create`, then read `s_feature_compat` and `s_journal_inum` from the image the service just wrote. It is **not** `@microvm`, so it runs in the required CI job, and it fails 100% of the time on `main`.

## Not run

`make e2e` and `make e2e-microvm` (real binaries, real VM). The guest-side `errors=remount-ro` change is exercised only against a recording syscall fake — the option itself is long-standing and valid, but one `make e2e-microvm` on a virt-capable host before merge would close that gap.
