### PR TITLE
feat: attribute every entry of a resolved sandbox to the source that decided it

### DIFF
--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -17,6 +17,39 @@ pub struct Source<'a> {
 /// The label the sandbox's own spec resolves under; every other source is labelled by the reference that named it.
 pub const ROOT_LABEL: &str = "the sandbox";
 
+/// The blocks a disclosure attributes, which are the ones §1.5 names plus `ports`, whose winners already have to answer for one another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Block {
+    Credential,
+    Tool,
+    Mount,
+    Port,
+    Egress,
+}
+
+/// What one source decided, and what deciding it replaced, so a reader sees where every line of a resolved sandbox came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Contribution {
+    pub block: Block,
+    pub key: String,
+    pub source: String,
+    pub displaced: Vec<Displaced>,
+}
+
+/// An entry a later source replaced, named as the reader would have seen it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Displaced {
+    pub source: String,
+    pub summary: String,
+}
+
+/// A merged sandbox and the record of which source decided each thing in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Merged {
+    pub spec: SandboxSpec,
+    pub contributions: Vec<Contribution>,
+}
+
 /// The graph is walked this deep and refused beyond, so a chain nobody can read cannot stall a launch.
 pub const MAX_DEPTH: usize = 5;
 
@@ -121,7 +154,7 @@ fn refuse_what_sits_out_of_reach(
 }
 
 /// Merge an ordered source list per §3.3.2: the last source to say something about a thing wins, and every keyed block unions by its key.
