### PR TITLE
fix: let a ceiling permit what its own patterns cover

### DIFF
--- a/crates/lns-policy/src/matching.rs
+++ b/crates/lns-policy/src/matching.rs
@@ -161,7 +161,8 @@ pub(crate) fn port_shaped(tail: &str) -> bool {
     !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit())
 }
 
-fn destination_covers(existing: &str, new: &str) -> bool {
+/// Whether every destination `new` names is also named by `existing` — the same reading the guest gate's first-match scan gives them.
+pub fn destination_covers(existing: &str, new: &str) -> bool {
     let (existing, new) = (classify(existing), classify(new));
     port_covers(&existing.port, &new.port) && hosts_cover(&existing.hosts, &new.hosts)
 }

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use lns_policy::matching::split_destination;
+use lns_policy::matching::{destination_covers, split_destination};
 use lns_policy::{NetworkPolicy, Policy, RouteRule, TcpEgressRule, Verdict};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,24 +104,30 @@ fn allowed_by_every_ceiling<R>(
         .all(|ceiling| live_rules(table(ceiling), closes).any(|permitted| permits(permitted, rule)))
 }
 
-/// Whether `permitted` covers `rule`: identical apart from binary scoping and the human-readable note neither layer grants anything by, and scoped no tighter than `rule` — a rule that only narrows a ceiling's grant to fewer callers grants nothing the ceiling didn't.
+/// Whether `permitted` covers `rule`: it names every destination `rule` does, grants them on the same terms, and is scoped no tighter — a rule that only narrows a ceiling's grant to fewer hosts or fewer callers grants nothing the ceiling didn't.
 fn permits(permitted: &RouteRule, rule: &RouteRule) -> bool {
     let widened = RouteRule {
+        match_pattern: permitted.match_pattern.clone(),
         binaries: permitted.binaries.clone(),
         description: permitted.description.clone(),
         ..rule.clone()
     };
-    widened == *permitted && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
+    widened == *permitted
+        && destination_covers(&permitted.match_pattern, &rule.match_pattern)
+        && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
 }
 
 /// The `egress.tcp` counterpart of [`permits`], scoping included: a ceiling that splices a destination for every caller also covers a rule splicing it for some of them.
 fn tcp_permits(permitted: &TcpEgressRule, rule: &TcpEgressRule) -> bool {
     let widened = TcpEgressRule {
+        match_pattern: permitted.match_pattern.clone(),
         binaries: permitted.binaries.clone(),
         description: permitted.description.clone(),
         ..rule.clone()
     };
-    widened == *permitted && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
+    widened == *permitted
+        && destination_covers(&permitted.match_pattern, &rule.match_pattern)
+        && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
 }
 
 fn scope_within(rule: Option<&[String]>, permitted: Option<&[String]>) -> bool {
@@ -541,6 +547,63 @@ mod tests {
     }
 
     #[test]
+    fn a_ceiling_authorizes_an_allow_its_own_wildcard_already_covers() {
+        let mut ceiling = allow("*.example.test");
+        ceiling.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&ceiling), &allow("api.example.test"));
+
+        assert!(
+            merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.match_pattern == "api.example.test"
+                    && rule.verdict == Verdict::Allow),
+            "the ceiling already permits every host under *.example.test, so approving one of them must not be dropped: {:?}",
+            merged.network.egress.http
+        );
+    }
+
+    #[test]
+    fn a_ceiling_still_refuses_an_allow_reaching_past_what_it_covers() {
+        let mut ceiling = allow("*.example.test");
+        ceiling.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&ceiling), &allow("api.other.test"));
+
+        assert!(
+            !merged.network.egress.http.iter().any(
+                |rule| rule.match_pattern == "api.other.test" && rule.verdict == Verdict::Allow
+            ),
+            "a host the ceiling never named stays clamped"
+        );
+    }
+
+    #[test]
+    fn a_ceilings_wildcard_does_not_authorize_a_wider_treatment_of_the_same_hosts() {
+        let mut ceiling = Policy::default();
+        ceiling.add_rule(RouteRule {
+            tls_terminate: true,
+            ..RouteRule::allow_host("*.example.test")
+        });
+        ceiling.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&ceiling), &allow("api.example.test"));
+
+        assert!(
+            !merged
+                .network
+                .egress
+                .http
+                .iter()
+                .any(|rule| rule.match_pattern == "api.example.test"),
+            "the ceiling grants those hosts only under inspection; an uninspected allow of one is not covered"
+        );
+    }
+
+    #[test]
     fn a_deny_by_default_layer_clamps_the_other_layers_tcp_allow() {
         let mut ceiling = Policy::default();
         ceiling.add_rule(RouteRule::deny_host("*"));
@@ -548,6 +611,25 @@ mod tests {
         assert!(
             merged.network.egress.tcp.is_empty(),
             "a locked-down layer names every destination it permits; the user cannot widen it"
+        );
+    }
+
+    #[test]
+    fn a_ceiling_authorizes_a_raw_splice_inside_a_range_it_already_splices() {
+        let mut ceiling = tcp_allow("10.0.0.0/8:5432");
+        ceiling.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&ceiling), &tcp_allow("10.0.0.5:5432"));
+
+        assert!(
+            merged
+                .network
+                .egress
+                .tcp
+                .iter()
+                .any(|rule| rule.match_pattern == "10.0.0.5:5432"),
+            "the ceiling already splices every address in 10.0.0.0/8 on that port, so naming one of them adds no reach: {:?}",
+            merged.network.egress.tcp
         );
     }
 


