### PR TITLE
feat: let a user merge their own mixins into a run

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -216,17 +216,13 @@ pub struct RunArgs {
     #[arg(skip)]
     pub tools: Vec<String>,
 
-    /// Merge a mixin into this run, after the ones the document declares. Repeatable; a tag is pinned before the run reports it.
+    /// Merge a mixin into this run, after the ones the document declares. Repeatable; a tag is pinned before the run reports it, and the pin is what the run carries.
     #[arg(long = "mixin", value_name = "REF")]
     pub mixins: Vec<String>,
 
     /// The mixins a pulled sandbox resolved into, ready to display; the merged document declares none of its own, so this is the only place a composed sandbox says so.
     #[arg(skip)]
     pub resolved_mixins: Vec<String>,
-
-    /// What each `--mixin` resolved to, in flag order, so the run boots the bytes its preflight pinned.
-    #[arg(skip)]
-    pub pinned_mixins: Vec<String>,
 
     #[arg(
         short = 'v',

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -216,9 +216,17 @@ pub struct RunArgs {
     #[arg(skip)]
     pub tools: Vec<String>,
 
-    /// The mixins a pulled sandbox resolved into; the merged document declares none of its own, so this is the only place a composed sandbox says so.
-    #[arg(skip)]
+    /// Merge a mixin into this run, after the ones the document declares. Repeatable; a tag is pinned before the run reports it.
+    #[arg(long = "mixin", value_name = "REF")]
     pub mixins: Vec<String>,
+
+    /// The mixins a pulled sandbox resolved into, ready to display; the merged document declares none of its own, so this is the only place a composed sandbox says so.
+    #[arg(skip)]
+    pub resolved_mixins: Vec<String>,
+
+    /// What each `--mixin` resolved to, in flag order, so the run boots the bytes its preflight pinned.
+    #[arg(skip)]
+    pub pinned_mixins: Vec<String>,
 
     #[arg(
         short = 'v',

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -691,7 +691,6 @@ mod tests {
         RunArgs {
             mixins: Vec::new(),
             resolved_mixins: Vec::new(),
-            pinned_mixins: Vec::new(),
             image: Some("alpine".to_string()),
             file: None,
             name: None,

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -690,6 +690,8 @@ mod tests {
     fn bare_run_args() -> RunArgs {
         RunArgs {
             mixins: Vec::new(),
+            resolved_mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             image: Some("alpine".to_string()),
             file: None,
             name: None,

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -84,6 +84,12 @@ pub fn mixin_display(resolved: &[String], typed: &[String], pinned: &[String]) -
         .collect()
 }
 
+/// What the mixin flags become once the preflight has answered: the run carries the digests it pinned, and the summary shows each beside the reference the user typed. A typed reference goes no further than this, so the boot can only merge bytes the disclosure named.
+pub fn adopt_pinned_mixins(args: &mut RunArgs, resolved: &[String], pinned: &[String]) {
+    args.resolved_mixins = mixin_display(resolved, &args.mixins, pinned);
+    args.mixins = pinned.to_vec();
+}
+
 pub fn print_run_summary(
     args: &RunArgs,
     size: lns_artifact::resources::VmSize,
@@ -388,7 +394,6 @@ mod tests {
         RunArgs {
             mixins: Vec::new(),
             resolved_mixins: Vec::new(),
-            pinned_mixins: Vec::new(),
             image: image.map(str::to_string),
             file: None,
             name: None,
@@ -592,6 +597,55 @@ mod tests {
             shown,
             [declared, format!("obs-tools:2 \u{2192} {pinned}")],
             "the user approves bytes, but a line that dropped the tag they typed would not tell them which flag produced it"
+        );
+    }
+
+    #[test]
+    fn a_tag_the_user_typed_never_travels_further_than_the_preflight() {
+        let pinned = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        let mut args = run_args(Some("prism"));
+        args.mixins = vec!["obs-tools:2".to_string()];
+        adopt_pinned_mixins(
+            &mut args,
+            std::slice::from_ref(&pinned),
+            std::slice::from_ref(&pinned),
+        );
+        assert_eq!(
+            args.mixins,
+            std::slice::from_ref(&pinned),
+            "the run merges the digest the preflight showed; a tag reaching the service could move between the disclosure and the merge, and the service refuses one outright"
+        );
+        assert_eq!(
+            args.resolved_mixins,
+            [format!("obs-tools:2 \u{2192} {pinned}")],
+            "the tag survives in the disclosure alone, so the user still sees which flag produced this digest"
+        );
+    }
+
+    #[test]
+    fn a_run_that_named_no_mixin_carries_none_after_the_preflight() {
+        let mut args = run_args(Some("prism"));
+        adopt_pinned_mixins(&mut args, &[], &[]);
+        assert!(args.mixins.is_empty());
+        assert!(
+            args.resolved_mixins.is_empty(),
+            "a sandbox that resolved nothing must not read as a composed one"
+        );
+    }
+
+    #[test]
+    fn a_mixin_only_the_document_declared_is_disclosed_without_being_carried() {
+        let declared = format!("ghcr.io/acme/base@sha256:{}", "a".repeat(64));
+        let mut args = run_args(Some("prism"));
+        adopt_pinned_mixins(&mut args, std::slice::from_ref(&declared), &[]);
+        assert_eq!(
+            args.resolved_mixins,
+            [declared],
+            "the document's own mixins are what the summary names"
+        );
+        assert!(
+            args.mixins.is_empty(),
+            "the service resolves a document's own mixins from the document, so sending them back would merge each source twice"
         );
     }
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -67,6 +67,23 @@ pub fn resolved_size(
     )
 }
 
+/// How the disclosure names each source: a reference the user typed as a tag reads as `typed -> pinned`, so what they approve names bytes without losing what they asked for.
+pub fn mixin_display(resolved: &[String], typed: &[String], pinned: &[String]) -> Vec<String> {
+    resolved
+        .iter()
+        .map(|entry| {
+            match typed
+                .iter()
+                .zip(pinned)
+                .find(|(typed, pin)| *pin == entry && *typed != entry)
+            {
+                Some((typed, _)) => format!("{typed} \u{2192} {entry}"),
+                None => entry.clone(),
+            }
+        })
+        .collect()
+}
+
 pub fn print_run_summary(
     args: &RunArgs,
     size: lns_artifact::resources::VmSize,
@@ -109,8 +126,8 @@ pub fn format_summary(
     if !args.tools.is_empty() {
         writeln!(s, "  Tools:     {}", args.tools.join(", ")).unwrap();
     }
-    if !args.mixins.is_empty() {
-        writeln!(s, "  Mixins:    {}", args.mixins.join(", ")).unwrap();
+    if !args.resolved_mixins.is_empty() {
+        writeln!(s, "  Mixins:    {}", args.resolved_mixins.join(", ")).unwrap();
     }
     if let Some(dir) = &args.workdir {
         writeln!(s, "  Workdir:   {dir}").unwrap();
@@ -370,6 +387,8 @@ mod tests {
     fn run_args(image: Option<&str>) -> RunArgs {
         RunArgs {
             mixins: Vec::new(),
+            resolved_mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             image: image.map(str::to_string),
             file: None,
             name: None,
@@ -499,6 +518,7 @@ mod tests {
     fn pulled_fileset_summaries_disclose_inline_source_and_root_owner() {
         let view = lns_ipc::SandboxView {
             mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: "sha256:abc".into(),
             image: "registry.example.test/runtime:1".into(),
@@ -546,9 +566,39 @@ mod tests {
     }
 
     #[test]
+    fn a_digest_the_user_typed_reads_once_rather_than_pointing_at_itself() {
+        let pinned = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        assert_eq!(
+            mixin_display(
+                std::slice::from_ref(&pinned),
+                std::slice::from_ref(&pinned),
+                std::slice::from_ref(&pinned),
+            ),
+            [pinned],
+            "a user who typed the digest already sees the bytes, so repeating it either side of an arrow says nothing"
+        );
+    }
+
+    #[test]
+    fn a_tag_the_user_named_reads_as_the_tag_and_the_digest_it_pinned_to() {
+        let pinned = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        let declared = format!("ghcr.io/acme/base@sha256:{}", "a".repeat(64));
+        let shown = mixin_display(
+            &[declared.clone(), pinned.clone()],
+            &["obs-tools:2".to_string()],
+            std::slice::from_ref(&pinned),
+        );
+        assert_eq!(
+            shown,
+            [declared, format!("obs-tools:2 \u{2192} {pinned}")],
+            "the user approves bytes, but a line that dropped the tag they typed would not tell them which flag produced it"
+        );
+    }
+
+    #[test]
     fn the_mixins_line_names_what_a_composed_sandbox_resolved_into() {
         let mut args = run_args(Some("prism"));
-        args.mixins = vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d".into()];
+        args.resolved_mixins = vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d".into()];
         let s = summary_of(
             &args,
             &Policy::default(),

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -155,9 +155,29 @@ impl RunTarget {
     }
 }
 
+/// A local run's mounts and ports come from the document the CLI parsed itself, so a mixin it never merged would be dropped without a word.
+pub fn refuse_mixins_on_a_local_run(mixins: &[String]) -> Result<()> {
+    if mixins.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "--mixin needs a published sandbox: a local document's mixins are not resolved yet, so publish it and run it by reference to use them"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_local_run_refuses_the_mixins_the_user_named_rather_than_dropping_them() {
+        refuse_mixins_on_a_local_run(&[]).expect("a run with no flag is untouched");
+        let err = refuse_mixins_on_a_local_run(&["ghcr.io/acme/obs:2".to_string()]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("--mixin needs a published sandbox"),
+            "a local run builds its mounts and ports from the document the CLI parsed, so accepting the flag here would drop what it contributes; got: {err:#}"
+        );
+    }
 
     use crate::sandbox::test_support::MapFs;
 

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -178,8 +178,10 @@ pub fn inspect_local<F: Fs, W: Write>(
     cwd: &Path,
     target: Option<&str>,
     file: Option<&Path>,
+    mixins: &[String],
     out: &mut W,
 ) -> Result<i32> {
+    crate::sandbox::refuse_mixins_unless_published(mixins)?;
     let path = match (target, file) {
         (Some(_), Some(_)) => bail!("pass an inspect target or --file, not both"),
         (Some(target), None) => crate::run::target::definition_file(target, cwd),
@@ -285,6 +287,7 @@ mod tests {
     fn inspect_cmd(target: Option<&str>) -> SandboxCommand {
         SandboxCommand::Inspect(crate::sandbox::SandboxInspectArgs {
             run: target.map(str::to_string),
+            mixins: Vec::new(),
             file: None,
         })
     }
@@ -422,10 +425,29 @@ mod tests {
     }
 
     #[test]
+    fn inspect_local_refuses_a_mixin_rather_than_rendering_without_it() {
+        let fs = fake("/work/lns.yaml", valid_yaml());
+        let mut out = Vec::new();
+        let err = inspect_local(
+            &fs,
+            Path::new("/work"),
+            None,
+            None,
+            &["ghcr.io/acme/obs:2".to_string()],
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("--mixin applies to a published sandbox reference"),
+            "this render never resolves anything, so honouring the flag silently would show a composition the file does not describe; got: {err:#}"
+        );
+    }
+
+    #[test]
     fn inspect_local_renders_the_effective_definition() {
         let fs = fake("/work/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        let code = inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(
@@ -444,7 +466,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  mixins:\n    - ./mixins/postgres-tools/\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(
             text.contains("mixin: ./mixins/postgres-tools/"),
@@ -457,7 +479,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  policy:\n    egress:\n      http:\n        - match: api.example.test\n          verdict: allow\n      tcp:\n        - match: db.internal:5432\n          verdict: allow\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(
             text.contains("1 route(s), 1 raw TCP rule(s)"),
@@ -470,7 +492,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  command: agent --serve\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();
         assert!(
             String::from_utf8(out)
                 .unwrap()
@@ -483,7 +505,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  env:\n    SHELL: /bin/sh\n    FOO: bar\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), None, None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("env:          FOO=bar"), "got: {text}");
         assert!(text.contains("env:          SHELL=/bin/sh"), "got: {text}");
@@ -519,7 +541,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n    - ref: registry.example.test/team/settings@sha256:abc\n      mountPath: /root/.agent/settings\n  credentials:\n    - envVar: SOME_TOKEN\n      placeholder: lns-placeholder-some-token\n      injections:\n        - kind: bearer_header\n          domain: api.some-provider.example\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), Some("."), None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), Some("."), None, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(
             text.contains("fileset:      ./skills -> /root/.agent/skills"),
@@ -542,7 +564,7 @@ mod tests {
         let yaml = "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  tools:\n    - node@22\n    - python@3.12\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
-        inspect_local(&fs, cwd(), Some("."), None, &mut out).unwrap();
+        inspect_local(&fs, cwd(), Some("."), None, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("tool: node@22"), "got: {text}");
         assert!(text.contains("tool: python@3.12"), "got: {text}");
@@ -552,7 +574,7 @@ mod tests {
     fn inspect_local_renders_another_directorys_definition_by_path() {
         let fs = fake("/other/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = inspect_local(&fs, cwd(), Some("../other"), None, &mut out).unwrap();
+        let code = inspect_local(&fs, cwd(), Some("../other"), None, &[], &mut out).unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("ghcr.io/team/base:1"), "got: {text}");
@@ -566,8 +588,15 @@ mod tests {
             ("/work/lns.dev.yaml", variant),
         ]);
         let mut out = Vec::new();
-        let code =
-            inspect_local(&fs, cwd(), None, Some(Path::new("lns.dev.yaml")), &mut out).unwrap();
+        let code = inspect_local(
+            &fs,
+            cwd(),
+            None,
+            Some(Path::new("lns.dev.yaml")),
+            &[],
+            &mut out,
+        )
+        .unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("ghcr.io/team/dev:1"), "got: {text}");
@@ -582,6 +611,7 @@ mod tests {
             cwd(),
             Some("."),
             Some(Path::new("lns.dev.yaml")),
+            &[],
             &mut out,
         )
         .unwrap_err();
@@ -593,6 +623,7 @@ mod tests {
         assert!(is_offline(&SandboxCommand::Inspect(
             crate::sandbox::SandboxInspectArgs {
                 run: None,
+                mixins: Vec::new(),
                 file: Some(std::path::PathBuf::from("lns.dev.yaml")),
             }
         )));
@@ -605,7 +636,7 @@ mod tests {
             "apiVersion: lns.run/v1\nkind: Sandbox\nmetadata:\n  name: hermes\nspec: {}\n",
         );
         let mut out = Vec::new();
-        let err = inspect_local(&fs, cwd(), None, None, &mut out).unwrap_err();
+        let err = inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("not a valid sandbox"));
     }
 }

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -210,6 +210,13 @@ pub struct SandboxInspectArgs {
         help = "Definition file to render instead of ./lns.yaml, offline. Cannot be combined with TARGET."
     )]
     pub file: Option<PathBuf>,
+
+    #[arg(
+        long = "mixin",
+        value_name = "REF",
+        help = "Resolve this mixin into the sandbox before rendering it, as `lns run --mixin` would. Repeatable."
+    )]
+    pub mixins: Vec<String>,
 }
 
 #[derive(clap::Args)]
@@ -447,7 +454,7 @@ where
             let Some(target) = &args.run else {
                 bail!("a local definition inspect runs offline, not through the service dispatch")
             };
-            inspect(svc, target, out).await
+            inspect(svc, target, &args.mixins, out).await
         }
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
@@ -476,6 +483,7 @@ where
     let inspection = svc
         .one_shot(Request::InspectImage {
             image: args.reference.clone(),
+            mixins: Vec::new(),
         })
         .await?;
     let (digest, tools) = match inspection {
@@ -853,9 +861,20 @@ async fn prune<W: std::io::Write>(
     }
 }
 
+/// `--mixin` composes a document before it boots, so a run that has already booted and a local file nothing resolved yet can only refuse it.
+pub fn refuse_mixins_unless_published(mixins: &[String]) -> Result<()> {
+    if mixins.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "--mixin applies to a published sandbox reference: a live run has already booted with what it merged, and a local document's mixins are not resolved yet"
+    )
+}
+
 async fn inspect<W: std::io::Write>(
     svc: &impl SandboxService,
     target: &str,
+    mixins: &[String],
     out: &mut W,
 ) -> Result<i32> {
     match svc
@@ -865,6 +884,7 @@ async fn inspect<W: std::io::Write>(
         .await?
     {
         Response::RunInspect { details } => {
+            refuse_mixins_unless_published(mixins)?;
             let policy = details
                 .config
                 .policy_path
@@ -875,7 +895,7 @@ async fn inspect<W: std::io::Write>(
         }
         // A reference the service knows no run for is a cached artifact; any other error is a real failure, not a miss.
         Response::Error { message } if is_unknown_run(&message) => {
-            inspect_cached(svc, target, out).await
+            inspect_cached(svc, target, mixins, out).await
         }
         Response::Error { message } => bail!("daemon error: {message}"),
         other => bail!("unexpected response from daemon: {other:?}"),
@@ -885,16 +905,18 @@ async fn inspect<W: std::io::Write>(
 async fn inspect_cached<W: std::io::Write>(
     svc: &impl SandboxService,
     reference: &str,
+    mixins: &[String],
     out: &mut W,
 ) -> Result<i32> {
     match svc
         .one_shot(Request::InspectImage {
             image: reference.to_string(),
+            mixins: mixins.to_vec(),
         })
         .await?
     {
         Response::ImageInspected { inspection } => {
-            render_cached_inspect(&inspection, out)?;
+            render_cached_inspect(&inspection, mixins, out)?;
             Ok(0)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
@@ -904,6 +926,7 @@ async fn inspect_cached<W: std::io::Write>(
 
 fn render_cached_inspect<W: std::io::Write>(
     inspection: &lns_ipc::ArtifactInspection,
+    typed: &[String],
     out: &mut W,
 ) -> Result<()> {
     match inspection {
@@ -914,7 +937,9 @@ fn render_cached_inspect<W: std::io::Write>(
                 writeln!(out, "digest: {}", view.digest)?;
             }
             writeln!(out, "image: {}", view.image)?;
-            for mixin in &view.mixins {
+            for mixin in
+                crate::run::summary::mixin_display(&view.mixins, typed, &view.pinned_mixins)
+            {
                 writeln!(out, "mixin: {mixin}")?;
             }
             if let Some(user) = &view.user {
@@ -1250,6 +1275,7 @@ mod tests {
         Response::ImageInspected {
             inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "ghcr.io/team/hermes:1.4.0".into(),
                 digest,
                 image: "docker.io/library/alpine@sha256:abc".into(),
@@ -1390,6 +1416,7 @@ mod tests {
             SandboxCommand::Validate(SandboxValidateArgs { file: None }),
             SandboxCommand::Inspect(SandboxInspectArgs {
                 run: None,
+                mixins: Vec::new(),
                 file: None,
             }),
         ] {
@@ -1480,7 +1507,7 @@ mod tests {
         assert!(matches!(
             svc.requests.lock().unwrap().as_slice(),
             [
-                Request::InspectImage { image },
+                Request::InspectImage { image, .. },
                 Request::PullImage {
                     image: pulled,
                     expected_digest
@@ -1979,10 +2006,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inspect_of_a_live_run_refuses_a_mixin_rather_than_ignoring_it() {
+        let svc = CannedService::new(Response::RunInspect {
+            details: Box::new(RunDetails {
+                summary: lns_ipc::RunSummary {
+                    id: "1a2b3c4d0000000000000000000000aa".into(),
+                    name: "reviewer".into(),
+                    image: "some-image".into(),
+                    command: String::new(),
+                    status: lns_ipc::RunStatus::Running,
+                    started: "2026-01-01T00:00:00Z".into(),
+                },
+                config: lns_ipc::RunConfig {
+                    policy_path: Some("/work/lns-policy.yaml".into()),
+                    ..Default::default()
+                },
+            }),
+        });
+        let mut out = Vec::new();
+        let err = inspect(&svc, "1", &["ghcr.io/acme/obs:2".to_string()], &mut out)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("--mixin applies to a published sandbox reference"),
+            "a live run has already booted, so rendering it as though the flag applied would describe a composition that never ran; got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn inspect_rejects_an_unrelated_response_variant() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = inspect(&svc, "1", &mut out).await.unwrap_err();
+        let err = inspect(&svc, "1", &[], &mut out).await.unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
     }
 
@@ -1992,7 +2047,7 @@ mod tests {
             message: "no active run with id 1".into(),
         });
         let mut out = Vec::new();
-        let err = inspect(&svc, "1", &mut out).await.unwrap_err();
+        let err = inspect(&svc, "1", &[], &mut out).await.unwrap_err();
         assert!(format!("{err:#}").contains("no active run with id 1"));
     }
 
@@ -2005,6 +2060,7 @@ mod tests {
             Response::ImageInspected {
                 inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                     mixins: Vec::new(),
+                    pinned_mixins: Vec::new(),
                     reference: "hermes:1.4.0".into(),
                     digest: format!("sha256:{}", "a".repeat(64)),
                     image: "docker.io/library/alpine@sha256:abc".into(),
@@ -2024,7 +2080,7 @@ mod tests {
             },
         );
         let mut out = Vec::new();
-        let code = inspect(&svc, "hermes:1.4.0", &mut out).await.unwrap();
+        let code = inspect(&svc, "hermes:1.4.0", &[], &mut out).await.unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("kind: Sandbox"), "got: {text}");
@@ -2050,7 +2106,7 @@ mod tests {
             },
         );
         let mut out = Vec::new();
-        inspect(&image, "x", &mut out).await.unwrap();
+        inspect(&image, "x", &[], &mut out).await.unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("kind: Image"), "got: {text}");
         assert!(text.contains("digest: sha256:abc"), "got: {text}");
@@ -2065,7 +2121,7 @@ mod tests {
             Response::Pong,
         );
         let mut out = Vec::new();
-        let err = inspect(&svc, "x", &mut out).await.unwrap_err();
+        let err = inspect(&svc, "x", &[], &mut out).await.unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
     }
 
@@ -2075,7 +2131,7 @@ mod tests {
             message: "daemon busy".into(),
         });
         let mut out = Vec::new();
-        let err = inspect(&svc, "reviewer", &mut out).await.unwrap_err();
+        let err = inspect(&svc, "reviewer", &[], &mut out).await.unwrap_err();
         assert!(
             format!("{err:#}").contains("daemon busy"),
             "a transient InspectRun error must surface, not be masked as no-such-image: {err:#}"
@@ -2499,7 +2555,7 @@ mod tests {
             }),
         });
         let mut out = Vec::new();
-        let code = inspect(&svc, "1", &mut out).await.unwrap();
+        let code = inspect(&svc, "1", &[], &mut out).await.unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -298,6 +298,7 @@ fn run_author(command: &super::SandboxCommand, ctx: RunCtx<'_>) -> Result<i32> {
             &cwd,
             args.run.as_deref(),
             args.file.as_deref(),
+            &args.mixins,
             &mut out,
         ),
         _ => unreachable!("run_author is only called for offline author verbs"),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -132,6 +132,7 @@ struct PublishedTarget {
     filesets: Vec<crate::run::summary::FilesetSummary>,
     tools: Vec<String>,
     mixins: Vec<String>,
+    pinned_mixins: Vec<String>,
 }
 
 fn published_target(
@@ -152,6 +153,7 @@ fn published_target(
                 filesets: crate::run::summary::fileset_summaries_from_view(&view),
                 tools: crate::run::summary::tools_from_view(&view),
                 mixins: view.mixins.clone(),
+                pinned_mixins: view.pinned_mixins.clone(),
             })
         }
         lns_ipc::ArtifactInspection::Image(_) => anyhow::bail!(
@@ -160,9 +162,14 @@ fn published_target(
     }
 }
 
-async fn preflight_published(socket: &Path, reference: &str) -> Result<PublishedTarget> {
+async fn preflight_published(
+    socket: &Path,
+    reference: &str,
+    mixins: &[String],
+) -> Result<PublishedTarget> {
     let request = Request::InspectImage {
         image: reference.to_string(),
+        mixins: mixins.to_vec(),
     };
     await_published_preflight(reference, real::send_request(socket, &request)).await
 }
@@ -196,9 +203,10 @@ pub async fn run_image(
     let client = real_client()?;
     let published = match &target {
         crate::run::target::RunTarget::Reference(reference) => {
-            Some(preflight_published(client.socket(), reference).await?)
+            Some(preflight_published(client.socket(), reference, &args.mixins).await?)
         }
         crate::run::target::RunTarget::Local { .. } => {
+            crate::run::target::refuse_mixins_on_a_local_run(&args.mixins)?;
             // A path-shaped REF resolved to a definition; the summary names its image, not the path.
             if args.image.is_some() {
                 args.image = Some(target.image());
@@ -259,9 +267,19 @@ pub async fn run_image(
         _ => Vec::new(),
     };
     // Only a pulled sandbox resolves its mixins today; a local document still declares them and is refused.
-    args.mixins = published
+    args.pinned_mixins = published
         .as_ref()
-        .map(|published| published.mixins.clone())
+        .map(|published| published.pinned_mixins.clone())
+        .unwrap_or_default();
+    args.resolved_mixins = published
+        .as_ref()
+        .map(|published| {
+            crate::run::summary::mixin_display(
+                &published.mixins,
+                &args.mixins,
+                &published.pinned_mixins,
+            )
+        })
         .unwrap_or_default();
     // The size travels as its own value: writing it back into args.cpus/args.mem would tell the service the user asked for it explicitly.
     let size = crate::run::summary::resolved_size(defaults.size, &args);
@@ -333,6 +351,7 @@ pub async fn run_image(
         env: args.env,
         image: Some(target.image()),
         resolved_image: published.as_ref().map(|published| published.image.clone()),
+        mixins: args.pinned_mixins,
         name: args.name,
         policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user,
@@ -1137,6 +1156,7 @@ mod tests {
             "registry.example.test/team/sandbox:1",
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d".into()],
+                pinned_mixins: vec!["ghcr.io/acme/obs@sha256:5b9e1f0a".into()],
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: digest.clone(),
                 image: "registry.example.test/runtime:1".into(),
@@ -1192,6 +1212,11 @@ mod tests {
             }]
         );
         assert_eq!(
+            target.pinned_mixins,
+            ["ghcr.io/acme/obs@sha256:5b9e1f0a"],
+            "the run boots the digest its preflight pinned, and this is the only hop that carries it there"
+        );
+        assert_eq!(
             target.mixins,
             ["ghcr.io/acme/postgres-tools@sha256:c41e8b7d"],
             "the run summary names what a composed sandbox resolved into, and this is the only hop that carries it there"
@@ -1217,6 +1242,7 @@ mod tests {
             "registry.example.test/team/sandbox:1",
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: String::new(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -267,20 +267,13 @@ pub async fn run_image(
         _ => Vec::new(),
     };
     // Only a pulled sandbox resolves its mixins today; a local document still declares them and is refused.
-    args.pinned_mixins = published
-        .as_ref()
-        .map(|published| published.pinned_mixins.clone())
-        .unwrap_or_default();
-    args.resolved_mixins = published
-        .as_ref()
-        .map(|published| {
-            crate::run::summary::mixin_display(
-                &published.mixins,
-                &args.mixins,
-                &published.pinned_mixins,
-            )
-        })
-        .unwrap_or_default();
+    if let Some(published) = published.as_ref() {
+        crate::run::summary::adopt_pinned_mixins(
+            &mut args,
+            &published.mixins,
+            &published.pinned_mixins,
+        );
+    }
     // The size travels as its own value: writing it back into args.cpus/args.mem would tell the service the user asked for it explicitly.
     let size = crate::run::summary::resolved_size(defaults.size, &args);
     let quiet = args.quiet;
@@ -351,7 +344,7 @@ pub async fn run_image(
         env: args.env,
         image: Some(target.image()),
         resolved_image: published.as_ref().map(|published| published.image.clone()),
-        mixins: args.pinned_mixins,
+        mixins: args.mixins,
         name: args.name,
         policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user,

--- a/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
@@ -55,6 +55,12 @@ Feature: inspecting a typed artifact before running it
     Then the exit code is 0
     And the output contains "credential: SOME_TOKEN -> api.some-provider.example"
 
+  Scenario: a mixin the user names reads as the tag and the digest it pinned to
+    Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox the user's mixin "obs-tools:2" resolved into "ghcr.io/acme/obs@sha256:5b9e1f0a7c3d284e6b15f907a2c8d63b40e19a7c25f8b0d3e6a94c17f582aa41"
+    When the user runs "lns inspect registry.example.test/some-sandbox:1.0 --mixin obs-tools:2"
+    Then the exit code is 0
+    And the output contains "mixin: obs-tools:2 → ghcr.io/acme/obs@sha256:5b9e1f0a7c3d284e6b15f907a2c8d63b40e19a7c25f8b0d3e6a94c17f582aa41"
+
   Scenario: inspecting a published sandbox names the mixins it resolved into
     Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox resolved from the mixin "ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582"
     When the user runs "lns inspect registry.example.test/some-sandbox:1.0"

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -89,6 +89,7 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
 fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -121,6 +122,7 @@ fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount
 fn pulled_view_with_inline_fileset(world: &mut BehaviourWorld, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -283,6 +285,7 @@ fn command_fails_naming(world: &mut BehaviourWorld, needle: String) -> Result<()
 fn pulled_view_with_host_path_fileset(world: &mut BehaviourWorld, source: String, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -38,6 +38,7 @@ fn definition(world: &BehaviourWorld) -> lns_artifact::sandbox::Definition {
 fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxView {
     lns_ipc::SandboxView {
         mixins: def.spec.mixins.clone(),
+        pinned_mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -179,6 +179,7 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
     );
     lns_ipc::SandboxView {
         mixins: def.spec.mixins.clone(),
+        pinned_mixins: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -67,6 +67,7 @@ fn validation_fails_naming_shape(w: &mut BehaviourWorld) -> Result<(), String> {
 fn published_sandbox_declaring_tools(w: &mut BehaviourWorld) {
     let view = SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: TOOLS_REFERENCE.into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -101,6 +102,7 @@ async fn run_inspect_on_its_reference(w: &mut BehaviourWorld) {
     let result = run_with_writers(
         &SandboxCommand::Inspect(lns_cli::sandbox::SandboxInspectArgs {
             run: Some(TOOLS_REFERENCE.into()),
+            mixins: Vec::new(),
             file: None,
         }),
         &svc,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -320,6 +320,7 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &SandboxCommand) {
             cwd,
             args.run.as_deref(),
             args.file.as_deref(),
+            &args.mixins,
             &mut out,
         ),
         _ => unreachable!("run_author_verb is only called for the offline author verbs"),
@@ -480,7 +481,7 @@ fn service_received_no_pull(w: &mut BehaviourWorld) {
 fn pull_is_bound_to_inspected_digest(w: &mut BehaviourWorld) {
     let requests = w.sandbox.requests.lock().unwrap();
     let inspected = requests.iter().find_map(|request| match request {
-        Request::InspectImage { image } => Some(image),
+        Request::InspectImage { image, .. } => Some(image),
         _ => None,
     });
     let pulled = requests.iter().find_map(|request| match request {
@@ -547,14 +548,24 @@ pub(crate) fn fake_sandbox_service(w: &BehaviourWorld) -> FakeSandboxService {
 }
 
 #[when(regex = r#"^the user runs "lns inspect ([^"]+)"$"#)]
-async fn run_lns_inspect(w: &mut BehaviourWorld, reference: String) {
+async fn run_lns_inspect(w: &mut BehaviourWorld, tail: String) {
+    let mut reference = None;
+    let mut mixins = Vec::new();
+    let mut words = tail.split_whitespace();
+    while let Some(word) = words.next() {
+        match word {
+            "--mixin" => mixins.extend(words.next().map(str::to_string)),
+            target => reference = Some(target.to_string()),
+        }
+    }
     let svc = fake_sandbox_service(w);
     let mut out: Vec<u8> = Vec::new();
     let mut stdout: Vec<u8> = Vec::new();
     let mut stderr: Vec<u8> = Vec::new();
     let result = run_with_writers(
         &SandboxCommand::Inspect(lns_cli::sandbox::SandboxInspectArgs {
-            run: Some(reference),
+            run: reference,
+            mixins,
             file: None,
         }),
         &svc,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -33,6 +33,7 @@ fn inspects_plain_image(world: &mut BehaviourWorld, reference: String) {
 fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -75,6 +76,7 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
 fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -104,6 +106,37 @@ fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
 }
 
 #[given(
+    regex = r#"^the service inspects "([^"]+)" as a sandbox the user's mixin "([^"]+)" resolved into "([^"]+)"$"#
+)]
+fn inspects_sandbox_with_a_pinned_flag_mixin(
+    world: &mut BehaviourWorld,
+    reference: String,
+    _tag: String,
+    pinned: String,
+) {
+    let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
+        mixins: vec![pinned.clone()],
+        pinned_mixins: vec![pinned],
+        reference: reference.clone(),
+        digest: full_digest(),
+        image: "registry.example.test/runtime:1".into(),
+        workdir: None,
+        user: None,
+        mounts: Vec::new(),
+        ports: Vec::new(),
+        filesets: Vec::new(),
+        connectors: Vec::new(),
+        env: Vec::new(),
+        credentials: Vec::new(),
+        tools: Vec::new(),
+        policy_flags: Vec::new(),
+        cpus: None,
+        mem_mib: None,
+    }));
+    cached_artifact(world, &reference, inspection);
+}
+
+#[given(
     regex = r#"^the service inspects "([^"]+)" as a sandbox resolved from the mixin "([^"]+)"$"#
 )]
 fn inspects_sandbox_resolved_from_a_mixin(
@@ -113,6 +146,7 @@ fn inspects_sandbox_resolved_from_a_mixin(
 ) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: vec![mixin],
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -138,6 +172,7 @@ fn inspects_sandbox_resolved_from_a_mixin(
 fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, mount: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -172,6 +207,7 @@ fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, moun
 fn inspects_sandbox_user(world: &mut BehaviourWorld, reference: String, user: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -202,6 +238,7 @@ fn inspects_sandbox_credential(
 ) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -235,6 +272,7 @@ fn inspects_sandbox_credential(
 fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -260,6 +298,7 @@ fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: Str
 fn inspects_sandbox_env(world: &mut BehaviourWorld, reference: String, entry: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
+        pinned_mixins: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -35,6 +35,7 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             reference,
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -64,6 +64,7 @@ fn registry_serves_sandbox(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
             mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             reference,
             digest,
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -90,6 +90,9 @@ pub enum Request {
     PruneImages,
     InspectImage {
         image: String,
+        /// The mixin references the user named on the command line, in flag order, so the preflight describes the document that will boot.
+        #[serde(default)]
+        mixins: Vec<String>,
     },
     TagImage {
         from: String,
@@ -274,6 +277,9 @@ pub struct SandboxView {
     /// The mixins this sandbox resolved into, since the merged document declares none of its own.
     #[serde(default)]
     pub mixins: Vec<String>,
+    /// What each mixin the user named resolved to, in the order they named them, so the run boots the bytes its preflight pinned.
+    #[serde(default)]
+    pub pinned_mixins: Vec<String>,
     #[serde(default)]
     pub workdir: Option<String>,
     /// The run-as user the sandbox declared, so a pulled artifact asking for root is visible before it boots.
@@ -457,6 +463,9 @@ pub struct RunImageArgs {
     pub image: Option<String>,
     #[serde(default)]
     pub resolved_image: Option<String>,
+    /// The mixins the preflight pinned, in the order the user named them; the run merges these, never a reference it has not resolved itself.
+    #[serde(default)]
+    pub mixins: Vec<String>,
     #[serde(default)]
     pub name: Option<String>,
     pub cpus: u8,
@@ -814,6 +823,7 @@ mod tests {
         let req = Request::RunImage(Box::new(RunImageArgs {
             image: Some("prism".into()),
             resolved_image: None,
+            mixins: Vec::new(),
             name: None,
             cpus: 1,
             mem: 512,
@@ -850,6 +860,7 @@ mod tests {
         let args = RunImageArgs {
             image: Some("ubuntu".into()),
             resolved_image: Some(format!("ubuntu@sha256:{}", "a".repeat(64))),
+            mixins: Vec::new(),
             name: None,
             cpus: 1,
             mem: 512,
@@ -979,6 +990,7 @@ mod tests {
         RunImageArgs {
             image: Some("some-image:1".into()),
             resolved_image: None,
+            mixins: Vec::new(),
             name: None,
             cpus: 2,
             mem: 1024,
@@ -1334,6 +1346,24 @@ mod tests {
     }
 
     #[test]
+    fn an_inspect_request_carries_the_mixins_the_user_named_and_defaults_to_none() {
+        let req = Request::InspectImage {
+            image: "registry.example.test/team/sandbox:1".into(),
+            mixins: vec!["ghcr.io/acme/obs-tools:2".into()],
+        };
+        let frame = crate::encode_frame(&req).unwrap();
+        let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, req);
+        let bare: Request =
+            serde_json::from_str(r#"{"type":"InspectImage","image":"registry.example.test/x:1"}"#)
+                .expect("an inspect naming no mixin decodes");
+        assert!(
+            matches!(bare, Request::InspectImage { ref mixins, .. } if mixins.is_empty()),
+            "an inspect with no flag asks about the artifact alone, so it must not invent a source the user never named"
+        );
+    }
+
+    #[test]
     fn registry_login_request_survives_a_round_trip() {
         let req = Request::RegistryLogin {
             registry: "ghcr.io".into(),
@@ -1374,6 +1404,7 @@ mod tests {
     fn sandbox_view_round_trips_declarative_launch_settings() {
         let view = SandboxView {
             mixins: vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582".into()],
+            pinned_mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:1".into(),
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -26,8 +26,7 @@ pub(crate) fn project_inspection(
     digest: String,
     artifact_type: Option<&str>,
     config_media_type: &str,
-    config_json: &[u8],
-    mixins: &[String],
+    resolution: &crate::artifact::mixin::Resolution,
     host: Option<lns_artifact::resources::HostCapacity>,
 ) -> Result<ArtifactInspection> {
     match dispatch(artifact_type, Some(config_media_type))? {
@@ -36,7 +35,7 @@ pub(crate) fn project_inspection(
             digest,
         })),
         RunPath::Sandbox => {
-            let def = lns_artifact::sandbox::parse(config_json)
+            let def = lns_artifact::sandbox::parse(&resolution.document)
                 .with_context(|| format!("inspecting sandbox {image_ref}"))?;
             let resolved = resolved_from_sandbox(&def);
             let (declared_size, _) = lns_artifact::resources::DeclaredSize::from_resources(
@@ -45,7 +44,8 @@ pub(crate) fn project_inspection(
             );
             Ok(ArtifactInspection::Sandbox(Box::new(
                 lns_ipc::SandboxView {
-                    mixins: mixins.to_vec(),
+                    mixins: resolution.mixins.clone(),
+                    pinned_mixins: resolution.pinned_extra.clone(),
                     reference: image_ref.to_string(),
                     digest,
                     cpus: declared_size.cpus,
@@ -132,6 +132,14 @@ mod tests {
             mem_mib: 16384,
         };
 
+    fn resolution(config: &str, mixins: &[String]) -> crate::artifact::mixin::Resolution {
+        crate::artifact::mixin::Resolution {
+            document: config.as_bytes().to_vec(),
+            mixins: mixins.to_vec(),
+            pinned_extra: Vec::new(),
+        }
+    }
+
     fn project_sandbox(config: &str) -> Result<ArtifactInspection> {
         project_sandbox_on(config, None)
     }
@@ -155,8 +163,7 @@ mod tests {
             digest(),
             Some(&artifact_type),
             &config_media_type,
-            config.as_bytes(),
-            mixins,
+            &resolution(config, mixins),
             host,
         )
     }
@@ -168,8 +175,7 @@ mod tests {
             digest(),
             None,
             "application/vnd.oci.image.config.v1+json",
-            b"{}",
-            &[],
+            &resolution("{}", &[]),
             None,
         )
         .unwrap();
@@ -190,8 +196,7 @@ mod tests {
             digest(),
             Some("application/vnd.acme.thing"),
             "application/vnd.oci.image.config.v1+json",
-            b"{}",
-            &[],
+            &resolution("{}", &[]),
             None,
         )
         .unwrap_err();
@@ -228,6 +233,7 @@ mod tests {
     ) -> ArtifactInspection {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -246,9 +252,10 @@ mod tests {
         }))
     }
 
-    fn sandbox_view_with_mixins(mixins: Vec<String>) -> ArtifactInspection {
+    fn sandbox_view_with_mixins(mixins: Vec<String>, pinned: Vec<String>) -> ArtifactInspection {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins,
+            pinned_mixins: pinned,
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -270,6 +277,7 @@ mod tests {
     fn sandbox_view_with_filesets(filesets: Vec<SandboxFileset>) -> ArtifactInspection {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
+            pinned_mixins: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -289,6 +297,29 @@ mod tests {
     }
 
     #[test]
+    fn a_view_separates_what_the_user_named_from_everything_the_merge_reached() {
+        let pinned = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        let declared = format!("ghcr.io/acme/base@sha256:{}", "a".repeat(64));
+        assert_eq!(
+            project_inspection(
+                "registry.example.test/team/sandbox:latest",
+                digest(),
+                Some(&lns_artifact::spec::Kind::Sandbox.artifact_type()),
+                &lns_artifact::spec::Kind::Sandbox.config_media_type(),
+                &crate::artifact::mixin::Resolution {
+                    document: br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1"}}"#.to_vec(),
+                    mixins: vec![declared.clone(), pinned.clone()],
+                    pinned_extra: vec![pinned.clone()],
+                },
+                None,
+            )
+            .unwrap(),
+            sandbox_view_with_mixins(vec![declared, pinned.clone()], vec![pinned]),
+            "only the references the user named can be shown beside the tag they typed, so the two lists cannot be one"
+        );
+    }
+
+    #[test]
     fn a_sandbox_projects_the_mixins_it_resolved_into_so_inspect_and_run_answer_alike() {
         let pinned = format!("ghcr.io/acme/postgres-tools@sha256:{}", "c".repeat(64));
         assert_eq!(
@@ -298,7 +329,7 @@ mod tests {
                 None,
             )
             .unwrap(),
-            sandbox_view_with_mixins(vec![pinned]),
+            sandbox_view_with_mixins(vec![pinned], Vec::new()),
             "the resolved document declares no mixins of its own, so only the list travelling beside it can tell a reader what this sandbox layers on"
         );
     }
@@ -430,6 +461,7 @@ mod tests {
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -509,6 +541,7 @@ mod tests {
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -546,6 +579,7 @@ mod tests {
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -575,6 +609,7 @@ mod tests {
             inspection,
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
+                pinned_mixins: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -4,9 +4,19 @@ use anyhow::{Context, Result, bail};
 use lns_artifact::merge::{MAX_DEPTH, Source, flatten, merge};
 use lns_artifact::sandbox::{Definition, SandboxSpec};
 
-/// Where a declared mixin's document comes from: a registry for a digest-pinned reference, the local filesystem for a directory beside the definition.
+/// A mixin's document and the reference that names exactly those bytes, since a user may ask for one by tag and what they approve has to name the bytes.
+#[derive(Debug)]
+pub struct FetchedMixin {
+    pub pinned: String,
+    pub document: String,
+}
+
+/// Where a mixin's document comes from: a registry for a digest-pinned reference, the local filesystem for a directory beside the definition.
 pub trait MixinSource: Send + Sync {
-    fn fetch(&self, reference: &str) -> impl std::future::Future<Output = Result<String>> + Send;
+    fn fetch(
+        &self,
+        reference: &str,
+    ) -> impl std::future::Future<Output = Result<FetchedMixin>> + Send;
 }
 
 /// Whether a pulled manifest is a mixin artifact, decided on the media types alone so the refusal reads the same whether the artifact is mistyped or another kind entirely.
@@ -18,38 +28,103 @@ pub fn is_a_mixin_artifact(artifact_type: Option<&str>, config_media_type: Optio
     }
 }
 
+/// The graph every ordering rule decides against, keyed by the pinned reference each source resolved to, with every reference that names a source translated to the same key.
+struct Fetched {
+    graph: BTreeMap<String, SandboxSpec>,
+    pinned_roots: Vec<String>,
+    pinned_extra: Vec<String>,
+}
+
+/// What one walk of the graph carries: the sources fetched so far, keyed by the reference that pins them, and the references still to visit.
+struct Walk {
+    graph: BTreeMap<String, SandboxSpec>,
+    pins: BTreeMap<String, String>,
+    frontier: Vec<String>,
+}
+
 /// Fetch every mixin the ordering rules can reach, so they decide against a complete graph rather than one that is still arriving.
 async fn collect<S: MixinSource>(
     roots: &[String],
+    extra: &[String],
     source: &S,
-) -> Result<BTreeMap<String, SandboxSpec>> {
-    let mut graph: BTreeMap<String, SandboxSpec> = BTreeMap::new();
-    let mut frontier: Vec<String> = roots.to_vec();
-    let mut depth = 1;
-    while !frontier.is_empty() && depth <= MAX_DEPTH {
-        let mut next = Vec::new();
-        for reference in frontier {
-            if graph.contains_key(&reference) {
-                continue;
-            }
-            if lns_artifact::sandbox::names_a_local_directory(&reference) {
-                bail!(
-                    "mixin {reference} names a local directory, which has no meaning on the machine that pulled this sandbox; a published document pins every mixin by digest"
-                );
-            }
-            let document = source
-                .fetch(&reference)
-                .await
-                .with_context(|| format!("resolving mixin {reference}"))?;
-            let mixin = lns_artifact::sandbox::parse_mixin(document.as_bytes())
-                .with_context(|| format!("reading mixin {reference}"))?;
-            next.extend(mixin.spec.mixins.iter().cloned());
-            graph.insert(reference, mixin.spec);
+) -> Result<Fetched> {
+    let mut walk = Walk {
+        graph: BTreeMap::new(),
+        pins: BTreeMap::new(),
+        frontier: Vec::new(),
+    };
+    let mut pinned_extra = Vec::new();
+    for reference in extra {
+        pinned_extra.push(visit(&mut walk, reference, true, source).await?);
+    }
+    for reference in roots {
+        visit(&mut walk, reference, false, source).await?;
+    }
+    let mut depth = 2;
+    while !walk.frontier.is_empty() && depth <= MAX_DEPTH {
+        for reference in std::mem::take(&mut walk.frontier) {
+            visit(&mut walk, &reference, false, source).await?;
         }
-        frontier = next;
         depth += 1;
     }
-    Ok(graph)
+    let mut graph = walk.graph;
+    for spec in graph.values_mut() {
+        spec.mixins = pinned(&spec.mixins, &walk.pins);
+    }
+    Ok(Fetched {
+        pinned_roots: pinned(roots, &walk.pins),
+        graph,
+        pinned_extra,
+    })
+}
+
+/// Say every reference the way the registry answered for it, so the walk and the graph agree on one identity per source; a reference nothing fetched is left alone for the depth limit to refuse.
+fn pinned(references: &[String], pins: &BTreeMap<String, String>) -> Vec<String> {
+    references
+        .iter()
+        .map(|reference| pins.get(reference).unwrap_or(reference).clone())
+        .collect()
+}
+
+/// Fetch one reference and answer with what pins it, reading each reference once however many documents name it.
+async fn visit<S: MixinSource>(
+    walk: &mut Walk,
+    reference: &str,
+    the_user_named_it: bool,
+    source: &S,
+) -> Result<String> {
+    if let Some(pinned) = walk.pins.get(reference) {
+        return Ok(pinned.clone());
+    }
+    refuse_a_directory(reference, the_user_named_it)?;
+    let fetched = source
+        .fetch(reference)
+        .await
+        .with_context(|| format!("resolving mixin {reference}"))?;
+    walk.pins
+        .insert(reference.to_string(), fetched.pinned.clone());
+    if !walk.graph.contains_key(&fetched.pinned) {
+        let mixin = lns_artifact::sandbox::parse_mixin(fetched.document.as_bytes())
+            .with_context(|| format!("reading mixin {reference}"))?;
+        walk.frontier.extend(mixin.spec.mixins.iter().cloned());
+        walk.graph.insert(fetched.pinned.clone(), mixin.spec);
+    }
+    Ok(fetched.pinned)
+}
+
+/// A directory has no published identity, so neither kind of reference may name one — but only one of them is the user's to correct.
+fn refuse_a_directory(reference: &str, the_user_named_it: bool) -> Result<()> {
+    if !lns_artifact::sandbox::names_a_local_directory(reference) {
+        return Ok(());
+    }
+    if the_user_named_it {
+        bail!(
+            "mixin {reference} cannot name a local directory: a run merges published bytes, so name a reference the disclosure can pin"
+        );
+    }
+    bail!(
+        "mixin {reference} names a local directory, which has no meaning on the machine that pulled this sandbox; a published document pins every mixin by digest"
+    )
 }
 
 /// Resolve a pulled artifact's mixins when it is a sandbox; a plain image has no document to merge and is returned untouched.
@@ -57,18 +132,21 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
     artifact_type: Option<&str>,
     config_media_type: Option<&str>,
     config_json: &[u8],
+    extra: &[String],
     source: &S,
 ) -> Result<Resolution> {
     if !matches!(
         crate::artifact::dispatch(artifact_type, config_media_type),
         Ok(crate::artifact::RunPath::Sandbox)
     ) {
+        refuse_mixins_without_a_document(extra)?;
         return Ok(Resolution {
             document: config_json.to_vec(),
             mixins: Vec::new(),
+            pinned_extra: Vec::new(),
         });
     }
-    resolve(config_json, source).await
+    resolve(config_json, extra, source).await
 }
 
 /// What a run boots, and the mixins that produced it — the merged document declares none of its own, so the references travel beside it.
@@ -76,20 +154,29 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
 pub struct Resolution {
     pub document: Vec<u8>,
     pub mixins: Vec<String>,
+    /// What each reference the user named resolved to, in the order they named them, so the boot merges the bytes the preflight showed.
+    pub pinned_extra: Vec<String>,
 }
 
 /// Resolve a published definition and every mixin it layers on into the one document a run boots (`docs/sandbox-spec.md` §3.3), returned as a definition the rest of the plan path reads exactly as it reads an authored one.
-pub async fn resolve<S: MixinSource>(config_json: &[u8], source: &S) -> Result<Resolution> {
+pub async fn resolve<S: MixinSource>(
+    config_json: &[u8],
+    extra: &[String],
+    source: &S,
+) -> Result<Resolution> {
     let def = lns_artifact::sandbox::parse(config_json)
         .context("reading the published sandbox document")?;
-    if def.spec.mixins.is_empty() {
+    if def.spec.mixins.is_empty() && extra.is_empty() {
         return Ok(Resolution {
             document: config_json.to_vec(),
             mixins: Vec::new(),
+            pinned_extra: Vec::new(),
         });
     }
-    let graph = collect(&def.spec.mixins, source).await?;
-    let sources = flatten(&def.spec, &[], &graph)?;
+    let fetched = collect(&def.spec.mixins, extra, source).await?;
+    let mut root = def.spec.clone();
+    root.mixins = fetched.pinned_roots;
+    let sources = flatten(&root, &fetched.pinned_extra, &fetched.graph)?;
     let merged = merge(&sources)?;
     let document = document(&def, &merged.spec)?;
     refuse_what_no_sandbox_could_be(&document, &sources)?;
@@ -100,7 +187,32 @@ pub async fn resolve<S: MixinSource>(config_json: &[u8], source: &S) -> Result<R
             .skip(1)
             .map(|source| source.label.clone())
             .collect(),
+        pinned_extra: fetched.pinned_extra,
     })
+}
+
+/// Only a sandbox document has blocks to merge into, so a run of anything else has to refuse what it was given rather than boot without it.
+pub fn refuse_mixins_without_a_document(extra: &[String]) -> Result<()> {
+    if extra.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "this reference has no sandbox document to merge into, so it cannot take the {} mixin(s) named for it",
+        extra.len()
+    )
+}
+
+/// The preflight pins what it showed, and the boot merges that — so a reference reaching the boot unpinned was never disclosed, whoever sent it.
+pub fn require_pinned_extras(extra: &[String]) -> Result<()> {
+    match extra
+        .iter()
+        .find(|reference| !lns_artifact::spec::is_digest_pinned_image(reference))
+    {
+        None => Ok(()),
+        Some(unpinned) => bail!(
+            "mixin {unpinned} reached the run unpinned; a run merges the digest its preflight showed, so pin it by digest"
+        ),
+    }
 }
 
 /// The resolved document is what boots, so it has to be one an author could have written — an override is normal, but its result still has to hold.
@@ -130,6 +242,7 @@ mod tests {
 
     struct Fake {
         documents: BTreeMap<String, String>,
+        pins: BTreeMap<String, String>,
         fetched: Mutex<Vec<String>>,
     }
 
@@ -147,21 +260,36 @@ mod tests {
                         )
                     })
                     .collect(),
+                pins: BTreeMap::new(),
                 fetched: Mutex::new(Vec::new()),
             }
+        }
+
+        fn pinning(mut self, reference: &str, pinned: &str) -> Self {
+            self.pins.insert(reference.to_string(), pinned.to_string());
+            self
         }
     }
 
     impl MixinSource for Fake {
-        async fn fetch(&self, reference: &str) -> Result<String> {
+        async fn fetch(&self, reference: &str) -> Result<FetchedMixin> {
             self.fetched
                 .lock()
                 .expect("fetch log poisoned")
                 .push(reference.to_string());
-            self.documents
+            let document = self
+                .documents
                 .get(reference)
                 .cloned()
-                .ok_or_else(|| anyhow::anyhow!("no such mixin here"))
+                .ok_or_else(|| anyhow::anyhow!("no such mixin here"))?;
+            Ok(FetchedMixin {
+                pinned: self
+                    .pins
+                    .get(reference)
+                    .cloned()
+                    .unwrap_or_else(|| reference.to_string()),
+                document,
+            })
         }
     }
 
@@ -204,7 +332,7 @@ mod tests {
             .iter()
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
-        let out = resolve(&sandbox(&spec), &Fake::new(&refs)).await?;
+        let out = resolve(&sandbox(&spec), &[], &Fake::new(&refs)).await?;
         lns_artifact::sandbox::parse(&out.document)
     }
 
@@ -212,7 +340,7 @@ mod tests {
     async fn a_document_with_no_mixins_is_returned_untouched() {
         let source = Fake::new(&[]);
         let original = sandbox(r#"{"image":"x:1"}"#);
-        let out = resolve(&original, &source).await.unwrap();
+        let out = resolve(&original, &[], &source).await.unwrap();
         assert_eq!(
             out.document, original,
             "nothing to resolve means nothing to rewrite"
@@ -231,7 +359,7 @@ mod tests {
     #[tokio::test]
     async fn a_plain_image_is_passed_through_without_a_fetch() {
         let source = Fake::new(&[]);
-        let out = resolve_if_a_sandbox(None, None, b"{}", &source)
+        let out = resolve_if_a_sandbox(None, None, b"{}", &[], &source)
             .await
             .expect("an image has no document to merge");
         assert_eq!(out.document, b"{}");
@@ -251,6 +379,7 @@ mod tests {
             Some(&sandbox_type),
             None,
             &sandbox(r#"{"image":"x:1"}"#),
+            &[],
             &Fake::new(&[]),
         )
         .await
@@ -309,7 +438,7 @@ mod tests {
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
         let source = Fake::new(&refs);
-        let resolution = resolve(&sandbox(&spec), &source)
+        let resolution = resolve(&sandbox(&spec), &[], &source)
             .await
             .expect("a diamond resolves");
         assert_eq!(
@@ -331,6 +460,7 @@ mod tests {
         let absent = pinned("absent");
         let err = resolve(
             &sandbox(&format!(r#"{{"image":"x:1","mixins":["{absent}"]}}"#)),
+            &[],
             &Fake::new(&[]),
         )
         .await
@@ -345,6 +475,7 @@ mod tests {
     async fn a_reference_that_is_not_a_mixin_document_refuses_the_run() {
         let reference = pinned("a-sandbox");
         let source = Fake {
+            pins: BTreeMap::new(),
             documents: BTreeMap::from([(
                 reference.clone(),
                 String::from_utf8(sandbox(r#"{"image":"x:1"}"#)).expect("utf-8 fixture"),
@@ -353,6 +484,7 @@ mod tests {
         };
         let err = resolve(
             &sandbox(&format!(r#"{{"image":"x:1","mixins":["{reference}"]}}"#)),
+            &[],
             &source,
         )
         .await
@@ -367,6 +499,7 @@ mod tests {
     async fn a_local_directory_reached_from_a_published_document_refuses_the_run() {
         let err = resolve(
             &sandbox(r#"{"image":"x:1","mixins":["./mixins/postgres-tools/"]}"#),
+            &[],
             &Fake::new(&[]),
         )
         .await
@@ -414,7 +547,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_document_that_will_not_parse_is_blamed_on_itself_and_not_on_its_mixins() {
-        let err = resolve(b"{}", &Fake::new(&[])).await.unwrap_err();
+        let err = resolve(b"{}", &[], &Fake::new(&[])).await.unwrap_err();
         assert!(
             format!("{err:#}").contains("reading the published sandbox document"),
             "a document that will not parse has no mixins to blame, and naming them sends a publisher looking in the wrong place; got: {err:#}"
@@ -432,6 +565,82 @@ mod tests {
         assert!(
             format!("{err:#}").contains("both publish host port 18080"),
             "ports merge by container number, so two sources can claim one host port without either document repeating one, and the run has to refuse rather than silently unpublish one of them; got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plain_image_refuses_the_mixins_the_user_named_rather_than_dropping_them() {
+        let sandbox_only = resolve_if_a_sandbox(None, None, b"{}", &[pinned("m")], &Fake::new(&[]))
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{sandbox_only:#}").contains("no sandbox document to merge into"),
+            "an image has nothing to merge, so silently running it without what the user asked for is the refusal this exists to make; got: {sandbox_only:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_declared_pin_the_registry_renders_differently_still_resolves() {
+        let declared = format!("ghcr.io/acme/m:17@sha256:{}", "c".repeat(64));
+        let rendered = format!("ghcr.io/acme/m@sha256:{}", "c".repeat(64));
+        let source = Fake::new(&[(declared.as_str(), r#"{"tools":["python@3.12"]}"#)])
+            .pinning(&declared, &rendered);
+        let out = resolve(
+            &sandbox(&format!(r#"{{"image":"x:1","mixins":["{declared}"]}}"#)),
+            &[],
+            &source,
+        )
+        .await
+        .expect("a document may pin a mixin in any form the registry accepts");
+        assert_eq!(
+            out.mixins,
+            [rendered],
+            "the disclosure names the identity the registry answered with, and the declared spelling has to reach it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_tag_the_user_names_reaches_the_merge_pinned() {
+        let tagged = "ghcr.io/acme/obs-tools:2";
+        let source =
+            Fake::new(&[(tagged, r#"{"tools":["python@3.12"]}"#)]).pinning(tagged, &pinned("obs"));
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1"}"#),
+            &[tagged.to_string()],
+            &source,
+        )
+        .await
+        .expect("a tag resolves");
+        assert_eq!(
+            out.pinned_extra,
+            [pinned("obs")],
+            "the boot merges what the preflight pinned, so the tag has to be answered here and not resolved twice"
+        );
+        assert_eq!(
+            out.mixins,
+            [pinned("obs")],
+            "the disclosure names bytes, so a tag that reached it unresolved could move after the user approved it"
+        );
+    }
+
+    #[test]
+    fn a_run_with_no_document_to_merge_into_refuses_the_mixins_named_for_it() {
+        refuse_mixins_without_a_document(&[]).expect("a run naming none is untouched");
+        let err = refuse_mixins_without_a_document(&[pinned("m")]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("no sandbox document to merge into"),
+            "a plain image has no blocks to merge, so running it while dropping what the request named would be a silent lie; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_reference_reaching_the_run_unpinned_is_refused_before_it_merges() {
+        require_pinned_extras(&[pinned("m")])
+            .expect("a pinned reference is what a preflight sends");
+        let err = require_pinned_extras(&["ghcr.io/acme/obs-tools:2".to_string()]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("reached the run unpinned"),
+            "a client that skipped the preflight would boot bytes nobody disclosed; got: {err:#}"
         );
     }
 

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -19,6 +19,7 @@ pub(crate) struct SandboxPlan {
 pub(crate) async fn peek_and_plan(
     image_ref: &str,
     verify_sandbox: bool,
+    mixins: &[String],
     run_id: &str,
     microvm: &str,
 ) -> Result<Option<SandboxPlan>> {
@@ -38,12 +39,17 @@ pub(crate) async fn peek_and_plan(
         image_ref,
         verify_sandbox,
     )? {
-        RunPath::SingleImage => Ok(None),
+        RunPath::SingleImage => {
+            crate::artifact::mixin::refuse_mixins_without_a_document(mixins)?;
+            Ok(None)
+        }
         RunPath::Sandbox => {
-            let document = crate::artifact::mixin::resolve(config_json.as_bytes(), &RegistryMixins)
-                .await
-                .with_context(|| format!("resolving {image_ref}"))?
-                .document;
+            crate::artifact::mixin::require_pinned_extras(mixins)?;
+            let document =
+                crate::artifact::mixin::resolve(config_json.as_bytes(), mixins, &RegistryMixins)
+                    .await
+                    .with_context(|| format!("resolving {image_ref}"))?
+                    .document;
             let resolved = crate::artifact::plan_published_sandbox(&document, image_ref)?;
             record_sandbox_run(run_id, microvm, image_ref, &digest, &resolved);
             crate::image_store::record_artifact_run(image_ref, &digest, &resolved.base_image)
@@ -167,7 +173,7 @@ pub(crate) fn refuse_unknown_connectors(policy: Option<&lns_policy::Policy>) -> 
 pub(crate) struct RegistryMixins;
 
 impl crate::artifact::mixin::MixinSource for RegistryMixins {
-    async fn fetch(&self, reference: &str) -> Result<String> {
+    async fn fetch(&self, reference: &str) -> Result<crate::artifact::mixin::FetchedMixin> {
         let registry = crate::image::caching_registry_for(reference)?;
         crate::image::pull_mixin_with(&registry, reference).await
     }
@@ -322,7 +328,7 @@ fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     }
 }
 
-pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
+pub(crate) async fn inspect(image_ref: &str, mixins: &[String]) -> Result<ArtifactInspection> {
     let reference: Reference = image_ref
         .parse()
         .with_context(|| format!("invalid image reference {image_ref}"))?;
@@ -337,6 +343,7 @@ pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
         manifest.artifact_type.as_deref(),
         Some(manifest.config.media_type.as_str()),
         config_json.as_bytes(),
+        mixins,
         &RegistryMixins,
     )
     .await
@@ -346,8 +353,7 @@ pub(crate) async fn inspect(image_ref: &str) -> Result<ArtifactInspection> {
         digest,
         manifest.artifact_type.as_deref(),
         &manifest.config.media_type,
-        &resolution.document,
-        &resolution.mixins,
+        &resolution,
         lns_artifact::resources::host::probe(),
     )
 }

--- a/crates/lns-service/src/image/mod.rs
+++ b/crates/lns-service/src/image/mod.rs
@@ -277,7 +277,10 @@ pub(crate) async fn pull_sandbox_with<R: Registry>(
 }
 
 /// Pull a declared mixin's document. The pin is verified before the type, because for a mixin the bytes are the identity: a reference that does not name exactly these bytes has nothing to be typed.
-pub(crate) async fn pull_mixin_with<R: Registry>(client: &R, reference: &str) -> Result<String> {
+pub(crate) async fn pull_mixin_with<R: Registry>(
+    client: &R,
+    reference: &str,
+) -> Result<crate::artifact::mixin::FetchedMixin> {
     let parsed: Reference = reference
         .parse()
         .with_context(|| format!("invalid mixin reference {reference}"))?;
@@ -289,7 +292,10 @@ pub(crate) async fn pull_mixin_with<R: Registry>(client: &R, reference: &str) ->
     ) {
         anyhow::bail!("{reference} is not a mixin artifact");
     }
-    Ok(config_json)
+    Ok(crate::artifact::mixin::FetchedMixin {
+        pinned: parsed.clone_with_digest(manifest_digest).to_string(),
+        document: config_json,
+    })
 }
 
 fn sandbox_pull_error(e: anyhow::Error) -> anyhow::Error {
@@ -1184,8 +1190,16 @@ mod tests {
         ensure_global_trace_subscriber();
         let registry = build_mixin_artifact().into_registry();
         let pinned = format!("registry.example.test/m@sha256:{}", "c".repeat(64));
-        let document = pull_mixin_with(&registry, &pinned).await.unwrap();
-        assert!(document.contains(r#""kind":"Mixin""#), "got: {document}");
+        let fetched = pull_mixin_with(&registry, &pinned).await.unwrap();
+        assert!(
+            fetched.document.contains(r#""kind":"Mixin""#),
+            "got: {}",
+            fetched.document
+        );
+        assert_eq!(
+            fetched.pinned, pinned,
+            "a reference that already names the bytes answers as itself"
+        );
         assert_eq!(
             registry.calls.lock().unwrap().as_slice(),
             ["manifest"],

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -212,8 +212,8 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
                     }),
             )
         }
-        Request::InspectImage { image } => image_response(
-            crate::artifact::real::inspect(image)
+        Request::InspectImage { image, mixins } => image_response(
+            crate::artifact::real::inspect(image, mixins)
                 .await
                 .map(|inspection| Response::ImageInspected { inspection }),
         ),
@@ -546,6 +546,7 @@ mod tests {
             &Request::RunImage(Box::new(lns_ipc::RunImageArgs {
                 image: None,
                 resolved_image: None,
+                mixins: Vec::new(),
                 name: None,
                 cpus: 1,
                 mem: 0,
@@ -2100,6 +2101,7 @@ mod tests {
             handle_request(
                 &Request::InspectImage {
                     image: "###".into(),
+                    mixins: Vec::new(),
                 },
                 Instant::now(),
             )

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -79,10 +79,19 @@ async fn orchestrate(
     // A local definition plans directly; a published sandbox reference boots its base image; a plain image passes through unchanged.
     let resolved_image = args.resolved_image.as_deref().or(args.image.as_deref());
     let sandbox_plan = match (args.definition.as_deref(), resolved_image) {
-        (Some(definition), _) => Some(crate::artifact::real::plan_local(definition).await?),
+        (Some(definition), _) => {
+            crate::artifact::mixin::refuse_mixins_without_a_document(&args.mixins)?;
+            Some(crate::artifact::real::plan_local(definition).await?)
+        }
         (None, Some(image_ref)) => {
-            crate::artifact::real::peek_and_plan(image_ref, args.verify_sandbox, &run_id, &microvm)
-                .await?
+            crate::artifact::real::peek_and_plan(
+                image_ref,
+                args.verify_sandbox,
+                &args.mixins,
+                &run_id,
+                &microvm,
+            )
+            .await?
         }
         (None, None) => None,
     };

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -33,4 +33,10 @@ pub struct DeclaredRig {
     pub mixins: std::collections::BTreeMap<String, String>,
     /// The tools the resolved document asks for, so a scenario can see what a mixin contributed.
     pub tools: Vec<String>,
+    /// What a reference resolves to, so a scenario can publish a mixin under a tag.
+    pub mixin_pins: std::collections::BTreeMap<String, String>,
+    /// Every source the resolution merged, as the disclosure names them.
+    pub resolved_mixins: Vec<String>,
+    /// The pins for the references the user named, in the order they named them.
+    pub pinned_extra: Vec<String>,
 }

--- a/crates/lns-service/tests/behaviours/mixin_flag.feature
+++ b/crates/lns-service/tests/behaviours/mixin_flag.feature
@@ -1,0 +1,30 @@
+Feature: a user adds their own mixins to a run
+  A run takes mixins the user names on the command line, on top of the ones the
+  document declares. They are the user's own live choice, so they come last and
+  beat everything the document said.
+
+  A reference the user types may be a tag, where a published document's may not.
+  The run pins it and reports the digest it resolved to, so what the user
+  approves names exact bytes.
+
+  Scenario: what the user adds reaches the run
+    Given a mixin declaring the tool "python@3.12"
+    When the published sandbox is resolved with that mixin added by the user
+    Then the run installs "python@3.12"
+
+  Scenario: what the user adds beats what the document declares
+    Given a mixin declaring the tool "node@22"
+    And the sandbox definition declares the tool "node@20"
+    When the published sandbox is resolved with that mixin added by the user
+    Then the run installs "node@22"
+
+  Scenario: a tag the user names is pinned before the run reports it
+    Given a mixin declaring the tool "python@3.12" published under the tag "obs-tools:2"
+    When the published sandbox is resolved with the user's mixin "obs-tools:2"
+    Then the resolution reports the mixin pinned by digest
+    And the resolution answers for the tag "obs-tools:2"
+
+  Scenario: a directory the user names refuses the run
+    When the published sandbox is resolved with the user's mixin "./obs-tools"
+    Then the launch is refused
+    And the error says a mixin the user named cannot be a directory

--- a/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
@@ -1,0 +1,100 @@
+use cucumber::{given, then, when};
+
+use crate::steps::mixin_resolution::{Installed, MIXIN, install_at};
+use crate::world::BehaviourWorld;
+
+/// What a tag the user names resolves to, since a registry answers for one under exact bytes.
+const PINNED_TAG: &str = "ghcr.io/acme/obs-tools@sha256:5b9e1f0a7c3d284e6b15f907a2c8d63b40e19a7c25f8b0d3e6a94c17f582aa41";
+
+#[given(regex = r#"^a mixin declaring the tool "([^"]+)" published under the tag "([^"]+)"$"#)]
+fn a_mixin_published_under_a_tag(w: &mut BehaviourWorld, tool: String, tag: String) {
+    install_at(w, &tag, "obs-tools", &format!(r#"{{"tools":["{tool}"]}}"#));
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.mixin_pins.insert(tag, PINNED_TAG.to_string());
+}
+
+#[given(regex = r#"^the sandbox definition declares the tool "([^"]+)"$"#)]
+fn the_definition_declares_a_tool(w: &mut BehaviourWorld, tool: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.definition = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","tools":["{tool}"]}}}}"#
+    ));
+}
+
+#[when("the published sandbox is resolved with that mixin added by the user")]
+async fn resolved_with_that_mixin_added(w: &mut BehaviourWorld) {
+    resolve_with(w, &[MIXIN.to_string()]).await;
+}
+
+#[when(regex = r#"^the published sandbox is resolved with the user's mixin "([^"]+)"$"#)]
+async fn resolved_with_the_users_mixin(w: &mut BehaviourWorld, reference: String) {
+    resolve_with(w, &[reference]).await;
+}
+
+async fn resolve_with(w: &mut BehaviourWorld, extra: &[String]) {
+    let (definition, installed) = {
+        let rig = w.declared.get_or_insert_with(Default::default);
+        let definition = rig.definition.clone().unwrap_or_else(|| {
+            r#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"hermes"},"spec":{"image":"ghcr.io/team/base:1"}}"#
+                .to_string()
+        });
+        (definition, Installed::from_rig(rig))
+    };
+    let planned =
+        match lns_service::artifact::mixin::resolve(definition.as_bytes(), extra, &installed).await
+        {
+            Ok(resolution) => {
+                let rig = w.declared.get_or_insert_with(Default::default);
+                rig.resolved_mixins.clone_from(&resolution.mixins);
+                rig.pinned_extra.clone_from(&resolution.pinned_extra);
+                lns_service::artifact::plan_published_sandbox(
+                    &resolution.document,
+                    "registry.example.test/some-sandbox:1",
+                )
+            }
+            Err(e) => Err(e),
+        };
+    crate::steps::declared_connectors::launch_resolved(w, planned);
+}
+
+#[then("the resolution reports the mixin pinned by digest")]
+fn resolution_reports_a_pinned_mixin(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no resolution happened")?;
+    if rig.resolved_mixins.is_empty() {
+        return Err("the resolution named no mixin at all".to_string());
+    }
+    match rig
+        .resolved_mixins
+        .iter()
+        .find(|entry| !entry.contains("@sha256:"))
+    {
+        None => Ok(()),
+        Some(unpinned) => Err(format!(
+            "a disclosure that names a tag lets the bytes it stood for change after the user approved them: {unpinned}"
+        )),
+    }
+}
+
+#[then(regex = r#"^the resolution answers for the tag "([^"]+)"$"#)]
+fn resolution_answers_for_the_tag(w: &mut BehaviourWorld, tag: String) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no resolution happened")?;
+    match rig.pinned_extra.as_slice() {
+        [pinned] if pinned.contains("@sha256:") && *pinned != tag => Ok(()),
+        other => Err(format!(
+            "the boot has to receive the pin the preflight showed, one per reference the user named, or the tag can move between them; got {other:?}"
+        )),
+    }
+}
+
+#[then("the error says a mixin the user named cannot be a directory")]
+fn error_says_a_named_mixin_cannot_be_a_directory(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    let error = rig.error.as_deref().ok_or("no launch error was recorded")?;
+    if error.contains("cannot name a local directory") {
+        Ok(())
+    } else {
+        Err(format!(
+            "a directory has no published identity to pin, so a run that accepted one would boot bytes no disclosure could name: {error}"
+        ))
+    }
+}

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -1,31 +1,56 @@
 use cucumber::{given, then, when};
-use lns_service::artifact::mixin::MixinSource;
+use lns_service::artifact::mixin::{FetchedMixin, MixinSource};
 
 use crate::world::BehaviourWorld;
 
 /// The one mixin every scenario declares, digest-pinned because a published document may reference nothing else.
-const MIXIN: &str = "ghcr.io/acme/some-mixin@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582";
+pub(crate) const MIXIN: &str = "ghcr.io/acme/some-mixin@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582";
 
-/// Serves the mixin documents a scenario installed, standing in for the registry the run pulls from.
-struct Installed(std::collections::BTreeMap<String, String>);
+/// Serves the mixin documents a scenario installed, answering for a tag under the pinned identity a registry would report.
+pub(crate) struct Installed {
+    documents: std::collections::BTreeMap<String, String>,
+    pins: std::collections::BTreeMap<String, String>,
+}
 
-impl MixinSource for Installed {
-    async fn fetch(&self, reference: &str) -> anyhow::Result<String> {
-        self.0
-            .get(reference)
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("nothing here answers for {reference}"))
+impl Installed {
+    pub(crate) fn from_rig(rig: &crate::declared_rig::DeclaredRig) -> Self {
+        Self {
+            documents: rig.mixins.clone(),
+            pins: rig.mixin_pins.clone(),
+        }
     }
 }
 
-fn install(w: &mut BehaviourWorld, spec: &str) {
+impl MixinSource for Installed {
+    async fn fetch(&self, reference: &str) -> anyhow::Result<FetchedMixin> {
+        let document = self
+            .documents
+            .get(reference)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("nothing here answers for {reference}"))?;
+        Ok(FetchedMixin {
+            pinned: self
+                .pins
+                .get(reference)
+                .cloned()
+                .unwrap_or_else(|| reference.to_string()),
+            document,
+        })
+    }
+}
+
+pub(crate) fn install_at(w: &mut BehaviourWorld, reference: &str, name: &str, spec: &str) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.mixins.insert(
-        MIXIN.to_string(),
+        reference.to_string(),
         format!(
-            r#"{{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{{"name":"some-mixin"}},"spec":{spec}}}"#
+            r#"{{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{{"name":"{name}"}},"spec":{spec}}}"#
         ),
     );
+}
+
+fn install(w: &mut BehaviourWorld, spec: &str) {
+    install_at(w, MIXIN, "some-mixin", spec);
 }
 
 fn definition(w: &mut BehaviourWorld, spec: &str) {
@@ -92,11 +117,11 @@ async fn sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
             rig.definition
                 .clone()
                 .expect("a Given step must declare the definition"),
-            Installed(rig.mixins.clone()),
+            Installed::from_rig(rig),
         )
     };
     let planned =
-        match lns_service::artifact::mixin::resolve(definition.as_bytes(), &installed).await {
+        match lns_service::artifact::mixin::resolve(definition.as_bytes(), &[], &installed).await {
             Ok(resolution) => lns_service::artifact::plan_published_sandbox(
                 &resolution.document,
                 "registry.example.test/some-sandbox:1",

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -9,6 +9,7 @@ pub mod forward;
 pub mod host_binds;
 pub mod image_management;
 pub mod ipc;
+pub mod mixin_flag;
 pub mod mixin_resolution;
 pub mod oauth_connector;
 pub mod pkce_connector;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,7 +66,7 @@ Lens Sandbox exposes a single noun — the **sandbox** — on two tiers:
 | `lns stop <RUN>`           | `lns sandbox stop <RUN>`          |
 | `lns logs <RUN>`           | `lns sandbox logs <RUN>`          |
 | `lns attach <RUN>`         | `lns sandbox attach <RUN>`        |
-| `lns inspect <TARGET>`     | `lns sandbox inspect <TARGET>`    |
+| `lns inspect <TARGET>`     | `lns sandbox inspect <TARGET> [--mixin <REF>]`    |
 | `lns rm <REF>`             | `lns sandbox rm <REF>`            |
 
 The lns-native verbs `validate`, `ls`, and `prune` live under `lns sandbox`
@@ -101,6 +101,7 @@ the `./lns.yaml` definition with its command overridden.
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |
 | `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with no rules if absent.                      |
+| `--mixin <REF>`              |                  | Merge a mixin into this run, after the ones the document declares (repeatable, in flag order — a later one wins). Published sandboxes only. A tag is allowed and is pinned before the run reports it; the summary shows `tag → digest`. |
 | `-w`, `--workdir <DIR>`      | `spec.workdir`, then image `WORKDIR` | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
 | `--env-file <FILE>`          |                  | Read `KEY=VALUE` lines from a file into the workload env (repeatable; later files and `-e` win). |
@@ -149,7 +150,7 @@ lns sandbox kill <RUN> [--signal <SIG>]
 lns sandbox stop <RUN> [-t <SECONDS>]
 lns sandbox logs [-f] <RUN>
 lns sandbox attach <RUN> [--detach-keys <CHORD>]
-lns sandbox inspect <TARGET>
+lns sandbox inspect <TARGET> [--mixin <REF>]
 
 # cache
 lns sandbox rm <REF>
@@ -174,7 +175,7 @@ interchangeable everywhere a run is addressed.
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |
 | `attach`   | `lns attach`   | Re-join a run's live output, most useful after `lns run -d`. The detach chord (`ctrl-p,ctrl-q` by default) leaves the run running and returns you to your shell (docker-attach style; no signal is sent). Stdin reaches the workload only if the run was started with stdin open. |
-| `inspect`  | `lns inspect`  | With no target, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: render that local definition's effective form, offline. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `Sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <ref> -> <mountPath>`), connectors, declared tools (`tool: node@22.11.0`), and any over-broad-policy flag; or a plain `Image`. |
+| `inspect`  | `lns inspect`  | With no target, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: render that local definition's effective form, offline. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `Sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <ref> -> <mountPath>`), connectors, declared tools (`tool: node@22.11.0`), the mixins it resolved into (`mixin: <ref>`), and any over-broad-policy flag; or a plain `Image`. `--mixin <REF>` resolves that mixin into the sandbox first, so a composition can be previewed without starting a run. |
 | `rm`       | `lns rm`       | Remove a cached sandbox and free its now-unreferenced layers; refuses a running one (a running id/name is rejected). |
 | `prune`    | —              | Remove every cached sandbox not held by a running one and, when none is live, reclaim the provisioned tool cache. Requires `-f`/`--force` — there is no interactive prompt. |
 


### PR DESCRIPTION
> Stacked on #225 (which is stacked on #223, #222 and #221). Base is `feat/mixin-resolution`.
>
> Implements [§3.3.1](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#331-how-a-mixin-enters-a-run) — the second of the two ways a mixin enters a run.

## Why

#225 resolves what a document declares. This adds what the user asks for: `lns run --mixin <REF>`, repeatable, merged after `spec.mixins` so the flags win. The merge engine already had the slot — `flatten(root, extra, graph)` — and every caller was passing `&[]`.

`lns inspect <REF> --mixin <REF>` ships with it, so a composition can be previewed without starting a run.

## A tag is allowed here, and that decides the shape

§3.3.1 makes the asymmetry deliberate: `spec.mixins` MUST be digest-pinned, because a published document has to resolve to the same thing for everyone; a reference the user types is their own live choice, and they see what it resolved to.

So `MixinSource::fetch` now answers with `FetchedMixin { pinned, document }` — `pull_mixin_with` already held the manifest digest and threw it away. The pin travels: preflight resolves and pins, `SandboxView.pinned_mixins` carries it back, `RunImageArgs.mixins` sends it to boot, and `peek_and_plan` refuses anything unpinned. **The boot never re-resolves the tag.** Re-resolving would mean the prompt described one document and the run merged another whenever the tag moved in between — the loophole §3.3.1 closes with "a `--mixin` is not a way to skip that".

The disclosure reads `tag → digest`:

```
  Mixins:    obs-tools:2 → ghcr.io/acme/obs@sha256:c41e8b7d…
```

A reference the user typed as a digest reads once rather than pointing at itself.

## One keyspace

Review caught this, and it was a regression against #225. The graph is keyed by the pinned reference, but `flatten` looks up whatever string named the source — and those differ whenever the registry's rendering does not round-trip the declared form. `clone_with_digest` drops the tag, so a document declaring `ghcr.io/acme/m:17@sha256:…` (exactly what `docker pull` prints, and what `validate_mixin_reference` accepts) resolved on the base branch and refused here.

`collect` now translates every reference — the root's, each mixin's own, and the user's — into the one identity the registry answered with, before the merge sees any of them. A reference nothing fetched is left alone on purpose, so the depth limit still refuses it in its own words rather than as a missing key.

## Where nothing can merge, the run refuses

Four places, all of which previously would have dropped the flag without a word:

| Target | Why it cannot merge |
|---|---|
| a local document | its mounts and ports come from the document the CLI parsed itself |
| a plain image | there is no sandbox document to merge into |
| a live run | it has already booted with what it merged |
| `--mixin ./dir` | a directory has no published identity for the disclosure to pin |

The last one reads differently from the same refusal on a declared mixin: one is the user's to correct, the other is the publisher's.

## Verification

`make lint`, `make complexity`, `make test`, full-workspace `make coverage` and `make e2e` (69 scenarios) all exit 0.

Layer 2 carries the behaviour: `mixin_flag.feature` in lns-service (what the user adds reaches the run; it beats the document; a tag is pinned before the run reports it; a directory refuses) and one scenario in `sandbox_inspect_cli.feature` for the rendering. Layer 3 fills the seams — the keyspace translation, the pin requirement at boot, the no-document refusal, the two inspect refusals, and the wire round-trips.

Review found four defects, each fixed with the failing test first:

| Defect | Now pinned by |
|---|---|
| a declared pin the registry renders differently no longer resolved | `a_declared_pin_the_registry_renders_differently_still_resolves` |
| `lns inspect --mixin` was silently ignored for a live run | `inspect_of_a_live_run_refuses_a_mixin_rather_than_ignoring_it` |
| and for a local definition | `inspect_local_refuses_a_mixin_rather_than_rendering_without_it` |
| the service dropped the request's mixins for a non-sandbox plan | `a_run_with_no_document_to_merge_into_refuses_the_mixins_named_for_it` |

Every fix was mutation-checked, as was each behaviour above.

## Deliberately out

Attribution when two flags pin to the same digest, or when a flag's pin also appears in `spec.mixins`: the digest shown is always right, but the tag is paired with the first match and a doubly-named source is listed twice. Polish, not a defect — it lands with per-source attribution.