-pub fn merge(sources: &[Source]) -> Result<SandboxSpec> {
+pub fn merge(sources: &[Source]) -> Result<Merged> {
     let mut spec = SandboxSpec::default();
 
     for source in sources {
@@ -140,12 +173,35 @@ pub fn merge(sources: &[Source]) -> Result<SandboxSpec> {
         }
     }
 
-    spec.credentials = fold(sources, |s| &s.credentials, |c| c.env_var.clone());
-    spec.tools = fold(sources, |s| &s.tools, |t| tool_name(t).to_string());
-    (spec.volumes, spec.filesets) = fold_mounts(sources);
-    let ports = fold_labelled(sources, |s| &s.ports, |p| p.container.to_string());
+    let mut contributions = Vec::new();
+    spec.credentials = fold(
+        sources,
+        |s| &s.credentials,
+        |c| c.env_var.clone(),
+        |c| c.env_var.clone(),
+        Block::Credential,
+        &mut contributions,
+    );
+    spec.tools = fold(
+        sources,
+        |s| &s.tools,
+        |t| tool_name(t).to_string(),
+        Clone::clone,
+        Block::Tool,
+        &mut contributions,
+    );
+    (spec.volumes, spec.filesets) = fold_mounts(sources, &mut contributions);
+    let ports = fold_labelled(
+        sources,
+        |s| &s.ports,
+        |p| p.container.to_string(),
+        |p| p.container.to_string(),
+    );
     refuse_a_host_port_two_sources_publish(&ports)?;
-    spec.ports = ports.into_iter().map(|(port, _)| port).collect();
+    for won in &ports {
+        contributions.push(won.contribution(Block::Port));
+    }
+    spec.ports = ports.into_iter().map(|won| won.item).collect();
 
     // A later source's entries are placed ahead of an earlier one's, so the latest entry matching a destination is the one that decides.
     for source in sources.iter().rev() {
@@ -157,42 +213,102 @@ pub fn merge(sources: &[Source]) -> Result<SandboxSpec> {
             .egress
             .tcp
             .extend(source.spec.policy.egress.tcp.iter().cloned());
+        // Egress is a union rather than a keyed replacement, so every entry is attributed and none displaces another.
+        for rule in source.spec.policy.egress.http.iter() {
+            contributions.push(egress_contribution(
+                rule.verdict,
+                &rule.match_pattern,
+                source.label,
+            ));
+        }
+        for rule in source.spec.policy.egress.tcp.iter() {
+            contributions.push(egress_contribution(
+                rule.verdict,
+                &rule.match_pattern,
+                source.label,
+            ));
+        }
     }
 
     // The mixins are what produced this document, so the resolved one declares none of its own.
     spec.mixins = Vec::new();
-    Ok(spec)
+    Ok(Merged {
+        spec,
+        contributions,
+    })
+}
+
+/// A rule is its verdict and its pattern together, because the verdict is the half that decides and two sources may disagree about one destination.
+fn egress_contribution(
+    verdict: lns_policy::Verdict,
+    match_pattern: &str,
+    source: &str,
+) -> Contribution {
+    let verdict = match verdict {
+        lns_policy::Verdict::Allow => "allow",
+        lns_policy::Verdict::Deny => "deny",
+    };
+    Contribution {
+        block: Block::Egress,
+        key: format!("{verdict} {match_pattern}"),
+        source: source.to_string(),
+        displaced: Vec::new(),
+    }
 }
 
 /// A mount, whichever block claimed it: one target is one keyspace across `volumes` and `filesets`, so a later source's claim of either kind displaces an earlier source's claim of either kind.
+#[derive(Clone)]
 enum Mount {
     Volume(Volume),
     Fileset(FilesetEntry),
 }
 
-fn fold_mounts(sources: &[Source]) -> (Vec<Volume>, Vec<FilesetEntry>) {
-    let mut order: Vec<String> = Vec::new();
-    let mut winners: BTreeMap<String, Mount> = BTreeMap::new();
-    let mut claim = |target: String, mount: Mount| {
-        if winners.insert(target.clone(), mount).is_none() {
-            order.push(target);
+impl Mount {
+    /// How a replaced mount reads back to the developer: the kind that held the target, and what it mounted there.
+    fn summary(&self) -> String {
+        match self {
+            Mount::Volume(volume) => format!("volume {}", volume.source()),
+            Mount::Fileset(_) => "fileset".to_string(),
         }
-    };
+    }
+}
+
+fn fold_mounts(
+    sources: &[Source],
+    into: &mut Vec<Contribution>,
+) -> (Vec<Volume>, Vec<FilesetEntry>) {
+    let mut order: Vec<String> = Vec::new();
+    let mut winners: BTreeMap<String, Won<Mount>> = BTreeMap::new();
     for source in sources {
         for volume in &source.spec.volumes {
-            claim(volume.target.clone(), Mount::Volume(volume.clone()));
+            claim(
+                &mut order,
+                &mut winners,
+                volume.target.clone(),
+                Mount::Volume(volume.clone()),
+                source.label,
+                Mount::summary,
+            );
         }
         for fileset in &source.spec.filesets {
-            claim(fileset.mount_path.clone(), Mount::Fileset(fileset.clone()));
+            claim(
+                &mut order,
+                &mut winners,
+                fileset.mount_path.clone(),
+                Mount::Fileset(fileset.clone()),
+                source.label,
+                Mount::summary,
+            );
         }
     }
     let mut volumes = Vec::new();
     let mut filesets = Vec::new();
-    for mount in order
+    for won in order
         .into_iter()
         .filter_map(|target| winners.remove(&target))
     {
-        match mount {
+        into.push(won.contribution(Block::Mount));
+        match won.item {
             Mount::Volume(volume) => volumes.push(volume),
             Mount::Fileset(fileset) => filesets.push(fileset),
         }
@@ -211,35 +327,62 @@ fn tool_name(entry: &str) -> &str {
     entry.split_once('@').map_or(entry, |(name, _)| name)
 }
 
+/// A key's winner, the source that decided it, and every entry that decision replaced.
+struct Won<T> {
+    item: T,
+    key: String,
+    source: String,
+    displaced: Vec<Displaced>,
+}
+
+impl<T> Won<T> {
+    fn contribution(&self, block: Block) -> Contribution {
+        Contribution {
+            block,
+            key: self.key.clone(),
+            source: self.source.clone(),
+            displaced: self.displaced.clone(),
+        }
+    }
+}
+
 /// Union one keyed block across every source, last-wins, in first-appearance order of the key so a reader sees the document's own entries before what a mixin added.
 fn fold<T: Clone>(
     sources: &[Source],
     items: fn(&SandboxSpec) -> &Vec<T>,
     key: fn(&T) -> String,
+    summary: fn(&T) -> String,
+    block: Block,
+    into: &mut Vec<Contribution>,
 ) -> Vec<T> {
-    fold_labelled(sources, items, key)
+    fold_labelled(sources, items, key, summary)
         .into_iter()
-        .map(|(item, _)| item)
+        .map(|won| {
+            into.push(won.contribution(block));
+            won.item
+        })
         .collect()
 }
 
-/// [`fold`], keeping the source each winner came from, for a block whose winners still have to answer for one another.
+/// [`fold`], keeping each winner whole, for a block whose winners still have to answer for one another.
 fn fold_labelled<T: Clone>(
     sources: &[Source],
     items: fn(&SandboxSpec) -> &Vec<T>,
     key: fn(&T) -> String,
-) -> Vec<(T, String)> {
+    summary: fn(&T) -> String,
+) -> Vec<Won<T>> {
     let mut order: Vec<String> = Vec::new();
-    let mut winners: BTreeMap<String, (T, String)> = BTreeMap::new();
+    let mut winners: BTreeMap<String, Won<T>> = BTreeMap::new();
     for source in sources {
         for item in items(source.spec) {
-            let key = key(item);
-            if winners
-                .insert(key.clone(), (item.clone(), source.label.to_string()))
-                .is_none()
-            {
-                order.push(key);
-            }
+            claim(
+                &mut order,
+                &mut winners,
+                key(item),
+                item.clone(),
+                source.label,
+                summary,
+            );
         }
     }
     order
@@ -248,11 +391,43 @@ fn fold_labelled<T: Clone>(
         .collect()
 }
 
+/// Record one source's claim of a key, keeping what it replaced so the disclosure can say what changed rather than only what won.
+fn claim<T: Clone>(
+    order: &mut Vec<String>,
+    winners: &mut BTreeMap<String, Won<T>>,
+    key: String,
+    item: T,
+    source: &str,
+    summary: fn(&T) -> String,
+) {
+    match winners.get_mut(&key) {
+        Some(won) => {
+            won.displaced.push(Displaced {
+                source: std::mem::replace(&mut won.source, source.to_string()),
+                summary: summary(&std::mem::replace(&mut won.item, item)),
+            });
+        }
+        None => {
+            order.push(key.clone());
+            winners.insert(
+                key.clone(),
+                Won {
+                    item,
+                    key,
+                    source: source.to_string(),
+                    displaced: Vec::new(),
+                },
+            );
+        }
+    }
+}
+
 /// A host port is one socket, so precedence cannot settle two sources publishing onto it: keeping the later mapping would silently unpublish a port the sandbox declared, and the resolved document would claim a host port twice — which `sandbox::parse` itself refuses.
-fn refuse_a_host_port_two_sources_publish(ports: &[(Port, String)]) -> Result<()> {
+fn refuse_a_host_port_two_sources_publish(ports: &[Won<Port>]) -> Result<()> {
     let mut held: BTreeMap<i64, &str> = BTreeMap::new();
-    for (port, label) in ports {
-        let Some(host) = port.host else { continue };
+    for won in ports {
+        let Some(host) = won.item.host else { continue };
+        let label = won.source.as_str();
         if let Some(holder) = held.insert(host, label) {
             bail!("{holder} and {label} both publish host port {host}; one of them has to move it");
         }
@@ -434,7 +609,167 @@ mod tests {
     }
 
     fn merged(owned: &[(String, SandboxSpec)]) -> SandboxSpec {
-        merge(&as_sources(owned)).expect("these sources resolve")
+        merge(&as_sources(owned))
+            .expect("these sources resolve")
+            .spec
+    }
+
+    fn contributions(owned: &[(String, SandboxSpec)]) -> Vec<Contribution> {
+        merge(&as_sources(owned))
+            .expect("these sources resolve")
+            .contributions
+    }
+
+    fn contribution(owned: &[(String, SandboxSpec)], block: Block, key: &str) -> Contribution {
+        contributions(owned)
+            .into_iter()
+            .find(|c| c.block == block && c.key == key)
+            .unwrap_or_else(|| panic!("no {block:?} contribution for {key}"))
+    }
+
+    #[test]
+    fn a_tool_a_later_source_redefines_names_the_source_and_what_it_replaced() {
+        let found = contribution(
+            &sources(&[
+                (ROOT_LABEL, r#"{"tools":["node@20","python@3.12"]}"#),
+                ("obs", r#"{"tools":["node@22"]}"#),
+            ]),
+            Block::Tool,
+            "node",
+        );
+        assert_eq!(found.source, "obs");
+        assert_eq!(
+            found.displaced,
+            [Displaced {
+                source: ROOT_LABEL.to_string(),
+                summary: "node@20".to_string()
+            }],
+            "a tool the developer read in the document is gone from the run, so the disclosure has to say which source took it and what it took it from"
+        );
+    }
+
+    #[test]
+    fn a_source_nothing_replaced_is_attributed_with_an_empty_displacement() {
+        let found = contribution(
+            &sources(&[
+                (ROOT_LABEL, r#"{"tools":["node@20"]}"#),
+                ("obs", r#"{"tools":["ripgrep@14"]}"#),
+            ]),
+            Block::Tool,
+            "ripgrep",
+        );
+        assert_eq!(found.source, "obs");
+        assert!(
+            found.displaced.is_empty(),
+            "a mixin that adds a tool replaced nothing, and saying otherwise would invent a conflict"
+        );
+    }
+
+    #[test]
+    fn a_mount_records_the_kind_that_held_the_target_before_it() {
+        let found = contribution(
+            &sources(&[
+                (
+                    ROOT_LABEL,
+                    r#"{"volumes":[{"type":"volume","name":"cache","target":"/cache"}]}"#,
+                ),
+                (
+                    "obs",
+                    r#"{"filesets":[{"inline":{"a.md":"x"},"mountPath":"/cache"}]}"#,
+                ),
+            ]),
+            Block::Mount,
+            "/cache",
+        );
+        assert_eq!(found.source, "obs");
+        assert_eq!(
+            found.displaced,
+            [Displaced {
+                source: ROOT_LABEL.to_string(),
+                summary: "volume cache".to_string()
+            }],
+            "one target is one keyspace, so a fileset taking a volume's target has to read as the replacement it is"
+        );
+    }
+
+    #[test]
+    fn a_credential_a_mixin_contributes_names_the_mixin() {
+        let found = contribution(
+            &sources(&[
+                (ROOT_LABEL, r#"{"image":"x:1"}"#),
+                (
+                    "obs",
+                    r#"{"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}]}"#,
+                ),
+            ]),
+            Block::Credential,
+            "SOME_TOKEN",
+        );
+        assert_eq!(
+            found.source, "obs",
+            "a credential the sandbox never asked for is exactly what a reader has to be able to trace to its mixin"
+        );
+    }
+
+    #[test]
+    fn every_egress_entry_is_attributed_and_none_displaces_another() {
+        let found = contributions(&sources(&[
+            (
+                ROOT_LABEL,
+                r#"{"policy":{"egress":{"http":[{"match":"api.base.example","verdict":"allow"}]}}}"#,
+            ),
+            (
+                "obs",
+                r#"{"policy":{"egress":{"http":[{"match":"api.obs.example","verdict":"allow"}]}}}"#,
+            ),
+        ]));
+        let rules: Vec<(&str, &str)> = found
+            .iter()
+            .filter(|c| c.block == Block::Egress)
+            .map(|c| (c.key.as_str(), c.source.as_str()))
+            .collect();
+        assert_eq!(
+            rules,
+            [
+                ("allow api.obs.example", "obs"),
+                ("allow api.base.example", ROOT_LABEL)
+            ],
+            "egress is a union in decision order, so every entry keeps its own source and nothing is reported as replaced"
+        );
+        assert!(
+            found
+                .iter()
+                .filter(|c| c.block == Block::Egress)
+                .all(|c| c.displaced.is_empty())
+        );
+    }
+
+    #[test]
+    fn a_third_source_records_both_the_sources_it_displaced() {
+        let found = contribution(
+            &sources(&[
+                (ROOT_LABEL, r#"{"tools":["node@20"]}"#),
+                ("obs", r#"{"tools":["node@21"]}"#),
+                ("pg", r#"{"tools":["node@22"]}"#),
+            ]),
+            Block::Tool,
+            "node",
+        );
+        assert_eq!(found.source, "pg");
+        assert_eq!(
+            found.displaced,
+            [
+                Displaced {
+                    source: ROOT_LABEL.to_string(),
+                    summary: "node@20".to_string()
+                },
+                Displaced {
+                    source: "obs".to_string(),
+                    summary: "node@21".to_string()
+                }
+            ],
+            "reporting only the last loser would hide that the document's own version lost too"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -224,6 +224,10 @@ pub struct RunArgs {
     #[arg(skip)]
     pub resolved_mixins: Vec<String>,
 
+    /// Which source decided each entry the summary shows, and what that decision replaced.
+    #[arg(skip)]
+    pub contributions: Vec<lns_ipc::SourceContribution>,
+
     #[arg(
         short = 'v',
         long = "volume",

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -691,6 +691,7 @@ mod tests {
         RunArgs {
             mixins: Vec::new(),
             resolved_mixins: Vec::new(),
+            contributions: Vec::new(),
             image: Some("alpine".to_string()),
             file: None,
             name: None,

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -85,9 +85,21 @@ pub fn mixin_display(resolved: &[String], typed: &[String], pinned: &[String]) -
 }
 
 /// What the mixin flags become once the preflight has answered: the run carries the digests it pinned, and the summary shows each beside the reference the user typed. A typed reference goes no further than this, so the boot can only merge bytes the disclosure named.
-pub fn adopt_pinned_mixins(args: &mut RunArgs, resolved: &[String], pinned: &[String]) {
+pub fn adopt_pinned_mixins(
+    args: &mut RunArgs,
+    resolved: &[String],
+    pinned: &[String],
+    contributions: &[lns_ipc::SourceContribution],
+) {
     args.resolved_mixins = mixin_display(resolved, &args.mixins, pinned);
     args.mixins = pinned.to_vec();
+    args.contributions = contributions.to_vec();
+}
+
+/// A target the user claimed with `-v` has no author but them, so the declared mount it displaced must not be named as the author of the one that boots.
+pub fn drop_overridden_mounts(args: &mut RunArgs, overridden: &[String]) {
+    args.contributions
+        .retain(|c| c.block != lns_ipc::ContributionBlock::Mount || !overridden.contains(&c.key));
 }
 
 pub fn print_run_summary(
@@ -104,6 +116,89 @@ pub fn print_run_summary(
     Ok(path)
 }
 
+/// How an entry names the source that decided it, empty for a run that resolved no mixin; only for a block whose keys are unique, never for egress, where two sources may key alike.
+fn attribution(args: &RunArgs, block: lns_ipc::ContributionBlock, key: &str) -> String {
+    if args.resolved_mixins.is_empty() {
+        return String::new();
+    }
+    args.contributions
+        .iter()
+        .find(|c| c.block == block && c.key == key)
+        .map(attribution_of)
+        .unwrap_or_default()
+}
+
+/// The suffix one contribution renders as, taken from the entry rather than found again by key, since a key names one entry only outside egress.
+fn attribution_of(found: &lns_ipc::SourceContribution) -> String {
+    let replaced: Vec<String> = found
+        .displaced
+        .iter()
+        .map(|d| format!(", replaced {} from {}", d.summary, short_source(&d.source)))
+        .collect();
+    format!(
+        "  [from {}{}]",
+        short_source(&found.source),
+        replaced.join("")
+    )
+}
+
+/// A source as the disclosure names it, with a digest shortened the way every other reference in this summary is.
+fn short_source(source: &str) -> String {
+    match source.split_once("@sha256:") {
+        Some((repo, digest)) if digest.chars().count() > 12 => {
+            let short: String = digest.chars().take(12).collect();
+            format!("{repo}@sha256:{short}…")
+        }
+        _ => source.to_string(),
+    }
+}
+
+/// Where every value in this summary starts, so a label too long to fit still lines its entries up under one another.
+const COLUMN: usize = 13;
+
+/// The blocks §1.5 names that an uncomposed run has never printed, since only a composed run has a second author to attribute them to.
+fn write_composed_blocks(s: &mut String, args: &RunArgs) {
+    let listed = |block| -> Vec<&lns_ipc::SourceContribution> {
+        args.contributions
+            .iter()
+            .filter(|c| c.block == block)
+            .collect()
+    };
+    write_block(s, "Rules", &listed(lns_ipc::ContributionBlock::Egress));
+    write_block(
+        s,
+        "Credentials",
+        &listed(lns_ipc::ContributionBlock::Credential),
+    );
+}
+
+fn write_block(s: &mut String, label: &str, entries: &[&lns_ipc::SourceContribution]) {
+    let Some((first, rest)) = entries.split_first() else {
+        return;
+    };
+    let heading = format!("  {label}:");
+    let pad = COLUMN.saturating_sub(heading.len()).max(1);
+    let value_column = heading.len() + pad;
+    writeln!(
+        s,
+        "{heading}{:pad$}{}{}",
+        "",
+        first.key,
+        attribution_of(first)
+    )
+    .unwrap();
+    for entry in rest {
+        writeln!(
+            s,
+            "{:value_column$}{}{}",
+            "",
+            entry.key,
+            attribution_of(entry)
+        )
+        .unwrap();
+    }
+}
+
 pub fn format_summary(
     args: &RunArgs,
     size: lns_artifact::resources::VmSize,
@@ -115,25 +210,43 @@ pub fn format_summary(
     s.push_str("lns run\n");
     writeln!(s, "  Image:     {}", image_line(args)).unwrap();
     let (volumes, binds) = crate::cli::split_mounts(&args.mounts);
+    let mount = lns_ipc::ContributionBlock::Mount;
     for vol in &volumes {
-        writeln!(s, "  Volume:    {}", volume_line(vol)).unwrap();
+        let from = attribution(args, mount, &vol.target);
+        writeln!(s, "  Volume:    {}{from}", volume_line(vol)).unwrap();
     }
     for bind in &binds {
-        writeln!(s, "  Bind:      {}", bind_line(bind)).unwrap();
+        let from = attribution(args, mount, &bind.target);
+        writeln!(s, "  Bind:      {}{from}", bind_line(bind)).unwrap();
     }
     for fileset in &args.filesets {
         writeln!(
             s,
-            "  Fileset:   {} -> {} (owner: {})",
-            fileset.source, fileset.mount_path, fileset.owner
+            "  Fileset:   {} -> {} (owner: {}){}",
+            fileset.source,
+            fileset.mount_path,
+            fileset.owner,
+            attribution(args, mount, &fileset.mount_path)
         )
         .unwrap();
     }
     if !args.tools.is_empty() {
-        writeln!(s, "  Tools:     {}", args.tools.join(", ")).unwrap();
+        let tools: Vec<String> = args
+            .tools
+            .iter()
+            .map(|tool| {
+                let key = tool.split_once('@').map_or(tool.as_str(), |(name, _)| name);
+                format!(
+                    "{tool}{}",
+                    attribution(args, lns_ipc::ContributionBlock::Tool, key)
+                )
+            })
+            .collect();
+        writeln!(s, "  Tools:     {}", tools.join(", ")).unwrap();
     }
     if !args.resolved_mixins.is_empty() {
         writeln!(s, "  Mixins:    {}", args.resolved_mixins.join(", ")).unwrap();
+        write_composed_blocks(&mut s, args);
     }
     if let Some(dir) = &args.workdir {
         writeln!(s, "  Workdir:   {dir}").unwrap();
@@ -317,10 +430,15 @@ fn ports_line(args: &RunArgs) -> String {
         .map(|p| {
             let bind = std::net::SocketAddr::new(p.host_ip, p.host_port);
             let mapping = format!("{bind} -> {}", p.container_port);
+            let from = attribution(
+                args,
+                lns_ipc::ContributionBlock::Port,
+                &p.container_port.to_string(),
+            );
             if p.host_ip.is_loopback() {
-                mapping
+                format!("{mapping}{from}")
             } else {
-                format!("{mapping} (exposed beyond this machine)")
+                format!("{mapping} (exposed beyond this machine){from}")
             }
         })
         .collect::<Vec<_>>()
@@ -394,6 +512,7 @@ mod tests {
         RunArgs {
             mixins: Vec::new(),
             resolved_mixins: Vec::new(),
+            contributions: Vec::new(),
             image: image.map(str::to_string),
             file: None,
             name: None,
@@ -524,6 +643,7 @@ mod tests {
         let view = lns_ipc::SandboxView {
             mixins: Vec::new(),
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: "sha256:abc".into(),
             image: "registry.example.test/runtime:1".into(),
@@ -609,6 +729,7 @@ mod tests {
             &mut args,
             std::slice::from_ref(&pinned),
             std::slice::from_ref(&pinned),
+            &[],
         );
         assert_eq!(
             args.mixins,
@@ -625,7 +746,7 @@ mod tests {
     #[test]
     fn a_run_that_named_no_mixin_carries_none_after_the_preflight() {
         let mut args = run_args(Some("prism"));
-        adopt_pinned_mixins(&mut args, &[], &[]);
+        adopt_pinned_mixins(&mut args, &[], &[], &[]);
         assert!(args.mixins.is_empty());
         assert!(
             args.resolved_mixins.is_empty(),
@@ -637,7 +758,7 @@ mod tests {
     fn a_mixin_only_the_document_declared_is_disclosed_without_being_carried() {
         let declared = format!("ghcr.io/acme/base@sha256:{}", "a".repeat(64));
         let mut args = run_args(Some("prism"));
-        adopt_pinned_mixins(&mut args, std::slice::from_ref(&declared), &[]);
+        adopt_pinned_mixins(&mut args, std::slice::from_ref(&declared), &[], &[]);
         assert_eq!(
             args.resolved_mixins,
             [declared],
@@ -670,6 +791,334 @@ mod tests {
             &PolicySource::FoundInCwd,
         );
         assert!(!authored.contains("Mixins:"), "got: {authored}");
+    }
+
+    fn contributed(
+        block: lns_ipc::ContributionBlock,
+        key: &str,
+        source: &str,
+        displaced: &[(&str, &str)],
+    ) -> lns_ipc::SourceContribution {
+        lns_ipc::SourceContribution {
+            block,
+            key: key.to_string(),
+            source: source.to_string(),
+            displaced: displaced
+                .iter()
+                .map(|(source, summary)| lns_ipc::DisplacedEntry {
+                    source: (*source).to_string(),
+                    summary: (*summary).to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    fn composed(args: &mut RunArgs, contributions: Vec<lns_ipc::SourceContribution>) {
+        args.resolved_mixins = vec![format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64))];
+        args.contributions = contributions;
+    }
+
+    #[test]
+    fn a_tool_a_mixin_replaced_names_the_mixin_and_the_version_it_replaced() {
+        let mut args = run_args(Some("prism"));
+        args.tools = vec!["node@22".into()];
+        composed(
+            &mut args,
+            vec![contributed(
+                lns_ipc::ContributionBlock::Tool,
+                "node",
+                &format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64)),
+                &[("the sandbox", "node@20")],
+            )],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("node@22  [from ghcr.io/acme/obs@sha256:cccccccccccc…, replaced node@20 from the sandbox]"),
+            "a developer reading `node@22` has to be able to see that a mixin put it there over the version their own document asked for; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_composed_run_lists_the_rules_and_credentials_the_merge_produced() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        composed(
+            &mut args,
+            vec![
+                contributed(
+                    lns_ipc::ContributionBlock::Egress,
+                    "api.vendor.example",
+                    &obs,
+                    &[],
+                ),
+                contributed(
+                    lns_ipc::ContributionBlock::Credential,
+                    "SOME_TOKEN",
+                    &obs,
+                    &[],
+                ),
+            ],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains(
+                "Rules:     api.vendor.example  [from ghcr.io/acme/obs@sha256:cccccccccccc…]"
+            ),
+            "a destination a mixin opened is the whole reason the merged table is disclosed before boot; got: {s}"
+        );
+        assert!(
+            s.contains("Credentials: SOME_TOKEN  [from ghcr.io/acme/obs@sha256:cccccccccccc…]"),
+            "a credential the sandbox never asked for has to be traceable to the source that asked; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_second_rule_lines_up_under_the_first_without_repeating_the_label() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        composed(
+            &mut args,
+            vec![
+                contributed(
+                    lns_ipc::ContributionBlock::Egress,
+                    "api.vendor.example",
+                    &obs,
+                    &[],
+                ),
+                contributed(
+                    lns_ipc::ContributionBlock::Egress,
+                    "proxy.vendor.example",
+                    "the sandbox",
+                    &[],
+                ),
+            ],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("\n             proxy.vendor.example  [from the sandbox]\n"),
+            "a merged table is read as a table, so the second entry has to sit under the first rather than restate the label; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_mount_the_user_added_on_the_command_line_is_attributed_to_nobody() {
+        let mut args = run_args(Some("prism"));
+        args.mounts = vec![lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
+            name: "scratch".into(),
+            target: "/scratch".into(),
+            read_only: false,
+        })];
+        composed(&mut args, Vec::new());
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("Volume:    scratch \u{2192} /scratch\n"),
+            "the user typed this one, so naming a source for it would invent an author; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_mount_the_user_overrode_loses_the_declared_sources_attribution() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        args.mounts = vec![lns_ipc::MountSpec::Named(lns_ipc::VolumeMount {
+            name: "mine".into(),
+            target: "/scratch".into(),
+            read_only: false,
+        })];
+        composed(
+            &mut args,
+            vec![contributed(
+                lns_ipc::ContributionBlock::Mount,
+                "/scratch",
+                &obs,
+                &[],
+            )],
+        );
+        drop_overridden_mounts(&mut args, &["/scratch".to_string()]);
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("Volume:    mine \u{2192} /scratch\n"),
+            "the mixin's mount is not what boots, so naming it as the author of the user's own mount inverts who decided this; got: {s}"
+        );
+    }
+
+    #[test]
+    fn two_sources_declaring_one_rule_each_keep_their_own_source() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        composed(
+            &mut args,
+            vec![
+                contributed(
+                    lns_ipc::ContributionBlock::Egress,
+                    "allow api.vendor.example",
+                    &obs,
+                    &[],
+                ),
+                contributed(
+                    lns_ipc::ContributionBlock::Egress,
+                    "allow api.vendor.example",
+                    "the sandbox",
+                    &[],
+                ),
+            ],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains(
+                "Rules:     allow api.vendor.example  [from ghcr.io/acme/obs@sha256:cccccccccccc…]"
+            ),
+            "got: {s}"
+        );
+        assert!(
+            s.contains("\n             allow api.vendor.example  [from the sandbox]\n"),
+            "egress is the one block two sources can key alike, so looking each line up by its key would name the first source twice and hide that the sandbox said this too; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_port_a_mixin_publishes_names_the_mixin() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        args.publish = vec![lns_ipc::PortPublish {
+            host_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            host_port: 8080,
+            container_port: 8080,
+            protocol: lns_ipc::Protocol::Tcp,
+        }];
+        composed(
+            &mut args,
+            vec![contributed(
+                lns_ipc::ContributionBlock::Port,
+                "8080",
+                &obs,
+                &[],
+            )],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("[from ghcr.io/acme/obs@sha256:cccccccccccc…]"),
+            "a mixin opening a host socket is a thing the developer is approving, so it has to name who asked; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_second_credential_lines_up_under_the_first() {
+        let mut args = run_args(Some("prism"));
+        let obs = format!("ghcr.io/acme/obs@sha256:{}", "c".repeat(64));
+        composed(
+            &mut args,
+            vec![
+                contributed(
+                    lns_ipc::ContributionBlock::Credential,
+                    "SOME_TOKEN",
+                    &obs,
+                    &[],
+                ),
+                contributed(
+                    lns_ipc::ContributionBlock::Credential,
+                    "SOME_OTHER_TOKEN",
+                    &obs,
+                    &[],
+                ),
+            ],
+        );
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        let first = s
+            .lines()
+            .find(|l| l.contains("SOME_TOKEN"))
+            .expect("the first credential renders");
+        let second = s
+            .lines()
+            .find(|l| l.contains("SOME_OTHER_TOKEN"))
+            .expect("the second credential renders");
+        assert_eq!(
+            first.find("SOME_TOKEN"),
+            second.find("SOME_OTHER_TOKEN"),
+            "a label wider than the column still has to line its own entries up, or the block stops reading as one list"
+        );
+    }
+
+    #[test]
+    fn a_source_whose_digest_is_not_ascii_truncates_on_a_character() {
+        let mut args = run_args(Some("prism"));
+        composed(
+            &mut args,
+            vec![contributed(
+                lns_ipc::ContributionBlock::Tool,
+                "node",
+                "some/dir@sha256:a\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}",
+                &[],
+            )],
+        );
+        args.tools = vec!["node@22".into()];
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(
+            s.contains("some/dir@sha256:a\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{2026}"),
+            "a directory the user named is theirs to spell, so shortening it by bytes would panic on a run that is otherwise fine; got: {s}"
+        );
+    }
+
+    #[test]
+    fn an_uncomposed_run_prints_exactly_what_it_printed_before_attribution_existed() {
+        let mut args = run_args(Some("prism"));
+        args.tools = vec!["node@22".into()];
+        let s = summary_of(
+            &args,
+            &Policy::default(),
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+        assert!(s.contains("Tools:     node@22\n"), "got: {s}");
+        assert!(
+            !s.contains("[from") && !s.contains("Rules:") && !s.contains("Credentials:"),
+            "a run that resolved no mixin has one author, so attributing every line to them is noise; got: {s}"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -1332,6 +1332,7 @@ mod tests {
             inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "ghcr.io/team/hermes:1.4.0".into(),
                 digest,
                 image: "docker.io/library/alpine@sha256:abc".into(),
@@ -2117,6 +2118,7 @@ mod tests {
                 inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                     mixins: Vec::new(),
                     pinned_mixins: Vec::new(),
+                    contributions: Vec::new(),
                     reference: "hermes:1.4.0".into(),
                     digest: format!("sha256:{}", "a".repeat(64)),
                     image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -133,6 +133,7 @@ struct PublishedTarget {
     tools: Vec<String>,
     mixins: Vec<String>,
     pinned_mixins: Vec<String>,
+    contributions: Vec<lns_ipc::SourceContribution>,
 }
 
 fn published_target(
@@ -154,6 +155,7 @@ fn published_target(
                 tools: crate::run::summary::tools_from_view(&view),
                 mixins: view.mixins.clone(),
                 pinned_mixins: view.pinned_mixins.clone(),
+                contributions: view.contributions.clone(),
             })
         }
         lns_ipc::ArtifactInspection::Mixin(_) => anyhow::bail!(
@@ -187,6 +189,7 @@ struct ResolvedDefinition {
     definition: String,
     mixins: Vec<String>,
     pinned_mixins: Vec<String>,
+    contributions: Vec<lns_ipc::SourceContribution>,
 }
 
 /// Ask the service to resolve a local definition's mixins, since only it can pull a reference and read a directory the way the run will.
@@ -216,10 +219,12 @@ async fn preflight_local(
             definition,
             mixins,
             pinned_mixins,
+            contributions,
         }) => Ok(ResolvedDefinition {
             definition,
             mixins,
             pinned_mixins,
+            contributions,
         }),
         Some(Response::Error { message }) => anyhow::bail!("{message}"),
         Some(other) => anyhow::bail!("unexpected response from daemon: {other:?}"),
@@ -284,6 +289,7 @@ pub async fn run_image(
             &mut args,
             &resolved.mixins,
             &resolved.pinned_mixins,
+            &resolved.contributions,
         );
     }
     let published = match &target {
@@ -356,8 +362,10 @@ pub async fn run_image(
             &mut args,
             &published.mixins,
             &published.pinned_mixins,
+            &published.contributions,
         );
     }
+    crate::run::summary::drop_overridden_mounts(&mut args, &consumer_mount_targets);
     // The size travels as its own value: writing it back into args.cpus/args.mem would tell the service the user asked for it explicitly.
     let size = crate::run::summary::resolved_size(defaults.size, &args);
     let quiet = args.quiet;
@@ -1269,6 +1277,7 @@ mod tests {
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d".into()],
                 pinned_mixins: vec!["ghcr.io/acme/obs@sha256:5b9e1f0a".into()],
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: digest.clone(),
                 image: "registry.example.test/runtime:1".into(),
@@ -1355,6 +1364,7 @@ mod tests {
             lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:1".into(),
                 digest: String::new(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -90,6 +90,7 @@ fn pulled_view_with_fileset(world: &mut BehaviourWorld, reference: String, mount
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -123,6 +124,7 @@ fn pulled_view_with_inline_fileset(world: &mut BehaviourWorld, mount: String) {
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),
@@ -286,6 +288,7 @@ fn pulled_view_with_host_path_fileset(world: &mut BehaviourWorld, source: String
     world.pulled_view = Some(lns_ipc::SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -39,6 +39,7 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
     lns_ipc::SandboxView {
         mixins: def.spec.mixins.clone(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -180,6 +180,7 @@ fn published_view(def: &lns_artifact::sandbox::Definition) -> lns_ipc::SandboxVi
     lns_ipc::SandboxView {
         mixins: def.spec.mixins.clone(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: "registry.example.test/team/sandbox:1".into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: def.spec.image.clone(),

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -68,6 +68,7 @@ fn published_sandbox_declaring_tools(w: &mut BehaviourWorld) {
     let view = SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: TOOLS_REFERENCE.into(),
         digest: format!("sha256:{}", "a".repeat(64)),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -34,6 +34,7 @@ fn inspects_sandbox_settings(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -77,6 +78,7 @@ fn inspects_sandbox_ports(world: &mut BehaviourWorld, reference: String) {
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -145,6 +147,7 @@ fn inspects_sandbox_with_a_pinned_flag_mixin(
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: vec![pinned.clone()],
         pinned_mixins: vec![pinned],
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -175,6 +178,7 @@ fn inspects_sandbox_resolved_from_a_mixin(
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: vec![mixin],
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -201,6 +205,7 @@ fn inspects_sandbox_filesets(world: &mut BehaviourWorld, reference: String, moun
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -236,6 +241,7 @@ fn inspects_sandbox_user(world: &mut BehaviourWorld, reference: String, user: St
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -267,6 +273,7 @@ fn inspects_sandbox_credential(
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -301,6 +308,7 @@ fn inspects_sandbox_permissive_policy(world: &mut BehaviourWorld, reference: Str
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),
@@ -327,6 +335,7 @@ fn inspects_sandbox_env(world: &mut BehaviourWorld, reference: String, entry: St
     let inspection = ArtifactInspection::Sandbox(Box::new(SandboxView {
         mixins: Vec::new(),
         pinned_mixins: Vec::new(),
+        contributions: Vec::new(),
         reference: reference.clone(),
         digest: full_digest(),
         image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -36,6 +36,7 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
         inspection: ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference,
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -65,6 +65,7 @@ fn registry_serves_sandbox(w: &mut BehaviourWorld, reference: String) {
         inspection: lns_ipc::ArtifactInspection::Sandbox(Box::new(lns_ipc::SandboxView {
             mixins: Vec::new(),
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference,
             digest,
             image: "docker.io/library/alpine@sha256:abc".into(),

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -20,12 +20,13 @@ pub use paths::{
     cache_root, connection_ledger, connection_ledger_anchor, data_root, short_run_id,
 };
 pub use protocol::{
-    ArtifactInspection, BindMount, BindSpec, CredentialBindDecision, ExecImageArgs, ImageInfo,
-    ImageView, LogLevel, MixinView, MountSpec, PortPublish, Protocol, Request, Response, RunConfig,
-    RunDetails, RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SandboxFileset,
-    SandboxFilesetOwner, SandboxMount, SandboxMountKind, SandboxPort, SandboxView, SignalKind,
-    StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, cmdline_unsafe_char,
-    validate_bind_source, validate_run_name, validate_volume_name, validate_volume_target,
+    ArtifactInspection, BindMount, BindSpec, ContributionBlock, CredentialBindDecision,
+    DisplacedEntry, ExecImageArgs, ImageInfo, ImageView, LogLevel, MixinView, MountSpec,
+    PortPublish, Protocol, Request, Response, RunConfig, RunDetails, RunImageArgs, RunStatsInfo,
+    RunStatus, RunSummary, SandboxFileset, SandboxFilesetOwner, SandboxMount, SandboxMountKind,
+    SandboxPort, SandboxView, SignalKind, SourceContribution, StatusInfo, VolumeInfo, VolumeMount,
+    VolumePruneFailure, cmdline_unsafe_char, validate_bind_source, validate_run_name,
+    validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -237,6 +237,9 @@ pub enum Response {
         mixins: Vec<String>,
         /// What each mixin the user named resolved to, in the order they named them.
         pinned_mixins: Vec<String>,
+        /// Which source decided each entry of the merged document, so the disclosure can attribute every line it shows.
+        #[serde(default)]
+        contributions: Vec<SourceContribution>,
     },
     ImageTagged {
         from: String,
@@ -315,6 +318,33 @@ pub struct MixinView {
     pub policy_flags: Vec<String>,
 }
 
+/// The block a contribution belongs to, which is what tells a renderer which line to attribute it to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContributionBlock {
+    Credential,
+    Tool,
+    Mount,
+    Port,
+    Egress,
+}
+
+/// One entry of a resolved sandbox, named by the source that decided it and by whatever that decision replaced (`docs/sandbox-spec.md` §1.5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceContribution {
+    pub block: ContributionBlock,
+    pub key: String,
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub displaced: Vec<DisplacedEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisplacedEntry {
+    pub source: String,
+    pub summary: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxView {
     pub reference: String,
@@ -327,6 +357,9 @@ pub struct SandboxView {
     /// What each mixin the user named resolved to, in the order they named them, so the run boots the bytes its preflight pinned.
     #[serde(default)]
     pub pinned_mixins: Vec<String>,
+    /// Which source decided each entry below, and what that decision replaced.
+    #[serde(default)]
+    pub contributions: Vec<SourceContribution>,
     #[serde(default)]
     pub workdir: Option<String>,
     /// The run-as user the sandbox declared, so a pulled artifact asking for root is visible before it boots.
@@ -1458,6 +1491,7 @@ mod tests {
         let view = SandboxView {
             mixins: vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d20a95f6c3d84b1e07f92a5c8d63b40e19a7c25f8b0d3e6a94c17f582".into()],
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference: "registry.example.test/team/sandbox:1".into(),
             digest: format!("sha256:{}", "a".repeat(64)),
             image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -123,6 +123,7 @@ pub(crate) fn project_inspection(
                 lns_ipc::SandboxView {
                     mixins: resolution.mixins.clone(),
                     pinned_mixins: resolution.pinned_extra.clone(),
+                    contributions: crate::artifact::mixin::on_the_wire(&resolution.contributions),
                     reference: image_ref.to_string(),
                     digest,
                     cpus: declared_size.cpus,
@@ -168,6 +169,7 @@ mod tests {
             document: config.as_bytes().to_vec(),
             mixins: mixins.to_vec(),
             pinned_extra: Vec::new(),
+            contributions: Vec::new(),
         }
     }
 
@@ -265,6 +267,7 @@ mod tests {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -287,6 +290,7 @@ mod tests {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins,
             pinned_mixins: pinned,
+            contributions: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -309,6 +313,7 @@ mod tests {
         ArtifactInspection::Sandbox(Box::new(SandboxView {
             mixins: Vec::new(),
             pinned_mixins: Vec::new(),
+            contributions: Vec::new(),
             reference: "registry.example.test/team/sandbox:latest".into(),
             digest: digest(),
             image: "registry.example.test/runtime:1".into(),
@@ -339,6 +344,7 @@ mod tests {
                 document: b"{}".to_vec(),
                 mixins: Vec::new(),
                 pinned_extra: Vec::new(),
+                contributions: Vec::new(),
             },
             None,
         )
@@ -364,6 +370,7 @@ mod tests {
                 document: document.into_bytes(),
                 mixins: Vec::new(),
                 pinned_extra: Vec::new(),
+                contributions: Vec::new(),
             },
             None,
         )
@@ -397,6 +404,7 @@ mod tests {
                 document: br#"{"apiVersion":"lns.run/v1","kind":"Mixin","metadata":{"name":"obs"},"spec":{"image":"x:1"}}"#.to_vec(),
                 mixins: Vec::new(),
                 pinned_extra: Vec::new(),
+                contributions: Vec::new(),
             },
             None,
         )
@@ -421,6 +429,7 @@ mod tests {
                     document: br#"{"apiVersion":"lns.run/v1","kind":"Sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1"}}"#.to_vec(),
                     mixins: vec![declared.clone(), pinned.clone()],
                     pinned_extra: vec![pinned.clone()],
+                    contributions: Vec::new(),
                 },
                 None,
             )
@@ -573,6 +582,7 @@ mod tests {
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -653,6 +663,7 @@ mod tests {
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -691,6 +702,7 @@ mod tests {
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),
@@ -721,6 +733,7 @@ mod tests {
             ArtifactInspection::Sandbox(Box::new(SandboxView {
                 mixins: Vec::new(),
                 pinned_mixins: Vec::new(),
+                contributions: Vec::new(),
                 reference: "registry.example.test/team/sandbox:latest".into(),
                 digest: digest(),
                 image: "registry.example.test/runtime:1".into(),

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -195,6 +195,7 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
             document: config_json.to_vec(),
             mixins: Vec::new(),
             pinned_extra: Vec::new(),
+            contributions: Vec::new(),
         });
     }
     resolve(config_json, extra, home, source).await
@@ -207,6 +208,8 @@ pub struct Resolution {
     pub mixins: Vec<String>,
     /// What each reference the user named resolved to, in the order they named them, so the boot merges the bytes the preflight showed.
     pub pinned_extra: Vec<String>,
+    /// Which source decided each entry of the merged document, and what that decision replaced.
+    pub contributions: Vec<lns_artifact::merge::Contribution>,
 }
 
 /// Resolve a published definition and every mixin it layers on into the one document a run boots (`docs/sandbox-spec.md` §3.3), returned as a definition the rest of the plan path reads exactly as it reads an authored one.
@@ -222,6 +225,7 @@ pub async fn resolve<S: MixinSource>(
             document: config_json.to_vec(),
             mixins: Vec::new(),
             pinned_extra: Vec::new(),
+            contributions: Vec::new(),
         });
     }
     let fetched = collect(&def.spec.mixins, extra, home, source).await?;
@@ -229,7 +233,7 @@ pub async fn resolve<S: MixinSource>(
     root.mixins = fetched.pinned_roots;
     let sources = flatten(&root, &fetched.pinned_extra, &fetched.graph)?;
     let merged = merge(&sources)?;
-    let document = document(&def, &merged)?;
+    let document = document(&def, &merged.spec)?;
     refuse_what_no_sandbox_could_be(&document, &sources)?;
     Ok(Resolution {
         document,
@@ -239,7 +243,36 @@ pub async fn resolve<S: MixinSource>(
             .map(|source| source.label.to_string())
             .collect(),
         pinned_extra: fetched.pinned_extra,
+        contributions: merged.contributions,
     })
+}
+
+/// Restate a merge's attribution for the wire, since lns-ipc names the document format without depending on the crate that merges it.
+pub fn on_the_wire(
+    contributions: &[lns_artifact::merge::Contribution],
+) -> Vec<lns_ipc::SourceContribution> {
+    contributions
+        .iter()
+        .map(|c| lns_ipc::SourceContribution {
+            block: match c.block {
+                lns_artifact::merge::Block::Credential => lns_ipc::ContributionBlock::Credential,
+                lns_artifact::merge::Block::Tool => lns_ipc::ContributionBlock::Tool,
+                lns_artifact::merge::Block::Mount => lns_ipc::ContributionBlock::Mount,
+                lns_artifact::merge::Block::Port => lns_ipc::ContributionBlock::Port,
+                lns_artifact::merge::Block::Egress => lns_ipc::ContributionBlock::Egress,
+            },
+            key: c.key.clone(),
+            source: c.source.clone(),
+            displaced: c
+                .displaced
+                .iter()
+                .map(|d| lns_ipc::DisplacedEntry {
+                    source: d.source.clone(),
+                    summary: d.summary.clone(),
+                })
+                .collect(),
+        })
+        .collect()
 }
 
 /// Only a sandbox document has blocks to merge into, so a run of anything else has to refuse what it was given rather than boot without it.
@@ -405,6 +438,71 @@ mod tests {
             .collect();
         let out = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs)).await?;
         lns_artifact::sandbox::parse(&out.document)
+    }
+
+    #[tokio::test]
+    async fn a_resolution_carries_which_source_decided_each_entry() {
+        let (spec, documents) = resolve_named(
+            r#"{"image":"x:1","tools":["node@20"],"mixins":["obs"]}"#,
+            &[("obs", r#"{"tools":["node@22"]}"#)],
+        );
+        let refs: Vec<(&str, &str)> = documents
+            .iter()
+            .map(|(r, b)| (r.as_str(), b.as_str()))
+            .collect();
+        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+            .await
+            .expect("a declared mixin resolves");
+        let wire = on_the_wire(&resolution.contributions);
+        let tool = wire
+            .iter()
+            .find(|c| c.block == lns_ipc::ContributionBlock::Tool && c.key == "node")
+            .expect("the merged document's tool is attributed");
+        assert_eq!(tool.source, pinned("obs"));
+        assert_eq!(
+            tool.displaced,
+            [lns_ipc::DisplacedEntry {
+                source: lns_artifact::merge::ROOT_LABEL.to_string(),
+                summary: "node@20".to_string()
+            }],
+            "the disclosure the CLI prints is built from this, so what a mixin replaced has to survive the wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn every_block_a_merge_attributes_survives_the_wire() {
+        let (spec, documents) = resolve_named(
+            r#"{"image":"x:1","mixins":["obs"]}"#,
+            &[(
+                "obs",
+                r#"{"tools":["node@22"],"volumes":[{"type":"volume","name":"cache","target":"/cache"}],"ports":[{"container":8080}],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}],"policy":{"egress":{"http":[{"match":"api.some-provider.example","verdict":"allow"}]}}}"#,
+            )],
+        );
+        let refs: Vec<(&str, &str)> = documents
+            .iter()
+            .map(|(r, b)| (r.as_str(), b.as_str()))
+            .collect();
+        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+            .await
+            .expect("a mixin declaring every block resolves");
+        let wire = on_the_wire(&resolution.contributions);
+        let found: Vec<(lns_ipc::ContributionBlock, &str)> =
+            wire.iter().map(|c| (c.block, c.key.as_str())).collect();
+        for expected in [
+            (lns_ipc::ContributionBlock::Tool, "node"),
+            (lns_ipc::ContributionBlock::Mount, "/cache"),
+            (lns_ipc::ContributionBlock::Port, "8080"),
+            (lns_ipc::ContributionBlock::Credential, "SOME_TOKEN"),
+            (
+                lns_ipc::ContributionBlock::Egress,
+                "allow api.some-provider.example",
+            ),
+        ] {
+            assert!(
+                found.contains(&expected),
+                "§1.5 names every rule, mount, tool and credential, so a block that never reaches the wire is a line the disclosure cannot attribute; missing {expected:?} from {found:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -369,6 +369,7 @@ pub(crate) async fn resolve_definition(
             .context("the resolved definition is not utf-8")?,
         mixins: resolution.mixins,
         pinned_mixins: resolution.pinned_extra,
+        contributions: crate::artifact::mixin::on_the_wire(&resolution.contributions),
     })
 }
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -601,8 +601,23 @@ A `--mixin` may be a tag, where a document's entry may not. The run pins it
 before it reports it, so the summary names the exact bytes you approved:
 
 ```
-  Mixins:    /work/mixins/debug-tools, observability:2 → ghcr.io/acme/observability@sha256:c41e8b7d…
+  Mixins:    /work/mixins/debug-tools, observability:2 → ghcr.io/acme/observability@sha256:c41e8b7d20a9…
 ```
+
+A composed run is a document you did not write in full, so the summary says
+where each line came from — and lists the rules and credentials the merge
+produced, which an uncomposed run has no second author to attribute:
+
+```
+  Volume:    cache → /home/agent/.cache  [from /work/mixins/debug-tools]
+  Tools:     node@22  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…, replaced node@20 from the sandbox]
+  Rules:     allow api.vendor.example  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
+             deny proxy.vendor.example  [from the sandbox]
+  Credentials: SOME_TOKEN  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
+```
+
+A run that resolved no mixin prints what it always has: one author, nothing to
+attribute.
 
 `lns inspect <REF> --mixin <REF>` shows the same composition without starting a
 run.


### PR DESCRIPTION
> Stacked on #231. Base is `feat/mixin-grant-key`; #229 and #230 have merged.
>
> Implements [§1.5](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#15-one-disclosure), which was normative and wholly unimplemented.

## What was missing

§1.5 is explicit about what a consumer approves:

> before boot, the run presents the merged result in full — every rule, mount, tool, and credential, each attributed to the mixin it came from

The summary printed a flat `Mixins: a, b, c` line and nothing else about composition. No source on any mount, fileset or tool — and **no merged egress table and no credentials at all**, for any run. So two of the four things §1.5 names were not merely unattributed; they were absent.

That matters beyond tidiness. [§4.2](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#42-the-egress-definition) says a later source turning a `deny` into an `allow` is *deliberate* — and the reason that is safe is "the developer approves the effective egress, not each contributor's opinion of it." The disclosure that argument rests on did not exist.

## The record

`merge()` returns `Merged { spec, contributions }`. A `Contribution` names its block, its key, the source that decided it, and every entry that decision displaced.

The record comes out of the fold that picks winners, not a second walk that could disagree with it. `fold_labelled` already carried each winner's label for the host-port refusal and threw the loser away on `insert`; keeping it is one `std::mem::replace`. A shared `claim()` now serves the keyed folds and `fold_mounts`, so volumes and filesets keep one keyspace and one displacement rule.

**Which blocks.** The four §1.5 names, plus `ports` — a mixin opening a host socket is a thing the developer is approving. Not `env`: §1.5 does not name it and the summary has never printed it, so attributing it would be inventing UI the spec does not ask for.

**Egress carries no displacement.** Its entries are unioned, and whether a later entry shadows an earlier one is destination-dependent — claiming a replacement would mean simulating the gate. Each entry is attributed to its own source and nothing is reported as replaced. The one fully-decidable case (two sources naming the identical rule) is visible because both lines render with their own source.

## What it looks like

```
lns run
  Image:     ghcr.io/acme/agent@sha256:ab12…
  Mixins:    obs-tools:2 → ghcr.io/acme/obs@sha256:cd34…, /work/mixins/pg
  Volume:    cache → /home/agent/.cache  [from /work/mixins/pg]
  Tools:     node@22  [from ghcr.io/acme/obs@sha256:cd34…, replaced node@20 from the sandbox]
  Rules:     allow api.vendor.example  [from ghcr.io/acme/obs@sha256:cd34…]
             deny proxy.vendor.example  [from the sandbox]
  Credentials: SOME_TOKEN  [from ghcr.io/acme/obs@sha256:cd34…]
```

A run that resolved no mixin prints byte-identically to before — it has one author, so attributing every line to them is noise. That is pinned by its own test.

## Review found four defects, and one of my tests was too weak to catch its own

| Defect | Why it mattered | Now pinned by |
|---|---|---|
| `write_block` re-looked each entry up **by key**, and egress is the one block two sources can key alike — so both lines named the *first* source | the override the disclosure exists to expose, shown with the wrong author | `two_sources_declaring_one_rule_each_keep_their_own_source` |
| a `-v` override left the displaced mixin named as author of the user's own mount | inverted trust attribution in a security disclosure | `a_mount_the_user_overrode_loses_the_declared_sources_attribution` |
| `short_source` sliced digests **by byte** and panicked on a non-ASCII directory path | reachable input; this file already had the char-safe idiom eight lines away | `a_source_whose_digest_is_not_ascii_truncates_on_a_character` |
| a second credential did not line up under the first | the label is wider than the column, and continuations ignored that | `a_second_credential_lines_up_under_the_first` |

The first one is worth calling out: **my initial test for it passed against the broken code**, because I used two different keys and the lookup found the right entry each time. Mutation-checking caught that the mutation stayed green. Rewritten with identical keys, it goes red.

Review also caught that I had dropped the **verdict** from a rule, so an `allow` and a `deny` rendered identically. A rule's key is now verdict-plus-pattern, which is also its honest identity — two sources disagreeing about one destination are two different rules.

`Block::Port` was computed and shipped unread; ports are now attributed rather than dead freight.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage` and `make e2e` (69 scenarios) all exit 0.

Layer 3 in `merge.rs` pins the record (attribution, displacement, a three-source chain keeping both losers, the volume/fileset keyspace, egress as a union). Layer 3 in `mixin.rs` pins that every block survives the wire. Layer 3 in `summary.rs` pins the rendering, including the four defects above.

Every new behaviour was mutation-checked. Removing the displacement push turns exactly the three displacement tests red and leaves the four attribution-only ones green; each of the four render fixes goes red on revert, and the byte-slice one reproduces the panic.
