### PR TITLE
fix: refuse a run that would boot unsupervised

### DIFF
--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -35,7 +35,9 @@ pub async fn handle(
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
+/// Every run boots with a supervisor session: `SupervisorSession::start` refuses rather than returning without one.
+const SUPERVISED: bool = true;
+
 // top-level boot sequence: tools → caches → ingest → supervisor → runtime → vm spec → session
 #[tracing::instrument(
     name = "lns.run",
@@ -45,7 +47,6 @@ pub async fn handle(
         image = args.image.as_deref().unwrap_or("<imageless>"),
         cpus = args.cpus,
         mem_mib = args.mem,
-        supervised = args.policy_path.is_some(),
     ),
     err,
 )]
@@ -135,7 +136,7 @@ async fn orchestrate(
         let guest_tools = guest_tools::ensure().await?;
         log::debug!("guest tools ready at +{:.2?}", prepare_started.elapsed());
         let (session, initrd) = tokio::try_join!(
-            supervisor::SupervisorSession::start_if_policy(
+            supervisor::SupervisorSession::start(
                 run_id.clone(),
                 microvm.clone(),
                 policy.as_deref().map(Path::new),
@@ -301,7 +302,7 @@ async fn orchestrate(
         imageless,
         &content_store,
         &guest_tools,
-        session.as_ref().map(|s| &s.assets),
+        Some(&session.assets),
         &fileset_specs,
     )?;
 
@@ -360,7 +361,7 @@ async fn orchestrate(
         args.entrypoint.as_deref(),
         &cmd,
         image.config.as_ref(),
-        session.as_ref(),
+        Some(&session),
     );
 
     #[cfg(target_os = "macos")]
@@ -402,9 +403,9 @@ async fn orchestrate(
         binds: bind_attachments,
         workload_uid: run_as.uid,
         workload_gid: vm::host_known_workload_gid(&run_as),
-        vsock: session.as_ref().map(|s| vm::VsockChannel {
+        vsock: Some(vm::VsockChannel {
             port: crate::relay::VSOCK_PORT,
-            fd_tx: s.relay.fd_tx.clone(),
+            fd_tx: session.relay.fd_tx.clone(),
         }),
         connector_tx: Some(connector_tx),
         #[cfg(target_os = "macos")]
@@ -420,7 +421,7 @@ async fn orchestrate(
         image.config.as_ref(),
         args.entrypoint.as_deref(),
         &cmd,
-        session.is_some(),
+        SUPERVISED,
     );
     let workdir = crate::workload_cwd::resolve(
         args.workdir.as_deref(),
@@ -437,13 +438,10 @@ async fn orchestrate(
         image.config.as_ref(),
         args.entrypoint.as_deref(),
         &cmd,
-        session.is_some(),
+        SUPERVISED,
         super::EnvInputs {
             user_env: &env,
-            extra_managed: session
-                .as_ref()
-                .map(|s| s.managed_env_vars.as_slice())
-                .unwrap_or(&[]),
+            extra_managed: session.managed_env_vars.as_slice(),
             workdir: workdir.as_deref(),
             tools: &tool_runtime,
         },
@@ -460,10 +458,7 @@ async fn orchestrate(
     let exec_environment = crate::run_registry::ExecEnvironment {
         session_env: composed.env.clone(),
         tools: tool_runtime,
-        placeholders: session
-            .as_ref()
-            .map(|s| s.placeholder_env.clone())
-            .unwrap_or_default(),
+        placeholders: session.placeholder_env.clone(),
         workdir: workdir.clone(),
     };
     let env: Vec<String> = composed.env;
@@ -476,7 +471,7 @@ async fn orchestrate(
         tty: args.tty,
         stdin: args.stdin,
         initial_winsize,
-        confine: session.is_none(),
+        confine: !SUPERVISED,
     };
 
     let frame_tx_for_session = frame_tx.clone();

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -81,7 +81,7 @@ pub struct RunConsent<'a> {
 }
 
 impl SupervisorSession {
-    pub async fn start_if_policy(
+    pub async fn start(
         run_id: String,
         microvm_name: String,
         policy: Option<&Path>,
@@ -89,16 +89,13 @@ impl SupervisorSession {
         consent: RunConsent<'_>,
         guest_tools_root: PathBuf,
         user_env: Vec<String>,
-    ) -> Result<Option<Self>> {
+    ) -> Result<Self> {
         let Some(policy_path) = policy else {
-            if sandbox_policy.is_some() {
-                bail!(
-                    "this sandbox ships a network policy but no local policy path was resolved to \
-                     layer it under; refusing to launch it unsupervised (its policy would go \
-                     unenforced)"
-                );
-            }
-            return Ok(None);
+            bail!(
+                "no local policy path was resolved for this run; refusing to launch it \
+                 unsupervised (there would be no approval gate, no network enforcement, and no \
+                 credential injection)"
+            );
         };
         adapter::start(
             run_id,
@@ -110,7 +107,6 @@ impl SupervisorSession {
             user_env,
         )
         .await
-        .map(Some)
     }
 }
 
@@ -306,33 +302,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_if_policy_returns_none_when_no_policy() {
-        let result = SupervisorSession::start_if_policy(
+    async fn a_run_with_no_policy_path_is_refused_rather_than_left_unsupervised() {
+        let result = SupervisorSession::start(
             "aa42".to_string(),
             "vm-42".into(),
             None,
             None,
-            test_consent(&[]),
-            PathBuf::from("/tmp"),
-            vec![],
-        )
-        .await
-        .unwrap();
-        assert!(
-            result.is_none(),
-            "no policy → unsupervised, no relay spun up"
-        );
-    }
-
-    #[tokio::test]
-    async fn start_if_policy_refuses_a_shipped_policy_with_no_local_path() {
-        let mut sandbox_policy = lns_policy::Policy::default();
-        sandbox_policy.add_rule(lns_policy::RouteRule::deny_host("api.example.test"));
-        let result = SupervisorSession::start_if_policy(
-            "aa42".to_string(),
-            "vm-42".into(),
-            None,
-            Some(&sandbox_policy),
             test_consent(&[]),
             PathBuf::from("/tmp"),
             vec![],
@@ -340,10 +315,10 @@ mod tests {
         .await;
         let err = result
             .err()
-            .expect("a sandbox that ships a policy must not boot unsupervised");
+            .expect("no policy path means no approval gate, no relay, no credential injection");
         assert!(
             format!("{err:#}").contains("refusing to launch it unsupervised"),
-            "got: {err:#}"
+            "the refusal must say the run would go unenforced: {err:#}"
         );
     }
 
@@ -575,7 +550,7 @@ mod tests {
         }
     }
 
-    /// An isolated `HOME` holding a one-oauth-connector user catalog and an ask-by-default policy, so `start_if_policy` drives a required slot's boot sign-in through the real grant sidecar.
+    /// An isolated `HOME` holding a one-oauth-connector user catalog and an ask-by-default policy, so `start` drives a required slot's boot sign-in through the real grant sidecar.
     struct BootSignInFixture {
         dir: tempfile::TempDir,
         policy_path: PathBuf,
@@ -646,7 +621,7 @@ mod tests {
         fixture: &BootSignInFixture,
         workload: &lns_policy::grants::WorkloadIdentity,
     ) -> SupervisorSession {
-        let result = SupervisorSession::start_if_policy(
+        SupervisorSession::start(
             "deadbeef00000000000000000000aa97".to_string(),
             "calm-finch".into(),
             Some(&fixture.policy_path),
@@ -661,8 +636,7 @@ mod tests {
             vec![],
         )
         .await
-        .expect("start_if_policy");
-        result.expect("Some(session) with policy set")
+        .expect("start")
     }
 
     #[tokio::test]
@@ -720,7 +694,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(env)]
-    async fn start_if_policy_with_policy_threads_through_adapter_to_supervisor_session() {
+    async fn start_with_policy_threads_through_adapter_to_supervisor_session() {
         use crate::approval_flow::window::{self, WindowState};
         use crate::test_env::EnvVarGuard;
         window::install(WindowState::new());
@@ -732,7 +706,7 @@ mod tests {
         let policy_path = d.path().join("lns-policy.yaml");
         std::fs::write(&policy_path, "network:\n  egress:\n    http: []\n").expect("policy");
 
-        let result = SupervisorSession::start_if_policy(
+        let result = SupervisorSession::start(
             "deadbeef00000000000000000000aa99".to_string(),
             "calm-finch".into(),
             Some(&policy_path),
@@ -742,8 +716,8 @@ mod tests {
             vec![],
         )
         .await
-        .expect("start_if_policy");
-        let session = result.expect("Some(session) with policy set");
+        .expect("start");
+        let session = result;
         assert_eq!(session.assets.supervisor_bin, supervisor_bin);
         drop(session);
         tokio::task::yield_now().await;
@@ -751,7 +725,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(env)]
-    async fn start_if_policy_merges_a_sandbox_policy_floor_under_the_local_overlay() {
+    async fn start_merges_a_sandbox_policy_floor_under_the_local_overlay() {
         use crate::approval_flow::window::{self, WindowState};
         use crate::test_env::EnvVarGuard;
         window::install(WindowState::new());
@@ -765,7 +739,7 @@ mod tests {
         let mut sandbox_policy = lns_policy::Policy::default();
         sandbox_policy.add_rule(lns_policy::RouteRule::deny_host("api.example.test"));
 
-        let result = SupervisorSession::start_if_policy(
+        let result = SupervisorSession::start(
             "deadbeef00000000000000000000aa98".to_string(),
             "calm-finch".into(),
             Some(&policy_path),
@@ -775,8 +749,8 @@ mod tests {
             vec![],
         )
         .await
-        .expect("start_if_policy");
-        let session = result.expect("Some(session) with a sandbox policy floor");
+        .expect("start");
+        let session = result;
         assert_eq!(session.assets.supervisor_bin, supervisor_bin);
         drop(session);
         tokio::task::yield_now().await;


### PR DESCRIPTION
## The defect

`SupervisorSession::start_if_policy` returned `Ok(None)` whenever the policy path was absent and the sandbox shipped no policy of its own. It refused only when the sandbox itself shipped one.

A `None` session means the run boots with **no approval gate, no network enforcement, no relay and no credential injection** — and says nothing about it.

lns-cli always sends `Some(path)` today, so this is reachable only by another IPC client, or by a future rename/relocation of the policy file that fails to resolve. In that case a migration bug degrades the run to no enforcement instead of failing loudly. That is the opposite of "a sandbox you don't turn off".

## The fix

`start_if_policy` becomes `start` and returns `Result<Self>`. The `Option` in the return type *was* the silent path, so it goes with it — a run either has a supervisor session or does not start.

The orchestrator stops threading a session that can no longer be absent.

## Notes for the reviewer of this PR

**No compiling red run, deliberately.** The old signature returned `Option`, so the new assertion cannot typecheck against it. The proof of the behavior change is the test this commit deletes:

```rust
async fn start_if_policy_returns_none_when_no_policy() {
    …
    assert!(result.is_none(), "no policy → unsupervised, no relay spun up");
}
```

That is the old contract in its own words; the new test asserts its opposite.

`start_if_policy_refuses_a_shipped_policy_with_no_local_path` is also deleted: with the refusal unconditional it exercises the identical branch and pins nothing extra.

## Follow-up this leaves open

Four callee seams still take an `Option`/`bool` for a state `orchestrate` can no longer reach — `runtime_layer::for_run`, `vm::ExecSpec::for_run`, `build_workload_argv`, `exec_env_strings` — and `workdir.feature` / `run_as_env.feature` still carry "An unsupervised run…" scenarios describing it. This PR names the invariant at those call sites with a `SUPERVISED` constant rather than changing four signatures. Collapsing the seams and their false-branch scenarios is the real cleanup; `confine` itself stays live via `exec`.

`make lint`, `make test`, `make complexity` green; `make coverage COVERAGE_CRATES="lns-service"` reports 105 files at 100%, 0 failures.