### PR TITLE
feat: key a connector grant on the mixins a run is composed of

### DIFF
--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -166,10 +166,19 @@ fn published_target(
 }
 
 /// A local run sends the merged document, so the mixins that produced it are already in it; a published one sends the pins its preflight showed, because the service merges them itself.
-fn mixins_for_the_run(target: &crate::run::target::RunTarget, pinned: &[String]) -> Vec<String> {
-    match target {
-        crate::run::target::RunTarget::Local { .. } => Vec::new(),
-        crate::run::target::RunTarget::Reference(_) => pinned.to_vec(),
+/// What a run request says about mixins: the boot merges `to_merge`, and a connector grant keys on `composed`.
+struct RunMixins {
+    to_merge: Vec<String>,
+    composed: Vec<String>,
+}
+
+fn mixins_for_the_run(target: &crate::run::target::RunTarget, pinned: &[String]) -> RunMixins {
+    RunMixins {
+        to_merge: match target {
+            crate::run::target::RunTarget::Local { .. } => Vec::new(),
+            crate::run::target::RunTarget::Reference(_) => pinned.to_vec(),
+        },
+        composed: pinned.to_vec(),
     }
 }
 
@@ -409,6 +418,7 @@ pub async fn run_image(
     let detach_chord = args.detach_keys.0.clone();
     let sandbox_user = args.effective_sandbox_user();
     let sandbox_uid = args.effective_sandbox_uid();
+    let run_mixins = mixins_for_the_run(&target, &args.mixins);
 
     let request = Request::RunImage(Box::new(RunImageArgs {
         cpus: args.effective_cpus(),
@@ -419,7 +429,8 @@ pub async fn run_image(
         env: args.env,
         image: Some(target.image()),
         resolved_image: published.as_ref().map(|published| published.image.clone()),
-        mixins: mixins_for_the_run(&target, &args.mixins),
+        mixins: run_mixins.to_merge,
+        composed_mixins: run_mixins.composed,
         name: args.name,
         policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user,
@@ -1231,16 +1242,22 @@ mod tests {
             project_dir: std::path::PathBuf::from("/work"),
         };
         assert!(
-            mixins_for_the_run(&local, &pinned).is_empty(),
+            mixins_for_the_run(&local, &pinned).to_merge.is_empty(),
             "the local preflight already merged them, so sending them again asks the service to merge a document it was not given"
         );
         assert_eq!(
             mixins_for_the_run(
                 &crate::run::target::RunTarget::Reference("ghcr.io/acme/agent:1".into()),
                 &pinned
-            ),
+            )
+            .to_merge,
             pinned,
             "a published run merges service-side, so the boot needs the pins its preflight showed"
+        );
+        assert_eq!(
+            mixins_for_the_run(&local, &pinned).composed,
+            pinned,
+            "a local run is still composed of what it merged, and a connector grant keys on that — sending nothing here spends the bare run's grant on a mixin the user added"
         );
     }
 

--- a/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
@@ -26,9 +26,7 @@ fn workload_of(key: &str) -> WorkloadIdentity {
     let dir = key
         .strip_prefix("def:")
         .unwrap_or_else(|| panic!("unrecognized workload key {key}"));
-    WorkloadIdentity::Definition {
-        dir: dir.to_string(),
-    }
+    WorkloadIdentity::definition(dir)
 }
 
 fn seed(world: &mut BehaviourWorld, record: GrantRecord) {
@@ -111,9 +109,7 @@ fn other_project_granted(world: &mut BehaviourWorld, project: String, id: String
         world,
         GrantRecord::allow(
             project,
-            &WorkloadIdentity::Definition {
-                dir: "/work/other".into(),
-            },
+            &WorkloadIdentity::definition("/work/other"),
             id,
             "SOME_TOKEN",
             vec!["api.some-provider.example".into()],

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -513,6 +513,9 @@ pub struct RunImageArgs {
     /// The mixins the preflight pinned, in the order the user named them; the run merges these, never a reference it has not resolved itself.
     #[serde(default)]
     pub mixins: Vec<String>,
+    /// The same references, still named for a local run whose document the preflight already merged: a connector grant keys on the composition, so layering one more mixin is asked about instead of inheriting the bare run's answer.
+    #[serde(default)]
+    pub composed_mixins: Vec<String>,
     #[serde(default)]
     pub name: Option<String>,
     pub cpus: u8,
@@ -871,6 +874,7 @@ mod tests {
             image: Some("prism".into()),
             resolved_image: None,
             mixins: Vec::new(),
+            composed_mixins: Vec::new(),
             name: None,
             cpus: 1,
             mem: 512,
@@ -908,6 +912,7 @@ mod tests {
             image: Some("ubuntu".into()),
             resolved_image: Some(format!("ubuntu@sha256:{}", "a".repeat(64))),
             mixins: Vec::new(),
+            composed_mixins: Vec::new(),
             name: None,
             cpus: 1,
             mem: 512,
@@ -1038,6 +1043,7 @@ mod tests {
             image: Some("some-image:1".into()),
             resolved_image: None,
             mixins: Vec::new(),
+            composed_mixins: Vec::new(),
             name: None,
             cpus: 2,
             mem: 1024,

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -7,19 +7,54 @@ use std::sync::{Mutex, PoisonError};
 
 use serde::{Deserialize, Serialize};
 
-/// What a sandbox run is, for the purpose of remembering a connector grant against it.
+/// Separates a composed mixin from what precedes it; a NUL, because neither a path nor an OCI reference may contain one, so no directory name can spell a key that belongs to another composition.
+const MIXIN: char = '\0';
+
+/// What a sandbox run is, for the purpose of remembering a connector grant against it: the workload, and the mixins the user composed onto it.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WorkloadIdentity {
+pub struct WorkloadIdentity {
+    workload: Workload,
+    mixins: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Workload {
     Definition { dir: String },
     Reference { repo: String, digest: String },
 }
 
 impl WorkloadIdentity {
-    pub fn key(&self) -> String {
-        match self {
-            WorkloadIdentity::Definition { dir } => format!("def:{dir}"),
-            WorkloadIdentity::Reference { repo, digest } => format!("ref:{repo}@{digest}"),
+    pub fn definition(dir: impl Into<String>) -> Self {
+        Self {
+            workload: Workload::Definition { dir: dir.into() },
+            mixins: Vec::new(),
         }
+    }
+
+    pub fn reference(repo: impl Into<String>, digest: impl Into<String>) -> Self {
+        Self {
+            workload: Workload::Reference {
+                repo: repo.into(),
+                digest: digest.into(),
+            },
+            mixins: Vec::new(),
+        }
+    }
+
+    /// The `--mixin` references the preflight pinned, in flag order, because the order decides the merge and so decides what boots.
+    pub fn composed_with(mut self, mixins: Vec<String>) -> Self {
+        self.mixins = mixins;
+        self
+    }
+
+    pub fn key(&self) -> String {
+        let workload = match &self.workload {
+            Workload::Definition { dir } => format!("def:{dir}"),
+            Workload::Reference { repo, digest } => format!("ref:{repo}@{digest}"),
+        };
+        self.mixins
+            .iter()
+            .fold(workload, |key, mixin| format!("{key}{MIXIN}{mixin}"))
     }
 }
 
@@ -319,14 +354,15 @@ mod tests {
     use serde_json::json;
 
     fn def(dir: &str) -> WorkloadIdentity {
-        WorkloadIdentity::Definition { dir: dir.into() }
+        WorkloadIdentity::definition(dir)
     }
 
     fn reference(repo: &str, digest: &str) -> WorkloadIdentity {
-        WorkloadIdentity::Reference {
-            repo: repo.into(),
-            digest: digest.into(),
-        }
+        WorkloadIdentity::reference(repo, digest)
+    }
+
+    fn mixin(name: &str) -> String {
+        format!("ghcr.io/acme/{name}@sha256:{}", "d".repeat(64))
     }
 
     #[test]
@@ -339,6 +375,79 @@ mod tests {
         assert_eq!(
             reference("ghcr.io/acme/agent", "sha256:abc").key(),
             "ref:ghcr.io/acme/agent@sha256:abc"
+        );
+    }
+
+    #[test]
+    fn a_composed_run_keys_apart_from_the_bare_one() {
+        assert_ne!(
+            def("/work").key(),
+            def("/work").composed_with(vec![mixin("obs")]).key(),
+            "a grant the developer gave the bare run would otherwise arm the same credential for whatever a mixin adds to it, with no card"
+        );
+    }
+
+    #[test]
+    fn a_published_sandbox_composed_by_a_flag_keys_apart_from_the_bare_one() {
+        let bare = reference("ghcr.io/acme/agent", "sha256:abc");
+        assert_ne!(
+            bare.key(),
+            bare.clone().composed_with(vec![mixin("obs")]).key(),
+            "a published digest pins the mixins the document declared, never the ones the user added on the command line"
+        );
+    }
+
+    #[test]
+    fn flag_order_decides_the_key_because_it_decides_the_merge() {
+        assert_ne!(
+            def("/work")
+                .composed_with(vec![mixin("a"), mixin("b")])
+                .key(),
+            def("/work")
+                .composed_with(vec![mixin("b"), mixin("a")])
+                .key(),
+            "the later mixin wins the merge, so two orders are two different sandboxes"
+        );
+    }
+
+    #[test]
+    fn no_directory_name_can_spell_another_compositions_key() {
+        let composed = def("/parent/work").composed_with(vec![mixin("obs")]);
+        assert_ne!(
+            composed.key(),
+            def(&format!("/parent/work+mixin:{}", mixin("obs"))).key(),
+            "a checkout can create that directory, and a key it collides with is a connector armed with no card"
+        );
+    }
+
+    #[test]
+    fn a_bare_run_keys_as_it_did_before_a_mixin_could_compose_one() {
+        assert_eq!(
+            def("/Users/me/app").composed_with(Vec::new()).key(),
+            "def:/Users/me/app",
+            "composing nothing must not re-key an existing grant, or every developer is asked again for a run that has not changed"
+        );
+    }
+
+    #[test]
+    fn one_composed_grant_does_not_answer_for_another_composition() {
+        let mut file = WorkloadGrantFile::default();
+        let granted = def("/work").composed_with(vec![mixin("obs")]);
+        file.upsert(GrantRecord::allow(
+            "/work",
+            &granted,
+            "some-provider",
+            "SOME_TOKEN",
+            vec!["api.some-provider.example".into()],
+        ));
+        assert!(
+            file.lookup(
+                "/work",
+                &def("/work").composed_with(vec![mixin("evil")]),
+                "some-provider"
+            )
+            .is_none(),
+            "the whole point of keying on the composition is that a different one has to be asked about"
         );
     }
 

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -408,6 +408,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_published_document_declaring_an_unpinned_mixin_refuses_before_it_is_fetched() {
+        let source = Fake::new(&[]);
+        let err = resolve(
+            &sandbox(r#"{"image":"x:1","mixins":["ghcr.io/acme/obs:2"]}"#),
+            &[],
+            &published(),
+            &source,
+        )
+        .await
+        .expect_err("a tag a published document declares resolves differently for each consumer");
+        assert!(
+            format!("{err:#}").contains("must be digest-pinned"),
+            "got: {err:#}"
+        );
+        assert!(
+            source
+                .fetched
+                .lock()
+                .expect("fetch log poisoned")
+                .is_empty(),
+            "the refusal has to land before the network, or a stranger's document chooses what this run pulls"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_mixin_declaring_an_unpinned_mixin_refuses_the_graph_below_it() {
+        let (spec, documents) = resolve_named(
+            r#"{"image":"x:1","mixins":["a"]}"#,
+            &[("a", r#"{"mixins":["ghcr.io/acme/obs:2"]}"#)],
+        );
+        let refs: Vec<(&str, &str)> = documents
+            .iter()
+            .map(|(r, b)| (r.as_str(), b.as_str()))
+            .collect();
+        let err = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+            .await
+            .expect_err("a pinned mixin naming a tag reopens exactly what pinning it closed");
+        assert!(
+            format!("{err:#}").contains("must be digest-pinned"),
+            "got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn a_document_with_no_mixins_is_returned_untouched() {
         let source = Fake::new(&[]);
         let original = sandbox(r#"{"image":"x:1"}"#);

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -476,9 +476,7 @@ mod tests {
             "api.some-provider.example",
         )];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let grants = allow_grants(
             &workload,
             "some-provider",
@@ -499,9 +497,7 @@ mod tests {
             provider_of("some-provider", "OTHER_TOKEN", "api.some-provider.example"),
         ];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let grants = allow_grants(
             &workload,
             "some-provider",
@@ -523,9 +519,7 @@ mod tests {
             "api.some-provider.example",
         )];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let armed = gate_armed_by_grant(
             &applied,
             &providers,
@@ -547,9 +541,7 @@ mod tests {
             "api.some-provider.example",
         )];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut grants = WorkloadGrantFile::default();
         grants.upsert(GrantRecord::deny(
             "proj",
@@ -570,9 +562,7 @@ mod tests {
             "api.some-provider.example",
         )];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let grants = allow_grants(
             &workload,
             "some-provider",
@@ -594,9 +584,7 @@ mod tests {
             "api.some-provider.example",
         )];
         let applied: HashSet<String> = ["some-provider".to_string()].into_iter().collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let grants = allow_grants(&workload, "some-provider", "SOME_TOKEN", "api.old.example");
         let armed = gate_armed_by_grant(&applied, &providers, "proj", &workload, &grants);
         assert!(
@@ -612,9 +600,7 @@ mod tests {
             "SOME_TOKEN",
             "api.some-provider.example",
         )];
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let grants = allow_grants(
             &workload,
             "some-provider",
@@ -635,9 +621,7 @@ mod tests {
             "SOME_TOKEN",
             "api.some-provider.example",
         )];
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let records = boot_sign_in_grants(
             &["some-provider".to_string()],
             &providers,
@@ -666,9 +650,7 @@ mod tests {
         let declared = vec![declaration("REMAPPED_TOKEN", "api.some-oauth.example")];
         let providers =
             resolve_applied_with_credentials(&Policy::default(), &declared, &catalog).providers;
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let records =
             boot_sign_in_grants(&["some-oauth".to_string()], &providers, "proj", &workload);
         assert_eq!(records.len(), 1);
@@ -696,9 +678,7 @@ mod tests {
         ];
         let run = resolve_applied_with_credentials(&Policy::default(), &declared, &catalog);
         let applied: HashSet<String> = run.providers.iter().map(|p| p.id().to_string()).collect();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut grants = WorkloadGrantFile::default();
         for record in boot_sign_in_grants(
             &["some-oauth".to_string()],
@@ -717,9 +697,7 @@ mod tests {
 
     #[test]
     fn boot_sign_in_grants_skip_an_id_that_resolved_no_provider() {
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let records = boot_sign_in_grants(&["some-oauth".to_string()], &[], "proj", &workload);
         assert!(
             records.is_empty(),

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -1576,9 +1576,7 @@ mod tests {
     #[test]
     fn a_consent_allow_persists_an_allow_grant_to_the_sidecar() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![some_provider()]);
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
         session.record_decision(
@@ -1599,9 +1597,7 @@ mod tests {
     #[test]
     fn a_forget_from_before_this_run_does_not_block_the_grant_it_consents_to_now() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut prior = WorkloadGrantFile::default();
         prior.revoke_project_connector("proj", "some-provider");
         store.save(&prior).unwrap();
@@ -1647,9 +1643,7 @@ mod tests {
     #[test]
     fn a_forget_landing_while_the_card_is_open_cancels_that_decision_and_no_later_one() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![some_provider()]);
 
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
@@ -1708,9 +1702,7 @@ mod tests {
     #[test]
     fn a_card_raised_over_an_unreadable_sidecar_can_only_cancel_never_wave_through() {
         let store = Arc::new(FlakyReadGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![some_provider()]);
         forget_from_another_process(store.as_ref());
 
@@ -1732,9 +1724,7 @@ mod tests {
     #[test]
     fn a_forget_that_landed_before_the_card_went_up_is_answered_by_it() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![some_provider()]);
 
         forget_from_another_process(store.as_ref());
@@ -1765,9 +1755,7 @@ mod tests {
         .with_custom_providers(Arc::new(vec![some_provider()]))
         .with_grants(
             "proj".into(),
-            WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            WorkloadIdentity::definition("/proj"),
             Arc::new(FailingGrantStore),
         );
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
@@ -1816,9 +1804,7 @@ mod tests {
     #[test]
     fn a_consent_whose_value_cannot_be_written_persists_no_grant() {
         let grants = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let store = Arc::new(CapturingStore::default());
         let session = grants_session_with_store(grants.clone(), workload.clone(), store.clone());
         store.fail_next(io::ErrorKind::PermissionDenied, "denied");
@@ -1848,9 +1834,7 @@ mod tests {
     #[test]
     fn a_connect_whose_token_cannot_be_written_persists_no_grant() {
         let grants = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let store = Arc::new(CapturingStore::default());
         let session = grants_session_with_store(grants.clone(), workload.clone(), store.clone());
         store.fail_next(io::ErrorKind::PermissionDenied, "denied");
@@ -1870,13 +1854,7 @@ mod tests {
     #[test]
     fn a_consent_for_an_undisclosed_id_persists_no_grant() {
         let store = Arc::new(CapturingGrantStore::default());
-        let session = grants_session(
-            store.clone(),
-            WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
-            vec![],
-        );
+        let session = grants_session(store.clone(), WorkloadIdentity::definition("/proj"), vec![]);
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
         session.record_decision(
             "c1",
@@ -1913,9 +1891,7 @@ mod tests {
     #[tokio::test]
     async fn a_network_offer_connect_persists_the_grant() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session_connectable(store.clone(), workload.clone());
         assert!(session.connect_connector_now("some-provider").await);
         assert!(
@@ -1931,9 +1907,7 @@ mod tests {
     #[test]
     fn a_connect_by_pasted_token_persists_the_grant() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session_connectable(store.clone(), workload.clone());
         session.connect_connector_with_token("some-provider", "some-real".into());
         assert!(
@@ -2139,9 +2113,7 @@ mod tests {
     #[test]
     fn a_card_deny_persists_a_per_workload_deny_and_emits_a_deny_frame() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let (tx, mut rx) = mpsc::unbounded_channel();
         let session = CredentialSession::new(
             CredentialStateFile::new(),
@@ -2177,9 +2149,7 @@ mod tests {
     #[test]
     fn the_run_flow_cannot_widen_a_deny_past_the_workload_even_when_asked_to() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![]);
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
 
@@ -2205,9 +2175,7 @@ mod tests {
     #[test]
     fn a_card_deny_for_an_undisclosed_id_persists_a_standing_deny() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let session = grants_session(store.clone(), workload.clone(), vec![]);
         session.submit_pending(pending("c1", "some-provider"), Instant::now());
         session.record_decision("c1", CredentialDecisionRequest::Deny);
@@ -2222,9 +2190,7 @@ mod tests {
     #[test]
     fn a_prior_workload_deny_suppresses_the_offer_without_re_prompting() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut prior = WorkloadGrantFile::default();
         prior.upsert(GrantRecord::deny(
             "proj",
@@ -2274,13 +2240,7 @@ mod tests {
             TEST_TIMEOUT,
         )
         .with_custom_providers(Arc::new(vec![some_provider()]))
-        .with_grants(
-            "proj".into(),
-            WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
-            store,
-        );
+        .with_grants("proj".into(), WorkloadIdentity::definition("/proj"), store);
         (session, notifier)
     }
 
@@ -2288,9 +2248,7 @@ mod tests {
     fn a_prior_deny_for_another_workload_does_not_suppress_this_workloads_card() {
         let foreign = GrantRecord::deny(
             "proj",
-            &WorkloadIdentity::Definition {
-                dir: "/other".into(),
-            },
+            &WorkloadIdentity::definition("/other"),
             "some-provider",
             "SOME_TOKEN",
             vec!["api.some-provider.example".into()],
@@ -2322,9 +2280,7 @@ mod tests {
     fn a_prior_deny_whose_connector_was_redefined_asks_again() {
         let stale = GrantRecord::deny(
             "proj",
-            &WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            &WorkloadIdentity::definition("/proj"),
             "some-provider",
             "OLD_TOKEN",
             vec!["api.old.example".into()],
@@ -2341,9 +2297,7 @@ mod tests {
     #[test]
     fn a_prior_deny_holds_when_the_run_resolves_no_provider_to_compare_against() {
         let store = Arc::new(CapturingGrantStore::default());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut prior = WorkloadGrantFile::default();
         prior.upsert(GrantRecord::deny(
             "proj",
@@ -2375,9 +2329,7 @@ mod tests {
     fn a_prior_deny_recorded_without_a_disclosure_still_suppresses_the_offer() {
         let unpinned = GrantRecord::deny(
             "proj",
-            &WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            &WorkloadIdentity::definition("/proj"),
             "some-provider",
             "",
             vec![],
@@ -2404,9 +2356,7 @@ mod tests {
         .with_custom_providers(Arc::new(vec![some_provider()]))
         .with_grants(
             "proj".into(),
-            WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            WorkloadIdentity::definition("/proj"),
             Arc::new(FailingGrantStore),
         );
         session.submit_pending(pending("c1", "some-provider"), Instant::now());

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -564,6 +564,7 @@ mod tests {
                 image: None,
                 resolved_image: None,
                 mixins: Vec::new(),
+                composed_mixins: Vec::new(),
                 name: None,
                 cpus: 1,
                 mem: 0,

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lns_ipc::{Response, WireFrame};
 use lns_policy::grants::WorkloadIdentity;
 use tokio::sync::mpsc::Sender;
@@ -183,19 +183,21 @@ fn canonical_dir_key(dir: &str) -> String {
 
 /// The identity a run's connector grants key against: a local definition by its directory (every `-f` variant of one project, and every symlink alias of it, shares it), a published sandbox by `repo@digest` (a republished digest re-offers). A run resolving neither refuses — plain-image runs are retired, and a shared fallback bucket would let one run's grant arm another's without a card.
 pub(super) fn workload_identity(
-    definition_dir: Option<&str>,
+    args: &lns_ipc::RunImageArgs,
     resolved_ref: Option<&str>,
     digest: Option<&str>,
 ) -> Result<WorkloadIdentity> {
-    if let Some(dir) = definition_dir {
-        Ok(WorkloadIdentity::Definition {
-            dir: canonical_dir_key(dir),
-        })
+    // A grant keys on what the run is composed of, never on `mixins`, which is only what the boot still has to merge — a local run sends that empty because its document already carries them.
+    crate::artifact::mixin::require_pinned_extras(&args.composed_mixins)
+        .context("keying this run's connector grants")?;
+    let composed = args.composed_mixins.clone();
+    if let Some(dir) = args.definition_dir.as_deref() {
+        Ok(WorkloadIdentity::definition(canonical_dir_key(dir)).composed_with(composed))
     } else if let (Some(reference), Some(digest)) = (resolved_ref, digest) {
-        Ok(WorkloadIdentity::Reference {
-            repo: normalize_repo(reference),
-            digest: digest.to_string(),
-        })
+        Ok(
+            WorkloadIdentity::reference(normalize_repo(reference), digest.to_string())
+                .composed_with(composed),
+        )
     } else {
         anyhow::bail!(
             "this run resolved neither a definition directory nor a published digest, so it cannot hold connector grants; run a sandbox definition or a published sandbox reference, and if `lns` was upgraded while this service kept running, restart it (`lns service stop` then `lns service start`) so the two match"
@@ -230,16 +232,62 @@ mod tests {
         );
     }
 
+    /// A run request carrying only what the identity reads, so a test can vary the definition dir and the composition without spelling forty launch settings.
+    fn run_args(definition_dir: Option<&str>, composed: &[String]) -> lns_ipc::RunImageArgs {
+        serde_json::from_value(serde_json::json!({
+            "image": "x:1",
+            "cpus": 2,
+            "mem": 2048,
+            "policy_path": null,
+            "cmd": [],
+            "debug": false,
+            "definition_dir": definition_dir,
+            "composed_mixins": composed,
+        }))
+        .expect("the fixture names every field the wire requires")
+    }
+
     #[test]
     fn workload_identity_keys_a_local_definition_by_its_directory() {
-        let id = workload_identity(Some("/Users/me/app"), Some("ghcr.io/team/base:1"), None)
-            .expect("a definition dir identifies the run");
+        let id = workload_identity(
+            &run_args(Some("/Users/me/app"), &[]),
+            Some("ghcr.io/team/base:1"),
+            None,
+        )
+        .expect("a definition dir identifies the run");
         assert_eq!(
             id,
-            WorkloadIdentity::Definition {
-                dir: "/Users/me/app".into()
-            },
+            WorkloadIdentity::definition("/Users/me/app"),
             "a local definition keys by its dir even though it carries a base image"
+        );
+    }
+
+    #[test]
+    fn workload_identity_carries_the_mixins_the_run_was_composed_with() {
+        let composed = [format!("ghcr.io/acme/obs@sha256:{}", "d".repeat(64))];
+        let id = workload_identity(&run_args(Some("/Users/me/app"), &composed), None, None)
+            .expect("a definition dir identifies the run");
+        assert_ne!(
+            id,
+            workload_identity(&run_args(Some("/Users/me/app"), &[]), None, None)
+                .expect("a definition dir identifies the run"),
+            "a run the user layered a mixin onto must not spend the grant the bare run earned"
+        );
+    }
+
+    #[test]
+    fn workload_identity_refuses_a_composition_named_by_a_moving_reference() {
+        let err = workload_identity(
+            &run_args(Some("/Users/me/app"), &["ghcr.io/acme/obs:2".to_string()]),
+            None,
+            None,
+        )
+        .expect_err(
+            "a tag resolves to different bytes tomorrow, so a grant keyed on it means nothing",
+        );
+        assert!(
+            format!("{err:#}").contains("keying this run's connector grants"),
+            "got: {err:#}"
         );
     }
 
@@ -251,9 +299,9 @@ mod tests {
         let link = dir.path().join("link");
         std::os::unix::fs::symlink(&real, &link).expect("create symlink");
 
-        let via_link = workload_identity(Some(link.to_str().unwrap()), None, None)
+        let via_link = workload_identity(&run_args(Some(link.to_str().unwrap()), &[]), None, None)
             .expect("a definition dir identifies the run");
-        let via_real = workload_identity(Some(real.to_str().unwrap()), None, None)
+        let via_real = workload_identity(&run_args(Some(real.to_str().unwrap()), &[]), None, None)
             .expect("a definition dir identifies the run");
         assert_eq!(
             via_link, via_real,
@@ -264,31 +312,30 @@ mod tests {
     #[test]
     fn workload_identity_falls_back_to_the_raw_dir_when_it_cannot_be_canonicalized() {
         assert_eq!(
-            workload_identity(Some("/no/such/project/dir"), None, None)
+            workload_identity(&run_args(Some("/no/such/project/dir"), &[]), None, None)
                 .expect("a definition dir identifies the run"),
-            WorkloadIdentity::Definition {
-                dir: "/no/such/project/dir".into()
-            }
+            WorkloadIdentity::definition("/no/such/project/dir")
         );
     }
 
     #[test]
     fn workload_identity_keys_a_published_reference_by_repo_and_digest() {
-        let id = workload_identity(None, Some("ghcr.io/acme/agent:1.4.0"), Some("sha256:abc"))
-            .expect("a resolved digest identifies the run");
+        let id = workload_identity(
+            &run_args(None, &[]),
+            Some("ghcr.io/acme/agent:1.4.0"),
+            Some("sha256:abc"),
+        )
+        .expect("a resolved digest identifies the run");
         assert_eq!(
             id,
-            WorkloadIdentity::Reference {
-                repo: "ghcr.io/acme/agent".into(),
-                digest: "sha256:abc".into()
-            }
+            WorkloadIdentity::reference("ghcr.io/acme/agent", "sha256:abc")
         );
     }
 
     #[test]
     fn workload_identity_refuses_a_run_without_a_definition_or_a_resolved_digest() {
         for (definition_dir, resolved_ref) in [(None, None), (None, Some("ghcr.io/acme/agent:1"))] {
-            let err = workload_identity(definition_dir, resolved_ref, None)
+            let err = workload_identity(&run_args(definition_dir, &[]), resolved_ref, None)
                 .expect_err("an unidentifiable run must refuse, never share a grant bucket");
             assert!(
                 format!("{err:#}").contains("cannot hold connector grants"),
@@ -299,7 +346,8 @@ mod tests {
 
     #[test]
     fn workload_identity_refusal_names_the_service_restart_a_stale_service_needs() {
-        let err = workload_identity(None, None, None).expect_err("an unidentifiable run refuses");
+        let err = workload_identity(&run_args(None, &[]), None, None)
+            .expect_err("an unidentifiable run refuses");
         assert!(
             format!("{err:#}").contains("lns service stop"),
             "a matching CLI always resolves an identity, so the developer who sees this is most likely running an upgraded `lns` against a service left running from before; got: {err:#}"

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -97,7 +97,7 @@ async fn orchestrate(
     };
     // Refuse an unidentifiable run before its sign-in gate can drag the user through a device flow.
     let workload = workload_identity(
-        args.definition_dir.as_deref(),
+        &args,
         resolved_image,
         sandbox_plan.as_ref().and_then(|p| p.digest.as_deref()),
     )?;

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -1247,9 +1247,7 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().join("grants.json");
         let store = JsonFileGrantStore::new(path.clone());
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
         let mut file = WorkloadGrantFile::default();
         file.upsert(GrantRecord::allow(
             "proj",
@@ -1613,9 +1611,7 @@ mod tests {
     }
 
     fn acme_workload() -> WorkloadIdentity {
-        WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        }
+        WorkloadIdentity::definition("/proj")
     }
 
     fn acme_grants(workload: &WorkloadIdentity) -> WorkloadGrantFile {

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -542,9 +542,7 @@ mod tests {
     fn test_consent(credentials: &[lns_spec::Credential]) -> RunConsent<'_> {
         RunConsent {
             credentials,
-            workload: lns_policy::grants::WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            workload: lns_policy::grants::WorkloadIdentity::definition("/proj"),
             signed_in: vec![],
             revocations_at_gate: std::collections::HashMap::new(),
         }
@@ -650,9 +648,7 @@ mod tests {
             GrantStore, GrantVerdict, JsonFileGrantStore, WorkloadIdentity, project_key,
         };
         let fixture = boot_sign_in_fixture();
-        let workload = WorkloadIdentity::Definition {
-            dir: "/proj".into(),
-        };
+        let workload = WorkloadIdentity::definition("/proj");
 
         let session = start_with_boot_sign_in(&fixture, &workload).await;
 
@@ -681,9 +677,7 @@ mod tests {
 
         let session = start_with_boot_sign_in(
             &fixture,
-            &lns_policy::grants::WorkloadIdentity::Definition {
-                dir: "/proj".into(),
-            },
+            &lns_policy::grants::WorkloadIdentity::definition("/proj"),
         )
         .await;
 

--- a/crates/lns-service/tests/behaviours/credential_rig.rs
+++ b/crates/lns-service/tests/behaviours/credential_rig.rs
@@ -241,9 +241,7 @@ impl CredentialRig {
                 .with_custom_providers(Arc::new(fixture_providers()))
                 .with_grants(
                     "rig-other-project".to_string(),
-                    WorkloadIdentity::Definition {
-                        dir: "/rig-other".to_string(),
-                    },
+                    WorkloadIdentity::definition("/rig-other"),
                     self.grant_store.clone(),
                 );
         session.submit_pending(
@@ -551,9 +549,7 @@ fn rig_grant_context(dir: &TempDir) -> (Arc<dyn GrantStore>, String, WorkloadIde
     (
         store,
         "rig-project".to_string(),
-        WorkloadIdentity::Definition {
-            dir: "/rig".to_string(),
-        },
+        WorkloadIdentity::definition("/rig"),
     )
 }
 

--- a/crates/lns-service/tests/behaviours/declared_connectors.feature
+++ b/crates/lns-service/tests/behaviours/declared_connectors.feature
@@ -66,6 +66,16 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
     Then the workload's environment contains the "SOME_TOKEN" placeholder
     And the boundary injection for "some-provider" stays unarmed
 
+  Scenario: A grant the bare run earned does not arm a run that layers a mixin onto it
+    Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
+    And the sandbox definition declares connector "some-provider"
+    And the directory's lns-policy.yaml connects "some-provider"
+    And the per-machine credential store has a stored value for "some-provider"
+    And the run composes the mixin "ghcr.io/acme/obs-tools"
+    When the sandbox is launched
+    Then the workload's environment contains the "SOME_TOKEN" placeholder
+    And the boundary injection for "some-provider" stays unarmed
+
   Scenario: A declared connector's machine-stored value stays unarmed until connected
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider" and allows the "api.some-provider.example" route

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -31,6 +31,8 @@ pub struct DeclaredRig {
     pub definition_snapshot: Option<String>,
     /// Mixin documents this machine can resolve, keyed by reference.
     pub mixins: std::collections::BTreeMap<String, String>,
+    /// Pinned `--mixin` references this run is composed of; the rig grants the bare identity, so a composed launch models a grant an earlier bare run earned.
+    pub composed_mixins: Vec<String>,
     /// The tools the resolved document asks for, so a scenario can see what a mixin contributed.
     pub tools: Vec<String>,
     /// What a reference resolves to, so a scenario can publish a mixin under a tag.

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -138,9 +138,7 @@ fn launch(
         .collect();
     rig.offered = run.connectable_ids.iter().cloned().collect();
     // The launch consents to its applied connectors by default (the grant a prior first-use card would have left); a scenario withholds an id to model a cloned overlay or a slot with no machine-local grant, and the gate then keeps it unarmed.
-    let workload = WorkloadIdentity::Definition {
-        dir: "/rig/project".into(),
-    };
+    let workload = WorkloadIdentity::definition("/rig/project");
     let mut grants = WorkloadGrantFile::default();
     for p in &run.providers {
         if run.armed.contains(p.id()) && !rig.withhold_grants.contains(p.id()) {
@@ -154,15 +152,16 @@ fn launch(
             ));
         }
     }
+    let composed = workload.clone().composed_with(rig.composed_mixins.clone());
     // A completed boot-gate sign-in grants the workload even where a prior grant was withheld, exactly as adapter::start records it before the gate.
-    for record in boot_sign_in_grants(&rig.signed_in, &run.providers, "rig-project", &workload) {
+    for record in boot_sign_in_grants(&rig.signed_in, &run.providers, "rig-project", &composed) {
         grants.upsert(record);
     }
     let armed = gate_armed_by_grant(
         &run.armed,
         &run.providers,
         "rig-project",
-        &workload,
+        &composed,
         &grants,
     );
     rig.wire = expand_credentials_with_custom(&rig.store, &run.providers, &armed, &|_| None);
@@ -216,6 +215,13 @@ fn overlay_connects_nothing(w: &mut BehaviourWorld) {
 fn overlay_connects(w: &mut BehaviourWorld, id: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.overlay.connectors.push(id);
+}
+
+#[given(regex = r#"^the run composes the mixin "([^"]+)"$"#)]
+fn run_composes_mixin(w: &mut BehaviourWorld, reference: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.composed_mixins
+        .push(format!("{reference}@sha256:{}", "d".repeat(64)));
 }
 
 #[given(regex = r#"^this workload has no grant for "([^"]+)"$"#)]


### PR DESCRIPTION
> Stacked on #230 (which is stacked on #229). Base is `feat/mixin-distribution`.
>
> Closes the last credential gap [§1.5](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#15-one-disclosure) opens: *"the approval is against a resolved digest, so what boots is what was approved."*

## The hole

A per-workload connector grant keyed on `(project, workload, connector)`, and `workload` was `def:<dir>` or `ref:<repo>@<digest>`. No mixin entered it.

So `lns run claude` and `lns run claude --mixin anything` shared one grant bucket. Once the developer allowed a connector for the bare run, every later composition of that run spent the credential **with no card**.

Two things already narrowed it, and neither closes it:

- The boot gate re-checks the connector's own shape — `grant_arms` compares the recorded env var and injection domains against what the resolved declaration discloses. A mixin that *adds* a credential, or moves one to a new domain, already misses the grant.
- A mixin's egress was capped by the directory ceiling.

What was left is the case where a mixin leaves `spec.credentials` alone and changes everything else. Tools, filesets, mounts, command, egress — all inherit the bare run's answer, because the recorded disclosure still matches exactly. The scenario in this PR is that case, and it armed a real value before the fix:

```
an injection for some-provider left with a value despite no per-directory consent: ["Bearer some-secret"]
```

## The key

`WorkloadIdentity` becomes a workload plus the mixins composed onto it, and `key()` appends each:

```
def:/work                                 # unchanged
def:/work\0ghcr.io/acme/obs@sha256:…      # a different bucket
```

The separator is a NUL, which neither a path nor an OCI reference may contain. Review caught the readable spelling first tried (`+mixin:`): `def:/parent/work` composed with a mixin rendered byte-identically to a bare definition in a directory named `work+mixin:ghcr.io/…`, which a checkout will happily create. Contrived, but the payoff is a connector armed with no card, and the encoding is free to change today — no composed key exists in any sidecar yet — while changing it after release re-asks every user.

Three properties this shape buys:

**A bare run keys exactly as before.** Composing nothing appends nothing, so no existing grant is invalidated and nobody is asked again for a run that has not changed.

**Only the `--mixin` flags enter the key, not `spec.mixins`.** A published sandbox's digest already pins the graph its document declares — every declared entry must be digest-pinned and publish refuses a directory — so `ref:<repo>@<digest>` covers it. `def:<dir>` deliberately does not track edits to the developer's own definition, and its `mixins:` list is one of those edits.

**Flag order is part of the key**, because the later mixin wins the merge. Two orders are two different sandboxes.

No resolved digest is invented. One does not exist anywhere today, and computing one would churn every grant on the developer's own local decisions — which §8 exempts from approval in the first place. The preflight already pins each source; the key names them.

## Why a second wire field

`RunImageArgs.mixins` means *what the boot must still merge*, and a local run sends it empty on purpose: #229 made the service resolve a local document during preflight, so the document the boot receives is already merged, and re-sending the extras made it refuse. That is why `plan_local` takes no mixins at all.

The grant needs the other fact — *what this run is composed of* — which is the same list on a published run and a non-empty one on a local run whose document was already merged. They are two different questions that happen to coincide on one path, so `composed_mixins` is its own field rather than an overload of the first.

## Verification

`make lint`, `make complexity`, `make test`, full-workspace `make coverage` and `make e2e` all exit 0.

Layer 3 in `grants.rs` pins the key itself: a composed run keys apart from the bare one on both target shapes, flag order matters, composing nothing is a no-op, and one composition's grant does not answer a lookup for another. Layer 3 in `run/mod.rs` pins that the composition reaches the identity the run gates on. Layer 2 (`declared_connectors.feature`) carries the behaviour end to end — a grant the bare run earned meets a composed launch and the value stays unarmed.

Every new assertion was mutation-checked, and three of them exist because review found the code green-on-arrival without them:

| Mutation | Now caught by |
|---|---|
| `key()` ignores the composition | the Layer 2 scenario, red with the credential armed |
| the CLI sends no composition for a local run | `a_local_run_sends_no_mixins_because_its_document_already_carries_them` |
| the service reads `mixins` instead of `composed_mixins` — safe for published runs, silently reopening only the local `--mixin` path | `workload_identity_carries_the_mixins_the_run_was_composed_with` |
| the separator goes back to a spellable string | `no_directory_name_can_spell_another_compositions_key` |

Both wiring lines sat in coverage-exempt tails, so each now lives inside a helper a test drives: `mixins_for_the_run` returns both lists, and `workload_identity` takes the request and reads the field itself.

Two regression tests in `mixin.rs` pin the property this key leans on — that a declared mixin reference must be digest-pinned. Review flagged a way around it; it turned out `validate_mixin_reference` already runs inside `parse_of_kind`, and `resolve` parses the root before collecting while `visit` parses every fetched mixin, so the pin holds at every level of the graph. The tests are there because the rationale depends on it, including that the refusal lands before any fetch.

`workload_identity` also refuses a composition named by a moving tag, so no future CLI path can put one into a grant key.

## Also

`WorkloadIdentity`'s two struct-literal spellings become `definition(…)` / `reference(…)` constructors, so adding the composition did not have to churn a dozen literals into carrying `mixins: Vec::new()`.
