### PR TITLE
feat: let a document declare the mixins it layers on

### DIFF
--- a/crates/lns-artifact/src/build.rs
+++ b/crates/lns-artifact/src/build.rs
@@ -216,6 +216,28 @@ mod tests {
     }
 
     #[test]
+    fn a_mixin_publishes_under_its_own_artifact_type() {
+        let doc = br#"{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{"name":"postgres-tools"},"spec":{"tools":["node@22"]}}"#;
+        let built = build_artifact(doc).expect("a mixin is a kit, published like any other");
+        assert_eq!(built.artifact_type, "application/vnd.lens.mixin.v1+json");
+        let manifest: Value = serde_json::from_slice(&built.manifest).unwrap();
+        assert_eq!(
+            manifest["config"]["mediaType"], "application/vnd.lens.mixin.config.v1+json",
+            "the media type names the kind, so a puller knows what it fetched before reading it"
+        );
+    }
+
+    #[test]
+    fn a_mixin_that_declares_a_launch_block_is_refused_before_it_publishes() {
+        let doc = br#"{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{"name":"postgres-tools"},"spec":{"image":"reg/base:1"}}"#;
+        let err = build_artifact(doc).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("a mixin must not declare image"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
     fn build_artifact_produces_a_config_only_manifest_with_matching_digests() {
         let built = build_artifact(&sandbox()).unwrap();
         assert_eq!(built.artifact_type, "application/vnd.lens.sandbox.v1+json");

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -116,6 +116,8 @@ pub struct SandboxSpec {
     #[serde(default)]
     pub credentials: Vec<lns_spec::Credential>,
     #[serde(default)]
+    pub mixins: Vec<String>,
+    #[serde(default)]
     pub tools: Vec<String>,
     #[serde(default)]
     pub volumes: Vec<Volume>,
@@ -170,6 +172,57 @@ struct Doc {
 
 /// Parse and cross-field-validate a `lns.run/v1` sandbox definition, offline.
 pub fn parse(config_json: &[u8]) -> Result<Definition> {
+    let doc = parse_of_kind(config_json, spec::Kind::Sandbox)?;
+    if doc.spec.image.trim().is_empty() {
+        bail!("sandbox must carry an image; it is the base OCI image the sandbox runs");
+    }
+    Ok(doc)
+}
+
+/// Parse and cross-field-validate a `lns.run/v1` mixin, offline. Its blocks follow the same rules as a sandbox's; what differs is that the five describing one launch are forbidden, and there is no image to require.
+pub fn parse_mixin(config_json: &[u8]) -> Result<Definition> {
+    parse_of_kind(config_json, spec::Kind::Mixin)
+}
+
+/// A remote mixin reference must be digest-pinned, because a published document has to resolve to the same thing for everyone.
+fn validate_mixin_reference(reference: &str) -> Result<()> {
+    if reference.trim().is_empty() {
+        bail!("a mixin entry must name a directory or an OCI reference");
+    }
+    let is_local_directory = reference == "."
+        || reference == ".."
+        || reference.starts_with("./")
+        || reference.starts_with("../")
+        || reference.starts_with('/');
+    if !is_local_directory && !spec::is_digest_pinned_image(reference) {
+        bail!(
+            "mixin reference {reference:?} must be digest-pinned (…@sha256:<64 hex>), so every consumer resolves the same document; a local directory starts with `./`, `../` or `/`"
+        );
+    }
+    Ok(())
+}
+
+/// The blocks a mixin may not carry: the five that describe one launch, which the sandbox owns, plus the connector list — how a credential is obtained is decided per machine, never by a document that travels with a workload.
+fn refuse_blocks_a_mixin_cannot_carry(spec: &SandboxSpec) -> Result<()> {
+    let launch_blocks = [
+        (!spec.image.trim().is_empty(), "image"),
+        (spec.command.is_some(), "command"),
+        (spec.workdir.is_some(), "workdir"),
+        (spec.user.is_some(), "user"),
+        (spec.resources.is_some(), "resources"),
+    ];
+    if let Some((_, block)) = launch_blocks.iter().find(|(declared, _)| *declared) {
+        bail!("a mixin must not declare {block}: it describes one launch, and the sandbox owns it");
+    }
+    if !spec.connectors.is_empty() {
+        bail!(
+            "a mixin must not name a connector: which method supplies a credential is decided per machine"
+        );
+    }
+    Ok(())
+}
+
+fn parse_of_kind(config_json: &[u8], kind: spec::Kind) -> Result<Definition> {
     let doc: Doc = serde_json::from_slice(config_json).context("parsing sandbox definition")?;
     if doc.api_version != API_VERSION {
         bail!(
@@ -177,9 +230,10 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
             doc.api_version
         );
     }
-    if doc.kind != KIND {
+    if doc.kind != kind.as_str() {
         bail!(
-            "expected kind {KIND} but definition declares {:?}",
+            "expected kind {} but definition declares {:?}",
+            kind.as_str(),
             doc.kind
         );
     }
@@ -190,8 +244,8 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
         metadata: doc.metadata,
         spec: serde_json::from_value(doc.spec).context("parsing sandbox spec")?,
     };
-    if doc.spec.image.trim().is_empty() {
-        bail!("sandbox must carry an image; it is the base OCI image the sandbox runs");
+    if kind == spec::Kind::Mixin {
+        refuse_blocks_a_mixin_cannot_carry(&doc.spec)?;
     }
     for key in doc.spec.env.keys() {
         if !lns_spec::is_legal_env_var_name(key) {
@@ -239,6 +293,9 @@ pub fn parse(config_json: &[u8]) -> Result<Definition> {
     }
     lns_spec::credential::validate_all(&doc.spec.credentials)
         .map_err(|problem| anyhow!(problem))?;
+    for reference in &doc.spec.mixins {
+        validate_mixin_reference(reference)?;
+    }
     crate::tools::parse_all(&doc.spec.tools)?;
     for fileset in &doc.spec.filesets {
         validate_fileset(fileset)?;
@@ -585,9 +642,17 @@ fn validate_volume_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Schema + cross-field guards for a sandbox definition.
+/// Parse whichever `lns.run/v1` document this is, so every verb answers for the kind the file declares rather than the one it expected.
+pub fn parse_document(config_json: &[u8]) -> Result<Definition> {
+    if spec::read_kind(config_json).ok() == Some(spec::Kind::Mixin) {
+        return parse_mixin(config_json);
+    }
+    parse(config_json)
+}
+
+/// Schema + cross-field guards for whichever `lns.run/v1` document this is.
 pub fn validate(config_json: &[u8]) -> Result<()> {
-    parse(config_json).map(|_| ())
+    parse_document(config_json).map(|_| ())
 }
 
 #[cfg(test)]
@@ -599,6 +664,144 @@ mod tests {
             r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{spec}}}"#
         )
         .into_bytes()
+    }
+
+    fn mixin_json(spec: &str) -> Vec<u8> {
+        format!(
+            r#"{{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{{"name":"postgres-tools"}},"spec":{spec}}}"#
+        )
+        .into_bytes()
+    }
+
+    const PINNED: &str = "ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582";
+
+    #[test]
+    fn a_mixin_reads_every_block_it_shares_with_a_sandbox() {
+        let def = parse_mixin(&mixin_json(
+            r#"{"env":{"MODE":"research"},"tools":["postgresql@17"],"policy":{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"allow"}]}},"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some-token"}],"filesets":[{"inline":{"USING-POSTGRES.md":"Connect with $DATABASE_URL."},"mountPath":"/home/agent/notes"}],"ports":[{"container":8080}],"volumes":[{"type":"volume","name":"cache","target":"/home/agent/.cache"}]}"#,
+        ))
+        .expect("a mixin's shared blocks follow the same rules as a sandbox's");
+        assert_eq!(def.metadata.name, "postgres-tools");
+        assert_eq!(def.spec.tools, vec!["postgresql@17".to_string()]);
+        assert_eq!(
+            def.spec.env.get("MODE").map(String::as_str),
+            Some("research")
+        );
+        assert_eq!(def.spec.ports[0].container, 8080);
+        assert_eq!(def.spec.volumes[0].target, "/home/agent/.cache");
+        assert_eq!(def.spec.policy.egress.tcp.len(), 1);
+        assert_eq!(def.spec.credentials[0].env_var, "SOME_TOKEN");
+        assert_eq!(def.spec.filesets[0].mount_path, "/home/agent/notes");
+    }
+
+    #[test]
+    fn a_mixin_refuses_each_block_that_describes_one_launch() {
+        for (spec, block) in [
+            (r#"{"image":"ghcr.io/team/base:1"}"#, "image"),
+            (r#"{"command":"agent --serve"}"#, "command"),
+            (r#"{"workdir":"/workspace"}"#, "workdir"),
+            (r#"{"user":"node"}"#, "user"),
+            (r#"{"resources":{"cpu":2}}"#, "resources"),
+        ] {
+            let err = parse_mixin(&mixin_json(spec)).unwrap_err();
+            assert!(
+                format!("{err:#}").contains(&format!("a mixin must not declare {block}")),
+                "a block the sandbox owns must be refused by name rather than silently ignored; got: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mixin_may_not_name_a_connector() {
+        let err = parse_mixin(&mixin_json(r#"{"connectors":["some-provider"]}"#)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("a mixin must not name a connector"),
+            "how a credential is obtained is the user's decision on their own machine, and the retired field stays a sandbox-only divergence rather than spreading to a new kind; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_mixin_reports_its_forbidden_block_before_that_block_is_validated() {
+        let err = parse_mixin(&mixin_json(r#"{"workdir":"relative/path"}"#)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("a mixin must not declare workdir"),
+            "the author needs the answer that matters — the block does not belong here at all — not a complaint about its contents; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_mixin_needs_no_image_of_its_own() {
+        assert!(
+            parse_mixin(&mixin_json(r#"{"tools":["postgresql@17"]}"#)).is_ok(),
+            "a mixin layers onto a sandbox, so the image requirement is the sandbox's alone"
+        );
+    }
+
+    #[test]
+    fn each_reader_answers_only_for_its_own_kind() {
+        let sandbox_err = parse_mixin(&def_json(r#"{"image":"x:1"}"#)).unwrap_err();
+        assert!(
+            format!("{sandbox_err:#}").contains("expected kind Mixin"),
+            "got: {sandbox_err:#}"
+        );
+        let mixin_err = parse(&mixin_json(r#"{"tools":["postgresql@17"]}"#)).unwrap_err();
+        assert!(
+            format!("{mixin_err:#}").contains("expected kind Sandbox"),
+            "got: {mixin_err:#}"
+        );
+    }
+
+    #[test]
+    fn a_document_declares_the_mixins_it_layers_on() {
+        let def = parse(&def_json(&format!(
+            r#"{{"image":"x:1","mixins":["./mixins/postgres-tools/","{PINNED}"]}}"#
+        )))
+        .expect("a local directory and a digest-pinned reference are both legal");
+        assert_eq!(def.spec.mixins.len(), 2);
+        let mixin_of_a_mixin = parse_mixin(&mixin_json(&format!(r#"{{"mixins":["{PINNED}"]}}"#)))
+            .expect("a mixin may build on other mixins, exactly as a sandbox does");
+        assert_eq!(mixin_of_a_mixin.spec.mixins.len(), 1);
+    }
+
+    #[test]
+    fn a_remote_mixin_reference_that_is_not_digest_pinned_is_refused() {
+        for reference in [
+            "ghcr.io/acme/postgres-tools:1.4.0",
+            "ghcr.io/acme/postgres-tools",
+            "ghcr.io/acme/postgres-tools@sha256:tooshort",
+        ] {
+            let err = parse(&def_json(&format!(
+                r#"{{"image":"x:1","mixins":["{reference}"]}}"#
+            )))
+            .unwrap_err();
+            assert!(
+                format!("{err:#}").contains("must be digest-pinned")
+                    && format!("{err:#}").contains("./"),
+                "a published sandbox has to resolve to the same thing for everyone, so a tag that can move is refused; {reference}: got {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_answers_for_the_kind_the_file_declares() {
+        assert!(
+            validate(&mixin_json(r#"{"tools":["postgresql@17"]}"#)).is_ok(),
+            "a mixin validates offline like any other document"
+        );
+        let err = validate(&mixin_json(r#"{"image":"ghcr.io/team/base:1"}"#)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("a mixin must not declare image"),
+            "routing on the declared kind is what lets the mixin rule report itself; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_mixin_entry_naming_nothing_is_refused() {
+        let err = parse(&def_json(r#"{"image":"x:1","mixins":["  "]}"#)).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("must name a directory or an OCI reference"),
+            "got: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/lns-artifact/src/spec.rs
+++ b/crates/lns-artifact/src/spec.rs
@@ -7,15 +7,17 @@ pub const API_VERSION: &str = "lens.dev/v1alpha1";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
     Sandbox,
+    Mixin,
     FileSet,
 }
 
-const ALL_KINDS: [Kind; 2] = [Kind::Sandbox, Kind::FileSet];
+const ALL_KINDS: [Kind; 3] = [Kind::Sandbox, Kind::Mixin, Kind::FileSet];
 
 impl Kind {
     pub fn as_str(self) -> &'static str {
         match self {
             Kind::Sandbox => "Sandbox",
+            Kind::Mixin => "Mixin",
             Kind::FileSet => "FileSet",
         }
     }
@@ -23,6 +25,7 @@ impl Kind {
     pub fn family(self) -> &'static str {
         match self {
             Kind::Sandbox => "sandbox",
+            Kind::Mixin => "mixin",
             Kind::FileSet => "fileset",
         }
     }
@@ -211,20 +214,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn kind_maps_family_and_media_types() {
-        assert_eq!(Kind::Sandbox.family(), "sandbox");
-        assert_eq!(Kind::Sandbox.as_str(), "Sandbox");
-        assert_eq!(
-            Kind::Sandbox.artifact_type(),
-            "application/vnd.lens.sandbox.v1+json"
-        );
-        assert_eq!(
-            Kind::Sandbox.config_media_type(),
-            "application/vnd.lens.sandbox.config.v1+json"
-        );
-        for kind in ALL_KINDS {
-            let _ = kind.as_str();
-            let _ = kind.family();
+    fn every_kind_carries_the_media_types_the_specification_names() {
+        for (kind, name, artifact_type, config_media_type) in [
+            (
+                Kind::Sandbox,
+                "Sandbox",
+                "application/vnd.lens.sandbox.v1+json",
+                "application/vnd.lens.sandbox.config.v1+json",
+            ),
+            (
+                Kind::Mixin,
+                "Mixin",
+                "application/vnd.lens.mixin.v1+json",
+                "application/vnd.lens.mixin.config.v1+json",
+            ),
+            (
+                Kind::FileSet,
+                "FileSet",
+                "application/vnd.lens.fileset.v1+json",
+                "application/vnd.lens.fileset.config.v1+json",
+            ),
+        ] {
+            assert_eq!(kind.as_str(), name);
+            assert_eq!(kind.artifact_type(), artifact_type);
+            assert_eq!(kind.config_media_type(), config_media_type);
         }
     }
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -494,6 +494,7 @@ mod tests {
     #[test]
     fn pulled_fileset_summaries_disclose_inline_source_and_root_owner() {
         let view = lns_ipc::SandboxView {
+            mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: "sha256:abc".into(),
             image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -158,7 +158,7 @@ pub fn validate<F: Fs, W: Write>(
         Err(problems) => problems,
     };
     if problems.is_empty()
-        && let Ok(def) = lns_artifact::sandbox::parse(&json)
+        && let Ok(def) = lns_artifact::sandbox::parse_document(&json)
     {
         problems.extend(super::fileset::path_fileset_problems(fs, project_dir, &def));
     }
@@ -195,6 +195,9 @@ pub fn inspect_local<F: Fs, W: Write>(
 fn render_effective<W: Write>(def: &lns_artifact::sandbox::Definition, out: &mut W) -> Result<()> {
     writeln!(out, "Sandbox: {}", def.metadata.name)?;
     writeln!(out, "  image:        {}", def.spec.image)?;
+    for mixin in &def.spec.mixins {
+        writeln!(out, "  mixin: {mixin}")?;
+    }
     if let Some(command) = &def.spec.command {
         writeln!(out, "  command:      {command}")?;
     }
@@ -434,6 +437,19 @@ mod tests {
             "got: {text}"
         );
         assert!(text.contains("connectors: some-provider"), "got: {text}");
+    }
+
+    #[test]
+    fn inspect_local_lists_the_mixins_the_definition_layers_on() {
+        let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  mixins:\n    - ./mixins/postgres-tools/\n";
+        let fs = fake("/work/lns.yaml", yaml);
+        let mut out = Vec::new();
+        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("mixin: ./mixins/postgres-tools/"),
+            "a run refuses this definition over its mixins, so the local view has to name them rather than read as though it declared none: {text}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/distribute.rs
+++ b/crates/lns-cli/src/sandbox/distribute.rs
@@ -102,8 +102,9 @@ pub fn pack_path_filesets<F: Fs + ?Sized>(
     doc: &[u8],
     reference: &str,
 ) -> Result<(Vec<u8>, Vec<PackedFileset>)> {
-    let def = lns_artifact::sandbox::parse(doc)
-        .map_err(|e| anyhow::anyhow!("refusing to push an invalid sandbox: {e:#}"))?;
+    let def = lns_artifact::sandbox::parse_document(doc)
+        .map_err(|e| anyhow::anyhow!("refusing to push an invalid document: {e:#}"))?;
+    refuse_unpinned_mixins(&def)?;
     if def.spec.filesets.is_empty() {
         return Ok((doc.to_vec(), Vec::new()));
     }
@@ -150,6 +151,18 @@ pub fn pack_path_filesets<F: Fs + ?Sized>(
     }
     let rewritten = serde_json::to_vec(&value).context("serializing the pinned definition")?;
     Ok((rewritten, packed))
+}
+
+/// A local directory means nothing on the machine that pulls the published document, and §3.3.1 pins a published `spec.mixins` entry by digest — so publish refuses what authoring accepts, exactly as it does for a fileset `path`.
+fn refuse_unpinned_mixins(def: &lns_artifact::sandbox::Definition) -> Result<()> {
+    for reference in &def.spec.mixins {
+        if !lns_artifact::spec::is_digest_pinned_image(reference) {
+            bail!(
+                "mixin {reference} is not digest-pinned; a published document pins every mixin by digest so every consumer resolves the same one"
+            );
+        }
+    }
+    Ok(())
 }
 
 fn owner_str(owner: lns_artifact::sandbox::FilesetOwner) -> &'static str {
@@ -475,7 +488,7 @@ mod tests {
         .await
         .unwrap_err();
         assert!(
-            format!("{err:#}").contains("invalid sandbox"),
+            format!("{err:#}").contains("invalid document"),
             "got: {err:#}"
         );
     }
@@ -520,6 +533,50 @@ mod tests {
         assert_eq!(packed.len(), 1);
         let value: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
         assert_eq!(value["spec"]["filesets"][0]["owner"], "root");
+    }
+
+    #[tokio::test]
+    async fn push_publishes_a_mixin_under_its_own_artifact_type() {
+        let producer = FakeProducer::ok(&format!("sha256:{}", "b".repeat(64)));
+        let mut out = Vec::new();
+        let code = push(
+            &fs_with_skills(),
+            cwd(),
+            &producer,
+            &unconsultable(),
+            br#"{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{"name":"postgres-tools"},"spec":{"env":{"MODE":"research"}}}"#,
+            "ghcr.io/acme/postgres-tools:1.4.0",
+            &mut out,
+        )
+        .await
+        .expect("a mixin is a kit, published like any other");
+        assert_eq!(code, 0);
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("ghcr.io/acme/postgres-tools:1.4.0"),
+            "got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn push_refuses_a_mixin_reference_a_consumer_could_not_resolve() {
+        let producer = FakeProducer::err("must not reach the producer");
+        let mut out = Vec::new();
+        let err = push(
+            &fs_with_skills(),
+            cwd(),
+            &producer,
+            &unconsultable(),
+            br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"hermes"},"spec":{"image":"x:1","mixins":["./mixins/postgres-tools/"]}}"#,
+            "ghcr.io/team/hermes:1.4.0",
+            &mut out,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("mixin ./mixins/postgres-tools/ is not digest-pinned"),
+            "a directory beside the author's file means nothing to a consumer, so publishing one would ship a reference nobody else can resolve; got: {err:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -914,6 +914,9 @@ fn render_cached_inspect<W: std::io::Write>(
                 writeln!(out, "digest: {}", view.digest)?;
             }
             writeln!(out, "image: {}", view.image)?;
+            for mixin in &view.mixins {
+                writeln!(out, "mixin: {mixin}")?;
+            }
             if let Some(user) = &view.user {
                 writeln!(out, "user: {user}")?;
             }
@@ -1246,6 +1249,7 @@ mod tests {
     fn sandbox_inspection_with_digest(tools: Vec<String>, digest: String) -> Response {
         Response::ImageInspected {
             inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
+                mixins: Vec::new(),
                 reference: "ghcr.io/team/hermes:1.4.0".into(),
                 digest,
                 image: "docker.io/library/alpine@sha256:abc".into(),
@@ -2000,6 +2004,7 @@ mod tests {
             },
             Response::ImageInspected {
                 inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
+                    mixins: Vec::new(),
                     reference: "hermes:1.4.0".into(),
                     digest: format!("sha256:{}", "a".repeat(64)),
                     image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -1129,6 +1129,7 @@ mod tests {
         let target = published_target(
             "registry.example.test/team/sandbox:1",
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: digest.clone(),
                 image: "registry.example.test/runtime:1".into(),
@@ -1203,6 +1204,7 @@ mod tests {
         let err = published_target(
             "registry.example.test/team/sandbox:1",
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: String::new(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -54,6 +54,20 @@ Feature: authoring a sandbox
     And the output contains "unknown field"
     And the service received no request
 
+  Scenario: validate answers for a mixin document too
+    Given an lns.yaml holding a mixin document
+    When the user runs sandbox command "validate"
+    Then the exit code is 0
+    And the output contains "valid"
+    And the service received no request
+
+  Scenario: validate refuses a mixin that claims a block the sandbox owns
+    Given an lns.yaml holding a mixin document that declares an image
+    When the user runs sandbox command "validate"
+    Then the command fails with an exit code other than 0
+    And the output contains "a mixin must not declare image"
+    And the service received no request
+
   Scenario: validate refuses a document the other verbs cannot run
     Given an lns.yaml written against the retired lens.dev/v1alpha1 group
     When the user runs sandbox command "validate"

--- a/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
@@ -1,7 +1,7 @@
 Feature: inspecting a typed artifact before running it
   `lns inspect <ref>` is the type-aware, pre-run view of a cached artifact: it
   names the kind, and for a published sandbox it lists the base image, declared
-  mounts, ports, and filesets with their mount paths, plus the connectors, and
+  mounts, ports, filesets with their mount paths, and mixins, plus the connectors, and
   it flags an over-broad shipped policy. It lets a consumer review the pieces
   before trusting a configured sandbox.
 
@@ -54,6 +54,12 @@ Feature: inspecting a typed artifact before running it
     When the user runs "lns inspect registry.example.test/some-sandbox:1.0"
     Then the exit code is 0
     And the output contains "credential: SOME_TOKEN -> api.some-provider.example"
+
+  Scenario: inspecting a sandbox lists the mixins it layers on
+    Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox declaring the mixin "ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582"
+    When the user runs "lns inspect registry.example.test/some-sandbox:1.0"
+    Then the exit code is 0
+    And the output contains "mixin: ghcr.io/acme/postgres-tools@sha256:"
 
   Scenario: inspecting a sandbox flags a permissive shipped policy
     Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox whose policy allows every destination

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -88,6 +88,7 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
 )]
 fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
+        mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -119,6 +120,7 @@ fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount
 )]
 fn pulled_view_with_inline_fileset(world: &mut BehaviourWorld, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
+        mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -280,6 +282,7 @@ fn command_fails_naming(world: &mut BehaviourWorld, needle: String) -> Result<()
 )]
 fn pulled_view_with_host_path_fileset(world: &mut BehaviourWorld, source: String, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
+        mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -37,6 +37,7 @@ fn definition(world: &BehaviourWorld) -> lns_artifact::sandbox::Definition {
 
 fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxView {
     lns_ipc::SandboxView {
+        mixins: def.spec.mixins.clone(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -178,6 +178,7 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
         Some(TEST_HOST),
     );
     lns_ipc::SandboxView {
+        mixins: def.spec.mixins.clone(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -66,6 +66,7 @@ fn validation_fails_naming_shape(w: &mut BehaviourWorld) -> Result<(), String> {
 #[given("a published sandbox declaring tools")]
 fn published_sandbox_declaring_tools(w: &mut BehaviourWorld) {
     let view = SandboxView {
+        mixins: Vec::new(),
         reference: TOOLS_REFERENCE.into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
@@ -63,6 +63,22 @@ fn lns_yaml_with_credential_without_injections(w: &mut BehaviourWorld, env_var: 
     );
 }
 
+#[given("an lns.yaml holding a mixin document")]
+fn lns_yaml_holding_a_mixin(w: &mut BehaviourWorld) {
+    seed(
+        w,
+        "apiVersion: lns.run/v1\nkind: Mixin\nmetadata:\n  name: postgres-tools\nspec:\n  tools:\n    - node@22\n",
+    );
+}
+
+#[given("an lns.yaml holding a mixin document that declares an image")]
+fn lns_yaml_holding_a_mixin_with_an_image(w: &mut BehaviourWorld) {
+    seed(
+        w,
+        "apiVersion: lns.run/v1\nkind: Mixin\nmetadata:\n  name: postgres-tools\nspec:\n  image: ghcr.io/team/base:1\n",
+    );
+}
+
 #[given("an lns.yaml written against the retired lens.dev/v1alpha1 group")]
 fn lns_yaml_from_the_retired_group(w: &mut BehaviourWorld) {
     seed(

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -32,6 +32,7 @@ fn inspects_plain_image(world: &mut BehaviourWorld, reference: String) {
 #[given(regex = r#"^the service inspects "([^"]+)" as a sandbox with launch settings$"#)]
 fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -73,6 +74,7 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
 )]
 fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -101,11 +103,35 @@ fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
     cached_artifact(world, &reference, inspection);
 }
 
+#[given(regex = r#"^the service inspects "([^"]+)" as a sandbox declaring the mixin "([^"]+)"$"#)]
+fn inspects_sandbox_mixins(world: &mut BehaviourWorld, reference: String, mixin: String) {
+    let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: vec![mixin],
+        reference: reference.clone(),
+        digest: full_digest(),
+        image: "registry.example.test/runtime:1".into(),
+        workdir: None,
+        user: None,
+        mounts: Vec::new(),
+        ports: Vec::new(),
+        filesets: Vec::new(),
+        connectors: Vec::new(),
+        env: Vec::new(),
+        credentials: Vec::new(),
+        tools: Vec::new(),
+        policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
+    }));
+    cached_artifact(world, &reference, inspection);
+}
+
 #[given(
     regex = r#"^the service inspects "([^"]+)" as a sandbox declaring a fileset at "([^"]+)"$"#
 )]
 fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, mount: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -139,6 +165,7 @@ fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, moun
 #[given(regex = r#"^the service inspects "([^"]+)" as a sandbox declaring user "([^"]+)"$"#)]
 fn inspects_sandbox_user(world: &mut BehaviourWorld, reference: String, user: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -168,6 +195,7 @@ fn inspects_sandbox_credential(
     domain: String,
 ) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -200,6 +228,7 @@ fn inspects_sandbox_credential(
 )]
 fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -224,6 +253,7 @@ fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: Str
 #[given(regex = r#"^the service inspects "([^"]+)" as a sandbox setting env "([^"]+)"$"#)]
 fn inspects_sandbox_env(world: &mut BehaviourWorld, reference: String, entry: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -34,6 +34,7 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
     });
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Sandbox(Box::new(SandboxView {
+            mixins: Vec::new(),
             reference,
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -63,6 +63,7 @@ fn registry_serves_sandbox(w: &mut BehaviourWorld, reference: String) {
     });
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
+            mixins: Vec::new(),
             reference,
             digest,
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -271,6 +271,9 @@ pub struct SandboxView {
     #[serde(default)]
     pub digest: String,
     pub image: String,
+    /// The mixins the document declares, so a reader sees the capabilities it layers on before trusting it.
+    #[serde(default)]
+    pub mixins: Vec<String>,
     #[serde(default)]
     pub workdir: Option<String>,
     /// The run-as user the sandbox declared, so a pulled artifact asking for root is visible before it boots.
@@ -1368,6 +1371,7 @@ mod tests {
     #[test]
     fn sandbox_view_round_trips_declarative_launch_settings() {
         let view = SandboxView {
+            mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:1".into(),
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -44,6 +44,7 @@ pub(crate) fn project_inspection(
             );
             Ok(ArtifactInspection::Sandbox(Box::new(
                 lns_ipc::SandboxView {
+                    mixins: def.spec.mixins.clone(),
                     reference: image_ref.to_string(),
                     digest,
                     cpus: declared_size.cpus,
@@ -214,6 +215,7 @@ mod tests {
         mounts: Vec<SandboxMount>,
     ) -> ArtifactInspection {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
+            mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -232,8 +234,30 @@ mod tests {
         }))
     }
 
+    fn sandbox_view_with_mixins(mixins: Vec<String>) -> ArtifactInspection {
+        ArtifactInspection::Sandbox(Box::new(SandboxView {
+            mixins,
+            reference: "registry.example.test/team/sandbox:latest".into(),
+            digest: digest(),
+            image: "registry.example.test/runtime:1".into(),
+            workdir: None,
+            user: None,
+            mounts: Vec::new(),
+            ports: Vec::new(),
+            filesets: Vec::new(),
+            connectors: Vec::new(),
+            env: Vec::new(),
+            credentials: Vec::new(),
+            tools: Vec::new(),
+            policy_flags: Vec::new(),
+            cpus: None,
+            mem_mib: None,
+        }))
+    }
+
     fn sandbox_view_with_filesets(filesets: Vec<SandboxFileset>) -> ArtifactInspection {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
+            mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -250,6 +274,19 @@ mod tests {
             cpus: None,
             mem_mib: None,
         }))
+    }
+
+    #[test]
+    fn a_sandbox_projects_the_mixins_it_declared_so_inspect_and_run_answer_alike() {
+        let pinned = format!("ghcr.io/acme/postgres-tools@sha256:{}", "c".repeat(64));
+        assert_eq!(
+            project_sandbox(&format!(
+                r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"some-sandbox"}},"spec":{{"image":"registry.example.test/runtime:1","mixins":["{pinned}"]}}}}"#
+            ))
+            .unwrap(),
+            sandbox_view_with_mixins(vec![pinned]),
+            "the run refuses this document over its mixins, so an inspect that omits them tells a reader the opposite of what the launch will say"
+        );
     }
 
     #[test]
@@ -378,6 +415,7 @@ mod tests {
         assert_eq!(
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -456,6 +494,7 @@ mod tests {
         assert_eq!(
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -492,6 +531,7 @@ mod tests {
         assert_eq!(
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -520,6 +560,7 @@ mod tests {
         assert_eq!(
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
+                mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -166,10 +166,31 @@ pub fn published_fileset_problems(resolved: &ResolvedSandbox) -> Vec<String> {
     problems
 }
 
+/// A document may declare the mixins it layers on, but nothing resolves them yet — so a run refuses rather than booting a sandbox without the capabilities its own document names.
+pub fn refuse_unresolved_mixins(def: &lns_artifact::sandbox::Definition) -> Result<()> {
+    if def.spec.mixins.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "this sandbox declares mixins ({}) and startup resolution is not implemented yet; \
+         remove them, or inline what they contribute, to run it today",
+        def.spec.mixins.join(", ")
+    )
+}
+
+/// Plan a published sandbox's config blob: the one place the pulled path turns a document into a run, so every guard between the two applies to a stranger's artifact as much as to a local file.
+pub fn plan_published_sandbox(config_json: &[u8], image_ref: &str) -> Result<ResolvedSandbox> {
+    let def = lns_artifact::sandbox::parse(config_json)
+        .with_context(|| format!("parsing published sandbox {image_ref}"))?;
+    refuse_unresolved_mixins(&def)?;
+    Ok(resolved_from_sandbox(&def))
+}
+
 /// Plan a local `lns.yaml` definition through the same path a published sandbox takes, so its policy, connectors, and resources apply identically.
 pub fn plan_local_sandbox(config_json: &[u8]) -> Result<ResolvedSandbox> {
     let def = lns_artifact::sandbox::parse(config_json)
         .context("parsing the local sandbox definition")?;
+    refuse_unresolved_mixins(&def)?;
     Ok(resolved_from_sandbox(&def))
 }
 

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -1,6 +1,6 @@
 use crate::artifact::assembly::{self, AssembledWorkload, ResolvedSandbox};
 use crate::artifact::fileset::{FilesetBudget, fileset_runtime_specs_with_budget};
-use crate::artifact::{RunPath, dispatch_run, resolved_from_sandbox};
+use crate::artifact::{RunPath, dispatch_run};
 use crate::image::{RealRegistry, Registry, registry_auth_for};
 use crate::runtime_layer::RuntimeFileSpec;
 use anyhow::{Context, Result};
@@ -40,9 +40,8 @@ pub(crate) async fn peek_and_plan(
     )? {
         RunPath::SingleImage => Ok(None),
         RunPath::Sandbox => {
-            let def = lns_artifact::sandbox::parse(config_json.as_bytes())
-                .with_context(|| format!("parsing published sandbox {image_ref}"))?;
-            let resolved = resolved_from_sandbox(&def);
+            let resolved =
+                crate::artifact::plan_published_sandbox(config_json.as_bytes(), image_ref)?;
             record_sandbox_run(run_id, microvm, image_ref, &digest, &resolved);
             crate::image_store::record_artifact_run(image_ref, &digest, &resolved.base_image)
                 .await

--- a/crates/lns-service/tests/behaviours/artifact_dispatch.feature
+++ b/crates/lns-service/tests/behaviours/artifact_dispatch.feature
@@ -26,3 +26,8 @@ Feature: run dispatches on the pulled artifact type
     Given a pulled reference whose manifest is a fileset artifact
     When the run resolves the reference for launch
     Then the run is refused because the artifact is not directly runnable
+
+  Scenario: A mixin is a kit a sandbox references, never one a run launches
+    Given a pulled reference whose manifest is a mixin artifact
+    When the run resolves the reference for launch
+    Then the run is refused because the artifact is not directly runnable

--- a/crates/lns-service/tests/behaviours/mixin_documents.feature
+++ b/crates/lns-service/tests/behaviours/mixin_documents.feature
@@ -1,0 +1,21 @@
+Feature: a document may declare the mixins it layers on
+  A sandbox states the mixins it builds on under `spec.mixins`, and a mixin may
+  build on others the same way. Resolution happens at startup — each mixin is
+  pulled and merged before the run presents the resolved sandbox for approval —
+  and that is not implemented yet. So a run refuses, naming what it could not
+  resolve, rather than booting a sandbox without the capabilities its own
+  document declares. Authoring and publishing already work: the document
+  validates offline, and `lns push` publishes a digest-pinned list as written.
+
+  Scenario: a declared mixin refuses the launch until startup resolution lands
+    Given the sandbox definition declares the mixin "ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582"
+    When the sandbox is launched
+    Then the launch is refused
+    And the error names "ghcr.io/acme/postgres-tools"
+    And the error says startup resolution is not implemented
+
+  Scenario: a pulled sandbox's declared mixin refuses the launch too
+    Given the sandbox definition declares the mixin "ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582"
+    When the published sandbox is launched
+    Then the launch is refused
+    And the error says startup resolution is not implemented

--- a/crates/lns-service/tests/behaviours/steps/artifact_dispatch.rs
+++ b/crates/lns-service/tests/behaviours/steps/artifact_dispatch.rs
@@ -18,6 +18,11 @@ async fn fileset_artifact(world: &mut BehaviourWorld) {
     world.artifact().artifact_type = Some(Kind::FileSet.artifact_type());
 }
 
+#[given("a pulled reference whose manifest is a mixin artifact")]
+async fn mixin_artifact(world: &mut BehaviourWorld) {
+    world.artifact().artifact_type = Some(Kind::Mixin.artifact_type());
+}
+
 #[given("a pulled reference whose manifest is a sandbox artifact")]
 async fn sandbox_artifact(world: &mut BehaviourWorld) {
     world.artifact().artifact_type = Some(Kind::Sandbox.artifact_type());

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -9,7 +9,7 @@ use lns_service::artifact::credential_boot::{
     BootGate, SlotPlan, boot_gate, plan_declared_connectors, sign_in_gate_ids,
 };
 use lns_service::artifact::policy::merge_effective;
-use lns_service::artifact::{plan_local_sandbox, resolved_from_sandbox};
+use lns_service::artifact::{plan_local_sandbox, plan_published_sandbox};
 use lns_service::credential_flow::connectors::{
     boot_sign_in_grants, gate_armed_by_grant, resolve_applied_with_credentials,
     resolve_connectable_with_credentials, run_providers, unknown_connector_ids,
@@ -234,8 +234,13 @@ fn published_sandbox_launched(w: &mut BehaviourWorld) {
         .definition
         .clone()
         .expect("a Given step must declare the definition");
-    let resolved = lns_artifact::sandbox::parse(definition.as_bytes());
-    launch(w, resolved.map(|def| resolved_from_sandbox(&def)));
+    launch(
+        w,
+        plan_published_sandbox(
+            definition.as_bytes(),
+            "registry.example.test/some-sandbox:1",
+        ),
+    );
 }
 
 fn oauth_connector(id: &str) -> Connector {

--- a/crates/lns-service/tests/behaviours/steps/mixin_documents.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_documents.rs
@@ -1,0 +1,24 @@
+use cucumber::{given, then};
+
+use crate::world::BehaviourWorld;
+
+#[given(regex = r#"^the sandbox definition declares the mixin "([^"]+)"$"#)]
+fn definition_declares_a_mixin(w: &mut BehaviourWorld, reference: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.definition = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","mixins":["{reference}"]}}}}"#
+    ));
+}
+
+#[then("the error says startup resolution is not implemented")]
+fn error_says_resolution_is_not_implemented(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    let error = rig.error.as_deref().ok_or("no launch error was recorded")?;
+    if error.contains("startup resolution is not implemented") {
+        Ok(())
+    } else {
+        Err(format!(
+            "a run that silently dropped a declared mixin would boot without what the document asked for; the refusal has to say why: {error}"
+        ))
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -9,6 +9,7 @@ pub mod forward;
 pub mod host_binds;
 pub mod image_management;
 pub mod ipc;
+pub mod mixin_documents;
 pub mod oauth_connector;
 pub mod pkce_connector;
 pub mod policy_guardrail;


### PR DESCRIPTION
> Stacked on #221. Base is `feat/credential-definition`, so review that one first.
>
> Implements [§3.1.9](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#319-mixins), [§3.3](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#33-kind-mixin)'s document rules, the Mixin line of [§5](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#5-validation-summary), and the `mixin` row of [§7](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#7-distribution)'s media-type table.

## Why

`mixin` is one of the three kinds [§3](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#3-kits) defines, and nothing in the code knew the word. `Kind` had two variants, `SandboxSpec` was `deny_unknown_fields`, so a document carrying `mixins:` was a hard parse failure on every load path — there was no forward-compatible window in which the field could land.

This is the first of the mixin stack: the kit **exists**, **validates** and **publishes**. Nothing resolves or merges yet.

## What this does

**`Kind::Mixin`.** Joins the enum, so §7's table falls out of the existing `family()` formatting — `application/vnd.lens.mixin.v1+json` and its config type — and `build_artifact` publishes a mixin with no change to the publish path's shape.

**Two readers over one grammar.** `sandbox::parse` splits into a shared `parse_of_kind` core plus `parse` (requires `image`) and `parse_mixin` (requires none, and refuses what a mixin may not carry). A mixin's spec type is `SandboxSpec` itself: §3.3 says its allowed blocks follow §3.1's rules, so a second struct would be the same fields with a second copy of every guard — and the merge that lands next merges like with like instead of translating between two shapes.

`parse_document` routes on the declared kind, so `lns sandbox validate` answers for whichever document it was handed rather than the one it expected.

**What a mixin may not carry.** The five blocks §3.3 forbids — `image`, `command`, `workdir`, `user`, `resources` — each refused by name, checked immediately after decode so an author hears "this block does not belong here" rather than a complaint about its contents. Plus `connectors`: the sandbox keeps that retired field as a shipping divergence, but [§1.4](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#14-credentials-and-what-a-connector-adds) is explicit that no kit names a connector, and admitting it on a brand-new kind would deepen the divergence rather than leave it.

**`spec.mixins[]`** on both kinds — §3.3 lets a mixin build on other mixins. A local directory validates; a remote reference must be digest-pinned.

## Two rules that pull in opposite directions, on purpose

| Surface | Rule |
|---|---|
| Authoring ([§3.1.9](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#319-mixins)) | A local directory or an OCI reference. |
| Publishing ([§3.3.1](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#331-how-a-mixin-enters-a-run)) | A published document's entries MUST be digest-pinned. |

So `mixins: ["./mixins/postgres-tools/"]` validates offline and is refused at `lns push` — exactly the shape a fileset `path` already has, and for the same reason: a directory beside the author's file means nothing on the machine that pulls the artifact.

## A run refuses, and says why

Startup resolution is not implemented, so a document declaring mixins would boot without the capabilities it names. `refuse_unresolved_mixins` refuses instead, naming them, on **both** plan paths — a local `lns.yaml` and a pulled artifact. `lns run <mixin-ref>` is refused separately by the existing kind dispatch: a mixin is a kit a sandbox references, never one a run launches.

Silently accepting the field would have been the worse failure: the document would say one thing and the run would do another.

## No guide changes

Nothing a user can do with a mixin end-to-end exists yet. Under the repo's rule that a guide answers "how do I use this today", the mixin story belongs in `docs/` when resolution lands, not before.

## Verification

`make lint`, `make complexity` and `make coverage` all exit 0, no new `IGNORES`. Full workspace suite clean. `make e2e` passes 69 scenarios.

Review found four behavioural defects in the first version of this commit, each now fixed with the failing test written first:

| Defect | Now pinned by |
|---|---|
| `lns push` refused every mixin document — `pack_path_filesets` parsed as a sandbox before `build_artifact` was reached | `push_publishes_a_mixin_under_its_own_artifact_type` |
| Push published a local-directory mixin entry verbatim, violating §3.3.1's MUST | `push_refuses_a_mixin_reference_a_consumer_could_not_resolve` |
| A mixin could smuggle `connectors` | `a_mixin_may_not_name_a_connector` |
| The pulled path's refusal had no test at any layer, and the Layer 2 glue bypassed it | `plan_published_sandbox` seam + a pulled-path scenario |

Each was mutation-verified after the fix — revert the production line, watch the test go red. The `plan_published_sandbox` extraction is worth calling out as more than a test fix: the pulled path had been hand-assembling parse + resolve, so a guard added to the local path did not automatically reach a stranger's artifact.