### PR DESCRIPTION
## The defect

`permits` / `tcp_permits` decided whether a deny-by-default ceiling authorizes another layer's allow by **exact rule equality** modulo `binaries` and `description`. A ceiling allowing `*.example.test` therefore did not authorize an overlay allow of `api.example.test`.

The user-visible shape: the approval card approves `api.example.test`, writes it to `lns-policy.yaml`, and the next run silently drops it because the artifact's ceiling only names the wildcard.

And there was no way around it. The artifact author could not simply add the exact host to the ceiling either — `first_shadowing_rule` reads such a rule as dead behind the wildcard, so the tool's own logic refuses to write it. The approved host had no path to survive at all.

## The fix

Only the destination comparison becomes subsumption, via `lns_policy::matching::destination_covers` — the same predicate `shadows` already reads patterns with. It was private; it is now `pub`, rather than growing a second pattern-subsumption implementation that could drift from the gate's reading.

`verdict`, `scheme`, `transport`, `tlsTerminate` and `rules` stay **equality**, deliberately. A ceiling granting hosts *under inspection* has not sanctioned an uninspected allow of one of them, and the relation is not orderable: termination enables header rewriting and credential injection a plain ceiling never permitted, while a plain overlay under an inspected ceiling is a plain widening. Equality is the only reading safe in both directions. The `..rule.clone()` construction also means any future field lands in the equality check by default — failing conservative, not open.

## Behavior change

An overlay allow that a covering ceiling wildcard previously dropped now survives. That is the intended §4.2 reading — the overlay grants nothing the ceiling had not already named — but it does change effective policy for existing directories.

## Tests

Four Layer 3 tests. The two target cases (`a_ceiling_authorizes_an_allow_its_own_wildcard_already_covers`, `a_ceiling_authorizes_a_raw_splice_inside_a_range_it_already_splices`) were each verified red — the second against a revert of the `tcp_permits` hunk specifically. Two guard rails pin that the fix does not over-correct: a host the ceiling never named stays clamped, and a ceiling's inspected wildcard does not authorize a wider treatment of the same hosts.

Worth recording about the tcp case: **the coverage gate could not have caught it.** That line was already executed by the existing identical-pattern tests, so 100% coverage said nothing about whether the subsumption leg worked, and reverting it failed no test. The mutation check is what found it.

The catch-all path was traced separately and is closed: `destination_covers(x, "*")` holds only when `x` is itself `*`; a bare `allow *` is never in `live_rules`; a decorated live `*` rule fails the equality leg or `scope_within`; and verdict equality stops a ceiling's `*` deny from ever "permitting" an allow.

## Follow-up, attached to the approval writer

Treatment equality is harmless today **only because the approval writer emits plain `allow_host` rules**. If it ever writes scheme-bound or `tlsTerminate` rules, this becomes a silent-drop path again. Whoever changes that writer needs to revisit `permits`.

`make lint`, `make test`, `make complexity` green; `make coverage COVERAGE_CRATES="lns-service lns-policy"` reports 105 and 11 files at 100%, 0 failures.