### PR TITLE
fix: let validate answer for the document every verb runs

### DIFF
--- a/crates/e2e-tests/tests/registry_selftest.rs
+++ b/crates/e2e-tests/tests/registry_selftest.rs
@@ -16,7 +16,7 @@ use std::net::TcpStream;
 
 fn sandbox_manifest() -> Vec<u8> {
     format!(
-        r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"reg/base@sha256:{}"}}}}"#,
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"image":"reg/base@sha256:{}"}}}}"#,
         "a".repeat(64)
     )
     .into_bytes()
@@ -58,8 +58,8 @@ async fn build_push_and_pull_round_trip_through_the_local_registry() {
         Some("application/vnd.lens.sandbox.v1+json"),
         "the pulled manifest must carry the lens artifactType"
     );
-    let parsed = lns_artifact::spec::parse_sandbox(config.as_bytes())
-        .expect("the pulled config is the sandbox spec");
+    let parsed = lns_artifact::sandbox::parse(config.as_bytes())
+        .expect("the pulled config loads through the same reader run and inspect use");
     assert_eq!(parsed.metadata.name, "some-sandbox");
 }
 

--- a/crates/lns-artifact/src/build.rs
+++ b/crates/lns-artifact/src/build.rs
@@ -209,7 +209,7 @@ mod tests {
 
     fn sandbox() -> Vec<u8> {
         format!(
-            r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"reg/base@sha256:{}"}}}}"#,
+            r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"image":"reg/base@sha256:{}"}}}}"#,
             "a".repeat(64)
         )
         .into_bytes()
@@ -287,17 +287,31 @@ mod tests {
 
     #[test]
     fn build_artifact_refuses_an_invalid_manifest() {
-        let floating = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"isolation":"microvm","baseImage":"reg/base:1"}}"#;
-        let err = build_artifact(floating).unwrap_err();
-        assert!(format!("{err:#}").contains("digest-pinned"), "got: {err:#}");
+        let imageless = br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{}}"#;
+        let err = build_artifact(imageless).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("must carry an image"),
+            "got: {err:#}"
+        );
     }
 
     #[test]
     fn build_artifact_refuses_an_unknown_kind() {
-        let doc = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sorcery","metadata":{"name":"x"},"spec":{}}"#;
+        let doc = br#"{"apiVersion":"lns.run/v1","kind":"Sorcery","metadata":{"name":"x"},"spec":{"image":"reg/base:1"}}"#;
         let err = build_artifact(doc).unwrap_err();
+        assert!(format!("{err:#}").contains("kind"), "got: {err:#}");
+    }
+
+    #[test]
+    fn build_artifact_refuses_a_document_no_verb_can_run() {
+        // Publishing a retired-group document would put an artifact in a registry that `lns run` and `lns inspect` both refuse to read.
+        let doc = format!(
+            r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"reg/base@sha256:{}"}}}}"#,
+            "a".repeat(64)
+        );
+        let err = build_artifact(doc.as_bytes()).unwrap_err();
         assert!(
-            format!("{err:#}").contains("unknown artifact kind"),
+            format!("{err:#}").contains(crate::sandbox::API_VERSION),
             "got: {err:#}"
         );
     }

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -34,18 +34,6 @@ const EXACT_SECRET_NAMES: &[&str] = &[
     ".docker",
 ];
 
-/// True when a document declares the user-facing `lns.run/v1` API group.
-pub fn is_sandbox_definition(config_json: &[u8]) -> bool {
-    #[derive(Deserialize)]
-    struct ApiOnly {
-        #[serde(rename = "apiVersion", default)]
-        api_version: String,
-    }
-    serde_json::from_slice::<ApiOnly>(config_json)
-        .map(|d| d.api_version == API_VERSION)
-        .unwrap_or(false)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Definition {
     pub metadata: Metadata,
@@ -175,8 +163,9 @@ struct Doc {
     #[serde(default)]
     kind: String,
     metadata: Metadata,
+    /// Read only after the group and kind decide, so another group's field names cannot answer as unknown fields of this one.
     #[serde(default)]
-    spec: SandboxSpec,
+    spec: serde_json::Value,
 }
 
 /// Parse and cross-field-validate a `lns.run/v1` sandbox definition, offline.
@@ -197,6 +186,10 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
     if !spec::is_valid_name(&doc.metadata.name) {
         bail!("invalid metadata.name {:?}", doc.metadata.name);
     }
+    let doc = Definition {
+        metadata: doc.metadata,
+        spec: serde_json::from_value(doc.spec).context("parsing sandbox spec")?,
+    };
     if doc.spec.image.trim().is_empty() {
         bail!("sandbox must carry an image; it is the base OCI image the sandbox runs");
     }
@@ -294,10 +287,7 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
             }
         }
     }
