### PR TITLE
feat!: let the later source decide where two disagree about a destination

### DIFF
--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -238,6 +238,21 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
     })
 }
 
+/// What a document's own egress contributes when nothing merges into it, so a run that layered on nothing still discloses every rule it will enforce (§1.5).
+pub fn own_egress(spec: &SandboxSpec) -> Vec<Contribution> {
+    let http = spec.policy.egress.http.iter();
+    let tcp = spec
+        .policy
+        .egress
+        .tcp
+        .iter()
+        .map(|rule| (rule.verdict, &rule.match_pattern));
+    http.map(|rule| (rule.verdict, &rule.match_pattern))
+        .chain(tcp)
+        .map(|(verdict, pattern)| egress_contribution(verdict, pattern, ROOT_LABEL))
+        .collect()
+}
+
 /// A rule is its verdict and its pattern together, because the verdict is the half that decides and two sources may disagree about one destination.
 fn egress_contribution(
     verdict: lns_policy::Verdict,

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -156,23 +156,35 @@ fn short_source(source: &str) -> String {
 /// Where every value in this summary starts, so a label too long to fit still lines its entries up under one another.
 const COLUMN: usize = 13;
 
-/// The blocks §1.5 names that an uncomposed run has never printed, since only a composed run has a second author to attribute them to.
-fn write_composed_blocks(s: &mut String, args: &RunArgs) {
+/// The blocks §1.5 names. A run that resolved no mixin still lists its rules — §4.2 lets a pulled entry outrank this directory only because the merged table is disclosed first — but names no source for them, since one author is not an attribution question.
+fn write_disclosed_blocks(s: &mut String, args: &RunArgs) {
     let listed = |block| -> Vec<&lns_ipc::SourceContribution> {
         args.contributions
             .iter()
             .filter(|c| c.block == block)
             .collect()
     };
-    write_block(s, "Rules", &listed(lns_ipc::ContributionBlock::Egress));
+    let composed = !args.resolved_mixins.is_empty();
+    write_block(
+        s,
+        "Rules",
+        &listed(lns_ipc::ContributionBlock::Egress),
+        composed,
+    );
     write_block(
         s,
         "Credentials",
         &listed(lns_ipc::ContributionBlock::Credential),
+        composed,
     );
 }
 
-fn write_block(s: &mut String, label: &str, entries: &[&lns_ipc::SourceContribution]) {
+fn write_block(
+    s: &mut String,
+    label: &str,
+    entries: &[&lns_ipc::SourceContribution],
+    attributed: bool,
+) {
     let Some((first, rest)) = entries.split_first() else {
         return;
     };
@@ -184,7 +196,11 @@ fn write_block(s: &mut String, label: &str, entries: &[&lns_ipc::SourceContribut
         "{heading}{:pad$}{}{}",
         "",
         first.key,
-        attribution_of(first)
+        if attributed {
+            attribution_of(first)
+        } else {
+            String::new()
+        }
     )
     .unwrap();
     for entry in rest {
@@ -193,7 +209,11 @@ fn write_block(s: &mut String, label: &str, entries: &[&lns_ipc::SourceContribut
             "{:value_column$}{}{}",
             "",
             entry.key,
-            attribution_of(entry)
+            if attributed {
+                attribution_of(entry)
+            } else {
+                String::new()
+            }
         )
         .unwrap();
     }
@@ -246,8 +266,8 @@ pub fn format_summary(
     }
     if !args.resolved_mixins.is_empty() {
         writeln!(s, "  Mixins:    {}", args.resolved_mixins.join(", ")).unwrap();
-        write_composed_blocks(&mut s, args);
     }
+    write_disclosed_blocks(&mut s, args);
     if let Some(dir) = &args.workdir {
         writeln!(s, "  Workdir:   {dir}").unwrap();
     }
@@ -1118,6 +1138,40 @@ mod tests {
         assert!(
             !s.contains("[from") && !s.contains("Rules:") && !s.contains("Credentials:"),
             "a run that resolved no mixin has one author, so attributing every line to them is noise; got: {s}"
+        );
+    }
+
+    #[test]
+    fn a_run_that_resolved_no_mixin_still_names_the_rules_the_sandbox_ships() {
+        let mut args = run_args(Some("prism"));
+        args.contributions = ["allow db.vendor.example:5432", "allow api.vendor.example"]
+            .into_iter()
+            .map(|key| lns_ipc::SourceContribution {
+                block: lns_ipc::ContributionBlock::Egress,
+                key: key.into(),
+                source: "the sandbox".into(),
+                displaced: Vec::new(),
+            })
+            .collect();
+        let mut closed = Policy::default();
+        closed.add_rule(RouteRule::deny_host("*"));
+
+        let s = summary_of(
+            &args,
+            &closed,
+            Path::new("./lns-policy.yaml"),
+            &PolicySource::FoundInCwd,
+        );
+
+        assert!(
+            s.contains("Rules:")
+                && s.contains("allow db.vendor.example:5432")
+                && s.contains("allow api.vendor.example"),
+            "§4.2 lets a pulled rule outrank this directory only because the merged table is disclosed first, and a raw allow this file cannot deny is exactly the entry that has to be named; got: {s}"
+        );
+        assert!(
+            !s.contains("[from"),
+            "one author is not an attribution question, so naming them on every line is noise; got: {s}"
         );
     }
 

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -147,7 +147,7 @@ pub struct ApprovalSession {
     connector: OnceLock<Arc<dyn ConnectPort>>,
     connecting: Mutex<HashSet<String>>,
     ledger: OnceLock<Arc<dyn LedgerRecorder>>,
-    policy_floor: OnceLock<Policy>,
+    shipped: OnceLock<Policy>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -180,7 +180,7 @@ impl ApprovalSession {
             connector: OnceLock::new(),
             connecting: Mutex::new(HashSet::new()),
             ledger: OnceLock::new(),
-            policy_floor: OnceLock::new(),
+            shipped: OnceLock::new(),
         }
     }
 
@@ -205,9 +205,9 @@ impl ApprovalSession {
         let _ = self.connector_routes.set(deriver);
     }
 
-    /// Installs a sandbox's shipped policy as an always-merged floor, so a watcher reload of the local overlay can never drop the sandbox's rules; idempotent, the first wins.
-    pub fn set_policy_floor(&self, floor: Policy) {
-        let _ = self.policy_floor.set(floor);
+    /// Installs a sandbox's shipped policy as the earlier source every reload re-merges under, so a watcher reload of the local decisions carries the sandbox's rules along rather than replacing them; idempotent, the first wins.
+    pub fn set_shipped_policy(&self, shipped: Policy) {
+        let _ = self.shipped.set(shipped);
     }
 
     /// Installs the connect port once the credential subsystem exists; idempotent, the first wins.
@@ -536,8 +536,8 @@ impl ApprovalSession {
 
     pub fn apply_external_policy(&self, mut new_policy: Policy) {
         *self.persisted.lock().expect("persisted mutex poisoned") = new_policy.clone();
-        if let Some(floor) = self.policy_floor.get() {
-            new_policy = crate::artifact::policy::merge_effective(Some(floor), &new_policy);
+        if let Some(shipped) = self.shipped.get() {
+            new_policy = crate::artifact::policy::merge_effective(Some(shipped), &new_policy);
         }
         if let Some(derive) = self.connector_routes.get() {
             let routes = derive(&new_policy.connectors);
@@ -1743,7 +1743,7 @@ pub(crate) mod tests {
         let (s, _n, _store, mut rx) = fixture();
         let mut document = Policy::default();
         document.add_rule(RouteRule::deny_host("api.example.test"));
-        s.set_policy_floor(document);
+        s.set_shipped_policy(document);
 
         let mut reloaded = Policy::default();
         reloaded.add_rule(RouteRule::allow_host("api.example.test"));

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -1739,31 +1739,28 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn a_policy_floor_survives_a_reload_keeping_its_deny_deny_dominant() {
+    fn a_reloaded_decision_decides_over_the_document_it_layers_onto() {
         let (s, _n, _store, mut rx) = fixture();
-        let mut floor = Policy::default();
-        floor.add_rule(RouteRule::deny_host("api.example.test"));
-        s.set_policy_floor(floor);
+        let mut document = Policy::default();
+        document.add_rule(RouteRule::deny_host("api.example.test"));
+        s.set_policy_floor(document);
 
-        // A watcher reload of the local overlay that *allows* the host must not drop the floor's deny.
         let mut reloaded = Policy::default();
         reloaded.add_rule(RouteRule::allow_host("api.example.test"));
         s.apply_external_policy(reloaded);
 
         let routes = s.current_policy().network.egress.http;
-        let deny_idx = routes
-            .iter()
-            .position(|r| r.match_pattern == "api.example.test" && r.verdict == Verdict::Deny);
         let allow_idx = routes
             .iter()
-            .position(|r| r.match_pattern == "api.example.test" && r.verdict == Verdict::Allow);
+            .position(|r| r.match_pattern == "api.example.test" && r.verdict == Verdict::Allow)
+            .expect("the approval the developer just made must survive the reload");
+        let deny_idx = routes
+            .iter()
+            .position(|r| r.match_pattern == "api.example.test" && r.verdict == Verdict::Deny)
+            .expect("what the document said is still in the table, behind the decision that overruled it");
         assert!(
-            deny_idx.is_some(),
-            "the floor's deny must survive the reload"
-        );
-        assert!(
-            deny_idx < allow_idx,
-            "the floor's deny must stay ordered before the reloaded allow: {routes:?}"
+            allow_idx < deny_idx,
+            "the developer's decisions file is the last source, so an approval they just made must decide rather than be dropped by the document under it: {routes:?}"
         );
         let _ = policy_frame(&mut rx);
     }

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -225,7 +225,7 @@ pub async fn resolve<S: MixinSource>(
             document: config_json.to_vec(),
             mixins: Vec::new(),
             pinned_extra: Vec::new(),
-            contributions: Vec::new(),
+            contributions: lns_artifact::merge::own_egress(&def.spec),
         });
     }
     let fetched = collect(&def.spec.mixins, extra, home, source).await?;
@@ -1007,5 +1007,30 @@ mod tests {
         );
         assert!(!is_a_mixin_artifact(None, None));
         assert!(!is_a_mixin_artifact(Some(""), None));
+    }
+
+    #[tokio::test]
+    async fn a_sandbox_that_layers_on_nothing_still_attributes_the_egress_it_ships() {
+        let out = resolve(
+            &sandbox(
+                r#"{"image":"x:1","policy":{"egress":{"tcp":[{"match":"db.vendor.example:5432","verdict":"allow"}]}}}"#,
+            ),
+            &[],
+            &published(),
+            &Fake::new(&[]),
+        )
+        .await
+        .expect("a document with no mixins resolves to itself");
+        assert_eq!(
+            out.contributions
+                .iter()
+                .map(|c| (c.key.as_str(), c.source.as_str()))
+                .collect::<Vec<_>>(),
+            [(
+                "allow db.vendor.example:5432",
+                lns_artifact::merge::ROOT_LABEL
+            )],
+            "§1.5 has a run disclose every rule it will enforce, and a run that pulled no mixin enforces these"
+        );
     }
 }

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
-use lns_policy::matching::{destination_covers, split_destination};
-use lns_policy::{NetworkPolicy, Policy, RouteRule, TcpEgressRule, Verdict};
+use lns_policy::matching::split_destination;
+use lns_policy::{NetworkPolicy, Policy, RouteRule, Verdict};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuardrailFlag {
@@ -90,104 +88,14 @@ fn push_unique<R: Clone + PartialEq>(merged: &mut Vec<R>, rule: &R) {
     }
 }
 
-/// A deny-by-default layer permits only the destinations it names, so an allow survives the merge only if every such ceiling layer carries a rule permitting it.
-fn allowed_by_every_ceiling<R>(
-    rule: &R,
-    ceilings: &[&Policy],
-    table: TableOf<R>,
-    closes: fn(&R) -> bool,
-    permits: fn(&R, &R) -> bool,
-) -> bool {
-    // A ceiling grants only what its own gate reaches, so a line stranded behind its catch-all authorizes nothing.
-    ceilings
-        .iter()
-        .all(|ceiling| live_rules(table(ceiling), closes).any(|permitted| permits(permitted, rule)))
-}
-
-/// Whether `permitted` covers `rule`: it names every destination `rule` does, grants them on the same terms, and is scoped no tighter — a rule that only narrows a ceiling's grant to fewer hosts or fewer callers grants nothing the ceiling didn't.
-fn permits(permitted: &RouteRule, rule: &RouteRule) -> bool {
-    let widened = RouteRule {
-        match_pattern: permitted.match_pattern.clone(),
-        binaries: permitted.binaries.clone(),
-        description: permitted.description.clone(),
-        ..rule.clone()
-    };
-    widened == *permitted
-        && destination_covers(&permitted.match_pattern, &rule.match_pattern)
-        && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
-}
-
-/// The `egress.tcp` counterpart of [`permits`], scoping included: a ceiling that splices a destination for every caller also covers a rule splicing it for some of them.
-fn tcp_permits(permitted: &TcpEgressRule, rule: &TcpEgressRule) -> bool {
-    let widened = TcpEgressRule {
-        match_pattern: permitted.match_pattern.clone(),
-        binaries: permitted.binaries.clone(),
-        description: permitted.description.clone(),
-        ..rule.clone()
-    };
-    widened == *permitted
-        && destination_covers(&permitted.match_pattern, &rule.match_pattern)
-        && scope_within(rule.binaries.as_deref(), permitted.binaries.as_deref())
-}
-
-fn scope_within(rule: Option<&[String]>, permitted: Option<&[String]>) -> bool {
-    match (rule, permitted) {
-        (_, None) => true,
-        (None, Some(_)) => false,
-        // Compared as paths, the way the guest compares them against /proc/<pid>/exe, so a redundant separator doesn't read as a different binary.
-        (Some(rule), Some(permitted)) => rule.iter().all(|binary| {
-            permitted
-                .iter()
-                .any(|listed| Path::new(listed) == Path::new(binary))
-        }),
-    }
-}
-
-/// A layer's rules up to its catch-all — the ones its own first-match gate still reaches, so one written behind it is not hoisted out from under it.
-fn live_rules<R>(table: &[R], closes: fn(&R) -> bool) -> impl Iterator<Item = &R> + Clone {
-    table.iter().take_while(move |rule| !closes(rule))
-}
-
-/// Fold one egress table across `layers` into the merged table the guest gate installs, deny-first and clamped by the deny-by-default `ceilings`.
-// Deny-first ordering is load-bearing: lens-sandbox-core's rule lookup is first-match-wins, so a destination denied by any layer must have its deny rule appear before any allow.
-fn merge_rule_table<R: Clone + PartialEq>(
-    layers: &[&Policy],
-    ceilings: &[&Policy],
-    table: TableOf<R>,
-    is_deny: fn(&R) -> bool,
-    closes: fn(&R) -> bool,
-    permits: fn(&R, &R) -> bool,
-) -> Vec<R> {
+/// Fold one egress table across `layers` into the merged table the guest gate installs: a later source's entries sit ahead of an earlier one's, and each source keeps its own order (`docs/sandbox-spec.md` §4.2).
+// The gate is first-match-wins, so placing a source ahead is what makes it decide.
+fn merge_rule_table<R: Clone + PartialEq>(layers: &[&Policy], table: TableOf<R>) -> Vec<R> {
     let mut merged: Vec<R> = Vec::new();
     for layer in layers {
-        for rule in live_rules(table(layer), closes).filter(|rule| is_deny(rule)) {
+        for rule in table(layer) {
             push_unique(&mut merged, rule);
         }
-    }
-    for layer in layers {
-        for rule in live_rules(table(layer), closes).filter(|rule| !is_deny(rule)) {
-            if allowed_by_every_ceiling(rule, ceilings, table, closes, permits) {
-                push_unique(&mut merged, rule);
-            }
-        }
-    }
-    // The catch-all goes last: ahead of the allows it would answer for the ones its own layer permits, and a deny wins so neither layer's lockdown is opened by the other's backstop.
-    let reached: Vec<&R> = layers
-        .iter()
-        .filter_map(|layer| table(layer).iter().find(|rule| closes(rule)))
-        .collect();
-    let closer = reached
-        .iter()
-        .find(|rule| is_deny(rule))
-        // Vacuous while http is the only table with a catch-all, since a ceiling's own first catch-all is a deny.
-        .or_else(|| {
-            reached
-                .iter()
-                .find(|rule| allowed_by_every_ceiling(**rule, ceilings, table, closes, permits))
-        })
-        .copied();
-    if let Some(closer) = closer {
-        push_unique(&mut merged, closer);
     }
     merged
 }
@@ -204,40 +112,20 @@ pub fn splice_connector_routes(
     table.splice(at..at, routes);
 }
 
-/// Whether a layer permits only what it names. Read from the `http` table alone and clamping both, because a raw rule must name a port and so can never be a catch-all.
+/// Whether the first catch-all the gate reaches in `egress.http` is a deny, read from that table alone because a raw rule must name a port and so can never be a catch-all.
 pub fn is_closed(policy: &Policy) -> bool {
     policy.network.is_closed()
 }
 
-/// Merge a sandbox's shipped `baseline` policy under a local `overlay` into one effective policy for the guest gate: denies from every layer come first so a first-match gate stays deny-dominant, a closed layer (see [`is_closed`]) is a ceiling an allow must clear in every such layer (so neither the artifact nor the user can widen the other's lockdown), and only the user's overlay connectors are applied — an artifact-declared connector the user hasn't connected in this directory is never force-armed, so it stays connectable and is offered as a live connect on first use.
+/// Merge a sandbox's shipped `baseline` policy under a local `overlay` into one effective policy for the guest gate: the overlay is the later source, so its entries decide every destination both name, and only its connectors are applied — an artifact-declared connector the user has not connected in this directory is never force-armed, so it stays connectable and is offered as a live connect on first use.
 pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
     let layers: Vec<&Policy> = std::iter::once(overlay).chain(baseline).collect();
-    let ceilings: Vec<&Policy> = layers
-        .iter()
-        .copied()
-        .filter(|policy| is_closed(policy))
-        .collect();
-    let http = merge_rule_table(
-        &layers,
-        &ceilings,
-        |policy| &policy.network.egress.http,
-        |rule: &RouteRule| rule.verdict == Verdict::Deny,
-        RouteRule::is_catch_all,
-        permits,
-    );
-    // Folded independently of `http`: an inspected route in a ceiling is not consent to splice the same host raw.
-    let tcp = merge_rule_table(
-        &layers,
-        &ceilings,
-        |policy| &policy.network.egress.tcp,
-        |rule: &TcpEgressRule| rule.verdict == Verdict::Deny,
-        // A raw rule must name a port, so no `egress.tcp` rule can be a catch-all.
-        |_| false,
-        tcp_permits,
-    );
     Policy {
         network: NetworkPolicy {
-            egress: lns_policy::Egress { http, tcp },
+            egress: lns_policy::Egress {
+                http: merge_rule_table(&layers, |policy| &policy.network.egress.http),
+                tcp: merge_rule_table(&layers, |policy| &policy.network.egress.tcp),
+            },
         },
         connectors: overlay.connectors.clone(),
     }
@@ -246,6 +134,18 @@ pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lns_policy::TcpEgressRule;
+
+    /// The merged table as the guest's first-match gate reads it, which is the only thing the merge means.
+    fn table(policy: &Policy) -> Vec<(&str, Verdict)> {
+        policy
+            .network
+            .egress
+            .http
+            .iter()
+            .map(|rule| (rule.match_pattern.as_str(), rule.verdict))
+            .collect()
+    }
 
     fn allow(host: &str) -> Policy {
         let mut p = Policy::default();
@@ -407,27 +307,17 @@ mod tests {
     }
 
     #[test]
-    fn a_catch_all_allow_survives_the_merge() {
-        // The shape the `defaultVerdict: allow` migration prescribes. Dropping it
-        // would rewrite the file's meaning to prompt-for-everything the moment a
-        // baseline appears under it, and only then.
-        let mut overlay = Policy::default();
-        overlay.add_rule(RouteRule::allow_host("*"));
-        let baseline = allow("api.example.test");
+    fn a_local_catch_all_allow_decides_everything_under_it() {
+        // The shape the `defaultVerdict: allow` migration prescribes.
+        let mut local = Policy::default();
+        local.add_rule(RouteRule::allow_host("*"));
 
-        let merged = merge_effective(Some(&baseline), &overlay);
+        let merged = merge_effective(Some(&allow("api.example.test")), &local);
 
-        let last = merged
-            .network
-            .egress
-            .http
-            .last()
-            .expect("the merged table cannot be empty");
         assert_eq!(
-            (last.match_pattern.as_str(), last.verdict),
-            ("*", Verdict::Allow),
-            "the catch-all must survive, behind the rules it backstops: {:?}",
-            merged.network.egress.http
+            table(&merged).first().copied(),
+            Some(("*", Verdict::Allow)),
+            "a developer who opened their own directory opened it, and §4.2 makes that their call to see in the disclosure rather than the merge's to refuse"
         );
     }
 
@@ -492,16 +382,22 @@ mod tests {
     }
 
     #[test]
-    fn merge_orders_every_layers_denies_before_allows() {
+    fn a_later_sources_entries_precede_an_earlier_sources() {
         let baseline = allow("api.example.test");
         let overlay = deny("api.example.test");
         let merged = merge_effective(Some(&baseline), &overlay);
         let routes = &merged.network.egress.http;
-        let deny_idx = routes.iter().position(|r| r.verdict == Verdict::Deny);
-        let allow_idx = routes.iter().position(|r| r.verdict == Verdict::Allow);
+        let deny_idx = routes
+            .iter()
+            .position(|r| r.verdict == Verdict::Deny)
+            .expect("the later source's deny must survive the merge");
+        let allow_idx = routes
+            .iter()
+            .position(|r| r.verdict == Verdict::Allow)
+            .expect("the earlier source's allow stays in the table, behind what overruled it");
         assert!(
             deny_idx < allow_idx,
-            "a first-match gate must see the deny first: {routes:?}"
+            "a first-match gate must see the later source first: {routes:?}"
         );
         assert!(
             !is_closed(&merged),
@@ -529,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_carries_both_layers_tcp_rules_denies_first() {
+    fn the_raw_table_carries_both_sources_in_precedence_order() {
         let baseline = tcp_allow("db.internal:5432");
         let overlay = tcp_deny("db.internal:5432");
         let merged = merge_effective(Some(&baseline), &overlay);
@@ -567,50 +463,106 @@ mod tests {
     }
 
     #[test]
-    fn a_ceiling_still_refuses_an_allow_reaching_past_what_it_covers() {
-        let mut ceiling = allow("*.example.test");
-        ceiling.add_rule(RouteRule::deny_host("*"));
+    fn a_local_allow_decides_a_destination_the_artifact_denies() {
+        let mut artifact = Policy::default();
+        artifact.add_rule(RouteRule::deny_host("docs.vendor.example"));
 
-        let merged = merge_effective(Some(&ceiling), &allow("api.other.test"));
+        let merged = merge_effective(Some(&artifact), &allow("docs.vendor.example"));
 
-        assert!(
-            !merged.network.egress.http.iter().any(
-                |rule| rule.match_pattern == "api.other.test" && rule.verdict == Verdict::Allow
-            ),
-            "a host the ceiling never named stays clamped"
+        let decided = merged
+            .network
+            .egress
+            .http
+            .iter()
+            .find(|rule| rule.match_pattern == "docs.vendor.example")
+            .expect("the destination both sources named is in the merged table");
+        assert_eq!(
+            decided.verdict,
+            Verdict::Allow,
+            "the local mixin is the last source, so nothing the developer pulled can overrule what they decided (docs/sandbox-spec.md §8.1)"
         );
     }
 
     #[test]
-    fn a_ceilings_wildcard_does_not_authorize_a_wider_treatment_of_the_same_hosts() {
-        let mut ceiling = Policy::default();
-        ceiling.add_rule(RouteRule {
-            tls_terminate: true,
-            ..RouteRule::allow_host("*.example.test")
-        });
-        ceiling.add_rule(RouteRule::deny_host("*"));
+    fn a_local_catch_all_deny_decides_every_destination_the_artifact_allows() {
+        let mut local = Policy::default();
+        local.add_rule(RouteRule::deny_host("*"));
 
-        let merged = merge_effective(Some(&ceiling), &allow("api.example.test"));
+        let merged = merge_effective(Some(&allow("api.vendor.example")), &local);
 
-        assert!(
-            !merged
+        assert_eq!(
+            merged
                 .network
                 .egress
                 .http
-                .iter()
-                .any(|rule| rule.match_pattern == "api.example.test"),
-            "the ceiling grants those hosts only under inspection; an uninspected allow of one is not covered"
+                .first()
+                .map(|rule| (rule.match_pattern.as_str(), rule.verdict)),
+            Some(("*", Verdict::Deny)),
+            "a developer locking their own directory down still holds, by sitting ahead of every pulled entry rather than by clamping them"
         );
     }
 
     #[test]
-    fn a_deny_by_default_layer_clamps_the_other_layers_tcp_allow() {
-        let mut ceiling = Policy::default();
-        ceiling.add_rule(RouteRule::deny_host("*"));
-        let merged = merge_effective(Some(&ceiling), &tcp_allow("db.internal:5432"));
-        assert!(
-            merged.network.egress.tcp.is_empty(),
-            "a locked-down layer names every destination it permits; the user cannot widen it"
+    fn a_destination_the_artifact_never_named_is_still_the_developers_to_allow() {
+        let mut artifact = allow("*.example.test");
+        artifact.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&artifact), &allow("api.other.test"));
+
+        assert_eq!(
+            table(&merged).first().copied(),
+            Some(("api.other.test", Verdict::Allow)),
+            "an artifact denying by default is stating what it needs, not a boundary over the developer who ran it (docs/sandbox-spec.md §4.2)"
+        );
+    }
+
+    #[test]
+    fn the_developers_own_treatment_of_a_host_decides_over_the_artifacts() {
+        let mut artifact = Policy::default();
+        artifact.add_rule(RouteRule {
+            tls_terminate: true,
+            ..RouteRule::allow_host("*.example.test")
+        });
+        artifact.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&artifact), &allow("api.example.test"));
+
+        assert_eq!(
+            table(&merged).first().copied(),
+            Some(("api.example.test", Verdict::Allow)),
+            "the developer asked for this host uninspected, and they are the later source"
+        );
+    }
+
+    #[test]
+    fn a_developers_http_catch_all_does_not_decide_the_raw_table_either() {
+        let mut artifact = Policy::default();
+        artifact
+            .network
+            .egress
+            .tcp
+            .push(TcpEgressRule::allow_destination("db.vendor.example:5432"));
+
+        let merged = merge_effective(Some(&artifact), &closed_allowing("api.trusted.example"));
+
+        assert_eq!(
+            merged.network.egress.tcp.len(),
+            1,
+            "the tables fold independently in both directions (§4.2), and a raw rule must name a port, so a `deny *` written in http is not a raw lockdown — a developer who means to close a raw destination names it in tcp"
+        );
+    }
+
+    #[test]
+    fn an_artifacts_http_lockdown_does_not_reach_into_the_developers_raw_table() {
+        let mut artifact = Policy::default();
+        artifact.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&artifact), &tcp_allow("db.internal:5432"));
+
+        assert_eq!(
+            merged.network.egress.tcp.len(),
+            1,
+            "the two tables fold independently, and neither is the other's ceiling"
         );
     }
 
@@ -634,13 +586,20 @@ mod tests {
     }
 
     #[test]
-    fn an_http_allow_in_a_ceiling_does_not_legitimize_a_raw_splice() {
-        let mut ceiling = allow("db.internal");
-        ceiling.add_rule(RouteRule::deny_host("*"));
-        let merged = merge_effective(Some(&ceiling), &tcp_allow("db.internal:5432"));
+    fn an_inspected_route_is_not_consent_to_splice_the_same_host_raw() {
+        let mut artifact = allow("db.internal");
+        artifact.add_rule(RouteRule::deny_host("*"));
+
+        let merged = merge_effective(Some(&artifact), &tcp_allow("db.internal:5432"));
+
         assert!(
-            merged.network.egress.tcp.is_empty(),
-            "an inspected route is not consent to splice the same host opaquely; the tables clamp independently"
+            merged
+                .network
+                .egress
+                .http
+                .iter()
+                .all(|rule| rule.match_pattern != "db.internal:5432"),
+            "the tables fold independently, so an http entry never becomes a raw one"
         );
     }
 
@@ -666,27 +625,6 @@ mod tests {
         assert!(
             scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
             "narrowing a splice the ceiling already grants every caller must survive, and a first-match gate must reach the narrower rule first or the narrowing is void: {merged:?}"
-        );
-    }
-
-    #[test]
-    fn merge_drops_a_raw_allow_for_a_binary_the_ceilings_own_scope_excludes() {
-        let mut overlay = tcp_allow("db.internal:5432");
-        overlay.network.egress.tcp[0].binaries = Some(vec!["/usr/bin/nc".into()]);
-        let mut ceiling = tcp_allow("db.internal:5432");
-        ceiling.network.egress.tcp[0].binaries = Some(vec!["/usr/bin/psql".into()]);
-        ceiling.add_rule(RouteRule::deny_host("*"));
-
-        let merged = merge_effective(Some(&ceiling), &overlay);
-
-        assert!(
-            !merged
-                .network
-                .egress
-                .tcp
-                .iter()
-                .any(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/nc".to_string()])),
-            "a ceiling that splices a destination for one binary must not be widened to another by an overlay scoped to it: {merged:?}"
         );
     }
 
@@ -718,26 +656,20 @@ mod tests {
     }
 
     #[test]
-    fn merge_does_not_let_an_overlay_allow_widen_a_deny_by_default_baseline() {
-        let mut baseline = allow("api.allowed.example");
-        baseline.add_rule(RouteRule::deny_host("*"));
-        let overlay = allow("api.overlay-only.example");
+    fn a_local_allow_the_artifact_never_named_decides_it() {
+        let mut artifact = allow("api.allowed.example");
+        artifact.add_rule(RouteRule::deny_host("*"));
 
-        let merged = merge_effective(Some(&baseline), &overlay);
+        let merged = merge_effective(Some(&artifact), &allow("api.overlay-only.example"));
 
-        assert!(
-            !merged.network.egress.http.iter().any(|rule| {
-                rule.match_pattern == "api.overlay-only.example" && rule.verdict == Verdict::Allow
-            }),
-            "a local overlay must not widen a sandbox's deny-by-default baseline: {merged:?}"
-        );
-        assert!(merged.network.egress.http.iter().any(|rule| {
-            rule.match_pattern == "api.allowed.example" && rule.verdict == Verdict::Allow
-        }));
-        assert!(
-            is_closed(&merged),
-            "a closed layer must leave the merged policy closed: {:?}",
-            merged.network.egress.http
+        assert_eq!(
+            table(&merged),
+            [
+                ("api.overlay-only.example", Verdict::Allow),
+                ("api.allowed.example", Verdict::Allow),
+                ("*", Verdict::Deny)
+            ],
+            "the developer's entry sits ahead of everything the artifact said, and the artifact's own backstop still closes what neither named"
         );
     }
 
@@ -750,50 +682,20 @@ mod tests {
     }
 
     #[test]
-    fn merge_clamps_an_untrusted_baseline_allow_against_a_user_deny_by_default() {
-        let overlay = closed_allowing("api.trusted.example");
-        let baseline = allow("attacker.example");
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            !merged.network.egress.http.iter().any(|rule| {
-                rule.match_pattern == "attacker.example" && rule.verdict == Verdict::Allow
-            }),
-            "a pulled artifact's allow must not punch through the user's deny-by-default lockdown: {merged:?}"
+    fn a_developers_lockdown_still_decides_a_destination_the_artifact_allows() {
+        let merged = merge_effective(
+            Some(&allow("attacker.example")),
+            &closed_allowing("api.trusted.example"),
         );
-        assert!(merged.network.egress.http.iter().any(|rule| {
-            rule.match_pattern == "api.trusted.example" && rule.verdict == Verdict::Allow
-        }));
-        assert!(
-            is_closed(&merged),
-            "a closed layer must leave the merged policy closed: {:?}",
-            merged.network.egress.http
-        );
-    }
 
-    #[test]
-    fn merge_does_not_let_an_unscoped_allow_clear_a_binary_scoped_ceiling() {
-        let overlay = allow("git.example.test");
-        let mut baseline = closed_allowing("git.example.test");
-        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            !merged.network.egress.http.iter().any(|rule| {
-                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
-            }),
-            "an artifact that only allows a host for one binary must not be widened to every caller by an unscoped overlay allow: {merged:?}"
-        );
-        assert!(
-            merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| { rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]) }),
-            "the scoped allow itself clears every ceiling and must survive, or the assertion above passes vacuously: {merged:?}"
+        assert_eq!(
+            table(&merged),
+            [
+                ("api.trusted.example", Verdict::Allow),
+                ("*", Verdict::Deny),
+                ("attacker.example", Verdict::Allow)
+            ],
+            "the gate reads first-match, so the developer's catch-all deny decides attacker.example even though the artifact's allow is still in the table"
         );
     }
 
@@ -867,54 +769,6 @@ mod tests {
     }
 
     #[test]
-    fn merge_drops_a_scoped_allow_for_a_binary_the_ceilings_own_scope_excludes() {
-        let mut overlay = allow("git.example.test");
-        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/curl".into()]);
-        let mut baseline = closed_allowing("git.example.test");
-        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            !merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/curl".to_string()])),
-            "a ceiling that names one binary must not be widened to another by an overlay scoped to it: {merged:?}"
-        );
-    }
-
-    #[test]
-    fn merge_does_not_let_a_scoped_overlay_allow_punch_through_a_ceiling() {
-        let mut overlay = allow("git.example.test");
-        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-        let baseline = closed_allowing("other.example.test");
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            !merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.match_pattern == "git.example.test"),
-            "scoping an allow to one binary must not exempt it from an artifact's deny-by-default ceiling: {merged:?}"
-        );
-        assert!(
-            merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.match_pattern == "other.example.test"),
-            "the ceiling's own allow must survive, or the assertion above passes on an empty merge: {merged:?}"
-        );
-    }
-
-    #[test]
     fn merge_keeps_an_allow_both_layers_carry_when_both_deny_by_default() {
         let overlay = closed_allowing("api.shared.example");
         let baseline = closed_allowing("api.shared.example");
@@ -935,25 +789,20 @@ mod tests {
     }
 
     #[test]
-    fn merge_drops_disjoint_allows_when_both_layers_deny_by_default() {
-        let overlay = closed_allowing("api.user-only.example");
-        let baseline = closed_allowing("api.artifact-only.example");
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            !merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.verdict == Verdict::Allow),
-            "two deny-by-default layers with disjoint allowlists intersect to nothing: {merged:?}"
+    fn two_lockdowns_leave_only_what_the_developer_named() {
+        let merged = merge_effective(
+            Some(&closed_allowing("api.artifact-only.example")),
+            &closed_allowing("api.user-only.example"),
         );
-        assert!(
-            is_closed(&merged),
-            "a closed layer must leave the merged policy closed: {:?}",
-            merged.network.egress.http
+
+        assert_eq!(
+            table(&merged),
+            [
+                ("api.user-only.example", Verdict::Allow),
+                ("*", Verdict::Deny),
+                ("api.artifact-only.example", Verdict::Allow)
+            ],
+            "the developer's catch-all deny reaches the artifact's own allow first, so what they did not name stays shut"
         );
     }
 

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -279,11 +279,8 @@ mod tests {
     }
 
     #[test]
-    fn a_dead_allow_in_a_ceiling_does_not_legitimize_another_layers_copy_of_it() {
-        // The ceiling grants only what its own gate would reach. A line stranded
-        // behind its catch-all — which is exactly what an unreachable approval
-        // leaves in the file — must not authorize an untrusted baseline's identical
-        // allow, or the lockdown is widened through a rule that never fires.
+    fn an_allow_stranded_behind_a_catch_all_does_not_decide_an_earlier_sources_copy_of_it() {
+        // An unreachable approval is what a lockdown leaves in the file, and the gate stops before it.
         let mut overlay = Policy::default();
         overlay.add_rule(RouteRule::deny_host("*"));
         overlay.add_rule(RouteRule::allow_host("attacker.example"));
@@ -301,7 +298,7 @@ mod tests {
         assert_eq!(
             (decided.match_pattern.as_str(), decided.verdict),
             ("*", Verdict::Deny),
-            "the baseline allow must not clear a ceiling through a dead rule: {:?}",
+            "a rule the gate never reaches decides nothing, so an earlier source's identical allow must not be reached either: {:?}",
             merged.network.egress.http
         );
     }
@@ -443,26 +440,6 @@ mod tests {
     }
 
     #[test]
-    fn a_ceiling_authorizes_an_allow_its_own_wildcard_already_covers() {
-        let mut ceiling = allow("*.example.test");
-        ceiling.add_rule(RouteRule::deny_host("*"));
-
-        let merged = merge_effective(Some(&ceiling), &allow("api.example.test"));
-
-        assert!(
-            merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.match_pattern == "api.example.test"
-                    && rule.verdict == Verdict::Allow),
-            "the ceiling already permits every host under *.example.test, so approving one of them must not be dropped: {:?}",
-            merged.network.egress.http
-        );
-    }
-
-    #[test]
     fn a_local_allow_decides_a_destination_the_artifact_denies() {
         let mut artifact = Policy::default();
         artifact.add_rule(RouteRule::deny_host("docs.vendor.example"));
@@ -562,26 +539,7 @@ mod tests {
         assert_eq!(
             merged.network.egress.tcp.len(),
             1,
-            "the two tables fold independently, and neither is the other's ceiling"
-        );
-    }
-
-    #[test]
-    fn a_ceiling_authorizes_a_raw_splice_inside_a_range_it_already_splices() {
-        let mut ceiling = tcp_allow("10.0.0.0/8:5432");
-        ceiling.add_rule(RouteRule::deny_host("*"));
-
-        let merged = merge_effective(Some(&ceiling), &tcp_allow("10.0.0.5:5432"));
-
-        assert!(
-            merged
-                .network
-                .egress
-                .tcp
-                .iter()
-                .any(|rule| rule.match_pattern == "10.0.0.5:5432"),
-            "the ceiling already splices every address in 10.0.0.0/8 on that port, so naming one of them adds no reach: {:?}",
-            merged.network.egress.tcp
+            "the two tables fold independently, and neither decides the other"
         );
     }
 
@@ -600,31 +558,6 @@ mod tests {
                 .iter()
                 .all(|rule| rule.match_pattern != "db.internal:5432"),
             "the tables fold independently, so an http entry never becomes a raw one"
-        );
-    }
-
-    #[test]
-    fn merge_keeps_a_raw_allow_that_only_narrows_which_binary_a_ceiling_already_splices() {
-        let mut overlay = tcp_allow("db.internal:5432");
-        overlay.network.egress.tcp[0].binaries = Some(vec!["/usr/bin/psql".into()]);
-        let mut ceiling = tcp_allow("db.internal:5432");
-        ceiling.add_rule(RouteRule::deny_host("*"));
-
-        let merged = merge_effective(Some(&ceiling), &overlay);
-
-        let scoped = merged
-            .network
-            .egress
-            .tcp
-            .iter()
-            .position(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/psql".to_string()]));
-        let open =
-            merged.network.egress.tcp.iter().position(|rule| {
-                rule.match_pattern == "db.internal:5432" && rule.binaries.is_none()
-            });
-        assert!(
-            scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
-            "narrowing a splice the ceiling already grants every caller must survive, and a first-match gate must reach the narrower rule first or the narrowing is void: {merged:?}"
         );
     }
 
@@ -696,95 +629,6 @@ mod tests {
                 ("attacker.example", Verdict::Allow)
             ],
             "the gate reads first-match, so the developer's catch-all deny decides attacker.example even though the artifact's allow is still in the table"
-        );
-    }
-
-    #[test]
-    fn merge_keeps_a_scoped_allow_that_only_narrows_what_a_ceiling_already_permits() {
-        let mut overlay = allow("git.example.test");
-        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-        let baseline = closed_allowing("git.example.test");
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        let scoped = merged
-            .network
-            .egress
-            .http
-            .iter()
-            .position(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]));
-        let open =
-            merged.network.egress.http.iter().position(|rule| {
-                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
-            });
-        assert!(
-            scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
-            "narrowing a host the ceiling already allows to every caller must survive the merge, and a first-match gate must see the narrower rule before the ceiling's open allow or the narrowing is void: {merged:?}"
-        );
-    }
-
-    #[test]
-    fn merge_keeps_a_scoped_allow_whose_ceiling_rule_differs_only_in_its_description() {
-        let mut overlay = allow("git.example.test");
-        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-        let mut baseline = closed_allowing("git.example.test");
-        baseline.network.egress.http[0].description = Some("git over https".into());
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        let scoped = merged
-            .network
-            .egress
-            .http
-            .iter()
-            .position(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git".to_string()]));
-        let open =
-            merged.network.egress.http.iter().position(|rule| {
-                rule.match_pattern == "git.example.test" && rule.binaries.is_none()
-            });
-        assert!(
-            scoped.is_some_and(|scoped| open.is_none_or(|open| scoped < open)),
-            "a note on the ceiling's rule is not part of its grant, so it must not decide whether the user's narrowing survives — dropping it leaves the ceiling's own open allow in force: {merged:?}"
-        );
-    }
-
-    #[test]
-    fn merge_reads_a_redundant_separator_as_the_same_binary_the_ceiling_named() {
-        let mut overlay = allow("git.example.test");
-        overlay.network.egress.http[0].binaries = Some(vec!["/usr/bin/git/".into()]);
-        let mut baseline = closed_allowing("git.example.test");
-        baseline.network.egress.http[0].binaries = Some(vec!["/usr/bin/git".into()]);
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            merged
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|rule| rule.binaries.as_deref() == Some(&["/usr/bin/git/".to_string()])),
-            "the guest compares these as paths and admits the same caller, so the merge must not read them as different binaries and drop the overlay: {merged:?}"
-        );
-    }
-
-    #[test]
-    fn merge_keeps_an_allow_both_layers_carry_when_both_deny_by_default() {
-        let overlay = closed_allowing("api.shared.example");
-        let baseline = closed_allowing("api.shared.example");
-
-        let merged = merge_effective(Some(&baseline), &overlay);
-
-        assert!(
-            merged.network.egress.http.iter().any(|rule| {
-                rule.match_pattern == "api.shared.example" && rule.verdict == Verdict::Allow
-            }),
-            "a host both the user and the artifact allow under deny-by-default is in the intersection and must survive: {merged:?}"
-        );
-        assert!(
-            is_closed(&merged),
-            "a closed layer must leave the merged policy closed: {:?}",
-            merged.network.egress.http
         );
     }
 

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -326,7 +326,7 @@ fn record_sandbox_run(
     }
 }
 
-/// Disclose the sandbox's shipped network policy and declared connectors at boot: name the policy as the deny-dominant baseline under the local overlay (warning if it is over-broad), and disclose that declared connectors seed placeholders but are offered on first use, never armed automatically.
+/// Disclose the sandbox's shipped network policy and declared connectors at boot: name the policy as the source your own decisions layer over (warning if it is over-broad), and disclose that declared connectors seed placeholders but are offered on first use, never armed automatically.
 fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     let Some(policy) = policy else {
         return;
@@ -334,7 +334,7 @@ fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     if policy.network != lns_policy::NetworkPolicy::default() {
         crate::log::info!(
             "policy",
-            "this sandbox ships a network policy; it governs the run as a deny-dominant baseline under your local lns-policy.yaml overlay"
+            "this sandbox ships a network policy; it governs the run except where your own lns-policy.yaml decides otherwise"
         );
         let summary =
             crate::artifact::policy::run_summary(&crate::artifact::policy::guardrail_flags(policy));

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -192,7 +192,7 @@ pub fn resolve_applied_with_credentials(
     let mut out = resolve_applied_connectors(&base, catalog);
     // `base` drops the supplier so its own env var cannot double-seed beside the declaration's, but the reach a connect earned is not the declaration's to withdraw.
     out.routes = applied_connector_routes(&policy.connectors, catalog);
-    let ceiling_denies = crate::artifact::policy::is_closed(policy);
+    let denies_by_default = crate::artifact::policy::is_closed(policy);
     for (credential, supplier) in supplied {
         out.providers.push(DefProvider::new(declared_provider_def(
             credential, supplier,
@@ -202,7 +202,7 @@ pub fn resolve_applied_with_credentials(
         };
         // A declaration is artifact-authored, so its supplier's route must not widen the user's lockdown — a connector connected here already carries its own.
         let connected_here = policy.connectors.contains(&integ.id);
-        if !ceiling_denies && !connected_here {
+        if !denies_by_default && !connected_here {
             out.routes
                 .extend(integ.routes.iter().map(|r| r.to_route_rule()));
         }
@@ -1314,7 +1314,7 @@ mod tests {
         assert_eq!(out.providers[0].env_var(), "PROVIDER_KEY");
     }
 
-    /// A deny-by-default directory: `is_closed` reads the http table, so the catch-all deny is what makes this policy a ceiling.
+    /// A deny-by-default directory: `is_closed` reads the http table, so the catch-all deny is what closes it.
     fn closed_policy_applying(ids: &[&str]) -> Policy {
         let mut policy = policy_applying(ids);
         policy.add_rule(lns_policy::RouteRule::deny_host("*"));

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -722,7 +722,7 @@ pub(super) async fn start(
 
     session.set_connector_route_deriver(make_connector_route_deriver(catalog.clone()));
     if let Some(baseline) = sandbox_policy {
-        session.set_policy_floor(baseline.clone());
+        session.set_shipped_policy(baseline.clone());
     }
 
     tokio::spawn(decision_delivery_loop(

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -723,7 +723,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(env)]
-    async fn start_merges_a_sandbox_policy_floor_under_the_local_overlay() {
+    async fn start_merges_a_sandbox_shipped_policy_under_the_local_decisions() {
         use crate::approval_flow::window::{self, WindowState};
         use crate::test_env::EnvVarGuard;
         window::install(WindowState::new());

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -504,23 +504,12 @@ fn request_denied_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(), 
         .as_ref()
         .and_then(|r| r.running_policy.as_ref())
         .ok_or("no running policy was produced")?;
-    // The guest gate is first-match-wins; the merged policy must present the deny before the connector's allow.
-    let verdict = policy
-        .network
-        .egress
-        .http
-        .iter()
-        .find(|r| r.match_pattern == host)
-        .map(|r| r.verdict)
-        // Nothing names the host: the catch-all the closed overlay carries is what decides it.
-        .unwrap_or(Verdict::Deny);
-    if verdict == Verdict::Deny {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected {host} to be denied, first match gave {verdict:?}; routes: {:?}",
+    match super::mixin_resolution::gate_verdict(policy, &host) {
+        Some(lns_policy::Verdict::Deny) => Ok(()),
+        other => Err(format!(
+            "expected {host} to be denied, the gate's first match gave {other:?}; routes: {:?}",
             policy.network.egress.http
-        ))
+        )),
     }
 }
 

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -155,6 +155,17 @@ fn run_installs(w: &mut BehaviourWorld, tool: String) -> Result<(), String> {
     }
 }
 
+/// What the guest's gate decides for a host: the first entry that matches it, since a merged table only means anything read in order. `None` is the destination nothing decided, which is asked about rather than refused.
+pub fn gate_verdict(policy: &lns_policy::Policy, host: &str) -> Option<lns_policy::Verdict> {
+    policy
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|rule| lns_policy::matching::domain_matches(&rule.match_pattern, host))
+        .map(|rule| rule.verdict)
+}
+
 #[then(regex = r#"^a workload request to "([^"]+)" is allowed by policy$"#)]
 fn request_allowed_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(), String> {
     let policy = w
@@ -162,19 +173,12 @@ fn request_allowed_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(),
         .as_ref()
         .and_then(|r| r.running_policy.as_ref())
         .ok_or("no running policy was produced")?;
-    let verdict = policy
-        .network
-        .egress
-        .http
-        .iter()
-        .find(|r| r.match_pattern == host)
-        .map(|r| r.verdict);
-    if verdict == Some(lns_policy::Verdict::Allow) {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected {host} to be allowed by what the mixin contributed, got {verdict:?}"
-        ))
+    match gate_verdict(policy, &host) {
+        Some(lns_policy::Verdict::Allow) => Ok(()),
+        other => Err(format!(
+            "expected {host} to be allowed by what the mixin contributed, the gate's first match gave {other:?}; routes: {:?}",
+            policy.network.egress.http
+        )),
     }
 }
 


### PR DESCRIPTION
> Stacked on #233 (→ #232 → #231). Base is `feat/lowercase-kind`.
>
> First of the steps closing [§8](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#8-the-local-mixin). This one closes [§4.2](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#42-the-egress-definition)'s ordering rule and the half of §8.1 that is about precedence.

## The divergence

§4.2 is normative and unambiguous:

> **Across sources, the later source decides.** Its entries are placed ahead of earlier ones in the merged table…
> A later source can therefore turn a `deny` into an `allow`. That is deliberate — overriding is what layering is for — and it is why the merged table is disclosed before boot rather than trusted silently: the developer approves the effective egress, not each contributor's opinion of it.

And §8.1: the developer's decisions are "Last in the merge… Nothing they pulled can overrule what they decided."

`merge_effective` did the opposite. It hoisted every layer's denies to the front, then dropped any allow that a deny-by-default layer did not independently permit (`allowed_by_every_ceiling`). A pulled artifact clamped the developer running it.

This behaviour appeared in no guide. It was undocumented code contradicting a normative section — which is how it survived.

## Why now

§4.2 names its own safeguard: the merged table is *disclosed before boot*. That disclosure did not exist until #232 in this stack, which is why this PR comes after it and not before. Deleting a clamp while nothing showed the developer the result would have removed a safety net with nothing underneath.

## What is lost, stated plainly

**A published artifact can no longer enforce an outbound lockdown against a careless local file.** A local `allow *` now outranks an artifact's targeted `deny telemetry.evil`.

§4.2 makes that trade deliberately, and it holds for this product: the artifact's deny is what the workload's author needed, not a boundary over the person running it; a destination nobody decided is still asked about; and enforced org ceilings are Lens Agents' job.

**The developer's own lockdown is not lost** — it is expressed by ordering instead of intersection. A local catch-all deny sits ahead of every pulled entry and decides them. Three tests that asserted the *losing* rule was absent now assert the *winning* rule comes first, which is what a first-match gate actually means.

One second-order fix falls out: an approval the developer had just clicked could previously be dropped by the clamp on the next watcher reload. Under precedence an approval sticks.

## The two tables stay independent, in both directions

A raw rule must name a port (§4.2), so no `tcp` catch-all is expressible and a `deny *` written in `http` was never a raw lockdown. The old code compensated by selecting ceilings from the `http` table and clamping *both* — which the specification does not describe.

Review caught that this flips a case my first accounting missed: a developer's `deny *` no longer suppresses a pulled artifact's raw-TCP allow. Landed as the spec-faithful behaviour and pinned as an explicit decision rather than an accident, beside the test for the reverse direction.

**One residual limitation is the specification's, and is deliberately not settled here:** a developer cannot express "deny all raw TCP" at all, only per-destination raw denies. Closing that needs a decision — a `tcp` catch-all grammar, or a rule that an `http` catch-all deny closes both tables — not a patch.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage` and `make e2e` (69 scenarios) all exit 0.

Net **375 deletions against 214 insertions**: `allowed_by_every_ceiling`, `permits`, `tcp_permits`, `scope_within`, `live_rules`, the deny-first hoist and the catch-all repositioning are all gone.

The twelve tests pinning the old model were split by what each actually asserted — four inverted (the direction the spec drops), three rewritten as ordering (the direction that survives), four deleted (binary-scope clamping, whose mechanism is gone; review confirmed the guest gate carries that property itself, failing closed for an excluded caller).

Mutation-checked: placing the artifact ahead of the developer turns the Layer 2 scenario *a mixin cannot open a directory that denies by default* red.

## A test helper that was lying

`request_denied_by_policy` commented "the guest gate is first-match-wins" and implemented `find(|r| r.match_pattern == host)` — an exact string compare that cannot see a `*` catch-all. The old clamp *deleted* the losing allow, so exact-match happened to give the right answer; once the allow legitimately survived behind the deny, the helper picked the wrong rule.

Both it and its sibling now share `gate_verdict()`, a real first-match through `domain_matches`. It also no longer treats "no rule matches" as denied — being asked is not being refused.

Review found the same class of defect in my own rewrite: `allow_idx < deny_idx` compares `Option<usize>`, and `None < Some(_)` is `true`, so the test passed on the very regression it guarded. Both positions are now bound with `expect` before comparing; making the merge drop the later source turns 22 tests red.

## Review round 2: the safeguard §4.2 names did not exist for an uncomposed run

The clamp's replacement is disclosure. Review found that for a **published sandbox that layers on nothing**, there was no disclosure at all — so the one state where the deleted clamp was load-bearing was also the state §4.2's reader did not cover.

The raw table is what made it visible. A directory's catch-all deny is an `http` rule, and a raw rule must name a port, so nothing a developer can write decides the raw table: a pulled `allow db.vendor.example:5432` fires while the summary — which reads the local file alone — reports the directory denies by default. It does not even print `0 raw allow`; with an empty local raw table it prints no raw signal at all.

The same hole covers `http`. An allow a pulled sandbox ships against a default-ask directory was equally unnamed, so this is a class, not a corner.

Two things were in the way, and both needed fixing:

- `mixin::resolve` returns early for a document with no mixins, so `contributions` was empty and there was nothing to print. It now attributes the document's own egress to `the sandbox`.
- The summary's `Rules:` block was gated on having resolved a mixin. It now prints whenever there are egress contributions; the `Mixins:` line stays gated.

An uncomposed run names no source on those lines — one author was never an attribution question, and `an_uncomposed_run_prints_exactly_what_it_printed_before_attribution_existed` still holds for a run that ships no rules.

The alternative was to re-add a clamp for `egress.tcp` alone. Rejected: it reverses a decision this PR's review already pinned deliberately, it reintroduces a mechanism §4.2 does not describe, it would settle the open "does an http catch-all close both tables" question in code by accident, and it closes one corner while leaving the http side of the same hole open.

## Two names that outlived their model

`set_policy_floor` documented itself as "an always-merged floor … can never drop the sandbox's rules". A floor is a lower bound that cannot be undercut, which is exactly what this PR deletes — the local file overrules it. It is `set_shipped_policy` now, described as the earlier source each reload re-merges under. `ceiling_denies` is `denies_by_default`.

## Seven tests that could no longer fail

The merge is unconditional concatenation now, so "rule X survives the merge" is structurally true for any input. Seven ceiling-era tests asserting only presence are deleted; review confirmed the two that looked like ordering proofs were redundant against `a_later_sources_entries_precede_an_earlier_sources` and `the_raw_table_carries_both_sources_in_precedence_order`. Reversing the layer order in `merge_effective` still turns three surviving tests red, so no coverage left with them.

One kept its assertion and lost its vocabulary: an allow stranded behind a catch-all must not let an earlier source's identical allow through, which is a real property of a first-match gate.

## Not in this PR

The rest of §8: the rule-4 tier in `flatten`, `spec.egress` vs `spec.policy.egress`, top-level `name:` vs `metadata.name`, moving `connectors:` to the grant sidecar, converting the decisions file to mixin grammar, and the `lns-local-mixin.yaml` rename.

