### PR TITLE
chore(deps): bump webbrowser to 1.2.4 for RUSTSEC-2026-0257

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7014,15 +7014,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -7252,7 +7252,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

[RUSTSEC-2026-0257](https://rustsec.org/advisories/RUSTSEC-2026-0257): `webbrowser`
≤1.2.1 lets a crafted `BROWSER` environment value inject arguments into the
browser command it spawns on Unix. Fixed in 1.2.2.

It reaches us transitively:

```
webbrowser v1.2.1
└── egui-winit v0.34.2
    └── eframe v0.34.2
        └── lns-service v0.17.0
```

The advisory was published 2026-07-29, after main's last CI run, so `make audit`
is red on **every** branch — including main — until the lockfile moves.

## Change

Lockfile only: `cargo update -p webbrowser` → 1.2.4 (semver-compatible, no
manifest change). `cargo audit` reports no vulnerabilities afterwards; the 13
pre-existing allowed warnings are unchanged.