-    Ok(Definition {
-        metadata: doc.metadata,
-        spec: doc.spec,
-    })
+    Ok(doc)
 }
 
 fn validate_fileset(fileset: &FilesetEntry) -> Result<()> {
@@ -1790,14 +1780,5 @@ mod tests {
         let metadata = br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"hermes","unexpected":true},"spec":{"image":"x:1"}}"#;
         let err = parse(metadata).unwrap_err();
         assert!(format!("{err:#}").contains("unknown field"), "got: {err:#}");
-    }
-
-    #[test]
-    fn is_sandbox_definition_detects_the_api_group() {
-        assert!(is_sandbox_definition(&def_json(r#"{"image":"x:1"}"#)));
-        assert!(!is_sandbox_definition(
-            br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox"}"#
-        ));
-        assert!(!is_sandbox_definition(b"not json"));
     }
 }

--- a/crates/lns-artifact/src/spec.rs
+++ b/crates/lns-artifact/src/spec.rs
@@ -5,12 +5,6 @@ use std::collections::BTreeMap;
 pub const API_VERSION: &str = "lens.dev/v1alpha1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Class {
-    Runtime,
-    Application,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
     Sandbox,
     FileSet,
@@ -30,13 +24,6 @@ impl Kind {
         match self {
             Kind::Sandbox => "sandbox",
             Kind::FileSet => "fileset",
-        }
-    }
-
-    pub fn class(self) -> Class {
-        match self {
-            Kind::FileSet => Class::Application,
-            _ => Class::Runtime,
         }
     }
 
@@ -82,13 +69,6 @@ pub struct Mount {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Isolation {
-    Microvm,
-    Container,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
 pub enum Quantity {
     Int(i64),
@@ -102,20 +82,6 @@ pub struct Resources {
     pub cpu: Option<Quantity>,
     #[serde(default)]
     pub memory: Option<Quantity>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SandboxSpec {
-    #[serde(rename = "baseImage", default)]
-    pub base_image: Option<String>,
-    pub isolation: Isolation,
-    #[serde(default)]
-    pub resources: Option<Resources>,
-    #[serde(default)]
-    pub capabilities: Vec<String>,
-    #[serde(rename = "supervisorVersion", default)]
-    pub supervisor_version: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -136,12 +102,6 @@ pub struct Port {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Sandbox {
-    pub metadata: Metadata,
-    pub spec: SandboxSpec,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileSet {
     pub metadata: Metadata,
     pub mount: Mount,
@@ -157,7 +117,9 @@ struct Doc {
     metadata: Metadata,
     #[serde(default)]
     mount: Option<Mount>,
-    spec: serde_json::Value,
+    // Every FileSet artifact ever published carries `spec: {}`, so the strict decoder has to know the key even though nothing reads it.
+    #[serde(rename = "spec", default)]
+    _spec: serde::de::IgnoredAny,
 }
 
 fn parse_doc(config_json: &[u8], expected: Kind) -> Result<Doc> {
@@ -178,31 +140,7 @@ fn parse_doc(config_json: &[u8], expected: Kind) -> Result<Doc> {
     if !is_valid_name(&doc.metadata.name) {
         bail!("invalid metadata.name {:?}", doc.metadata.name);
     }
-    if expected.class() == Class::Runtime && doc.mount.is_some() {
-        bail!(
-            "{} is a runtime-layer artifact and must not carry a mount",
-            expected.as_str()
-        );
-    }
     Ok(doc)
-}
-
-pub fn parse_sandbox(config_json: &[u8]) -> Result<Sandbox> {
-    let doc = parse_doc(config_json, Kind::Sandbox)?;
-    let spec: SandboxSpec = serde_json::from_value(doc.spec).context("parsing sandbox spec")?;
-    if spec.isolation != Isolation::Microvm {
-        bail!("sandbox isolation must be microvm; lns runs workloads only inside a microVM");
-    }
-    let Some(image) = &spec.base_image else {
-        bail!("microvm sandbox must carry a baseImage; the workload rootfs lives on the sandbox");
-    };
-    if !is_digest_pinned_image(image) {
-        bail!("sandbox baseImage {image} must be digest-pinned (…@sha256:<64 hex>)");
-    }
-    Ok(Sandbox {
-        metadata: doc.metadata,
-        spec,
-    })
 }
 
 pub fn validate_mount_path(path: &str) -> Result<()> {
@@ -245,19 +183,6 @@ pub fn read_kind(config_json: &[u8]) -> Result<Kind> {
     Kind::from_kind_str(&kind).ok_or_else(|| anyhow::anyhow!("unknown artifact kind {kind:?}"))
 }
 
-/// Run the schema + cross-field guards for whatever kind the document declares.
-pub fn validate_any(config_json: &[u8]) -> Result<()> {
-    match read_kind(config_json)? {
-        Kind::Sandbox => {
-            parse_sandbox(config_json)?;
-        }
-        Kind::FileSet => {
-            parse_fileset(config_json)?;
-        }
-    }
-    Ok(())
-}
-
 pub(crate) fn is_valid_name(name: &str) -> bool {
     let bytes = name.as_bytes();
     if bytes.is_empty() || bytes.len() > 63 {
@@ -295,11 +220,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn kind_maps_family_class_and_media_types() {
+    fn kind_maps_family_and_media_types() {
         assert_eq!(Kind::Sandbox.family(), "sandbox");
         assert_eq!(Kind::Sandbox.as_str(), "Sandbox");
-        assert_eq!(Kind::Sandbox.class(), Class::Runtime);
-        assert_eq!(Kind::FileSet.class(), Class::Application);
         assert_eq!(
             Kind::Sandbox.artifact_type(),
             "application/vnd.lens.sandbox.v1+json"
@@ -356,93 +279,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_doc_rejects_wrong_api_version_kind_name_and_mount() {
-        let bad_api = br#"{"apiVersion":"v0","kind":"Sandbox","metadata":{"name":"x"},"spec":{}}"#;
-        assert!(format!("{:#}", parse_sandbox(bad_api).unwrap_err()).contains("apiVersion"));
-        let bad_kind = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"FileSet","metadata":{"name":"x"},"spec":{}}"#;
-        assert!(format!("{:#}", parse_sandbox(bad_kind).unwrap_err()).contains("expected kind"));
-        let bad_name = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"-bad"},"spec":{}}"#;
-        assert!(format!("{:#}", parse_sandbox(bad_name).unwrap_err()).contains("metadata.name"));
-        let runtime_mount = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"x"},"mount":{"path":"/x"},"spec":{}}"#;
-        assert!(
-            format!("{:#}", parse_sandbox(runtime_mount).unwrap_err())
-                .contains("must not carry a mount")
-        );
+    fn parse_doc_rejects_wrong_api_version_kind_and_name() {
+        let bad_api = br#"{"apiVersion":"v0","kind":"FileSet","metadata":{"name":"skills"},"mount":{"path":"/skills"},"spec":{}}"#;
+        assert!(format!("{:#}", parse_fileset(bad_api).unwrap_err()).contains("apiVersion"));
+        let bad_kind = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"skills"},"mount":{"path":"/skills"},"spec":{}}"#;
+        assert!(format!("{:#}", parse_fileset(bad_kind).unwrap_err()).contains("expected kind"));
+        let bad_name = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"FileSet","metadata":{"name":"-bad"},"mount":{"path":"/skills"},"spec":{}}"#;
+        assert!(format!("{:#}", parse_fileset(bad_name).unwrap_err()).contains("metadata.name"));
     }
 
     #[test]
     fn parse_doc_rejects_malformed_json() {
         assert!(
-            format!("{:#}", parse_sandbox(b"not json").unwrap_err()).contains("parsing artifact")
-        );
-    }
-
-    #[test]
-    fn versioned_artifacts_reject_unknown_fields_recursively() {
-        let digest = format!("reg/base@sha256:{}", "a".repeat(64));
-        let sandbox_docs = [
-            format!(
-                r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"{digest}"}},"unexpected":true}}"#
-            ),
-            format!(
-                r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox","unexpected":true}},"spec":{{"isolation":"microvm","baseImage":"{digest}"}}}}"#
-            ),
-            format!(
-                r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"{digest}","unexpected":true}}}}"#
-            ),
-            format!(
-                r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"{digest}","resources":{{"cpu":1,"unexpected":true}}}}}}"#
-            ),
-        ];
-        for doc in sandbox_docs {
-            let err = parse_sandbox(doc.as_bytes()).unwrap_err();
-            assert!(format!("{err:#}").contains("unknown field"), "got: {err:#}");
-        }
-
-        let fileset = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"FileSet","metadata":{"name":"skills"},"mount":{"path":"/skills","readOlny":true},"spec":{}}"#;
-        let err = parse_fileset(fileset).unwrap_err();
-        assert!(format!("{err:#}").contains("unknown field"), "got: {err:#}");
-    }
-
-    #[test]
-    fn parse_sandbox_accepts_a_digest_pinned_base_image() {
-        let json = format!(
-            r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"reg/base@sha256:{}","resources":{{"cpu":2,"memory":"1Gi"}}}}}}"#,
-            "a".repeat(64)
-        );
-        let sandbox = parse_sandbox(json.as_bytes()).unwrap();
-        assert_eq!(sandbox.spec.isolation, Isolation::Microvm);
-        assert!(sandbox.spec.base_image.is_some());
-        assert_eq!(sandbox.spec.resources.unwrap().cpu, Some(Quantity::Int(2)));
-    }
-
-    #[test]
-    fn parse_sandbox_rejects_a_floating_base_image() {
-        let json = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"isolation":"microvm","baseImage":"reg/base:1"}}"#;
-        let err = parse_sandbox(json).unwrap_err();
-        assert!(format!("{err:#}").contains("digest-pinned"));
-    }
-
-    #[test]
-    fn parse_sandbox_rejects_a_non_microvm_isolation() {
-        let json = format!(
-            r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"container","baseImage":"reg/base@sha256:{}"}}}}"#,
-            "a".repeat(64)
-        );
-        let err = parse_sandbox(json.as_bytes()).unwrap_err();
-        assert!(
-            format!("{err:#}").contains("isolation must be microvm"),
-            "lns is microVM-only, so a container sandbox must be refused: {err:#}"
-        );
-    }
-
-    #[test]
-    fn parse_sandbox_requires_a_base_image() {
-        let json = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"isolation":"microvm"}}"#;
-        let err = parse_sandbox(json).unwrap_err();
-        assert!(
-            format!("{err:#}").contains("must carry a baseImage"),
-            "a rootless microvm sandbox has nothing to boot; got: {err:#}"
+            format!("{:#}", parse_fileset(b"not json").unwrap_err()).contains("parsing artifact")
         );
     }
 
