### PR TITLE
feat: let a definition declare a host file or a home-anchored bind

### DIFF
--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -74,11 +74,18 @@ pub struct Volume {
     /// Subpaths of a bind the workload must not see, relative to the bind root; masked in the guest exactly as a `.lensignore` entry is.
     #[serde(default)]
     exclude: Vec<String>,
+    /// A bind source the running machine does not have is skipped instead of refusing the run.
+    #[serde(default)]
+    optional: bool,
 }
 
 impl Volume {
     pub fn exclude(&self) -> &[String] {
         &self.exclude
+    }
+
+    pub fn optional(&self) -> bool {
+        self.optional
     }
 
     pub fn source(&self) -> &str {
@@ -130,7 +137,7 @@ pub struct SandboxSpec {
     pub ports: Vec<Port>,
 }
 
-/// Files shipped inside the artifact: a local directory packed and digest-pinned at push (path), or a pre-published FileSet (ref), snapshot-mounted at mountPath.
+/// Files shipped inside the artifact: a local directory packed and digest-pinned at push (path), or a pre-published FileSet (ref), snapshot-mounted at mountPath. A hostPath instead names one file on the machine that runs it, snapshotted at launch and never packed.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FilesetEntry {
@@ -140,10 +147,15 @@ pub struct FilesetEntry {
     pub reference: Option<String>,
     #[serde(default)]
     pub inline: Option<BTreeMap<String, String>>,
+    #[serde(rename = "hostPath", default)]
+    pub host_path: Option<String>,
     #[serde(rename = "mountPath")]
     pub mount_path: String,
     #[serde(default)]
     pub owner: FilesetOwner,
+    /// A hostPath the running machine does not have is skipped instead of refusing the run.
+    #[serde(default)]
+    pub optional: bool,
 }
 
 /// Who owns the materialized files in the guest: the run-as workload user (so the workload can rewrite its own seeded state), or root (pinned inputs the workload must not touch).
@@ -291,21 +303,44 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
 fn validate_fileset(fileset: &FilesetEntry) -> Result<()> {
     let source_count = usize::from(fileset.path.is_some())
         + usize::from(fileset.reference.is_some())
-        + usize::from(fileset.inline.is_some());
+        + usize::from(fileset.inline.is_some())
+        + usize::from(fileset.host_path.is_some());
     if source_count != 1 || fileset.inline.as_ref().is_some_and(BTreeMap::is_empty) {
         bail!(
-            "fileset targeting {} must set exactly one of path, ref, or inline",
+            "fileset targeting {} must set exactly one of path, ref, inline, or hostPath",
             fileset.mount_path
         );
     }
-    if fileset.path.as_ref().is_some_and(String::is_empty) {
-        bail!("fileset path must not be empty");
+    if let Some(path) = &fileset.path {
+        if path.is_empty() {
+            bail!("fileset path must not be empty");
+        }
+        if path.starts_with('~') {
+            bail!(
+                "fileset path {path:?} is packed from a directory beside this document, so it cannot be home-anchored; use hostPath to read one file from the machine that runs the sandbox"
+            );
+        }
     }
     if fileset.reference.as_ref().is_some_and(String::is_empty) {
         bail!("fileset ref must not be empty");
     }
     if let Some(inline) = &fileset.inline {
         validate_inline_files(inline)?;
+    }
+    match &fileset.host_path {
+        Some(host_path) => {
+            validate_host_source(host_path)?;
+            if fileset.mount_path.ends_with('/') {
+                bail!(
+                    "fileset hostPath {host_path} names a guest file, so mountPath {} must not end in `/`",
+                    fileset.mount_path
+                );
+            }
+        }
+        None if fileset.optional => bail!(
+            "optional applies to a hostPath fileset only; a packed or inline fileset always ships"
+        ),
+        None => {}
     }
     spec::validate_mount_path(&fileset.mount_path).context("fileset mountPath")?;
     if overlaps_runtime_namespace(&fileset.mount_path) {
@@ -461,6 +496,11 @@ fn validate_volume(volume: &Volume) -> Result<()> {
     if !volume.exclude.is_empty() && !volume.is_bind() {
         bail!("exclude applies to a bind volume only; a named volume has no host subpaths to hide");
     }
+    if volume.optional && !volume.is_bind() {
+        bail!(
+            "optional applies to a bind volume only; a named volume is created on demand, never absent"
+        );
+    }
     for entry in &volume.exclude {
         validate_bind_relative_path(entry)?;
     }
@@ -512,9 +552,13 @@ fn validate_bind_relative_path(entry: &str) -> Result<()> {
     Ok(())
 }
 
+/// A `~/` source is the one form a published definition can aim at the consumer's own home, and the keep/drop scan it meets later reads top-level names only, so a secret-shaped segment is refused here; an absolute or project-relative source keeps the rules it already had.
 fn validate_bind_source(source: &str) -> Result<()> {
     if source.is_empty() {
         bail!("bind source must not be empty");
+    }
+    if source.starts_with('~') && !source.starts_with("~/") {
+        bail!("invalid bind source {source:?}: only `~/` is supported, not another user's home");
     }
     if source
         .chars()
@@ -525,7 +569,41 @@ fn validate_bind_source(source: &str) -> Result<()> {
     if source.split('/').any(|segment| segment == "..") {
         bail!("bind source {source:?} must not contain a `..` path segment");
     }
+    if source.starts_with("~/") {
+        refuse_secret_shaped_segment("bind source", source)?;
+    }
     Ok(())
+}
+
+fn refuse_secret_shaped_segment(kind: &str, source: &str) -> Result<()> {
+    if let Some(secret) = source.split('/').find(|s| looks_like_secret_name(s)) {
+        bail!(
+            "{kind} {source} is secret-shaped ({secret}) — real secrets stay outside the workload"
+        );
+    }
+    Ok(())
+}
+
+/// A hostPath names one file on the machine that runs the definition; it must anchor somewhere portable, stay inside what it anchors to, and never be secret-shaped — a hostPath file gets no KEEP/DROP prompt, so its name is the only guard it has.
+pub fn validate_host_source(source: &str) -> Result<()> {
+    if source.starts_with('~') && !source.starts_with("~/") {
+        bail!("invalid hostPath {source:?}: only `~/` is supported, not another user's home");
+    }
+    if !(source.starts_with('/') || source.starts_with("~/")) {
+        bail!("invalid hostPath {source:?}: must start with `/` or `~/`");
+    }
+    if source.split('/').any(|segment| segment == "..") {
+        bail!("invalid hostPath {source:?}: must not contain a `..` path segment");
+    }
+    if source
+        .chars()
+        .any(|c| c.is_whitespace() || c.is_control() || c == '"' || c == '\'')
+    {
+        bail!(
+            "invalid hostPath {source:?}: must be free of whitespace, quotes, and control characters"
+        );
+    }
+    refuse_secret_shaped_segment("hostPath", source)
 }
 
 fn validate_volume_name(name: &str) -> Result<()> {
@@ -959,6 +1037,91 @@ mod tests {
     }
 
     #[test]
+    fn a_home_rooted_bind_source_parses() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"~/.claude","target":"/home/agent/.claude"}]}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            def.spec.volumes[0].source(),
+            "~/.claude",
+            "the tilde travels verbatim; the CLI anchors it to this machine's home"
+        );
+    }
+
+    #[test]
+    fn a_user_relative_bind_source_is_refused() {
+        for source in ["~alice/.claude", "~"] {
+            let spec = format!(
+                r#"{{"image":"x:1","volumes":[{{"type":"bind","source":"{source}","target":"/work"}}]}}"#
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("only `~/` is supported"),
+                "source {source} would otherwise bind a literal {source:?} directory under the project: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_home_rooted_bind_source_naming_a_secret_store_is_refused() {
+        for source in [
+            "~/.ssh",
+            "~/.gnupg",
+            "~/.aws",
+            "~/.gnupg/private-keys-v1.d",
+            "~/.ssh/id_rsa",
+        ] {
+            let spec = format!(
+                r#"{{"image":"x:1","volumes":[{{"type":"bind","source":"{source}","target":"/work"}}]}}"#
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("secret-shaped"),
+                "`~/` is the first form that lets a pulled sandbox name the consumer's own home, and the bind's top-level scan never reaches a nested key store — {source}: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_absolute_bind_source_keeps_the_rules_it_already_had() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"/srv/.ssh","target":"/work"}]}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            def.spec.volumes[0].source(),
+            "/srv/.ssh",
+            "an absolute source names the author's own machine and cannot travel; tightening it is a separate change"
+        );
+    }
+
+    #[test]
+    fn an_optional_bind_parses_and_defaults_to_required() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"~/.claude","target":"/home/agent/.claude","optional":true},{"type":"bind","source":".","target":"/workspace"}]}"#,
+        ))
+        .unwrap();
+        assert!(def.spec.volumes[0].optional());
+        assert!(
+            !def.spec.volumes[1].optional(),
+            "a bind whose host path is missing must refuse the run unless the author opted out"
+        );
+    }
+
+    #[test]
+    fn optional_is_refused_on_a_named_volume() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"volume","source":"cache","target":"/cache","optional":true}]}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("bind volume only"),
+            "a named volume is created on demand, so it is never absent: got {err:#}"
+        );
+    }
+
+    #[test]
     fn parse_accepts_an_exclude_list_on_a_bind_volume() {
         let def = parse(&def_json(
             r#"{"image":"x:1","volumes":[{"type":"bind","source":".","target":"/workspace","exclude":[".cargo","tmp/scratch"]}]}"#,
@@ -1085,10 +1248,178 @@ mod tests {
             let spec = format!(r#"{{"image":"x:1","filesets":[{entry}]}}"#);
             let err = parse(&def_json(&spec)).unwrap_err();
             assert!(
-                format!("{err:#}").contains("exactly one of path, ref, or inline"),
+                format!("{err:#}").contains("exactly one of path, ref, inline, or hostPath"),
                 "got: {err:#}"
             );
         }
+    }
+
+    #[test]
+    fn a_home_anchored_fileset_path_is_refused_for_the_reason_it_cannot_work() {
+        for source in ["~/skills", "~", "~alice/skills"] {
+            let spec =
+                format!(r#"{{"image":"x:1","filesets":[{{"path":"{source}","mountPath":"/s"}}]}}"#);
+            let message = format!("{:#}", parse(&def_json(&spec)).unwrap_err());
+            assert!(
+                message.contains("packed from a directory beside") && message.contains("hostPath"),
+                "a packed path is never home-anchored, so the launch-time refusal claimed this machine has no home directory on a machine that plainly has one — {source}: got {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_fileset_parses_with_its_mount_path() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","filesets":[{"hostPath":"~/.gitconfig","mountPath":"/home/agent/.gitconfig","optional":true}]}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            def.spec.filesets[0].host_path.as_deref(),
+            Some("~/.gitconfig"),
+            "the declared host path travels verbatim; expansion is a launch-time concern"
+        );
+        assert!(def.spec.filesets[0].optional);
+    }
+
+    #[test]
+    fn a_host_path_fileset_is_required_unless_it_says_otherwise() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","filesets":[{"hostPath":"/etc/gitconfig","mountPath":"/etc/gitconfig"}]}"#,
+        ))
+        .unwrap();
+        assert!(
+            !def.spec.filesets[0].optional,
+            "an absent host path must refuse the run unless the author opted out"
+        );
+    }
+
+    #[test]
+    fn a_host_path_fileset_ships_the_field_under_its_camel_case_name() {
+        let entry: FilesetEntry = serde_json::from_str(
+            r#"{"hostPath":"~/.gitconfig","mountPath":"/home/agent/.gitconfig"}"#,
+        )
+        .expect("hostPath is the wire name; host_path would silently drop the source");
+        assert_eq!(entry.host_path.as_deref(), Some("~/.gitconfig"));
+    }
+
+    #[test]
+    fn a_fileset_setting_both_host_path_and_path_is_refused() {
+        for entry in [
+            r#"{"hostPath":"~/.gitconfig","path":"./skills","mountPath":"/s"}"#,
+            r#"{"hostPath":"~/.gitconfig","ref":"reg/skills@sha256:abc","mountPath":"/s"}"#,
+            r#"{"hostPath":"~/.gitconfig","inline":{"settings.json":"{}"},"mountPath":"/s"}"#,
+        ] {
+            let spec = format!(r#"{{"image":"x:1","filesets":[{entry}]}}"#);
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("exactly one of path, ref, inline, or hostPath"),
+                "got: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_must_be_absolute_or_home_rooted() {
+        for source in ["./x", "../x", "~", "~alice/x", "x", ""] {
+            let spec = format!(
+                r#"{{"image":"x:1","filesets":[{{"hostPath":{},"mountPath":"/s"}}]}}"#,
+                serde_json::to_string(source).unwrap()
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("hostPath"),
+                "source {source:?}: got {err:#}"
+            );
+        }
+        for source in ["/etc/gitconfig", "~/.gitconfig"] {
+            let spec = format!(
+                r#"{{"image":"x:1","filesets":[{{"hostPath":"{source}","mountPath":"/s"}}]}}"#
+            );
+            parse(&def_json(&spec)).unwrap_or_else(|e| panic!("source {source}: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn a_user_relative_host_path_names_the_one_form_that_is_supported() {
+        for source in ["~", "~alice/x"] {
+            let spec = format!(
+                r#"{{"image":"x:1","filesets":[{{"hostPath":"{source}","mountPath":"/s"}}]}}"#
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("only `~/` is supported"),
+                "source {source}: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_naming_a_secret_shaped_file_is_refused() {
+        for source in ["~/.npmrc", "~/.ssh/id_rsa", "~/.aws/credentials", "/x/.env"] {
+            let spec = format!(
+                r#"{{"image":"x:1","filesets":[{{"hostPath":"{source}","mountPath":"/s"}}]}}"#
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("secret-shaped"),
+                "a hostPath file gets no KEEP/DROP prompt, so the name check is its only guard — {source}: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_that_could_split_the_guest_cmdline_is_refused() {
+        for source in ["/etc/git config", "/etc/\"gitconfig", "/etc/../shadow"] {
+            let spec = format!(
+                r#"{{"image":"x:1","filesets":[{{"hostPath":{},"mountPath":"/s"}}]}}"#,
+                serde_json::to_string(source).unwrap()
+            );
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("hostPath"),
+                "source {source:?}: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_mount_path_naming_a_directory_is_refused() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","filesets":[{"hostPath":"~/.gitconfig","mountPath":"/home/agent/"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("names a guest file"),
+            "a hostPath fileset copies one file to one guest path, so a directory mountPath has no meaning: {err:#}"
+        );
+    }
+
+    #[test]
+    fn optional_is_refused_on_a_fileset_without_a_host_path() {
+        for entry in [
+            r#"{"path":"./skills","mountPath":"/s","optional":true}"#,
+            r#"{"ref":"reg/skills@sha256:abc","mountPath":"/s","optional":true}"#,
+            r#"{"inline":{"settings.json":"{}"},"mountPath":"/s","optional":true}"#,
+        ] {
+            let spec = format!(r#"{{"image":"x:1","filesets":[{entry}]}}"#);
+            let err = parse(&def_json(&spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("optional applies to a hostPath fileset only"),
+                "got: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_path_fileset_still_collides_with_another_mount_target() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"name":"data","target":"/s"}],"filesets":[{"hostPath":"~/.gitconfig","mountPath":"/s"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("duplicate mount target /s"),
+            "got: {err:#}"
+        );
     }
 
     #[test]
@@ -1252,7 +1583,7 @@ mod tests {
             let spec = format!(r#"{{"image":"x:1","filesets":[{entry}]}}"#);
             let err = parse(&def_json(&spec)).unwrap_err();
             assert!(
-                format!("{err:#}").contains("exactly one of path, ref, or inline"),
+                format!("{err:#}").contains("exactly one of path, ref, inline, or hostPath"),
                 "got: {err:#}"
             );
         }

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -211,7 +211,7 @@ pub struct RunArgs {
     pub declared_unpublished: Vec<u16>,
 
     #[arg(skip)]
-    pub filesets: Vec<(String, String, String)>,
+    pub filesets: Vec<crate::run::summary::FilesetSummary>,
 
     #[arg(skip)]
     pub tools: Vec<String>,
@@ -737,6 +737,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: true,
                 exclude: Vec::new(),
+                optional: false,
             })
         );
     }
@@ -802,6 +803,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: false,
                 exclude: Vec::new(),
+                optional: false,
             })
         );
     }

--- a/crates/lns-cli/src/run/declarative.rs
+++ b/crates/lns-cli/src/run/declarative.rs
@@ -11,6 +11,7 @@ pub struct MountDefault {
     pub target: String,
     pub read_only: bool,
     pub exclude: Vec<String>,
+    pub optional: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +50,7 @@ impl Defaults {
                     target: volume.target.clone(),
                     read_only: volume.read_only(),
                     exclude: volume.exclude().to_vec(),
+                    optional: volume.optional(),
                 })
                 .collect(),
             ports: definition
@@ -79,6 +81,7 @@ impl Defaults {
                     target: mount.target.clone(),
                     read_only: mount.read_only,
                     exclude: mount.exclude.clone(),
+                    optional: mount.optional,
                 })
                 .collect(),
             ports: view
@@ -161,6 +164,7 @@ pub struct Resolved {
 pub fn resolve(
     defaults: &Defaults,
     project_dir: &Path,
+    home: Option<&Path>,
     explicit_workdir: Option<String>,
     explicit_mounts: Vec<lns_ipc::MountSpec>,
 ) -> Result<Resolved> {
@@ -172,7 +176,7 @@ pub fn resolve(
         .mounts
         .iter()
         .filter(|mount| !overridden_targets.contains(mount.target.as_str()))
-        .map(|mount| resolve_mount(mount, project_dir))
+        .map(|mount| resolve_mount(mount, project_dir, home))
         .collect::<Result<Vec<_>>>()?;
     mounts.extend(explicit_mounts);
     Ok(Resolved {
@@ -181,16 +185,21 @@ pub fn resolve(
     })
 }
 
-fn resolve_mount(mount: &MountDefault, project_dir: &Path) -> Result<lns_ipc::MountSpec> {
+fn resolve_mount(
+    mount: &MountDefault,
+    project_dir: &Path,
+    home: Option<&Path>,
+) -> Result<lns_ipc::MountSpec> {
     lns_ipc::validate_volume_target(&mount.target).map_err(anyhow::Error::msg)?;
     if mount.bind {
-        let source = resolve_bind_source(&mount.source, project_dir)?;
+        let source = resolve_bind_source(&mount.source, project_dir, home)?;
         lns_ipc::validate_bind_source(&source).map_err(anyhow::Error::msg)?;
         return Ok(lns_ipc::MountSpec::Bind(lns_ipc::BindSpec {
             host_source: source,
             target: mount.target.clone(),
             read_only: mount.read_only,
             exclude: mount.exclude.clone(),
+            optional: mount.optional,
         }));
     }
     lns_ipc::validate_volume_name(&mount.source).map_err(anyhow::Error::msg)?;
@@ -201,15 +210,28 @@ fn resolve_mount(mount: &MountDefault, project_dir: &Path) -> Result<lns_ipc::Mo
     }))
 }
 
-pub(crate) fn resolve_bind_source(source: &str, project_dir: &Path) -> Result<String> {
+pub(crate) fn resolve_bind_source(
+    source: &str,
+    project_dir: &Path,
+    home: Option<&Path>,
+) -> Result<String> {
+    if let Some(under_home) = source.strip_prefix("~/") {
+        let home = home.with_context(|| {
+            format!("cannot resolve {source}: this machine has no home directory")
+        })?;
+        return normalized_utf8(&home.join(under_home));
+    }
     let source = Path::new(source);
     let joined = if source.is_absolute() {
         source.to_path_buf()
     } else {
         project_dir.join(source)
     };
-    let normalized = normalize_absolute(&joined)?;
-    normalized
+    normalized_utf8(&joined)
+}
+
+fn normalized_utf8(path: &Path) -> Result<String> {
+    normalize_absolute(path)?
         .into_os_string()
         .into_string()
         .map_err(|_| anyhow::anyhow!("bind source is not valid UTF-8"))
@@ -243,7 +265,7 @@ mod tests {
     #[test]
     fn relative_bind_sources_are_normalized_under_the_project_directory() {
         assert_eq!(
-            resolve_bind_source("./src", Path::new("/work/project")).unwrap(),
+            resolve_bind_source("./src", Path::new("/work/project"), None).unwrap(),
             "/work/project/src"
         );
     }
@@ -251,15 +273,38 @@ mod tests {
     #[test]
     fn absolute_bind_sources_are_normalized_without_using_the_project_directory() {
         assert_eq!(
-            resolve_bind_source("/work/./project", Path::new("/elsewhere")).unwrap(),
+            resolve_bind_source("/work/./project", Path::new("/elsewhere"), None).unwrap(),
             "/work/project"
         );
     }
 
     #[test]
     fn resolution_rejects_a_relative_project_directory() {
-        let err = resolve_bind_source(".", Path::new("relative")).unwrap_err();
+        let err = resolve_bind_source(".", Path::new("relative"), None).unwrap_err();
         assert!(format!("{err:#}").contains("project directory must be absolute"));
+    }
+
+    #[test]
+    fn a_home_rooted_source_resolves_against_the_invoking_users_home_not_the_project() {
+        assert_eq!(
+            resolve_bind_source(
+                "~/.claude",
+                Path::new("/work/project"),
+                Some(Path::new("/home/some-user"))
+            )
+            .unwrap(),
+            "/home/some-user/.claude"
+        );
+    }
+
+    #[test]
+    fn a_home_rooted_source_without_a_known_home_is_refused() {
+        let err = resolve_bind_source("~/.claude", Path::new("/work/project"), None).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("~/.claude"),
+            "the refusal must name the path, so nothing ever binds a literal `~` directory under the project: {message}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/run/host_bind.rs
+++ b/crates/lns-cli/src/run/host_bind.rs
@@ -131,7 +131,15 @@ pub fn resolve_binds(
     for spec in specs {
         let root = Path::new(&spec.host_source);
         if !scan.exists(root) {
-            bail!("host path does not exist: {}", spec.host_source);
+            if !spec.optional {
+                bail!("host path does not exist: {}", spec.host_source);
+            }
+            writeln!(
+                output,
+                "lns: skipping optional bind {} — not present on this host",
+                spec.host_source
+            )?;
+            continue;
         }
         if !scan.is_dir(root) {
             bail!(
@@ -276,6 +284,7 @@ mod tests {
             target: target.into(),
             read_only: false,
             exclude: Vec::new(),
+            optional: false,
         }
     }
 

--- a/crates/lns-cli/src/run/pull_confirm.rs
+++ b/crates/lns-cli/src/run/pull_confirm.rs
@@ -7,7 +7,7 @@ pub struct PulledEffects<'a> {
     pub reference: &'a str,
     pub binds: &'a [lns_ipc::BindSpec],
     pub volumes: &'a [lns_ipc::VolumeMount],
-    pub filesets: &'a [(String, String, String)],
+    pub filesets: &'a [crate::run::summary::FilesetSummary],
     pub tools: &'a [String],
 }
 
@@ -95,15 +95,21 @@ fn disclosure(effects: &PulledEffects) -> String {
         )
         .unwrap();
     }
-    for (source, mount_path, owner) in effects.filesets {
-        let mode = if owner == "workload" {
+    for fileset in effects.filesets {
+        let mode = if fileset.owner == "workload" {
             "read and write"
         } else {
             "read"
         };
+        let provenance = if fileset.from_host {
+            "a file read from this machine at launch, which the workload can"
+        } else {
+            "author-published files the workload can"
+        };
         writeln!(
             s,
-            "  Fileset:   {source} → {mount_path} — author-published files the workload can {mode} (owner: {owner})"
+            "  Fileset:   {} → {} — {provenance} {mode} (owner: {})",
+            fileset.source, fileset.mount_path, fileset.owner
         )
         .unwrap();
     }
@@ -127,6 +133,7 @@ mod tests {
             target: "/work".into(),
             read_only,
             exclude: Vec::new(),
+            optional: false,
         }
     }
 
@@ -142,6 +149,15 @@ mod tests {
         (r, String::from_utf8(out).unwrap())
     }
 
+    fn fileset(source: &str, mount_path: &str, owner: &str) -> crate::run::summary::FilesetSummary {
+        crate::run::summary::FilesetSummary {
+            source: source.into(),
+            mount_path: mount_path.into(),
+            owner: owner.into(),
+            from_host: false,
+        }
+    }
+
     fn volume(name: &str, read_only: bool) -> lns_ipc::VolumeMount {
         lns_ipc::VolumeMount {
             name: name.into(),
@@ -152,7 +168,7 @@ mod tests {
 
     fn mounts<'a>(
         binds: &'a [lns_ipc::BindSpec],
-        filesets: &'a [(String, String, String)],
+        filesets: &'a [crate::run::summary::FilesetSummary],
     ) -> PulledEffects<'a> {
         volume_mounts(binds, &[], filesets)
     }
@@ -160,7 +176,7 @@ mod tests {
     fn volume_mounts<'a>(
         binds: &'a [lns_ipc::BindSpec],
         volumes: &'a [lns_ipc::VolumeMount],
-        filesets: &'a [(String, String, String)],
+        filesets: &'a [crate::run::summary::FilesetSummary],
     ) -> PulledEffects<'a> {
         PulledEffects {
             reference: "ghcr.io/team/hermes:1",
@@ -185,6 +201,7 @@ mod tests {
             target: target.into(),
             read_only: false,
             exclude: Vec::new(),
+            optional: false,
         })
     }
 
@@ -270,16 +287,12 @@ mod tests {
     #[test]
     fn disclosure_names_each_fileset_with_its_mount_path_and_access_mode() {
         let filesets = [
-            (
-                "reg/skills@sha256:abcabcabcabc…".to_string(),
-                "/root/.agent/skills".to_string(),
-                "workload".to_string(),
+            fileset(
+                "reg/skills@sha256:abcabcabcabc…",
+                "/root/.agent/skills",
+                "workload",
             ),
-            (
-                "inline".to_string(),
-                "/etc/agent".to_string(),
-                "root".to_string(),
-            ),
+            fileset("inline", "/etc/agent", "root"),
         ];
         let (r, out) = confirm(&mounts(&[], &filesets), false, true, "yes\n");
         r.unwrap();
@@ -351,11 +364,7 @@ mod tests {
 
     #[test]
     fn no_terminal_fails_closed_and_points_at_the_yes_flag() {
-        let filesets = [(
-            "reg/skills@sha256:abc".to_string(),
-            "/skills".to_string(),
-            "workload".to_string(),
-        )];
+        let filesets = [fileset("reg/skills@sha256:abc", "/skills", "workload")];
         let (r, out) = confirm(&mounts(&[], &filesets), false, false, "");
         let err = r.unwrap_err().to_string();
         assert!(err.contains("--yes"), "must name the escape hatch: {err}");

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -98,8 +98,13 @@ pub fn format_summary(
     for bind in &binds {
         writeln!(s, "  Bind:      {}", bind_line(bind)).unwrap();
     }
-    for (source, mount, owner) in &args.filesets {
-        writeln!(s, "  Fileset:   {source} -> {mount} (owner: {owner})").unwrap();
+    for fileset in &args.filesets {
+        writeln!(
+            s,
+            "  Fileset:   {} -> {} (owner: {})",
+            fileset.source, fileset.mount_path, fileset.owner
+        )
+        .unwrap();
     }
     if !args.tools.is_empty() {
         writeln!(s, "  Tools:     {}", args.tools.join(", ")).unwrap();
@@ -188,12 +193,14 @@ fn flags_line(args: &RunArgs) -> String {
     }
 }
 
-/// The summary shows a path verbatim, shortens a ref digest to 12 characters, and names embedded files as inline.
+/// The summary shows a path verbatim, shortens a ref digest to 12 characters, names embedded files as inline, and names a host file as one so the operator sees which of their files a sandbox reads.
 pub fn fileset_source_display(fileset: &lns_artifact::sandbox::FilesetEntry) -> String {
     fileset_display(
         fileset.path.as_deref(),
         fileset.reference.as_deref(),
         fileset.inline.is_some(),
+        fileset.host_path.as_deref(),
+        fileset.optional,
     )
 }
 
@@ -209,6 +216,8 @@ pub fn fileset_view_source_display(fileset: &lns_ipc::SandboxFileset) -> String 
         fileset.path.as_deref(),
         fileset.reference.as_deref(),
         fileset.inline,
+        fileset.host_path.as_deref(),
+        fileset.optional,
     )
 }
 
@@ -219,16 +228,24 @@ pub fn fileset_view_owner_display(owner: lns_ipc::SandboxFilesetOwner) -> &'stat
     }
 }
 
+/// One disclosed fileset. `from_host` separates a file read off the machine running the sandbox from the files the document itself ships.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesetSummary {
+    pub source: String,
+    pub mount_path: String,
+    pub owner: String,
+    pub from_host: bool,
+}
+
 /// A pulled sandbox disclosed the same way at launch as a local one: its preflight view's filesets become summary lines.
-pub fn fileset_summaries_from_view(view: &lns_ipc::SandboxView) -> Vec<(String, String, String)> {
+pub fn fileset_summaries_from_view(view: &lns_ipc::SandboxView) -> Vec<FilesetSummary> {
     view.filesets
         .iter()
-        .map(|fileset| {
-            (
-                fileset_view_source_display(fileset),
-                fileset.mount_path.clone(),
-                fileset_view_owner_display(fileset.owner).to_string(),
-            )
+        .map(|fileset| FilesetSummary {
+            source: fileset_view_source_display(fileset),
+            mount_path: fileset.mount_path.clone(),
+            owner: fileset_view_owner_display(fileset.owner).to_string(),
+            from_host: fileset.host_path.is_some(),
         })
         .collect()
 }
@@ -238,7 +255,17 @@ pub fn tools_from_view(view: &lns_ipc::SandboxView) -> Vec<String> {
     view.tools.clone()
 }
 
-fn fileset_display(path: Option<&str>, reference: Option<&str>, inline: bool) -> String {
+fn fileset_display(
+    path: Option<&str>,
+    reference: Option<&str>,
+    inline: bool,
+    host_path: Option<&str>,
+    optional: bool,
+) -> String {
+    if let Some(host_path) = host_path {
+        let suffix = if optional { " (optional)" } else { "" };
+        return format!("host file {host_path}{suffix}");
+    }
     if let Some(path) = path {
         return path.to_string();
     }
@@ -399,8 +426,10 @@ mod tests {
             path: path.map(str::to_string),
             reference: reference.map(str::to_string),
             inline: None,
+            host_path: None,
             mount_path: "/s".into(),
             owner: lns_artifact::sandbox::FilesetOwner::default(),
+            optional: false,
         }
     }
 
@@ -414,6 +443,24 @@ mod tests {
         assert_eq!(
             fileset_source_display(&fileset_entry(None, Some(&long))),
             format!("reg/skills@sha256:{}…", "a".repeat(12))
+        );
+    }
+
+    #[test]
+    fn fileset_display_names_a_host_file_and_marks_it_optional() {
+        let mut fileset = fileset_entry(None, None);
+        fileset.host_path = Some("~/.gitconfig".into());
+
+        assert_eq!(
+            fileset_source_display(&fileset),
+            "host file ~/.gitconfig",
+            "the tilde stays verbatim so the operator recognizes the file the sandbox asked for"
+        );
+
+        fileset.optional = true;
+        assert_eq!(
+            fileset_source_display(&fileset),
+            "host file ~/.gitconfig (optional)"
         );
     }
 
@@ -458,8 +505,10 @@ mod tests {
                 path: None,
                 reference: None,
                 inline: true,
+                host_path: None,
                 mount_path: "/etc/agent".into(),
                 owner: lns_ipc::SandboxFilesetOwner::Root,
+                optional: false,
             }],
             connectors: Vec::new(),
             env: Vec::new(),
@@ -472,11 +521,12 @@ mod tests {
 
         assert_eq!(
             fileset_summaries_from_view(&view),
-            vec![(
-                "inline".to_string(),
-                "/etc/agent".to_string(),
-                "root".to_string()
-            )]
+            vec![FilesetSummary {
+                source: "inline".to_string(),
+                mount_path: "/etc/agent".to_string(),
+                owner: "root".to_string(),
+                from_host: false,
+            }]
         );
     }
 
@@ -601,6 +651,7 @@ mod tests {
             target: "/work".into(),
             read_only: false,
             exclude: Vec::new(),
+            optional: false,
         })];
         let s = summary_of(
             &args,
@@ -622,6 +673,7 @@ mod tests {
             target: "/cfg".into(),
             read_only: true,
             exclude: Vec::new(),
+            optional: false,
         })];
         let s = summary_of(
             &args,

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -116,7 +116,7 @@ fn absolutize_fileset_paths(
         .context("spec.filesets is not an array")?;
     for (index, fileset) in def.spec.filesets.iter().enumerate() {
         if let Some(path) = &fileset.path {
-            let rooted = crate::run::declarative::resolve_bind_source(path, cwd)
+            let rooted = crate::run::declarative::resolve_bind_source(path, cwd, None)
                 .with_context(|| format!("fileset {path}"))?;
             entries[index]["path"] = serde_json::Value::String(rooted);
         }

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -129,7 +129,7 @@ fn resolve_host_binds(
 struct PublishedTarget {
     image: String,
     defaults: crate::run::declarative::Defaults,
-    filesets: Vec<(String, String, String)>,
+    filesets: Vec<crate::run::summary::FilesetSummary>,
     tools: Vec<String>,
 }
 
@@ -222,6 +222,7 @@ pub async fn run_image(
     let resolved = crate::run::declarative::resolve(
         &defaults,
         target.project_dir().unwrap_or(&cwd),
+        dirs::home_dir().as_deref(),
         args.workdir.take(),
         std::mem::take(&mut args.mounts),
     )?;
@@ -240,12 +241,11 @@ pub async fn run_image(
             .spec
             .filesets
             .iter()
-            .map(|fileset| {
-                (
-                    crate::run::summary::fileset_source_display(fileset),
-                    fileset.mount_path.clone(),
-                    crate::run::summary::fileset_owner_display(fileset.owner).to_string(),
-                )
+            .map(|fileset| crate::run::summary::FilesetSummary {
+                source: crate::run::summary::fileset_source_display(fileset),
+                mount_path: fileset.mount_path.clone(),
+                owner: crate::run::summary::fileset_owner_display(fileset.owner).to_string(),
+                from_host: fileset.host_path.is_some(),
             })
             .collect(),
         (_, Some(published)) => published.filesets.clone(),
@@ -1140,6 +1140,7 @@ mod tests {
                     target: "/workspace".into(),
                     read_only: false,
                     exclude: Vec::new(),
+                    optional: false,
                 }],
                 ports: Vec::new(),
                 filesets: vec![lns_ipc::SandboxFileset {
@@ -1149,6 +1150,8 @@ mod tests {
                         "b".repeat(64)
                     )),
                     inline: false,
+                    host_path: None,
+                    optional: false,
                     mount_path: "/root/.agent/skills".into(),
                     owner: lns_ipc::SandboxFilesetOwner::Workload,
                 }],
@@ -1170,14 +1173,15 @@ mod tests {
         assert_eq!(target.defaults.mounts[0].source, ".");
         assert_eq!(
             target.filesets,
-            [(
-                format!(
+            [crate::run::summary::FilesetSummary {
+                source: format!(
                     "registry.example.test/team/skills@sha256:{}…",
                     "b".repeat(12)
                 ),
-                "/root/.agent/skills".to_string(),
-                "workload".to_string()
-            )]
+                mount_path: "/root/.agent/skills".to_string(),
+                owner: "workload".to_string(),
+                from_host: false,
+            }]
         );
     }
 

--- a/crates/lns-cli/tests/behaviours/declarative_filesets.feature
+++ b/crates/lns-cli/tests/behaviours/declarative_filesets.feature
@@ -48,3 +48,25 @@ Feature: declared filesets ship files inside the sandbox artifact
     When the pulled sandbox run is prepared
     Then the run summary discloses an inline fileset at "/home/sandbox" owned by root
     And the run summary does not contain the inline file content
+
+  Scenario: a local run discloses a host file source and that it is optional
+    Given an lns.yaml declaring a hostPath fileset "~/.gitconfig" mounted at "/home/agent/.gitconfig" and optional
+    When the local sandbox run is prepared
+    Then the run summary shows a Fileset line `host file ~/.gitconfig (optional) -> /home/agent/.gitconfig`
+
+  Scenario: a pulled sandbox's host file is named in the disclosure before it boots
+    Given a pulled sandbox whose view declares a hostPath fileset "~/.gitconfig" at "/home/agent/.gitconfig" and optional
+    When the pulled sandbox effects are confirmed with no answer
+    Then the disclosure names the host file "host file ~/.gitconfig (optional) → /home/agent/.gitconfig"
+    And the run is refused without a confirmation
+
+  Scenario: the disclosure says a host file is read from this machine, not shipped by the author
+    Given a pulled sandbox whose view declares a hostPath fileset "~/.gitconfig" at "/home/agent/.gitconfig" and optional
+    When the pulled sandbox effects are confirmed with no answer
+    Then the disclosure names the host file "read from this machine at launch"
+    And the disclosure does not call the host file author-published
+
+  Scenario: the disclosure still calls a packed fileset author-published
+    Given a pulled sandbox whose view declares an inline fileset at "/home/sandbox" owned by root
+    When the pulled sandbox effects are confirmed with no answer
+    Then the disclosure names the host file "author-published files"

--- a/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
+++ b/crates/lns-cli/tests/behaviours/host_bind_mounts.feature
@@ -104,3 +104,40 @@ Feature: lns run mounts host directories into the sandbox (docker `-v host:guest
     When the user runs `lns run -v /Users/me/proj:/work alpine` interactively
     Then the summary shows a bind line "/Users/me/proj → /work (read-write)"
     And the summary shows ".env: kept (exposed)"
+
+  Scenario: A home-rooted declared bind resolves against this machine's home
+    Given a definition declaring a bind from "~/.claude" to "/home/agent/.claude"
+    And this machine's home directory is "/home/some-user"
+    When the declared mounts resolve
+    Then the host bind source is "/home/some-user/.claude"
+
+  Scenario: A project-relative declared bind still resolves against the project directory
+    Given a definition declaring a bind from "./src" to "/work"
+    And this machine's home directory is "/home/some-user"
+    When the declared mounts resolve
+    Then the host bind source is "/work/project/src"
+
+  Scenario: A home-rooted declared bind on a machine with no home is refused
+    Given a definition declaring a bind from "~/.claude" to "/home/agent/.claude"
+    And this machine has no home directory
+    When the declared mounts resolve
+    Then the mount resolution fails naming "~/.claude"
+
+  Scenario: An optional bind whose host path is missing is skipped and the run continues
+    Given an optional declared bind from "/Users/me/.claude" to "/home/agent/.claude"
+    And the host path "/Users/me/.claude" does not exist
+    When the declared binds are resolved interactively
+    Then no host bind is resolved
+    And the output says the bind was skipped because it is not present on this host
+
+  Scenario: A required bind whose host path is missing still fails the run
+    Given a required declared bind from "/Users/me/.claude" to "/home/agent/.claude"
+    And the host path "/Users/me/.claude" does not exist
+    When the declared binds are resolved interactively
+    Then the command fails with "host path does not exist"
+
+  Scenario: An optional bind whose host path is present is mounted like any other
+    Given an optional declared bind from "/Users/me/.claude" to "/home/agent/.claude"
+    And the host directory "/Users/me/.claude" contains no secret-shaped files
+    When the declared binds are resolved interactively
+    Then the resolved host binds are exactly "/Users/me/.claude -> /home/agent/.claude"

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -111,7 +111,7 @@ Feature: authoring a sandbox
     Given an lns.yaml declaring a fileset entry with both path and ref
     When the user runs sandbox command "validate"
     Then the command fails with an exit code other than 0
-    And the output contains "exactly one of path, ref, or inline"
+    And the output contains "exactly one of path, ref, inline, or hostPath"
 
   Scenario: validate refuses a relative fileset mountPath
     Given an lns.yaml declaring fileset "./skills" mounted at "skills"
@@ -148,7 +148,7 @@ Feature: authoring a sandbox
     Given an lns.yaml declaring a fileset entry with inline content and path
     When the user runs sandbox command "validate"
     Then the command fails with an exit code other than 0
-    And the output contains "exactly one of path, ref, or inline"
+    And the output contains "exactly one of path, ref, inline, or hostPath"
 
   Scenario Outline: validate refuses an unsafe inline file path
     Given an lns.yaml declaring an inline fileset with path "<path>" at "/home/sandbox"

--- a/crates/lns-cli/tests/behaviours/sandbox_distribute.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_distribute.feature
@@ -123,3 +123,11 @@ Feature: distributing a sandbox
     When the user runs sandbox command "tag hermes:1.4.0 hermes:latest"
     Then the exit code is 0
     And the sandbox "hermes:latest" resolves to the same cached artifact
+
+  Scenario: push carries a hostPath fileset verbatim and packs nothing for it
+    Given a valid lns.yaml in the current directory declaring a hostPath fileset "~/.gitconfig" mounted at "/home/agent/.gitconfig"
+    And the registry accepts the push
+    When the user runs sandbox command "push ghcr.io/team/hermes:1.4.0"
+    Then the exit code is 0
+    And only the sandbox artifact is pushed
+    And the published sandbox config carries the hostPath unchanged

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -60,12 +60,11 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
             .spec
             .filesets
             .iter()
-            .map(|fileset| {
-                (
-                    fileset_source_display(fileset),
-                    fileset.mount_path.clone(),
-                    lns_cli::run::summary::fileset_owner_display(fileset.owner).to_string(),
-                )
+            .map(|fileset| lns_cli::run::summary::FilesetSummary {
+                source: fileset_source_display(fileset),
+                mount_path: fileset.mount_path.clone(),
+                owner: lns_cli::run::summary::fileset_owner_display(fileset.owner).to_string(),
+                from_host: fileset.host_path.is_some(),
             })
             .collect();
     }
@@ -100,6 +99,8 @@ fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount
             path: None,
             reference: Some(reference),
             inline: false,
+            host_path: None,
+            optional: false,
             mount_path: mount,
             owner: lns_ipc::SandboxFilesetOwner::Workload,
         }],
@@ -129,6 +130,8 @@ fn pulled_view_with_inline_fileset(world: &mut BehaviourWorld, mount: String) {
             path: None,
             reference: None,
             inline: true,
+            host_path: None,
+            optional: false,
             mount_path: mount,
             owner: lns_ipc::SandboxFilesetOwner::Root,
         }],
@@ -267,6 +270,97 @@ fn command_fails_naming(world: &mut BehaviourWorld, needle: String) -> Result<()
     } else {
         Err(format!(
             "expected a failure naming {needle:?}, got exit {} with: {}",
+            result.exit_code, result.output
+        ))
+    }
+}
+
+#[cucumber::given(
+    regex = r#"^a pulled sandbox whose view declares a hostPath fileset "([^"]+)" at "([^"]+)" and optional$"#
+)]
+fn pulled_view_with_host_path_fileset(world: &mut BehaviourWorld, source: String, mount: String) {
+    world.pulled_view = Some(lns_ipc::SandboxView {
+        reference: "registry.example.test/team/sandbox:1".into(),
+        digest: format!("sha256:{}", "a".repeat(64)),
+        image: "registry.example.test/runtime:1".into(),
+        workdir: None,
+        user: None,
+        mounts: Vec::new(),
+        ports: Vec::new(),
+        filesets: vec![lns_ipc::SandboxFileset {
+            path: None,
+            reference: None,
+            inline: false,
+            host_path: Some(source),
+            mount_path: mount,
+            owner: lns_ipc::SandboxFilesetOwner::Workload,
+            optional: true,
+        }],
+        connectors: Vec::new(),
+        env: Vec::new(),
+        credentials: Vec::new(),
+        tools: Vec::new(),
+        policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
+    });
+}
+
+#[when("the pulled sandbox effects are confirmed with no answer")]
+fn pulled_effects_confirmed(world: &mut BehaviourWorld) {
+    let view = world.pulled_view.take().expect("a pulled view is staged");
+    let filesets = lns_cli::run::summary::fileset_summaries_from_view(&view);
+    let effects = lns_cli::run::pull_confirm::PulledEffects {
+        reference: &view.reference,
+        binds: &[],
+        volumes: &[],
+        filesets: &filesets,
+        tools: &[],
+    };
+    let mut input = std::io::Cursor::new(String::new());
+    let mut out = Vec::new();
+    let outcome = lns_cli::run::pull_confirm::confirm_pulled_effects(
+        &effects, false, true, &mut input, &mut out,
+    );
+    world.summary_output = String::from_utf8(out).expect("non-utf8 disclosure");
+    world.result = Some(CliRun {
+        exit_code: i32::from(outcome.is_err()),
+        output: outcome.err().map(|e| format!("{e:#}")).unwrap_or_default(),
+    });
+}
+
+#[then(regex = r#"^the disclosure names the host file "([^"]+)"$"#)]
+fn disclosure_names_host_file(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    if world.summary_output.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {needle:?} in the disclosure:\n{}",
+            world.summary_output
+        ))
+    }
+}
+
+#[then("the disclosure does not call the host file author-published")]
+fn disclosure_does_not_claim_author_published(world: &mut BehaviourWorld) -> Result<(), String> {
+    if world.summary_output.contains("author-published") {
+        Err(format!(
+            "a host file is read from the consumer's own machine, so calling it author-published inverts what the operator is consenting to:\n{}",
+            world.summary_output
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[then("the run is refused without a confirmation")]
+fn run_refused_without_confirmation(world: &mut BehaviourWorld) -> Result<(), String> {
+    let result = world.result.as_ref().ok_or("no run captured")?;
+    if result.exit_code != 0 && result.output.contains("declined") {
+        Ok(())
+    } else {
+        Err(format!(
+            "a host file must not be read without consent, got exit {} with: {}",
             result.exit_code, result.output
         ))
     }

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -63,7 +63,7 @@ fn resolve_defaults(world: &mut BehaviourWorld, defaults: &Defaults, project: &P
     let mut argv = vec!["lns".to_string(), "run".to_string()];
     argv.extend(flags.split_whitespace().map(str::to_string));
     let args: RunArgs = parse_args(&argv).expect("override flags must parse");
-    let resolved = resolve(defaults, project, args.workdir, args.mounts)
+    let resolved = resolve(defaults, project, None, args.workdir, args.mounts)
         .expect("declarative settings must resolve");
     let (volumes, binds) = lns_cli::cli::split_mounts(&resolved.mounts);
     world.resolved_run = Some(ResolvedRunView {
@@ -197,6 +197,7 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
                 target: volume.target.clone(),
                 read_only: volume.read_only(),
                 exclude: volume.exclude().to_vec(),
+                optional: volume.optional(),
             })
             .collect(),
         ports: Vec::new(),
@@ -263,7 +264,7 @@ fn resolve_declarative_binds(world: &mut BehaviourWorld) {
 }
 
 fn resolve_binds_with(world: &mut BehaviourWorld, defaults: Defaults) {
-    let resolved = resolve(&defaults, Path::new("/work"), None, Vec::new()).unwrap();
+    let resolved = resolve(&defaults, Path::new("/work"), None, None, Vec::new()).unwrap();
     let bind_specs = lns_cli::cli::split_mounts(&resolved.mounts).1;
     let dir = FakeDir {
         entries: world.host_bind.entries.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
+++ b/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
@@ -92,6 +92,7 @@ fn request_roots_sources_at(w: &mut BehaviourWorld, dir: String) -> Result<(), S
         &Defaults::from_definition(&def, Some(TEST_HOST)),
         &project,
         None,
+        None,
         Vec::new(),
     )
     .map_err(|e| format!("declarative settings did not resolve: {e:#}"))?;

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -313,6 +313,7 @@ fn later_run_no_prompt(world: &mut BehaviourWorld) -> Result<(), String> {
             target: m.target.clone(),
             read_only: m.read_only,
             exclude: Vec::new(),
+            optional: false,
         })
         .collect();
     let dir = dir_from(world);
@@ -369,4 +370,147 @@ fn summary_shows_bind_line(world: &mut BehaviourWorld, line: String) -> Result<(
 #[then(regex = r#"^the summary shows "([^"]+)"$"#)]
 fn summary_shows(world: &mut BehaviourWorld, line: String) -> Result<(), String> {
     summary_contains(world, &line)
+}
+
+#[given(regex = r#"^a definition declaring a bind from "([^"]+)" to "([^"]+)"$"#)]
+fn definition_declares_bind(world: &mut BehaviourWorld, source: String, target: String) {
+    world
+        .declared_mounts
+        .mounts
+        .push(lns_cli::run::declarative::MountDefault {
+            bind: true,
+            source,
+            target,
+            read_only: false,
+            exclude: Vec::new(),
+            optional: false,
+        });
+}
+
+#[given(regex = r#"^this machine's home directory is "([^"]+)"$"#)]
+fn machine_home_is(world: &mut BehaviourWorld, home: String) {
+    world.declared_mounts.home = Some(std::path::PathBuf::from(home));
+}
+
+#[given("this machine has no home directory")]
+fn machine_has_no_home(world: &mut BehaviourWorld) {
+    world.declared_mounts.home = None;
+}
+
+#[when("the declared mounts resolve")]
+fn declared_mounts_resolve(world: &mut BehaviourWorld) {
+    let defaults = lns_cli::run::declarative::Defaults {
+        mounts: world.declared_mounts.mounts.clone(),
+        ..Default::default()
+    };
+    world.declared_mounts.outcome = Some(
+        lns_cli::run::declarative::resolve(
+            &defaults,
+            Path::new("/work/project"),
+            world.declared_mounts.home.as_deref(),
+            None,
+            Vec::new(),
+        )
+        .map(|resolved| resolved.mounts)
+        .map_err(|e| format!("{e:#}")),
+    );
+}
+
+#[then(regex = r#"^the host bind source is "([^"]+)"$"#)]
+fn host_bind_source_is(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    let mounts = world
+        .declared_mounts
+        .outcome
+        .as_ref()
+        .ok_or("no declared-mount resolution captured")?
+        .as_ref()
+        .map_err(|e| format!("resolution failed: {e}"))?;
+    let sources: Vec<&str> = mounts
+        .iter()
+        .filter_map(|mount| match mount {
+            lns_ipc::MountSpec::Bind(bind) => Some(bind.host_source.as_str()),
+            lns_ipc::MountSpec::Named(_) => None,
+        })
+        .collect();
+    if sources == [expected.as_str()] {
+        Ok(())
+    } else {
+        Err(format!("expected [{expected:?}], got {sources:?}"))
+    }
+}
+
+#[then(regex = r#"^the mount resolution fails naming "([^"]+)"$"#)]
+fn mount_resolution_fails(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    match world
+        .declared_mounts
+        .outcome
+        .as_ref()
+        .ok_or("no declared-mount resolution captured")?
+    {
+        Err(message) if message.contains(&needle) => Ok(()),
+        other => Err(format!(
+            "expected a failure naming {needle:?}, got {other:?}"
+        )),
+    }
+}
+
+#[given(regex = r#"^an? (optional|required) declared bind from "([^"]+)" to "([^"]+)"$"#)]
+fn declared_bind_spec(world: &mut BehaviourWorld, kind: String, source: String, target: String) {
+    world.host_bind.declared_specs.push(lns_ipc::BindSpec {
+        host_source: source,
+        target,
+        read_only: false,
+        exclude: Vec::new(),
+        optional: kind == "optional",
+    });
+}
+
+#[when("the declared binds are resolved interactively")]
+fn declared_binds_resolved(world: &mut BehaviourWorld) {
+    let specs = world.host_bind.declared_specs.clone();
+    let dir = dir_from(world);
+    let store = FakeStore {
+        state: Mutex::new(world.host_bind.decisions.clone()),
+    };
+    let mut input = std::io::Cursor::new(world.host_bind.answer.clone().unwrap_or_default());
+    let mut out = Vec::new();
+    let result =
+        resolve_binds(&specs, &dir, &store, true, &mut input, &mut out).map_err(|e| e.to_string());
+    world.resolved_run = Some(ResolvedRunView {
+        binds: result
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|bind| format!("{} -> {}", bind.host_source, bind.target))
+            .collect(),
+        ..Default::default()
+    });
+    world.host_bind.outcome = Some(HostBindOutcome {
+        result,
+        prompt: String::from_utf8(out).unwrap(),
+        persisted: store.state.into_inner().unwrap(),
+        summary: String::new(),
+    });
+}
+
+#[then("no host bind is resolved")]
+fn no_host_bind_resolved(world: &mut BehaviourWorld) -> Result<(), String> {
+    let binds = resolved_binds(world)?;
+    if binds.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "a skipped bind must reach neither the secret scan, the wire, nor the audit record, got {binds:?}"
+        ))
+    }
+}
+
+#[then("the output says the bind was skipped because it is not present on this host")]
+fn output_reports_skipped_bind(world: &mut BehaviourWorld) -> Result<(), String> {
+    let prompt = &outcome(world)?.prompt;
+    if prompt.contains("skipping optional bind") && prompt.contains("not present on this host") {
+        Ok(())
+    } else {
+        Err(format!("expected a skip line, got {prompt:?}"))
+    }
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
@@ -95,6 +95,18 @@ fn lns_yaml_with_ref_fileset(w: &mut BehaviourWorld, reference: String, mount: S
     );
 }
 
+#[given(
+    regex = r#"^an lns\.yaml declaring a hostPath fileset "([^"]+)" mounted at "([^"]+)" and optional$"#
+)]
+fn lns_yaml_with_host_path_fileset(w: &mut BehaviourWorld, source: String, mount: String) {
+    seed(
+        w,
+        &fileset_yaml(&format!(
+            "    - hostPath: {source}\n      mountPath: {mount}\n      optional: true\n"
+        )),
+    );
+}
+
 #[given("an lns.yaml declaring a fileset entry with both path and ref")]
 fn lns_yaml_with_conflicting_fileset(w: &mut BehaviourWorld) {
     seed(

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_distribute.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_distribute.rs
@@ -176,3 +176,30 @@ fn sandbox_resolves_to_same_artifact(w: &mut BehaviourWorld, to: String) -> Resu
         ))
     }
 }
+
+#[given(
+    regex = r#"^a valid lns\.yaml in the current directory declaring a hostPath fileset "([^"]+)" mounted at "([^"]+)"$"#
+)]
+fn valid_lns_yaml_with_host_path_fileset(w: &mut BehaviourWorld, source: String, mount: String) {
+    w.author_files.insert(
+        std::path::PathBuf::from("/work/lns.yaml"),
+        format!(
+            "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: ghcr.io/team/base:1\n  filesets:\n    - hostPath: {source}\n      mountPath: {mount}\n      optional: true\n"
+        ),
+    );
+}
+
+#[then("the published sandbox config carries the hostPath unchanged")]
+fn published_config_keeps_host_path(w: &mut BehaviourWorld) -> Result<(), String> {
+    let doc = w.pushed_doc.as_ref().ok_or("no definition was pushed")?;
+    let value: serde_json::Value =
+        serde_json::from_slice(doc).map_err(|error| format!("invalid pushed json: {error}"))?;
+    let entry = &value["spec"]["filesets"][0];
+    if entry["hostPath"] == "~/.gitconfig" && entry.get("ref").is_none() {
+        Ok(())
+    } else {
+        Err(format!(
+            "a hostPath is what makes the artifact portable — packing or rewriting it would pin the author's machine, got {entry}"
+        ))
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -44,6 +44,7 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
                 target: "/workspace".into(),
                 read_only: false,
                 exclude: Vec::new(),
+                optional: false,
             },
             SandboxMount {
                 kind: SandboxMountKind::Volume,
@@ -51,6 +52,7 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
                 target: "/home/node/.cache".into(),
                 read_only: true,
                 exclude: Vec::new(),
+                optional: false,
             },
         ],
         ports: Vec::new(),
@@ -118,6 +120,8 @@ fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, moun
                 "a".repeat(64)
             )),
             inline: false,
+            host_path: None,
+            optional: false,
             mount_path: mount,
             owner: lns_ipc::SandboxFilesetOwner::Workload,
         }],

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -50,6 +50,7 @@ pub struct BehaviourWorld {
     /// Exact pins the scripted index answers "not listed" for at push verification.
     pub unlisted_pins: std::collections::HashSet<String>,
     pub host_bind: HostBindRig,
+    pub declared_mounts: DeclaredMountRig,
     /// In-memory `./lns.yaml` (and friends) for the offline author verbs; keyed by path under the fake cwd `/work`.
     pub author_files: std::collections::HashMap<std::path::PathBuf, String>,
     /// Request sequence each shortcut-equivalence invocation sent, in invocation order.
@@ -68,6 +69,8 @@ pub struct HostBindRig {
     pub decisions: std::collections::HashMap<String, SecretDisposition>,
     pub answer: Option<String>,
     pub outcome: Option<HostBindOutcome>,
+    /// Binds a definition declared, rather than ones a `-v` flag parsed — the only way `optional` reaches `resolve_binds`.
+    pub declared_specs: Vec<lns_ipc::BindSpec>,
 }
 
 #[derive(Debug)]
@@ -76,6 +79,14 @@ pub struct HostBindOutcome {
     pub prompt: String,
     pub persisted: std::collections::HashMap<String, SecretDisposition>,
     pub summary: String,
+}
+
+/// A definition's declared mounts plus the home this machine reports, for driving `declarative::resolve` offline.
+#[derive(Debug, Default)]
+pub struct DeclaredMountRig {
+    pub mounts: Vec<lns_cli::run::declarative::MountDefault>,
+    pub home: Option<std::path::PathBuf>,
+    pub outcome: Option<Result<Vec<lns_ipc::MountSpec>, String>>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -315,9 +315,14 @@ pub struct SandboxFileset {
     pub reference: Option<String>,
     #[serde(default)]
     pub inline: bool,
+    /// The host file the sandbox declared, verbatim — shape, never payload, so a consumer sees which of their files it reads.
+    #[serde(default)]
+    pub host_path: Option<String>,
     pub mount_path: String,
     #[serde(default)]
     pub owner: SandboxFilesetOwner,
+    #[serde(default)]
+    pub optional: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -351,6 +356,9 @@ pub struct SandboxMount {
     /// Subpaths a published bind excluded, so a pulled sandbox's declared exclusions are visible and applied.
     #[serde(default)]
     pub exclude: Vec<String>,
+    /// True when the published bind is skipped on a machine that lacks its source, rather than refusing the run.
+    #[serde(default)]
+    pub optional: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -631,6 +639,8 @@ pub struct BindSpec {
     pub read_only: bool,
     /// Subpaths the definition excluded, unioned with any `.lensignore` before the secret scan.
     pub exclude: Vec<String>,
+    /// True when an absent host source skips the bind instead of refusing the run.
+    pub optional: bool,
 }
 
 impl BindSpec {
@@ -649,8 +659,9 @@ impl BindSpec {
             host_source: source.to_string(),
             target: target.to_string(),
             read_only,
-            // A `-v` carries no exclude; the definition is the author surface for that.
+            // A `-v` carries neither exclude nor optional; the definition is the author surface for both.
             exclude: Vec::new(),
+            optional: false,
         })
     }
 }
@@ -1376,6 +1387,7 @@ mod tests {
                 target: "/workspace".into(),
                 read_only: true,
                 exclude: Vec::new(),
+                optional: false,
             }],
             ports: vec![
                 SandboxPort {
@@ -1394,6 +1406,8 @@ mod tests {
                     "a".repeat(64)
                 )),
                 inline: false,
+                host_path: None,
+                optional: false,
                 mount_path: "/root/.agent/skills".into(),
                 owner: SandboxFilesetOwner::Workload,
             }],
@@ -1550,6 +1564,7 @@ mod tests {
                 target: "/work".into(),
                 read_only: false,
                 exclude: Vec::new(),
+                optional: false,
             })
         );
     }

--- a/crates/lns-service/src/artifact/assembly.rs
+++ b/crates/lns-service/src/artifact/assembly.rs
@@ -8,6 +8,15 @@ pub struct LocalFileset {
     pub owner: lns_artifact::sandbox::FilesetOwner,
 }
 
+/// A definition's hostPath fileset: one file on the machine that runs it, snapshotted into the guest at launch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostFileset {
+    pub source: String,
+    pub mount_path: String,
+    pub owner: lns_artifact::sandbox::FilesetOwner,
+    pub optional: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineFileset {
     pub files: BTreeMap<String, String>,
@@ -19,6 +28,7 @@ pub struct InlineFileset {
 pub struct ResolvedSandbox {
     pub base_image: String,
     pub local_filesets: Vec<LocalFileset>,
+    pub host_filesets: Vec<HostFileset>,
     pub inline_filesets: Vec<InlineFileset>,
     pub filesets: Vec<ResolvedFileset>,
     pub command: Option<String>,

--- a/crates/lns-service/src/artifact/fileset.rs
+++ b/crates/lns-service/src/artifact/fileset.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeSet;
 use std::io::Read;
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use lns_artifact::sandbox::FilesetOwner;
 use oci_client::Reference;
 use oci_client::manifest::OciImageManifest;
 
-use crate::artifact::assembly::{InlineFileset, LocalFileset};
+use crate::artifact::assembly::{HostFileset, InlineFileset, LocalFileset};
 use crate::content_store::ContentStore;
 use crate::runtime_layer::{RuntimeFileSpec, RuntimeSource};
 
@@ -123,6 +123,85 @@ pub fn local_fileset_specs<D: SnapshotDir + ?Sized>(
         out.absorb(local.owner, &local.mount_path, specs);
     }
     Ok(())
+}
+
+/// What a host path resolves to, symlinks followed, so the seam reports facts and this module decides what they mean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostFileFacts {
+    pub mode: u32,
+    pub is_regular_file: bool,
+}
+
+/// Host-file seam for hostPath filesets; `RealSnapshotDir` in `real.rs` is the std::fs leaf.
+pub trait HostFileProbe {
+    fn home(&self) -> Option<PathBuf>;
+    /// `Ok(None)` when nothing resolves at the path, which includes a symlink whose target is gone.
+    fn stat(&self, path: &Path) -> std::io::Result<Option<HostFileFacts>>;
+}
+
+/// Snapshot each declared host file into one guest-write spec at its mountPath, so a definition can seed the guest from the machine that runs it; an absent path refuses the plan unless the author marked it optional.
+pub fn host_fileset_specs<P: HostFileProbe + ?Sized>(
+    probe: &P,
+    hosts: &[HostFileset],
+    out: &mut MaterializedFilesets,
+) -> Result<()> {
+    for host in hosts {
+        let resolved = resolve_host_source(probe, &host.source)?;
+        let facts = probe
+            .stat(&resolved)
+            .with_context(|| format!("hostPath {} ({})", host.source, resolved.display()))?;
+        let Some(facts) = host_file_facts(host, &resolved, facts)? else {
+            continue;
+        };
+        let specs = vec![RuntimeFileSpec {
+            guest_path: host.mount_path.clone(),
+            mode: facts.mode,
+            source: RuntimeSource::HostFile(resolved),
+        }];
+        out.absorb(host.owner, &host.mount_path, specs);
+    }
+    Ok(())
+}
+
+/// `Ok(None)` is the one benign miss: an optional path nothing resolves at, announced on the run's own log so the operator sees why the guest is unseeded.
+fn host_file_facts(
+    host: &HostFileset,
+    resolved: &Path,
+    facts: Option<HostFileFacts>,
+) -> Result<Option<HostFileFacts>> {
+    let Some(facts) = facts else {
+        if !host.optional {
+            bail!(
+                "hostPath {} is not present on this host ({}); create it or declare the fileset optional",
+                host.source,
+                resolved.display()
+            );
+        }
+        crate::log::info!(
+            "fileset",
+            "skipping optional hostPath {} — not present on this host",
+            host.source
+        );
+        return Ok(None);
+    };
+    if !facts.is_regular_file {
+        bail!(
+            "hostPath {} ({}) is not a regular file; a hostPath fileset seeds the guest with one file",
+            host.source,
+            resolved.display()
+        );
+    }
+    Ok(Some(facts))
+}
+
+fn resolve_host_source<P: HostFileProbe + ?Sized>(probe: &P, source: &str) -> Result<PathBuf> {
+    let Some(under_home) = source.strip_prefix("~/") else {
+        return Ok(PathBuf::from(source));
+    };
+    let home = probe.home().with_context(|| {
+        format!("cannot resolve hostPath {source}: this machine has no home directory")
+    })?;
+    Ok(home.join(under_home))
 }
 
 pub fn inline_fileset_specs(inline_filesets: &[InlineFileset], out: &mut MaterializedFilesets) {
@@ -616,6 +695,246 @@ mod tests {
                 .iter()
                 .any(|s| s.guest_path == OWNED_MANIFEST_PATH),
             "pinned inputs must not be transferred to the workload"
+        );
+    }
+
+    struct StagedHost {
+        facts: Option<HostFileFacts>,
+        unreadable: bool,
+        home: Option<PathBuf>,
+    }
+
+    impl StagedHost {
+        fn present() -> Self {
+            Self {
+                facts: Some(HostFileFacts {
+                    mode: 0o644,
+                    is_regular_file: true,
+                }),
+                unreadable: false,
+                home: Some(PathBuf::from("/home/some-user")),
+            }
+        }
+    }
+
+    impl HostFileProbe for StagedHost {
+        fn home(&self) -> Option<PathBuf> {
+            self.home.clone()
+        }
+
+        fn stat(&self, _path: &Path) -> std::io::Result<Option<HostFileFacts>> {
+            if self.unreadable {
+                return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+            }
+            Ok(self.facts)
+        }
+    }
+
+    fn host(source: &str, mount_path: &str, owner: FilesetOwner, optional: bool) -> HostFileset {
+        HostFileset {
+            source: source.into(),
+            mount_path: mount_path.into(),
+            owner,
+            optional,
+        }
+    }
+
+    #[test]
+    fn a_workload_owned_host_file_joins_the_chown_manifest() {
+        let mut out = MaterializedFilesets::default();
+        host_fileset_specs(
+            &StagedHost::present(),
+            &[host(
+                "~/.gitconfig",
+                "/home/agent/.gitconfig",
+                FilesetOwner::Workload,
+                false,
+            )],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(
+            out.owned_paths
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["/home/agent/.gitconfig"],
+            "without the chown the workload cannot rewrite the file it was seeded with"
+        );
+        assert!(
+            out.into_specs()
+                .iter()
+                .any(|spec| spec.guest_path == OWNED_MANIFEST_PATH)
+        );
+    }
+
+    #[test]
+    fn a_root_owned_host_file_does_not() {
+        let mut out = MaterializedFilesets::default();
+        host_fileset_specs(
+            &StagedHost::present(),
+            &[host(
+                "/etc/gitconfig",
+                "/etc/gitconfig",
+                FilesetOwner::Root,
+                false,
+            )],
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.owned_paths.is_empty());
+        assert!(
+            !out.into_specs()
+                .iter()
+                .any(|spec| spec.guest_path == OWNED_MANIFEST_PATH)
+        );
+    }
+
+    #[test]
+    fn a_host_file_keeps_the_mode_the_host_reports() {
+        let mut out = MaterializedFilesets::default();
+        host_fileset_specs(
+            &StagedHost {
+                facts: Some(HostFileFacts {
+                    mode: 0o600,
+                    is_regular_file: true,
+                }),
+                ..StagedHost::present()
+            },
+            &[host(
+                "~/.gitconfig",
+                "/home/agent/.gitconfig",
+                FilesetOwner::Workload,
+                false,
+            )],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(out.specs[0].mode, 0o600);
+    }
+
+    #[test]
+    fn a_host_path_that_resolves_to_something_other_than_a_regular_file_is_refused() {
+        let err = host_fileset_specs(
+            &StagedHost {
+                facts: Some(HostFileFacts {
+                    mode: 0o755,
+                    is_regular_file: false,
+                }),
+                ..StagedHost::present()
+            },
+            &[host("/etc", "/etc/gitconfig", FilesetOwner::Root, true)],
+            &mut MaterializedFilesets::default(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("/etc") && format!("{err:#}").contains("regular file"),
+            "a directory or device is not a file the guest can be seeded with, and `optional` must not swallow it: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_host_path_the_probe_cannot_read_names_the_path_it_failed_on() {
+        let err = host_fileset_specs(
+            &StagedHost {
+                unreadable: true,
+                ..StagedHost::present()
+            },
+            &[host(
+                "~/.gitconfig",
+                "/home/agent/.gitconfig",
+                FilesetOwner::Workload,
+                true,
+            )],
+            &mut MaterializedFilesets::default(),
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("~/.gitconfig") && message.contains("/home/some-user/.gitconfig"),
+            "a denied stat is not an absent file, so `optional` must not skip it silently: {message}"
+        );
+    }
+
+    #[test]
+    fn an_absent_optional_host_path_is_skipped_and_tells_the_operator_one_line() {
+        let mut out = MaterializedFilesets::default();
+        let frames = crate::log::testing::capture_run_frames(|| {
+            host_fileset_specs(
+                &StagedHost {
+                    facts: None,
+                    ..StagedHost::present()
+                },
+                &[host(
+                    "~/.gitconfig",
+                    "/home/agent/.gitconfig",
+                    FilesetOwner::Workload,
+                    true,
+                )],
+                &mut out,
+            )
+            .unwrap();
+        });
+        assert!(
+            out.specs.is_empty(),
+            "an absent optional host file must reach nothing downstream: {:?}",
+            out.specs
+        );
+        assert_eq!(
+            frames,
+            vec![lns_ipc::WireFrame::Json(lns_ipc::Response::RunLog {
+                level: lns_ipc::LogLevel::Info,
+                verb: Some("fileset".to_string()),
+                message: "skipping optional hostPath ~/.gitconfig — not present on this host"
+                    .to_string(),
+            })],
+            "the run span carries this line to the CLI, which prints it as one status line; drop it and the guest is silently unseeded"
+        );
+    }
+
+    #[test]
+    fn a_home_rooted_host_path_without_a_known_home_is_refused() {
+        let err = host_fileset_specs(
+            &StagedHost {
+                home: None,
+                ..StagedHost::present()
+            },
+            &[host(
+                "~/.gitconfig",
+                "/home/agent/.gitconfig",
+                FilesetOwner::Workload,
+                true,
+            )],
+            &mut MaterializedFilesets::default(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("~/.gitconfig"),
+            "an unresolvable home must name the path rather than seed a literal `~` file: {err:#}"
+        );
+    }
+
+    #[test]
+    fn an_absent_required_host_path_names_both_the_declared_and_the_resolved_path() {
+        let err = host_fileset_specs(
+            &StagedHost {
+                facts: None,
+                ..StagedHost::present()
+            },
+            &[host(
+                "~/.gitconfig",
+                "/home/agent/.gitconfig",
+                FilesetOwner::Workload,
+                false,
+            )],
+            &mut MaterializedFilesets::default(),
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("~/.gitconfig"), "got: {message}");
+        assert!(
+            message.contains("/home/some-user/.gitconfig"),
+            "the resolved path is what the operator has to create — including when a symlink is what points nowhere, which the probe reports as this same absence: {message}"
         );
     }
 

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -65,6 +65,7 @@ pub(crate) fn project_inspection(
                             target: volume.target.clone(),
                             read_only: volume.read_only(),
                             exclude: volume.exclude().to_vec(),
+                            optional: volume.optional(),
                         })
                         .collect(),
                     ports: declared_view_ports(&def.spec.ports)?,
@@ -76,6 +77,8 @@ pub(crate) fn project_inspection(
                             path: fileset.path.clone(),
                             reference: fileset.reference.clone(),
                             inline: fileset.inline.is_some(),
+                            host_path: fileset.host_path.clone(),
+                            optional: fileset.optional,
                             mount_path: fileset.mount_path.clone(),
                             owner: match fileset.owner {
                                 lns_artifact::sandbox::FilesetOwner::Workload => {
@@ -238,6 +241,26 @@ mod tests {
         }))
     }
 
+    fn sandbox_view_with_filesets(filesets: Vec<SandboxFileset>) -> ArtifactInspection {
+        ArtifactInspection::Sandbox(Box::new(SandboxView {
+            reference: "registry.example.test/team/sandbox:latest".into(),
+            digest: digest(),
+            image: "registry.example.test/runtime:1".into(),
+            workdir: None,
+            user: None,
+            mounts: Vec::new(),
+            ports: Vec::new(),
+            filesets,
+            connectors: Vec::new(),
+            env: Vec::new(),
+            credentials: Vec::new(),
+            tools: Vec::new(),
+            policy_flags: Vec::new(),
+            cpus: None,
+            mem_mib: None,
+        }))
+    }
+
     #[test]
     fn a_sandbox_projects_the_run_as_user_it_declared_so_a_pull_can_disclose_it() {
         assert_eq!(
@@ -304,9 +327,54 @@ mod tests {
                     target: "/workspace".into(),
                     read_only: false,
                     exclude: vec![".cargo".into(), "tmp/scratch".into()],
+                    optional: false,
                 }]
             ),
             "a pulled sandbox whose exclusions are dropped here publishes masks that never apply"
+        );
+    }
+
+    #[test]
+    fn a_sandbox_discloses_a_host_file_source_and_whether_it_is_optional() {
+        assert_eq!(
+            project_sandbox(
+                r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","filesets":[{"hostPath":"~/.gitconfig","mountPath":"/home/agent/.gitconfig","optional":true}]}}"#
+            )
+            .unwrap(),
+            sandbox_view_with_filesets(vec![SandboxFileset {
+                path: None,
+                reference: None,
+                inline: false,
+                host_path: Some("~/.gitconfig".into()),
+                mount_path: "/home/agent/.gitconfig".into(),
+                owner: lns_ipc::SandboxFilesetOwner::Workload,
+                optional: true,
+            }]),
+            "a pulled sandbox that reads a file off the consumer's machine must say which file, before it boots"
+        );
+    }
+
+    #[test]
+    fn a_sandbox_projects_whether_its_bind_is_optional() {
+        assert_eq!(
+            project_sandbox(
+                r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","volumes":[{"type":"bind","source":"~/.claude","target":"/home/agent/.claude","optional":true}]}}"#
+            )
+            .unwrap(),
+            sandbox_view_with(
+                None,
+                None,
+                None,
+                vec![SandboxMount {
+                    kind: SandboxMountKind::Bind,
+                    source: "~/.claude".into(),
+                    target: "/home/agent/.claude".into(),
+                    read_only: false,
+                    exclude: Vec::new(),
+                    optional: true,
+                }]
+            ),
+            "dropping this makes a pulled optional bind required again, so a consumer without the directory could not run the sandbox at all"
         );
     }
 
@@ -331,6 +399,7 @@ mod tests {
                         target: "/workspace".into(),
                         read_only: false,
                         exclude: Vec::new(),
+                        optional: false,
                     },
                     SandboxMount {
                         kind: SandboxMountKind::Volume,
@@ -338,6 +407,7 @@ mod tests {
                         target: "/root/.cache".into(),
                         read_only: true,
                         exclude: Vec::new(),
+                        optional: false,
                     },
                 ],
                 ports: vec![
@@ -358,6 +428,8 @@ mod tests {
                                 .into()
                         ),
                         inline: false,
+                        host_path: None,
+                        optional: false,
                         mount_path: "/root/.agent/skills".into(),
                         owner: lns_ipc::SandboxFilesetOwner::Workload,
                     },
@@ -365,6 +437,8 @@ mod tests {
                         path: None,
                         reference: None,
                         inline: true,
+                        host_path: None,
+                        optional: false,
                         mount_path: "/etc/agent".into(),
                         owner: lns_ipc::SandboxFilesetOwner::Root,
                     },

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -80,6 +80,22 @@ pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> Resolve
                 })
             })
             .collect(),
+        host_filesets: def
+            .spec
+            .filesets
+            .iter()
+            .filter_map(|fileset| {
+                fileset
+                    .host_path
+                    .as_ref()
+                    .map(|source| assembly::HostFileset {
+                        source: source.clone(),
+                        mount_path: fileset.mount_path.clone(),
+                        owner: fileset.owner,
+                        optional: fileset.optional,
+                    })
+            })
+            .collect(),
         inline_filesets: def
             .spec
             .filesets

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -52,7 +52,13 @@ pub(crate) async fn peek_and_plan(
             if !problems.is_empty() {
                 anyhow::bail!("refusing to run {image_ref}: {}", problems.join("; "));
             }
-            let fileset_specs = materialize_filesets(&resolved).await?.into_specs();
+            let mut materialized = materialize_filesets(&resolved).await?;
+            crate::artifact::fileset::host_fileset_specs(
+                &RealSnapshotDir,
+                &resolved.host_filesets,
+                &mut materialized,
+            )?;
+            let fileset_specs = materialized.into_specs();
             Ok(Some(SandboxPlan {
                 workload: assembly::assemble(&resolved),
                 fileset_specs,
@@ -70,6 +76,11 @@ pub(crate) async fn plan_local(definition_json: &str) -> Result<SandboxPlan> {
     crate::artifact::fileset::local_fileset_specs(
         &RealSnapshotDir,
         &resolved.local_filesets,
+        &mut materialized,
+    )?;
+    crate::artifact::fileset::host_fileset_specs(
+        &RealSnapshotDir,
+        &resolved.host_filesets,
         &mut materialized,
     )?;
     Ok(SandboxPlan {
@@ -111,6 +122,28 @@ impl crate::artifact::fileset::SnapshotDir for RealSnapshotDir {
         }
         entries.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(entries)
+    }
+}
+
+impl crate::artifact::fileset::HostFileProbe for RealSnapshotDir {
+    fn home(&self) -> Option<std::path::PathBuf> {
+        dirs::home_dir()
+    }
+
+    /// `metadata`, not `symlink_metadata`: a stow/chezmoi dotfile is a symlink, and the read that follows this seeds from the target too.
+    fn stat(
+        &self,
+        path: &std::path::Path,
+    ) -> std::io::Result<Option<crate::artifact::fileset::HostFileFacts>> {
+        use std::os::unix::fs::PermissionsExt;
+        match std::fs::metadata(path) {
+            Ok(metadata) => Ok(Some(crate::artifact::fileset::HostFileFacts {
+                mode: metadata.permissions().mode() & 0o777,
+                is_regular_file: metadata.is_file(),
+            })),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -328,9 +361,54 @@ pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifact::fileset::{HostFileFacts, HostFileProbe};
     use oci_client::manifest::{OciDescriptor, OciImageManifest};
     use sha2::{Digest, Sha256};
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn a_symlinked_host_file_reads_as_the_file_it_points_at() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("dotfiles").join("gitconfig");
+        std::fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&target, b"[user]").expect("write");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o640)).expect("chmod");
+        let link = dir.path().join(".gitconfig");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        assert_eq!(
+            RealSnapshotDir.stat(&link).expect("stat"),
+            Some(HostFileFacts {
+                mode: 0o640,
+                is_regular_file: true
+            }),
+            "stow, chezmoi and home-manager all leave ~/.gitconfig a symlink, and the read that follows this one seeds from the target; refusing the link here refuses the whole run and leaves `optional` powerless"
+        );
+    }
+
+    #[test]
+    fn a_symlink_with_no_target_counts_as_an_absent_host_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let link = dir.path().join(".gitconfig");
+        std::os::unix::fs::symlink(dir.path().join("gone"), &link).expect("symlink");
+        assert_eq!(
+            RealSnapshotDir.stat(&link).expect("stat"),
+            None,
+            "nothing is behind the link, so there is no file to seed: absent is the honest answer, and an optional fileset skips it instead of refusing the run"
+        );
+    }
+
+    #[test]
+    fn a_directory_at_a_host_path_is_still_reported_as_not_a_regular_file() {
+        assert_eq!(
+            RealSnapshotDir
+                .stat(tempfile::tempdir().expect("tempdir").path())
+                .expect("stat")
+                .map(|facts| facts.is_regular_file),
+            Some(false),
+            "following the link must not soften the genuine case: a directory is not a file the guest can be seeded with"
+        );
+    }
 
     struct StreamingRegistry {
         blob: Vec<u8>,

--- a/crates/lns-service/src/log.rs
+++ b/crates/lns-service/src/log.rs
@@ -327,6 +327,28 @@ where
 }
 
 #[cfg(test)]
+pub(crate) mod testing {
+    use super::*;
+
+    /// The frames `f`'s `crate::log` events reach the CLI as, captured by running it inside a run span wired exactly as the run orchestrator wires one.
+    pub(crate) fn capture_run_frames<T>(f: impl FnOnce() -> T) -> Vec<WireFrame> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<WireFrame>(16);
+        let subscriber = tracing_subscriber::registry().with(FrameForwardLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("lns.run");
+            let _entered = span.enter();
+            attach_to_run_span(tx);
+            f();
+        });
+        let mut frames = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            frames.push(frame);
+        }
+        frames
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};

--- a/crates/lns-service/tests/behaviours/sandbox_filesets.feature
+++ b/crates/lns-service/tests/behaviours/sandbox_filesets.feature
@@ -60,3 +60,31 @@ Feature: a sandbox's declared filesets are planned into the launch
     Given a published sandbox declaring an inline file at "/home/sandbox"
     When the sandbox is planned
     Then the plan accepts the inline fileset without a fileset ref
+
+  Scenario: a hostPath fileset lands at its mountPath as a host-file write
+    Given a definition declaring a hostPath fileset "/etc/gitconfig" at "/home/agent/.gitconfig"
+    And the host file "/etc/gitconfig" exists with mode 0644
+    When the host files are planned
+    Then the plan carries a host-file write from "/etc/gitconfig" to "/home/agent/.gitconfig"
+
+  Scenario: a home-rooted hostPath resolves against this machine's home
+    Given a definition declaring a hostPath fileset "~/.gitconfig" at "/home/agent/.gitconfig"
+    And this machine's home directory is "/home/some-user"
+    And the host file "/home/some-user/.gitconfig" exists with mode 0644
+    When the host files are planned
+    Then the plan carries a host-file write from "/home/some-user/.gitconfig" to "/home/agent/.gitconfig"
+
+  Scenario: an absent optional hostPath fileset is planned as nothing
+    Given a definition declaring an optional hostPath fileset "/etc/gitconfig" at "/home/agent/.gitconfig"
+    When the host files are planned
+    Then the plan carries no guest-write spec
+
+  Scenario: an absent required hostPath fileset refuses the plan
+    Given a definition declaring a hostPath fileset "/etc/gitconfig" at "/home/agent/.gitconfig"
+    When the host files are planned
+    Then the plan is refused naming "/etc/gitconfig"
+
+  Scenario: a published sandbox may declare a hostPath fileset but still not a local path fileset
+    Given a published sandbox declaring a hostPath fileset "~/.gitconfig" at "/home/agent/.gitconfig"
+    When the sandbox is planned
+    Then the plan accepts the hostPath fileset

--- a/crates/lns-service/tests/behaviours/steps/sandbox_filesets.rs
+++ b/crates/lns-service/tests/behaviours/steps/sandbox_filesets.rs
@@ -286,3 +286,150 @@ fn plan_accepts_inline_without_ref(world: &mut BehaviourWorld) -> Result<(), Str
         ))
     }
 }
+
+struct StagedHost {
+    files: std::collections::HashMap<std::path::PathBuf, u32>,
+    home: Option<std::path::PathBuf>,
+}
+
+impl lns_service::artifact::fileset::HostFileProbe for StagedHost {
+    fn home(&self) -> Option<std::path::PathBuf> {
+        self.home.clone()
+    }
+
+    fn stat(
+        &self,
+        path: &Path,
+    ) -> std::io::Result<Option<lns_service::artifact::fileset::HostFileFacts>> {
+        Ok(self
+            .files
+            .get(path)
+            .map(|mode| lns_service::artifact::fileset::HostFileFacts {
+                mode: *mode,
+                is_regular_file: true,
+            }))
+    }
+}
+
+#[given(
+    regex = r#"^a (published sandbox|definition) declaring an? (optional )?hostPath fileset "([^"]+)" at "([^"]+)"$"#
+)]
+fn definition_with_host_path_fileset(
+    world: &mut BehaviourWorld,
+    _who: String,
+    optional: String,
+    source: String,
+    mount: String,
+) {
+    let optional = !optional.is_empty();
+    world.fileset_definition = Some(sandbox_json(&format!(
+        r#"{{"hostPath":"{source}","mountPath":"{mount}","optional":{optional}}}"#
+    )));
+}
+
+#[given(regex = r#"^the host file "([^"]+)" exists with mode 0([0-7]+)$"#)]
+fn host_file_exists(world: &mut BehaviourWorld, path: String, mode: String) {
+    let mode = u32::from_str_radix(&mode, 8).expect("octal mode");
+    world
+        .host_files
+        .insert(std::path::PathBuf::from(path), mode);
+}
+
+#[given(regex = r#"^this machine's home directory is "([^"]+)"$"#)]
+fn machine_home_is(world: &mut BehaviourWorld, home: String) {
+    world.host_home = Some(std::path::PathBuf::from(home));
+}
+
+#[when("the host files are planned")]
+fn plan_host_files(world: &mut BehaviourWorld) {
+    let json = world
+        .fileset_definition
+        .take()
+        .expect("the scenario must declare a definition");
+    let def = lns_artifact::sandbox::parse(&json).expect("valid sandbox fixture");
+    let resolved = resolved_from_sandbox(&def);
+    let probe = StagedHost {
+        files: world.host_files.clone(),
+        home: world.host_home.clone(),
+    };
+    let mut materialized = MaterializedFilesets::default();
+    match lns_service::artifact::fileset::host_fileset_specs(
+        &probe,
+        &resolved.host_filesets,
+        &mut materialized,
+    ) {
+        Ok(()) => {
+            world.fileset_problems = Some(Vec::new());
+            world.host_file_writes = materialized
+                .specs
+                .iter()
+                .filter_map(|spec| match &spec.source {
+                    lns_service::runtime_layer::RuntimeSource::HostFile(path) => {
+                        Some((path.to_string_lossy().into_owned(), spec.guest_path.clone()))
+                    }
+                    _ => None,
+                })
+                .collect();
+            capture_materialized(world, materialized);
+        }
+        Err(error) => world.fileset_problems = Some(vec![format!("{error:#}")]),
+    }
+}
+
+#[then(regex = r#"^the plan carries a host-file write from "([^"]+)" to "([^"]+)"$"#)]
+fn plan_carries_host_file_write(
+    world: &mut BehaviourWorld,
+    source: String,
+    guest_path: String,
+) -> Result<(), String> {
+    if world
+        .host_file_writes
+        .contains(&(source.clone(), guest_path.clone()))
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "a hostPath fileset must plan as a launch-time snapshot of the host file, not a live share — expected ({source:?}, {guest_path:?}) among {:?}",
+            world.host_file_writes
+        ))
+    }
+}
+
+#[then("the plan carries no guest-write spec")]
+fn plan_carries_no_spec(world: &mut BehaviourWorld) -> Result<(), String> {
+    let problems = world.fileset_problems.as_ref().ok_or("no plan ran")?;
+    let specs = world.fileset_specs.as_ref().ok_or("no plan captured")?;
+    if problems.is_empty() && specs.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected an empty plan, got problems={problems:?} specs={specs:?}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the plan is refused naming "([^"]+)"$"#)]
+fn plan_refused_naming(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let problems = world.fileset_problems.as_ref().ok_or("no plan ran")?;
+    if problems.iter().any(|problem| problem.contains(&needle)) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected a refusal naming {needle:?}, got {problems:?}"
+        ))
+    }
+}
+
+#[then("the plan accepts the hostPath fileset")]
+fn plan_accepts_host_path(world: &mut BehaviourWorld) -> Result<(), String> {
+    let problems = world.fileset_problems.as_ref().ok_or("no plan ran")?;
+    let plan = world.fileset_plan.as_ref().ok_or("no plan captured")?;
+    if problems.is_empty() && plan.local_filesets.is_empty() && plan.host_filesets.len() == 1 {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected one accepted hostPath fileset, got problems={problems:?}, local={:?}, host={:?}",
+            plan.local_filesets, plan.host_filesets
+        ))
+    }
+}

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -74,6 +74,12 @@ pub struct BehaviourWorld {
     pub fileset_contents: std::collections::HashMap<String, String>,
     /// The chown-manifest body the planned specs ship for lns-init, when any fileset is workload-owned.
     pub fileset_manifest: Option<String>,
+    /// Host files a hostPath scenario stages, by resolved absolute path, with the mode a probe reports.
+    pub host_files: std::collections::HashMap<std::path::PathBuf, u32>,
+    /// The home this scenario's machine reports; `None` means the machine has none.
+    pub host_home: Option<std::path::PathBuf>,
+    /// Host-file guest writes the plan produced, as (host source, guest path).
+    pub host_file_writes: Vec<(String, String)>,
 
     /// Run id registered by a lifecycle scenario (stop / inspect / logs).
     pub lifecycle_run: Option<String>,

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -427,6 +427,36 @@ shell or environment-variable interpolation, so use `source: .`, not `$PWD`.
 Paths are normalized, and a relative source cannot escape the project with
 `..`.
 
+A source that starts with `~/` resolves against the home directory of the user
+who runs `lns`, on the machine that runs it. This is the portable way for a
+definition to reach a per-user directory such as `~/.claude`. Only the `~/` form
+is supported: a bare `~` and another user's home (`~alice/…`) are refused,
+because a definition that names one machine's account is not portable.
+
+A `~/` source that names a secret store — `~/.ssh`, `~/.aws`, `~/.gnupg`, or any
+other secret-shaped segment — is refused offline, exactly as a `hostPath` is.
+The keep/drop prompt reads the top-level names under a bind root only, so it
+cannot be the guard for a bind whose root *is* the key store. An absolute or
+project-relative source keeps the rules it always had, because it names the
+author's own machine and cannot travel.
+
+A bind whose source is absent refuses the run and names the path. Add
+`optional: true` to skip it instead, so one definition runs both on a machine
+that has the directory and on a machine that does not:
+
+```yaml
+spec:
+  volumes:
+    - type: bind
+      source: ~/.claude            # this machine's own agent state
+      target: /home/agent/.claude
+      optional: true               # skipped, with one line, when it is absent
+```
+
+A skipped bind reaches nothing downstream — not the secret scan, not the guest,
+not the audit record. `optional` applies to a bind only; a named volume is
+created on demand and is never absent.
+
 Launch flags are the final override layer. Lens Sandbox starts with the mounts
 from `lns.yaml`, replaces a declarative mount when an explicit `--volume` or
 `--mount` targets the same guest path, and keeps mounts with other targets.
@@ -453,6 +483,9 @@ spec:
         mcp.json: |
           {"mcpServers":{}}
       mountPath: /home/sandbox
+    - hostPath: ~/.gitconfig      # one file from the machine that runs it
+      mountPath: /home/agent/.gitconfig
+      optional: true
 ```
 
 - **`path`** names a directory in the authoring project. A local `lns run`
@@ -462,7 +495,9 @@ spec:
   artifact, uploaded alongside the sandbox, and rewritten to a digest-pinned
   `ref` in the published config. (`spec.image` is published exactly as written —
   `lns push` does not resolve it; pin it by digest yourself for a reproducible
-  base, as above.)
+  base, as above.) A `path` is a directory beside the definition, so it cannot
+  be home-anchored: a `~/…` `path` is refused and names `hostPath` as the field
+  that reads the machine that runs the sandbox.
 - **`ref`** names a pre-published FileSet artifact, always pinned by digest. A
   pulled sandbox's filesets are fetched and materialized at launch; `lns
   inspect` lists every fileset (`fileset: <ref> -> <mountPath>`) so you can
@@ -475,8 +510,23 @@ spec:
   Inline files remain in the published sandbox config, so `lns push`
   does not create a companion FileSet artifact for them. Inspect and run output
   disclose the inline source, mount path, and owner, never the file contents.
-- Each entry sets exactly one of `path`/`ref`/`inline`. `inline` must contain at
-  least one file. Every inline key must be a relative path without empty, `.`,
+- **`hostPath`** names one file on the machine that *runs* the sandbox, not on
+  the author's. It is read once at launch and written to `mountPath`, so the
+  guest gets a snapshot, never a live share — the file a workload edits inside
+  the guest dies with the microVM, and the host copy is never touched. This is
+  the portable way to seed the tool identity a workload needs, such as
+  `~/.gitconfig`. The path must be absolute or start with `~/` (resolved
+  against the home of the user who runs `lns`), and `mountPath` names a guest
+  **file**, so it must not end in `/`. A `hostPath` is carried into the
+  published config verbatim — `lns push` packs nothing for it, which is exactly
+  what keeps the artifact portable. Add `optional: true` when the file may be
+  absent: an absent required `hostPath` refuses the run and names the path, an
+  absent optional one is skipped and reported as one status line of the run.
+  A `hostPath` that is a symlink reads the file it points at, so a dotfile that
+  stow, chezmoi, or home-manager manages works; a link that points nowhere
+  counts as absent. `optional` applies to a `hostPath` entry only.
+- Each entry sets exactly one of `path`/`ref`/`inline`/`hostPath`. `inline` must
+  contain at least one file. Every inline key must be a relative path without empty, `.`,
   or `..` components. `mountPath` is an absolute
   guest path; duplicates — including collisions with a volume `target` — are
   rejected offline, as is any mount into the sandbox's own `/.lens` runtime
@@ -489,8 +539,9 @@ spec:
   MCP configs an agent must not rewrite mid-run. Either way the snapshot is
   ephemeral: changes die with the microVM.
 - A secret-shaped file (`.env`, keys, credential stores) anywhere in a `path`
-  fileset, or as any path component in an `inline`
-  fileset refuses `validate`, `run`, and `push` outright: a fileset is baked
+  fileset, as any path component in an `inline`
+  fileset, or as any segment of a `hostPath`
+  refuses `validate`, `run`, and `push` outright: a fileset is baked
   into an artifact, so there is no keep/drop prompt to catch it later — real
   secrets stay outside the workload. Ship the tool's *configuration* in a
   fileset and bind its *credential* through `spec.credentials`, so the
@@ -636,7 +687,7 @@ directory while holding back the parts a workload must not see:
 spec:
   volumes:
     - type: bind
-      source: /Users/you/dev     # an absolute path; `~` is not expanded
+      source: ~/dev              # or an absolute path
       target: /work
       exclude:
         - .cargo          # host toolchains the guest must not use


### PR DESCRIPTION
## The problem

A definition cannot name anything on the machine that runs it.

`SandboxSpec` carries `image`, `command`, `workdir`, `env`, `resources`, `policy`, `connectors`, `credentials`, `tools`, `volumes`, `filesets` and `ports`. Every fileset source is artifact-side: `path` is packed and digest-pinned at push, `ref` is a published FileSet, `inline` lives in the document. A `bind` volume can name a host directory, but only as an absolute path — which is the publisher's own machine — or a project-relative one, since `resolve_bind_source` does no `~` expansion.

So a sandbox that wants the user's git config or their agent state has to get it from `-v` flags supplied by a wrapper script, and the definition itself cannot express "the user's git config". A colleague who runs the published artifact gets neither. That is the gap: it makes an otherwise-publishable definition depend on a wrapper that travels separately.

## What a definition can now say

```yaml
filesets:
  - hostPath: ~/.gitconfig
    mountPath: /home/agent/.gitconfig
    optional: true
volumes:
  - type: bind
    source: ~/.claude
    target: /home/agent/.claude
    optional: true
```

- **`hostPath`** is a fourth fileset source beside `path`, `ref` and `inline`. It names one file on the machine that runs the sandbox, snapshotted into the guest at launch. Unlike `path` it is never packed into the artifact — it is carried verbatim through publish, and that asymmetry is exactly what makes it portable. It reuses the existing `RuntimeSource::HostFile` materialization and joins the same `/.lens/fileset-owned` chown manifest, so no second ownership path appears.
- **`~/` bind sources** resolve against the consumer's own home. Expansion deliberately lives in two places — the CLI for bind sources, the service for `hostPath` — because a published definition never passes through the CLI's JSON rewrite. Both are pinned by test, and both resolve against the invoking user's home only.
- **`optional`** defaults to `false` on both. An absent required host path refuses the run and names it; an absent optional one is skipped and reported. Only true absence is skipped: a probe error propagates, and a path that exists but is not a regular file is refused even when optional.

Symlinks follow (`std::fs::metadata`), so a stow/chezmoi-managed `~/.gitconfig` works, and a dangling link counts as absent. That matches the bind half, which uses `Path::exists()`, and the later `std::fs::read` which already followed links.

## Why `~/` needed a guard the absolute form did not

`~/` is the first source form that lets a **pulled** definition aim at the consumer's own home — an absolute `/Users/<author>/…` is useless on another machine, so this reach is new.

The existing protection does not cover it. `host_bind.rs`'s secret scan is `secret_shaped_top_level`, i.e. top-level names only, so `private-keys-v1.d` is not secret-shaped and the GPG private keys beneath it would be exposed after a single `y` — and `lns run --yes` skips the consent card entirely. A `hostPath` gets no KEEP/DROP prompt at all, so its name is the only guard it has.

So a `~/`-anchored bind source is refused when any segment is secret-shaped, using the same `looks_like_secret_name` check the file half uses. This bites at parse, which every load path goes through, so it is upstream of the consent card and unreachable by `--yes`.

Absolute and project-relative bind sources keep the rules they already had — tightening those is a separate change, and `an_absolute_bind_source_keeps_the_rules_it_already_had` documents the boundary so a later change is a deliberate one.

Only `~/` is supported; `~user` and a bare `~` are refused naming the one form that works. A packed fileset `path` starting with `~` is refused too, since a packed path is a directory beside the document and can never be home-anchored — previously it failed later with a message claiming the machine had no home directory.

## Disclosure

The run summary and the pulled-artifact consent card both name the host path before boot, and the declared string is shown, never the file's contents.

The card previously described every fileset as "author-published files" — inverted for a host file, which is read from the *consumer's* machine, and this card is the consent surface for exactly that. The `(source, mountPath, owner)` triple that flattened the source kind away is now a named `FilesetSummary` carrying it, so a host file reads "a file read from this machine at launch" while packed, inline and ref filesets keep their original wording.

## Verification

`make lint`, `make complexity`, `make coverage` — all exit 0. Every touched file at 100%; no `IGNORES` entry added or reworded. 397/397 lns-cli scenarios, 207/207 lns-service scenarios, 185 lns-artifact unit tests.

A published sandbox may declare a `hostPath` but still may not declare a local `path` fileset — `published_fileset_problems` was not widened, and there is a guard test for it.

## Follow-ups, not in this PR

- `docs/sandbox-spec.md` needs the same rules in §3.1.10, §3.1.11, the §5 validation summary and §6 publish-time transforms. That file is not on `origin/main` yet, so this PR does not fork it.
- `lns run --yes --quiet` names no host file at all (`--yes` skips the card, `--quiet` skips the summary). Pre-existing pattern shared with binds, but worth a deliberate decision now that a consumer file can be involved.
- The disclosure shows a `hostPath` tilde verbatim while bind lines show the resolved absolute path.
- An `optional` host path on a machine with no resolvable home refuses the run rather than skipping — `optional` means "the file is absent", not "there is no home".
- No `@microvm` scenario proves a `hostPath` lands in a booted guest; local `path` filesets already drive the same `RuntimeSource::HostFile` path end to end, and this adds no new guest-side code.
