### PR TITLE
feat!: name a document's egress where the specification names it

### DIFF
--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -121,11 +121,9 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
         }
     }
     if !world.project_egress.is_empty() {
-        spec_tail.push_str("\n  policy:\n    egress:\n      http:");
+        spec_tail.push_str("\n  egress:\n    http:");
         for host in &world.project_egress {
-            spec_tail.push_str(&format!(
-                "\n        - match: {host}\n          verdict: allow"
-            ));
+            spec_tail.push_str(&format!("\n      - match: {host}\n        verdict: allow"));
         }
     }
     if !world.project_tools.is_empty() {

--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -205,23 +205,21 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
 
     // A later source's entries are placed ahead of an earlier one's, so the latest entry matching a destination is the one that decides.
     for source in sources.iter().rev() {
-        spec.policy
-            .egress
+        spec.egress
             .http
-            .extend(source.spec.policy.egress.http.iter().cloned());
-        spec.policy
-            .egress
+            .extend(source.spec.egress.http.iter().cloned());
+        spec.egress
             .tcp
-            .extend(source.spec.policy.egress.tcp.iter().cloned());
+            .extend(source.spec.egress.tcp.iter().cloned());
         // Egress is a union rather than a keyed replacement, so every entry is attributed and none displaces another.
-        for rule in source.spec.policy.egress.http.iter() {
+        for rule in source.spec.egress.http.iter() {
             contributions.push(egress_contribution(
                 rule.verdict,
                 &rule.match_pattern,
                 source.label,
             ));
         }
-        for rule in source.spec.policy.egress.tcp.iter() {
+        for rule in source.spec.egress.tcp.iter() {
             contributions.push(egress_contribution(
                 rule.verdict,
                 &rule.match_pattern,
@@ -240,9 +238,8 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
 
 /// What a document's own egress contributes when nothing merges into it, so a run that layered on nothing still discloses every rule it will enforce (§1.5).
 pub fn own_egress(spec: &SandboxSpec) -> Vec<Contribution> {
-    let http = spec.policy.egress.http.iter();
+    let http = spec.egress.http.iter();
     let tcp = spec
-        .policy
         .egress
         .tcp
         .iter()
@@ -731,11 +728,11 @@ mod tests {
         let found = contributions(&sources(&[
             (
                 ROOT_LABEL,
-                r#"{"policy":{"egress":{"http":[{"match":"api.base.example","verdict":"allow"}]}}}"#,
+                r#"{"egress":{"http":[{"match":"api.base.example","verdict":"allow"}]}}"#,
             ),
             (
                 "obs",
-                r#"{"policy":{"egress":{"http":[{"match":"api.obs.example","verdict":"allow"}]}}}"#,
+                r#"{"egress":{"http":[{"match":"api.obs.example","verdict":"allow"}]}}"#,
             ),
         ]));
         let rules: Vec<(&str, &str)> = found
@@ -959,14 +956,14 @@ mod tests {
         let merged = merged(&sources(&[
             (
                 "base",
-                r#"{"policy":{"egress":{"http":[{"match":"api.example.test","verdict":"deny"}]}}}"#,
+                r#"{"egress":{"http":[{"match":"api.example.test","verdict":"deny"}]}}"#,
             ),
             (
                 "later",
-                r#"{"policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#,
+                r#"{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}"#,
             ),
         ]));
-        let table = &merged.policy.egress.http;
+        let table = &merged.egress.http;
         assert_eq!(table.len(), 2, "both entries survive the union");
         assert_eq!(
             table[0].verdict,
@@ -980,14 +977,14 @@ mod tests {
         let merged = merged(&sources(&[
             (
                 "base",
-                r#"{"policy":{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"deny"}]}}}"#,
+                r#"{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"deny"}]}}"#,
             ),
             (
                 "later",
-                r#"{"policy":{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"allow"}]}}}"#,
+                r#"{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"allow"}]}}"#,
             ),
         ]));
-        let table = &merged.policy.egress.tcp;
+        let table = &merged.egress.tcp;
         assert_eq!(table.len(), 2);
         assert_eq!(
             table[0].verdict,
@@ -1016,10 +1013,9 @@ mod tests {
     fn one_documents_own_order_survives_inside_its_own_entries() {
         let merged = merged(&sources(&[(
             "base",
-            r#"{"policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"},{"match":"*","verdict":"deny"}]}}}"#,
+            r#"{"egress":{"http":[{"match":"api.example.test","verdict":"allow"},{"match":"*","verdict":"deny"}]}}"#,
         )]));
         let patterns: Vec<&str> = merged
-            .policy
             .egress
             .http
             .iter()
@@ -1061,7 +1057,7 @@ mod tests {
     fn a_merged_document_round_trips_through_its_own_serialization() {
         let merged = merged(&sources(&[(
             "base",
-            r#"{"image":"x:1","command":"agent","workdir":"/w","user":"node","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some"}],"tools":["node@22"],"volumes":[{"type":"bind","source":".","target":"/w"}],"filesets":[{"inline":{"a.md":"x"},"mountPath":"/notes"}],"ports":[{"container":8080}],"policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#,
+            r#"{"image":"x:1","command":"agent","workdir":"/w","user":"node","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some"}],"tools":["node@22"],"volumes":[{"type":"bind","source":".","target":"/w"}],"filesets":[{"inline":{"a.md":"x"},"mountPath":"/notes"}],"ports":[{"container":8080}],"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}"#,
         )]));
         let json = serde_json::to_string(&merged).expect("a merged spec serializes");
         assert_eq!(

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, anyhow, bail};
-use lns_policy::NetworkPolicy;
+use lns_policy::Egress;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -109,7 +109,7 @@ pub struct SandboxSpec {
     #[serde(default)]
     pub resources: Option<Resources>,
     #[serde(default)]
-    pub policy: NetworkPolicy,
+    pub egress: Egress,
     #[serde(default)]
     pub connectors: Vec<String>,
     #[serde(default)]
@@ -278,11 +278,11 @@ fn parse_of_kind(config_json: &[u8], kind: spec::Kind) -> Result<Definition> {
         validate_resources(resources)?;
     }
     doc.spec
-        .policy
+        .egress
         .validate_local_transport()
         .context("sandbox policy")?;
     doc.spec
-        .policy
+        .egress
         .validate_binary_scopes()
         .context("sandbox policy")?;
     if let Some(workdir) = &doc.spec.workdir {
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     fn a_mixin_reads_every_block_it_shares_with_a_sandbox() {
         let def = parse_mixin(&mixin_json(
-            r#"{"env":{"MODE":"research"},"tools":["postgresql@17"],"policy":{"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"allow"}]}},"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some-token"}],"filesets":[{"inline":{"USING-POSTGRES.md":"Connect with $DATABASE_URL."},"mountPath":"/home/agent/notes"}],"ports":[{"container":8080}],"volumes":[{"type":"volume","name":"cache","target":"/home/agent/.cache"}]}"#,
+            r#"{"env":{"MODE":"research"},"tools":["postgresql@17"],"egress":{"tcp":[{"match":"db.example.com:5432","verdict":"allow"}]},"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some-token"}],"filesets":[{"inline":{"USING-POSTGRES.md":"Connect with $DATABASE_URL."},"mountPath":"/home/agent/notes"}],"ports":[{"container":8080}],"volumes":[{"type":"volume","name":"cache","target":"/home/agent/.cache"}]}"#,
         ))
         .expect("a mixin's shared blocks follow the same rules as a sandbox's");
         assert_eq!(def.metadata.name, "postgres-tools");
@@ -715,7 +715,7 @@ mod tests {
         );
         assert_eq!(def.spec.ports[0].container, 8080);
         assert_eq!(def.spec.volumes[0].target, "/home/agent/.cache");
-        assert_eq!(def.spec.policy.egress.tcp.len(), 1);
+        assert_eq!(def.spec.egress.tcp.len(), 1);
         assert_eq!(def.spec.credentials[0].env_var, "SOME_TOKEN");
         assert_eq!(def.spec.filesets[0].mount_path, "/home/agent/notes");
     }
@@ -774,6 +774,23 @@ mod tests {
         assert!(
             format!("{mixin_err:#}").contains("expected kind sandbox"),
             "got: {mixin_err:#}"
+        );
+    }
+
+    #[test]
+    fn a_document_names_its_egress_where_the_specification_names_it() {
+        let def = parse(&def_json(
+            r#"{"image":"x:1","egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}"#,
+        ))
+        .expect("§3.1's field table names this block `egress`, not `policy`");
+        assert_eq!(def.spec.egress.http.len(), 1);
+        let err = parse(&def_json(
+            r#"{"image":"x:1","policy":{"egress":{"http":[]}}}"#,
+        ))
+        .expect_err("the old spelling is gone rather than accepted alongside the new one");
+        assert!(
+            format!("{err:#}").contains("policy"),
+            "the refusal has to name the key it did not know; got: {err:#}"
         );
     }
 
@@ -886,7 +903,7 @@ mod tests {
     #[test]
     fn parse_reads_the_whole_flat_definition() {
         let json = def_json(
-            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","workdir":"/workspace","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"},{"match":"*","verdict":"deny"}]}},"connectors":["some-provider"],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"some_LNSPLACEHOLDER0000"}],"volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"home","target":"/root/.home","readOnly":true}],"ports":[{"container":8080}]}"#,
+            r#"{"image":"ghcr.io/team/base:1","command":"agent --serve","workdir":"/workspace","env":{"MODE":"research"},"resources":{"cpu":2,"memory":"1Gi"},"egress":{"http":[{"match":"api.example.test","verdict":"allow"},{"match":"*","verdict":"deny"}]},"connectors":["some-provider"],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"some_LNSPLACEHOLDER0000"}],"volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","source":"home","target":"/root/.home","readOnly":true}],"ports":[{"container":8080}]}"#,
         );
         let def = parse(&json).unwrap();
         assert_eq!(def.metadata.name, "hermes");
@@ -898,11 +915,11 @@ mod tests {
             Some("research")
         );
         assert_eq!(
-            def.spec.policy.egress.http.last().unwrap().match_pattern,
+            def.spec.egress.http.last().unwrap().match_pattern,
             "*",
             "a closed baseline carries its lockdown as a catch-all deny"
         );
-        assert_eq!(def.spec.policy.egress.http.len(), 2);
+        assert_eq!(def.spec.egress.http.len(), 2);
         assert_eq!(def.spec.connectors, vec!["some-provider".to_string()]);
         assert_eq!(def.spec.credentials[0].env_var, "SOME_TOKEN");
         assert_eq!(def.spec.volumes[0].source(), ".");
@@ -915,27 +932,15 @@ mod tests {
     #[test]
     fn parse_reads_an_omitted_policy_as_deciding_nothing() {
         let def = parse(&def_json(r#"{"image":"ghcr.io/team/base:1"}"#)).unwrap();
-        assert!(def.spec.policy.egress.http.is_empty());
-        assert!(def.spec.policy.egress.tcp.is_empty());
+        assert!(def.spec.egress.http.is_empty());
+        assert!(def.spec.egress.tcp.is_empty());
         assert!(def.spec.connectors.is_empty());
-    }
-
-    #[test]
-    fn parse_rejects_a_default_transport_the_file_no_longer_carries() {
-        let err = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"defaultTransport":"upstream"}}"#,
-        ))
-        .unwrap_err();
-        assert!(
-            format!("{err:#}").contains("defaultTransport is no longer part of a policy file"),
-            "got: {err:#}"
-        );
     }
 
     #[test]
     fn parse_rejects_an_upstream_route_transport() {
         let err = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","transport":"upstream"}]}}}"#,
+            r#"{"image":"ghcr.io/team/base:1","egress":{"http":[{"match":"api.example.test","verdict":"allow","transport":"upstream"}]}}"#,
         ))
         .unwrap_err();
         assert!(
@@ -947,7 +952,7 @@ mod tests {
     #[test]
     fn parse_rejects_a_relative_binary_scope() {
         let err = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["git"]}]}}}"#,
+            r#"{"image":"ghcr.io/team/base:1","egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["git"]}]}}"#,
         ))
         .unwrap_err();
         assert!(
@@ -959,7 +964,7 @@ mod tests {
     #[test]
     fn parse_rejects_an_empty_binary_scope() {
         let err = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":[]}]}}}"#,
+            r#"{"image":"ghcr.io/team/base:1","egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":[]}]}}"#,
         ))
         .unwrap_err();
         assert!(
@@ -971,11 +976,11 @@ mod tests {
     #[test]
     fn parse_accepts_an_absolute_binary_scope() {
         let def = parse(&def_json(
-            r#"{"image":"ghcr.io/team/base:1","policy":{"egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["/usr/bin/git"]}]}}}"#,
+            r#"{"image":"ghcr.io/team/base:1","egress":{"http":[{"match":"git.example.test","verdict":"allow","binaries":["/usr/bin/git"]}]}}"#,
         ))
         .unwrap();
         assert_eq!(
-            def.spec.policy.egress.http[0].binaries,
+            def.spec.egress.http[0].binaries,
             Some(vec!["/usr/bin/git".to_string()])
         );
     }
@@ -2010,9 +2015,9 @@ mod tests {
         let specs = [
             r#"{"image":"x:1","unexpected":true}"#,
             r#"{"image":"x:1","resources":{"cpu":1,"unexpected":true}}"#,
-            r#"{"image":"x:1","policy":{"unexpected":true}}"#,
-            r#"{"image":"x:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","unexpected":true}]}}}"#,
-            r#"{"image":"x:1","policy":{"egress":{"http":[{"match":"api.example.test","verdict":"allow","rules":[{"path":"/v1","unexpected":true}]}]}}}"#,
+            r#"{"image":"x:1","egress":{"unexpected":true}}"#,
+            r#"{"image":"x:1","egress":{"http":[{"match":"api.example.test","verdict":"allow","unexpected":true}]}}"#,
+            r#"{"image":"x:1","egress":{"http":[{"match":"api.example.test","verdict":"allow","rules":[{"path":"/v1","unexpected":true}]}]}}"#,
             r#"{"image":"x:1","credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-fake","injectons":[]}]}"#,
             r#"{"image":"x:1","volumes":[{"name":"data","target":"/data","readOlny":true}]}"#,
             r#"{"image":"x:1","filesets":[{"path":"./skills","mountPath":"/skills","unexpected":true}]}"#,

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -19,10 +19,9 @@ spec:
   resources:
     cpu: 1
     memory: 512Mi
-  policy:
-    egress:
-      http: []
-      tcp: []
+  egress:
+    http: []
+    tcp: []
   connectors: []
   credentials: []
   volumes:
@@ -242,9 +241,9 @@ fn render_effective<W: Write>(def: &lns_artifact::sandbox::Definition, out: &mut
     }
     writeln!(
         out,
-        "  policy:       {} route(s){}",
-        def.spec.policy.egress.http.len(),
-        raw_rule_note(def.spec.policy.egress.tcp.len())
+        "  egress:       {} route(s){}",
+        def.spec.egress.http.len(),
+        raw_rule_note(def.spec.egress.tcp.len())
     )?;
     if !def.spec.connectors.is_empty() {
         writeln!(out, "  connectors: {}", def.spec.connectors.join(", "))?;
@@ -460,7 +459,7 @@ mod tests {
             "got: {text}"
         );
         assert!(
-            text.contains("policy:") && text.contains("route(s)"),
+            text.contains("egress:") && text.contains("route(s)"),
             "got: {text}"
         );
         assert!(text.contains("connectors: some-provider"), "got: {text}");
@@ -481,7 +480,7 @@ mod tests {
 
     #[test]
     fn inspect_local_counts_raw_rules_apart_from_routes() {
-        let yaml = "apiVersion: lns.run/v1\nkind: sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  policy:\n    egress:\n      http:\n        - match: api.example.test\n          verdict: allow\n      tcp:\n        - match: db.internal:5432\n          verdict: allow\n";
+        let yaml = "apiVersion: lns.run/v1\nkind: sandbox\nmetadata:\n  name: hermes\nspec:\n  image: x:1\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n    tcp:\n      - match: db.internal:5432\n        verdict: allow\n";
         let fs = fake("/work/lns.yaml", yaml);
         let mut out = Vec::new();
         inspect_local(&fs, cwd(), None, None, &[], &mut out).unwrap();

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -87,7 +87,7 @@ Feature: authoring a sandbox
     When the user runs sandbox command "inspect"
     Then the exit code is 0
     And the output contains "image"
-    And the output contains "policy"
+    And the output contains "egress"
     And the service received no request
 
   Scenario: inspect discloses the run-as user a definition asks for

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -69,5 +69,5 @@ Feature: managing cached sandboxes
     Given the sandbox "hermes:1.4.0" was pulled and then locally edited
     When the user runs sandbox command "diff hermes:1.4.0"
     Then the exit code is 0
-    And the output contains "policy"
+    And the output contains "egress"
     And the output shows the local changes since the pulled version

--- a/crates/lns-cli/tests/behaviours/sandbox_run.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_run.feature
@@ -29,11 +29,11 @@ Feature: running a sandbox
     Then the exit code is 0
     And the service received a request to run a sandbox
 
-  Scenario: run carries the local definition's policy, connectors, and resources to the service
-    Given a valid lns.yaml declaring a policy, connectors, and resources
+  Scenario: run carries the local definition's egress, connectors, and resources to the service
+    Given a valid lns.yaml declaring egress, connectors, and resources
     When the user runs "lns run"
     Then the exit code is 0
-    And the service request carries the definition's policy, connectors, and resources
+    And the service request carries the definition's egress, connectors, and resources
 
   Scenario: run with no reference and no lns.yaml fails clearly
     Given the current directory has no lns.yaml

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -226,16 +226,16 @@ fn surface_service_refusal(message: &str) -> CliRun {
     }
 }
 
-#[given("a valid lns.yaml declaring a policy, connectors, and resources")]
+#[given("a valid lns.yaml declaring egress, connectors, and resources")]
 fn lns_yaml_with_policy_connectors_resources(w: &mut BehaviourWorld) {
     w.author_files.insert(
         PathBuf::from("/work/lns.yaml"),
-        "apiVersion: lns.run/v1\nkind: sandbox\nmetadata:\n  name: hermes\nspec:\n  image: ghcr.io/team/base:1\n  policy:\n    egress:\n      http: []\n  connectors:\n    - some-provider\n  resources:\n    cpu: 2\n    memory: 1Gi\n"
+        "apiVersion: lns.run/v1\nkind: sandbox\nmetadata:\n  name: hermes\nspec:\n  image: ghcr.io/team/base:1\n  egress:\n    http: []\n  connectors:\n    - some-provider\n  resources:\n    cpu: 2\n    memory: 1Gi\n"
             .to_string(),
     );
 }
 
-#[then("the service request carries the definition's policy, connectors, and resources")]
+#[then("the service request carries the definition's egress, connectors, and resources")]
 fn request_carries_definition(w: &mut BehaviourWorld) -> Result<(), String> {
     let json = w
         .sandbox_run
@@ -245,9 +245,9 @@ fn request_carries_definition(w: &mut BehaviourWorld) -> Result<(), String> {
     let value: serde_json::Value =
         serde_json::from_str(json).map_err(|e| format!("definition was not json: {e}"))?;
     let spec = &value["spec"];
-    if spec["policy"].is_null() || spec["connectors"].is_null() || spec["resources"].is_null() {
+    if spec["egress"].is_null() || spec["connectors"].is_null() || spec["resources"].is_null() {
         return Err(format!(
-            "expected policy, connectors, and resources in the definition, got: {spec}"
+            "expected egress, connectors, and resources in the definition, got: {spec}"
         ));
     }
     Ok(())

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -115,11 +115,10 @@ impl TryFrom<EgressRaw> for Egress {
     }
 }
 
-impl NetworkPolicy {
-    /// Whether the first catch-all `egress.http` rule the gate reaches is a deny, which decides everything the named rules leave rather than asking.
+impl Egress {
+    /// Whether the first catch-all `http` rule the gate reaches is a deny, which decides everything the named rules leave rather than asking.
     pub fn is_closed(&self) -> bool {
-        self.egress
-            .http
+        self.http
             .iter()
             .find(|rule| rule.is_catch_all())
             .is_some_and(|rule| rule.verdict == Verdict::Deny)
@@ -127,7 +126,6 @@ impl NetworkPolicy {
 
     pub fn validate_local_transport(&self) -> io::Result<()> {
         let uses_upstream = self
-            .egress
             .http
             .iter()
             .any(|route| route.transport == Transport::Upstream);
@@ -141,10 +139,21 @@ impl NetworkPolicy {
     }
 
     pub fn validate_binary_scopes(&self) -> io::Result<()> {
-        self.egress
-            .http
-            .iter()
-            .try_for_each(RouteRule::validate_binaries)
+        self.http.iter().try_for_each(RouteRule::validate_binaries)
+    }
+}
+
+impl NetworkPolicy {
+    pub fn is_closed(&self) -> bool {
+        self.egress.is_closed()
+    }
+
+    pub fn validate_local_transport(&self) -> io::Result<()> {
+        self.egress.validate_local_transport()
+    }
+
+    pub fn validate_binary_scopes(&self) -> io::Result<()> {
+        self.egress.validate_binary_scopes()
     }
 }
 

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -103,7 +103,9 @@ pub(crate) fn project_inspection(
                 credentials: mixin.spec.credentials.clone(),
                 tools: mixin.spec.tools.clone(),
                 policy_flags: declared_policy_flags(&lns_policy::Policy {
-                    network: mixin.spec.policy.clone(),
+                    network: lns_policy::NetworkPolicy {
+                        egress: mixin.spec.egress.clone(),
+                    },
                     ..Default::default()
                 }),
             })))
@@ -573,7 +575,7 @@ mod tests {
 
     #[test]
     fn a_sandbox_projects_its_volumes_ports_filesets_and_over_broad_policy_flag() {
-        let config = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","workdir":"/work","volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","name":"cache","target":"/root/.cache","readOnly":true}],"ports":[{"container":8080},{"host":9090,"container":3000}],"filesets":[{"ref":"registry.example.test/team/skills@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mountPath":"/root/.agent/skills"},{"inline":{"settings.json":"do-not-print"},"mountPath":"/etc/agent","owner":"root"}],"policy":{"egress":{"http":[{"match":"*","verdict":"allow"}]}}}}"#;
+        let config = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{"name":"some-sandbox"},"spec":{"image":"registry.example.test/runtime:1","workdir":"/work","volumes":[{"type":"bind","source":".","target":"/workspace"},{"type":"volume","name":"cache","target":"/root/.cache","readOnly":true}],"ports":[{"container":8080},{"host":9090,"container":3000}],"filesets":[{"ref":"registry.example.test/team/skills@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mountPath":"/root/.agent/skills"},{"inline":{"settings.json":"do-not-print"},"mountPath":"/etc/agent","owner":"root"}],"egress":{"http":[{"match":"*","verdict":"allow"}]}}}"#;
 
         let inspection = project_sandbox(config).unwrap();
 

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -475,7 +475,7 @@ mod tests {
             r#"{"image":"x:1","mixins":["obs"]}"#,
             &[(
                 "obs",
-                r#"{"tools":["node@22"],"volumes":[{"type":"volume","name":"cache","target":"/cache"}],"ports":[{"container":8080}],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}],"policy":{"egress":{"http":[{"match":"api.some-provider.example","verdict":"allow"}]}}}"#,
+                r#"{"tools":["node@22"],"volumes":[{"type":"volume","name":"cache","target":"/cache"}],"ports":[{"container":8080}],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}],"egress":{"http":[{"match":"api.some-provider.example","verdict":"allow"}]}}"#,
             )],
         );
         let refs: Vec<(&str, &str)> = documents
@@ -1013,7 +1013,7 @@ mod tests {
     async fn a_sandbox_that_layers_on_nothing_still_attributes_the_egress_it_ships() {
         let out = resolve(
             &sandbox(
-                r#"{"image":"x:1","policy":{"egress":{"tcp":[{"match":"db.vendor.example:5432","verdict":"allow"}]}}}"#,
+                r#"{"image":"x:1","egress":{"tcp":[{"match":"db.vendor.example:5432","verdict":"allow"}]}}"#,
             ),
             &[],
             &published(),

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -70,7 +70,7 @@ pub fn dispatch_run(
 /// Map a flat `kind: sandbox` definition onto a resolved run: its base image plus the inline config, with no component graph to assemble. A definition that ships neither a network policy nor connectors plans with no policy baseline, so the directory's overlay governs verbatim.
 pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> ResolvedSandbox {
     let ships_policy =
-        def.spec.policy != lns_policy::NetworkPolicy::default() || !def.spec.connectors.is_empty();
+        def.spec.egress != lns_policy::Egress::default() || !def.spec.connectors.is_empty();
     ResolvedSandbox {
         base_image: def.spec.image.clone(),
         user: def.spec.user.clone(),
@@ -137,7 +137,9 @@ pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> Resolve
         env: def.spec.env.clone(),
         resources: def.spec.resources.clone(),
         policy: ships_policy.then(|| lns_policy::Policy {
-            network: def.spec.policy.clone(),
+            network: lns_policy::NetworkPolicy {
+                egress: def.spec.egress.clone(),
+            },
             connectors: def.spec.connectors.clone(),
         }),
         credentials: def.spec.credentials.clone(),
@@ -274,7 +276,7 @@ mod tests {
     #[test]
     fn resolved_from_sandbox_carries_the_base_image_command_env_and_policy() {
         let def = lns_artifact::sandbox::parse(
-            br#"{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{"name":"hermes"},"spec":{"image":"ghcr.io/team/base@sha256:abc","command":"agent --serve","env":{"MODE":"research"},"policy":{"egress":{"http":[{"match":"*","verdict":"deny"}]}},"connectors":["some-provider"],"user":"root"}}"#,
+            br#"{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{"name":"hermes"},"spec":{"image":"ghcr.io/team/base@sha256:abc","command":"agent --serve","env":{"MODE":"research"},"egress":{"http":[{"match":"*","verdict":"deny"}]},"connectors":["some-provider"],"user":"root"}}"#,
         )
         .unwrap();
         let resolved = resolved_from_sandbox(&def);

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -201,7 +201,7 @@ fn published_declares_one(w: &mut BehaviourWorld, id: String) {
 fn definition_declares_with_allowed_route(w: &mut BehaviourWorld, id: String, host: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.definition = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","connectors":["{id}"],"policy":{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"ghcr.io/team/base:1","connectors":["{id}"],"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
     ));
 }
 

--- a/crates/lns-service/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_tools.rs
@@ -85,7 +85,7 @@ fn lns_yaml_with_tools_and_policy(w: &mut BehaviourWorld, entries: String) {
         .collect();
     let rig = w.tools.get_or_insert_with(Default::default);
     rig.definition = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"registry.example.test/runtime:1","policy":{{"egress":{{"http":[{{"match":"*","verdict":"deny"}}]}}}},"tools":[{}]}}}}"#,
+        r#"{{"apiVersion":"lns.run/v1","kind":"sandbox","metadata":{{"name":"hermes"}},"spec":{{"image":"registry.example.test/runtime:1","egress":{{"http":[{{"match":"*","verdict":"deny"}}]}},"tools":[{}]}}}}"#,
         tools.join(",")
     ));
 }

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -71,9 +71,7 @@ fn mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
 fn mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
     install(
         w,
-        &format!(
-            r#"{{"policy":{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
-        ),
+        &format!(r#"{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}"#),
     );
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -181,7 +181,7 @@ interchangeable everywhere a run is addressed.
 
 The `./lns.yaml` definition (`apiVersion: lns.run/v1`, `kind: sandbox`) carries a
 `spec` with `image` (**required** base OCI image), and the optional `command`,
-`workdir`, `volumes`, `env`, `policy`, and `connectors`. Declarative mounts
+`workdir`, `volumes`, `env`, `egress`, and `connectors`. Declarative mounts
 accept `type: bind` or `type: volume`, `source`, an absolute `target`, and optional
 `readOnly`; explicit run mounts replace declarations with the same target. See
 [Running workloads — defining a sandbox](running-workloads.md#defining-a-sandbox).

--- a/docs/examples/claude-code/lns.yaml
+++ b/docs/examples/claude-code/lns.yaml
@@ -21,17 +21,16 @@ spec:
   resources:
     cpu: 4
     memory: 6Gi
-  policy:
-    egress:
-      http:
-        - match: registry.npmjs.org
-          verdict: allow
-        - match: api.anthropic.com
-          verdict: allow
-        - match: platform.claude.com
-          verdict: allow
-        - match: downloads.claude.ai
-          verdict: allow
+  egress:
+    http:
+      - match: registry.npmjs.org
+        verdict: allow
+      - match: api.anthropic.com
+        verdict: allow
+      - match: platform.claude.com
+        verdict: allow
+      - match: downloads.claude.ai
+        verdict: allow
   connectors:
     - claude-code-subscription
   volumes:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,9 +135,8 @@ spec:
   resources:
     cpu: 1
     memory: 512Mi
-  policy:
-    egress:
-      http: []
+  egress:
+    http: []
   connectors: []
   credentials: []
   volumes:

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -37,9 +37,8 @@ spec:
   resources:
     cpu: 1
     memory: 512Mi
-  policy:
-    egress:
-      http: []
+  egress:
+    http: []
   connectors: []
   credentials: []
   volumes:
@@ -64,7 +63,7 @@ The `spec` fields:
 | `workdir`      | Absolute guest working directory. It is created when missing.                 |
 | `user`         | The run-as user the sandbox needs, `USER[:GROUP]` like `-u`, so a definition that needs root is runnable as published. A per-run `-u` still wins, and the image's own `USER` is the fallback when this is unset. |
 | `env`          | Non-secret environment variables seeded into the workload.                   |
-| `policy`       | The network policy — the `egress.http` and `egress.tcp` rule tables (see [Policy](policy.md)). |
+| `egress`       | Where the workload may reach — the `http` and `tcp` rule tables (see [Policy](policy.md)). |
 | `connectors` | Ids of the [connectors](connectors.md) the sandbox would like to use. Declaring seeds the connector's placeholder env var but is not a grant: a declared id is offered on first use (accept its connect card to arm it), never armed automatically — so an untrusted published sandbox can't open a route or spend a bound credential behind your back. An id the machine's catalog doesn't know refuses the launch. |
 | `credentials`  | The secrets the workload needs, one entry each: the variable it reads (`envVar`), the fake value it holds (`placeholder`, which must contain `placeholder` or `lns` and be at least 16 characters), and the destinations the real value may travel to (`injections[]`, each a `kind` and a `domain`, which may name a host family but never the catch-all `*`). An `api_key_header` injection also names the `header` it sets. A declaration names no connector — this machine decides how the value is obtained. A connector whose own claim covers a declared domain supplies it: an `oauth`-kind one blocks the launch on its sign-in, a credential-kind one binds through the ordinary first-use value decision. With no catalog entry claiming the domain, the first request asks for a pasted value. Two entries may not share an `envVar`. See [Credentials](credentials.md#value-decisions). |
 | `resources`    | vCPUs and memory the sandbox boots with (`cpu`, `memory` with a unit suffix, or `N%` of the host); per-run `--cpus` / `--mem` flags win. |
@@ -1057,7 +1056,7 @@ or `lns pull` simply fetches or rebuilds it again.
 
 [`examples/claude-code/`](examples/claude-code/) is a complete recipe that ties
 these pieces together: it runs Claude Code inside a sandbox using `spec.image`
-plus node declared under `spec.tools`, `spec.env`, a tight `policy` allowlist,
+plus node declared under `spec.tools`, `spec.env`, a tight `spec.egress` allowlist,
 the `claude-code-subscription` connector, a `.` bind at `/workspace`, and a
 self-contained inline fileset that seeds the agent's home. Copy its `lns.yaml`
 into your project and `lns run`.


### PR DESCRIPTION
> Stacked on #236 (→ #233 → #232 → #231). Base is `feat/later-source-decides`.
>
> Closes a format divergence from [§3.1](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#31-kind-sandbox) / [§4.2](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#42-the-egress-definition).

## The divergence

§3.1's field table calls the block **`egress`** ("Where the workload may reach"), §3.1.6 shows it written directly under `spec`, and §4.2 says "Every kind declares it as `spec.egress`".

The code carried it as `spec.policy.egress` — one level deeper, under a key the specification does not use.

## Why now, and not later

A later step in this plan has the run **write** the per-directory decisions file as a `kind: mixin` document. Writing `spec.policy.egress` into it would invent a file shape the specification does not describe, which [CLAUDE.md's transitional rule 1](https://github.com/lensapp/lens-sandbox/blob/main/CLAUDE.md#the-rules) forbids. So this lands first.

## The change removes a level

`NetworkPolicy` was a struct with one field. `SandboxSpec.policy: NetworkPolicy` becomes `SandboxSpec.egress: Egress`, and the three methods that only ever read `self.egress` — `is_closed`, `validate_local_transport`, `validate_binary_scopes` — move to `Egress`, where they were always looking.

`NetworkPolicy` stays, delegating: it is still the shape of the standalone decisions file (`Policy { network, connectors }`) and of the guest wire message. A later step may retire it; this one does not pre-empt that.

`lns inspect` labelled the block `policy:` in its output. It now prints `egress:`, so what you read matches what you type.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage` and `make e2e` (69 scenarios) all exit 0.

Layer 3 `a_document_names_its_egress_where_the_specification_names_it` asserts the new spelling parses and that `policy` is refused **by name** — `SandboxSpec` already carries `deny_unknown_fields`, so the old spelling fails loudly rather than being silently ignored. It was red first.

Deleted `parse_rejects_a_default_transport_the_file_no_longer_carries`: it pinned that a *sandbox document* carrying `policy.defaultTransport` gets the specific retirement message, and `policy` no longer exists in a sandbox document. Verified before deleting that the message is still pinned twice for the path that does have the shim — the standalone policy file.

## Three over-matches, caught

The sweep was regex-driven, and `policy` means four different things here: the spec block, the `lns policy` command, the standalone file, and the Rust type. It wrongly rewrote (1) the negative case inside my own new test, turning "assert `policy` is refused" into a positive — it failed loudly, which is how it surfaced; (2) a `lns --help` scenario asserting the CLI lists the `policy` **command**; (3) a `deny_unknown_fields` recursion fixture whose nesting moved. All three restored.