@@ -507,26 +356,5 @@ mod tests {
             assert_eq!(Kind::from_kind_str(kind.as_str()), Some(kind));
         }
         assert_eq!(Kind::from_kind_str("Sorcery"), None);
-    }
-
-    #[test]
-    fn validate_any_dispatches_to_each_kind_parser() {
-        let base = format!("reg/base@sha256:{}", "a".repeat(64));
-        let sandbox = format!(
-            r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"{base}"}}}}"#
-        );
-        validate_any(sandbox.as_bytes()).unwrap();
-        validate_any(br#"{"apiVersion":"lens.dev/v1alpha1","kind":"FileSet","metadata":{"name":"skills"},"mount":{"path":"/root/.some-agent/skills"},"spec":{}}"#).unwrap();
-    }
-
-    #[test]
-    fn validate_any_rejects_an_unknown_kind_and_unparseable_json() {
-        let unknown = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sorcery","metadata":{"name":"x"},"spec":{}}"#;
-        assert!(
-            format!("{:#}", validate_any(unknown).unwrap_err()).contains("unknown artifact kind")
-        );
-        assert!(
-            format!("{:#}", validate_any(b"nope").unwrap_err()).contains("parsing artifact kind")
-        );
     }
 }

--- a/crates/lns-artifact/src/validate.rs
+++ b/crates/lns-artifact/src/validate.rs
@@ -1,17 +1,7 @@
-use crate::spec;
-
-/// Validate a single artifact document: schema + cross-field guards for its declared kind, plus the guards that belong to authoring only — whether this build can provision a declared tool is deliberately not part of parsing, since a consumer must still be able to inspect an artifact whose tool the shipped registry has since dropped.
+/// Validate a sandbox definition: the schema and cross-field guards `run`, `inspect` and `push` all load it through, plus the guards that belong to authoring only — whether this build can provision a declared tool is deliberately not part of parsing, since a consumer must still be able to inspect an artifact whose tool the shipped registry has since dropped.
 pub fn validate(doc: &[u8]) -> Result<(), Vec<String>> {
-    let is_sandbox = crate::sandbox::is_sandbox_definition(doc);
-    let schema = if is_sandbox {
-        crate::sandbox::validate(doc)
-    } else {
-        spec::validate_any(doc)
-    };
-    schema.map_err(|e| vec![format!("schema: {e:#}")])?;
-    if is_sandbox {
-        refuse_unprovisionable_tools(doc).map_err(|problem| vec![problem])?;
-    }
+    crate::sandbox::validate(doc).map_err(|e| vec![format!("schema: {e:#}")])?;
+    refuse_unprovisionable_tools(doc).map_err(|problem| vec![problem])?;
     Ok(())
 }
 
