### PR TITLE
fix: refuse two mappings on one host port before boot

### DIFF
--- a/crates/lns-cli/src/run/declarative.rs
+++ b/crates/lns-cli/src/run/declarative.rs
@@ -142,10 +142,45 @@ pub fn compose_ports(
             .into_iter()
             .filter(|port| !substituted.contains(&port.container_port)),
     );
+    let published = dedupe_identical(published);
+    refuse_host_port_collision(&published)?;
     Ok(ComposedPorts {
         published,
         declared_unpublished,
     })
+}
+
+/// The same mapping asked for twice is one binding, not a collision — the second bind would fail on a port the user did ask for.
+fn dedupe_identical(published: Vec<lns_ipc::PortPublish>) -> Vec<lns_ipc::PortPublish> {
+    let mut unique: Vec<lns_ipc::PortPublish> = Vec::new();
+    for port in published {
+        if !unique.contains(&port) {
+            unique.push(port);
+        }
+    }
+    unique
+}
+
+/// The per-document check covers the declared entries alone, so only the merge with `-p` can put two container ports on one host binding — and the bind that loses is one the user never typed.
+fn refuse_host_port_collision(published: &[lns_ipc::PortPublish]) -> Result<()> {
+    for (index, port) in published.iter().enumerate() {
+        let clash = published[..index].iter().find(|held| {
+            held.host_ip == port.host_ip
+                && held.host_port == port.host_port
+                && held.protocol == port.protocol
+                && held.container_port != port.container_port
+        });
+        if let Some(clash) = clash {
+            bail!(
+                "{}:{} is asked to forward to container port {} and container port {}; publish them on different host ports",
+                port.host_ip,
+                port.host_port,
+                clash.container_port,
+                port.container_port
+            );
+        }
+    }
+    Ok(())
 }
 
 fn declared_port(value: i64, side: &str) -> Result<u16> {

--- a/crates/lns-cli/tests/behaviours/declarative_ports.feature
+++ b/crates/lns-cli/tests/behaviours/declarative_ports.feature
@@ -41,3 +41,18 @@ Feature: declared ports publish like compose locally and like docker run when pu
     Given an lns.yaml declaring ports 3003
     When the local sandbox is run with `-P`
     Then a Ports line shows `127.0.0.1:3003 -> 3003`
+
+  Scenario: two mappings on one host port are refused before boot
+    Given an lns.yaml declaring ports 3003
+    When the local sandbox is run with `-p 3003:9999` and the ports are composed
+    Then composing the ports is refused, naming host port 3003
+
+  Scenario: an explicit -p reusing a declared host port is refused
+    Given an lns.yaml declaring ports 8080:9090
+    When the local sandbox is run with `-p 8080:7000` and the ports are composed
+    Then composing the ports is refused, naming host port 8080
+
+  Scenario: the same mapping asked for twice is published once
+    Given an lns.yaml declaring ports 3003
+    When the local sandbox is run with `-p 4000:5000 -p 4000:5000` and the ports are composed
+    Then `127.0.0.1:4000 -> 5000` is published exactly once

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -8,6 +8,8 @@ use lns_cli::run::summary::print_run_summary;
 
 use crate::world::{BehaviourWorld, TEST_HOST};
 
+const TEST_LOOPBACK: &str = "127.0.0.1";
+
 fn ports_yaml(ports: &str) -> String {
     let entries: String = ports
         .split(" and ")
@@ -146,6 +148,62 @@ fn summary_notes_declared_unpublished(
         Err(format!(
             "expected a declared-but-unpublished note for port {port} in:\n{}",
             world.summary_output
+        ))
+    }
+}
+
+fn compose(world: &mut BehaviourWorld, flags: &str) {
+    let defaults = Defaults::from_definition(&definition(world), Some(TEST_HOST));
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    let mut args: RunArgs = parse_args(&argv).expect("port flags must parse");
+    match compose_ports(&defaults.ports, std::mem::take(&mut args.publish), true) {
+        Ok(composed) => world.composed_ports = composed.published,
+        Err(e) => world.port_composition_error = Some(format!("{e:#}")),
+    }
+}
+
+#[when(regex = r"^the local sandbox is run with `([^`]+)` and the ports are composed$")]
+fn compose_with_flags(world: &mut BehaviourWorld, flags: String) {
+    compose(world, &flags);
+}
+
+#[then(regex = r"^composing the ports is refused, naming host port (\d+)$")]
+fn composition_refused(world: &mut BehaviourWorld, port: String) -> Result<(), String> {
+    let binding = format!("{TEST_LOOPBACK}:{port} is asked to forward");
+    match &world.port_composition_error {
+        Some(message) if message.contains(&binding) => Ok(()),
+        Some(message) => Err(format!(
+            "the refusal must name the {TEST_LOOPBACK}:{port} binding: {message}"
+        )),
+        None => Err(format!(
+            "two mappings on host port {port} must be refused before boot"
+        )),
+    }
+}
+
+#[then(regex = r"^`([\d.]+):(\d+) -> (\d+)` is published exactly once$")]
+fn published_exactly_once(
+    world: &mut BehaviourWorld,
+    ip: String,
+    host: u16,
+    container: u16,
+) -> Result<(), String> {
+    let matching = world
+        .composed_ports
+        .iter()
+        .filter(|port| {
+            port.host_ip.to_string() == ip
+                && port.host_port == host
+                && port.container_port == container
+        })
+        .count();
+    if matching == 1 {
+        Ok(())
+    } else {
+        Err(format!(
+            "{ip}:{host} -> {container} must be published once, not {matching} times: {:?}",
+            world.composed_ports
         ))
     }
 }

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -18,6 +18,8 @@ pub struct BehaviourWorld {
     pub argv: Vec<String>,
     pub cwd: Option<TempDir>,
     pub summary_output: String,
+    pub port_composition_error: Option<String>,
+    pub composed_ports: Vec<lns_ipc::PortPublish>,
     pub phase_output: Vec<u8>,
     pub detached_stdout: Vec<u8>,
     pub pipe: Option<PhasePipe>,


### PR DESCRIPTION
## The defect

`compose_ports` de-duplicates declared ports on the **container** port and never inspects the host port. An `lns.yaml` declaring container 3003 plus an explicit `-p 3003:9999` emits two mappings, both bound to `127.0.0.1:3003`.

The per-document uniqueness check in lns-artifact covers the declared entries alone, so only the merge with `-p` can reach this. The result is a booted-then-aborted run blaming a port the user never typed, instead of an offline refusal.

## The fix

`refuse_host_port_collision` refuses when two entries share `(host_ip, host_port, protocol)` but differ in container port, naming both. `compose_ports` is called with `?` from `service/orchestrator.rs`, so the refusal lands before any boot.

The same mapping asked for twice is *not* that case — `-p 4000:5000 -p 4000:5000` is one binding, not a conflict — so identical entries collapse first.

## Tests

Two Layer 2 scenarios for the collision, written first and watched fail. The dedupe scenario needed a second attempt worth recording: written first against the run summary's Ports line, it passed against unfixed code, because that step is `contains`-based and the duplicated mapping still matched. It now asserts against the composed `PortPublish` set and counts occurrences — verified red ("must be published once, not 2 times") before going green.

## Known gap, deliberately not fixed here

A wildcard bind escapes the check: declared 3003 on loopback plus `-p 0.0.0.0:3003:9999` differs in `host_ip`, so it composes. Those binds do overlap on Linux (EADDRINUSE), while macOS may permit it with loopback shadowing the wildcard.

The fix shape is to treat an unspecified `host_ip` as colliding with every IP on that port — but whether the binds actually conflict depends on whether the service's forwarder sets `SO_REUSEPORT`, which I could not determine from the CLI side. Left as a follow-up rather than guessed at.

`make lint`, `make test`, `make complexity` green; `make coverage COVERAGE_CRATES="lns-cli"` reports 32 files at 100%, 0 failures.