### PR TITLE
fix: quote the red-first argument-hint so strict YAML parsers load the skill

### DIFF
--- a/.claude/skills/red-first/SKILL.md
+++ b/.claude/skills/red-first/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: red-first
 description: Red-test-first fix loop for bugs and behavior changes — state the defect as a claim, write the failing test before any production code, watch it fail for the stated reason, then make the smallest change that turns it green. Includes follow-up sweeps (coverage of new properties, side-effect accounting, fixture reality checks), mutation proofs for green-on-arrival tests, and a strictly bounded, optional end-to-end phase used only when a contract crosses a component boundary. Use this whenever the user reports a bug, asks to fix an issue, asks whether a finding is real and then wants it fixed, asks to verify a fix with tests, or asks to harden tests against regressions — even if they don't say "TDD" or "red test".
-argument-hint: [issue description] [optional: suspected cause or proposed fix]
+argument-hint: "[issue description] [optional: suspected cause or proposed fix]"
 ---
 
 # Red-First Fix Loop


### PR DESCRIPTION
## Why

`.claude/skills/red-first/SKILL.md` line 4 carries an unquoted `argument-hint`:

```yaml
argument-hint: [issue description] [optional: suspected cause or proposed fix]
```

That value is not valid YAML — `[…]` opens a flow sequence, and the second bracketed group after it cannot follow. Claude Code's lenient frontmatter reader tolerates it, but any spec-compliant parser refuses the document, so strict consumers skip the skill. First observed with the pi coding agent, which reports it as a skill conflict at startup:

```
[Skill conflicts]
  /workspace/.agents/skills/red-first/SKILL.md
    Unexpected flow-seq-start at node end at line 3, column 36
```

## What

Quote the value. One line; no behavioural change for consumers that already loaded it.

Verified with js-yaml (strict): the frontmatter now parses and `argument-hint` round-trips as the intended string. All other `.claude/skills/*/SKILL.md` frontmatter blocks were scanned the same way and are clean.