@@ -40,7 +30,7 @@ pub fn refuse_unprovisionable_tools(doc: &[u8]) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    fn sandbox(base_image: &str) -> Vec<u8> {
+    fn retired_group_sandbox(base_image: &str) -> Vec<u8> {
         format!(
             r#"{{"apiVersion":"lens.dev/v1alpha1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"isolation":"microvm","baseImage":"{base_image}"}}}}"#
         )
@@ -55,19 +45,20 @@ mod tests {
     }
 
     #[test]
-    fn a_well_formed_sandbox_validates() {
-        let doc = sandbox(&format!("reg/base@sha256:{}", "a".repeat(64)));
-        validate(&doc).unwrap();
-    }
-
-    #[test]
-    fn a_schema_violation_is_reported() {
-        let doc = sandbox("reg/base:1");
-        let problems = validate(&doc).unwrap_err();
-        assert!(
-            problems.iter().any(|p| p.contains("digest-pinned")),
-            "a floating base image must be reported: {problems:?}"
-        );
+    fn a_document_from_the_retired_group_is_not_a_definition() {
+        // `run -f`, `inspect -f` and `push` all load a definition through `sandbox::parse`, so validating one against the older group's schema would pass a file none of them can run.
+        for doc in [
+            retired_group_sandbox(&format!("reg/base@sha256:{}", "a".repeat(64))),
+            retired_group_sandbox("reg/base:1"),
+        ] {
+            let problems = validate(&doc).unwrap_err();
+            assert!(
+                problems
+                    .iter()
+                    .any(|p| p.contains("apiVersion") && p.contains(crate::sandbox::API_VERSION)),
+                "the answer must name the group a definition is read as: {problems:?}"
+            );
+        }
     }
 
     #[test]
@@ -120,9 +111,12 @@ mod tests {
 
     #[test]
     fn an_unknown_kind_is_reported() {
-        let doc = br#"{"apiVersion":"lens.dev/v1alpha1","kind":"Sorcery","metadata":{"name":"x"},"spec":{}}"#;
+        let doc = br#"{"apiVersion":"lns.run/v1","kind":"Sorcery","metadata":{"name":"x"},"spec":{"image":"reg/base:1"}}"#;
         let problems = validate(doc).unwrap_err();
-        assert!(problems.iter().any(|p| p.contains("unknown artifact kind")));
+        assert!(
+            problems.iter().any(|p| p.contains("kind")),
+            "got: {problems:?}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -54,6 +54,20 @@ Feature: authoring a sandbox
     And the output contains "unknown field"
     And the service received no request
 
+  Scenario: validate refuses a document the other verbs cannot run
+    Given an lns.yaml written against the retired lens.dev/v1alpha1 group
+    When the user runs sandbox command "validate"
+    Then the command fails with an exit code other than 0
+    And the output contains "lns.run/v1"
+    And the service received no request
+
+  Scenario: validate and inspect agree on the same document
+    Given an lns.yaml written against the retired lens.dev/v1alpha1 group
+    When the user runs sandbox command "validate"
+    Then the command fails with an exit code other than 0
+    When the user runs sandbox command "inspect"
+    Then the command fails with an exit code other than 0
+
   Scenario: inspect with no target renders the effective definition offline
     Given a valid lns.yaml in the current directory
     When the user runs sandbox command "inspect"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
@@ -63,6 +63,17 @@ fn lns_yaml_with_required_credential(w: &mut BehaviourWorld, name: String, env: 
     );
 }
 
+#[given("an lns.yaml written against the retired lens.dev/v1alpha1 group")]
+fn lns_yaml_from_the_retired_group(w: &mut BehaviourWorld) {
+    seed(
+        w,
+        &format!(
+            "apiVersion: lens.dev/v1alpha1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  isolation: microvm\n  baseImage: ghcr.io/team/base@sha256:{}\n",
+            "a".repeat(64)
+        ),
+    );
+}
+
 #[given("an lns.yaml with a misspelled volume readOnly field")]
 fn lns_yaml_with_unknown_nested_field(w: &mut BehaviourWorld) {
     seed(


### PR DESCRIPTION
## The defect

`lns sandbox validate` routed on `apiVersion` alone. A document written against the retired `lens.dev/v1alpha1` group printed **"is valid"** while `inspect -f` and `run -f` both refused the same file. The one command whose job is to answer the question gave the wrong answer.

While verifying it, the disagreement turned out to be wider than reported: `lns push` accepted such a document too, because `build_artifact` gated on the same routing. That published an artifact into a registry no verb can read.

## The fix

Validation now loads a definition the way every other verb does — through `sandbox::parse`.

`sandbox::parse` also decides on the group and kind **before** it reads the spec. Without that, a retired-group document answers `unknown field \`isolation\`` instead of naming its `apiVersion` — the older schema's field names look like typos in this one.

## The deletions that fall out

Routing validation to one reader left the retired group's *Sandbox* parser with no caller, so it goes: `parse_sandbox`, `Sandbox`, `SandboxSpec`, `Isolation`, `Class`, `Kind::class()`, `validate_any`, `is_sandbox_definition`. `Class` had no user outside `spec.rs`, so the chain unravelled cleanly.

`parse_doc`'s runtime-layer mount guard goes with it — its only Runtime caller was `parse_sandbox`, and a stray top-level `mount:` on an `lns.run/v1` document is already refused by that document's `deny_unknown_fields`.

**The FileSet half stays untouched.** Every fileset artifact ever published carries `lens.dev/v1alpha1` inside the config blob a sandbox's `filesets[].ref` pins, and the consumer bails on any other `apiVersion`. `Doc.spec` in `spec.rs` lost its only reader but keeps its key as `IgnoredAny`, because those published documents all carry `spec: {}`.

This lands the *Sandbox* half of "one API group" ahead of the wider retirement; the wire-bearing FileSet half is deliberately left for that work.

## Tests

Two Layer 2 scenarios in `sandbox_author.feature`, written first and watched fail for the stated reason — `validate` exited 0 on a document `inspect` refuses. `parse_doc` keeps its coverage through `parse_fileset`, which still uses it.

`make lint`, `make test`, `make complexity` green. Coverage unchanged from the branch point: the single `lns-artifact/src/tools/mod.rs` FAIL reproduces identically on a clean tree.