### PR TITLE
feat!: keep which connectors a project connected out of the file it commits

### DIFF
--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use lns_policy::Policy;
 use lns_policy::connectors::{
     AuthKind, Catalog, Connector, ConnectorRoute, CredentialAuth, bundled_connectors,
     effective_connectors,
@@ -404,12 +403,7 @@ pub async fn connect(
         }
     };
     let path = policy_path(args.policy.as_deref(), cwd);
-    let mut policy = Policy::load_or_default(&path)
-        .with_context(|| format!("loading policy from {}", path.display()))?;
-    policy.connect(args.id.clone());
-    policy
-        .save_atomic(&path)
-        .with_context(|| format!("writing policy to {}", path.display()))?;
+    connect_project(grants_path, &project_key(&path), &args.id)?;
     writeln!(writer, "{closing}")?;
     // Binding the value cannot lift a workload's decline, so say what will: otherwise the connect reports success and the workload goes on being refused with nothing on screen explaining it.
     match standing_declines(grants_path, &project_key(&path), &args.id) {
@@ -455,22 +449,39 @@ pub fn disconnect(
     writer: &mut impl Write,
 ) -> Result<i32> {
     let path = policy_path(args.policy.as_deref(), cwd);
-    let mut policy = Policy::load_or_default(&path)
-        .with_context(|| format!("loading policy from {}", path.display()))?;
-    if !policy.disconnect(&args.id) {
-        bail!("{:?} is not connected in {}", args.id, path.display());
-    }
-    // Forget the grants before dropping the id, so a sidecar this run cannot update leaves a still-connected policy to retry rather than stale grants a later reconnect would inherit.
-    let cleared = clear_project_grants(grants_path, &project_key(&path), &args.id)?;
-    policy
-        .save_atomic(&path)
-        .with_context(|| format!("writing policy to {}", path.display()))?;
+    let project = project_key(&path);
+    let cleared = disconnect_project(grants_path, &project, &args.id)?
+        .ok_or_else(|| anyhow::anyhow!("{:?} is not connected in {project}", args.id))?;
     let grants_note = match cleared {
         0 => String::new(),
         n => format!(" and forgot {n} per-workload grant(s)"),
     };
     writeln!(writer, "Disconnected {:?}{grants_note}", args.id)?;
     Ok(0)
+}
+
+/// Record that this project connected a connector, in the one file that also holds what each workload in it may spend.
+fn connect_project(grants_path: &Path, project: &str, connector: &str) -> Result<()> {
+    JsonFileGrantStore::new(grants_path.to_path_buf())
+        .update(&mut |file| file.connect(project, connector))
+        .with_context(|| format!("updating grants at {}", grants_path.display()))?;
+    Ok(())
+}
+
+/// Drop the project's connection and every grant under it in one write, answering with how many grants went; `None` when it was never connected.
+fn disconnect_project(grants_path: &Path, project: &str, connector: &str) -> Result<Option<usize>> {
+    let store = JsonFileGrantStore::new(grants_path.to_path_buf());
+    let mut cleared = None;
+    store
+        .update(&mut |file| {
+            if !file.disconnect(project, connector) {
+                return false;
+            }
+            cleared = Some(file.revoke_project_connector(project, connector));
+            true
+        })
+        .with_context(|| format!("updating grants at {}", grants_path.display()))?;
+    Ok(cleared)
 }
 
 /// Drop every per-workload grant for one connector in a project from the sidecar, returning how many were removed; the forget is always recorded, even with nothing to remove, because a run still deciding is exactly the one whose grant this has to cancel.
@@ -584,6 +595,13 @@ mod tests {
     use lns_policy::connectors::{OauthAuth, OauthFlow};
     use lns_policy::providers::{InjectionDef, InjectionKind};
     use tempfile::TempDir;
+
+    fn connected_at(dir: &Path) -> Vec<String> {
+        JsonFileGrantStore::new(dir.join("grants.json"))
+            .load()
+            .expect("the sidecar reads back")
+            .connected_in(&project_key(&dir.join("lns-policy.yaml")))
+    }
 
     #[test]
     fn standing_declines_reports_none_when_the_sidecar_cannot_be_read() {
@@ -1019,8 +1037,11 @@ mod tests {
         )
         .await
         .unwrap();
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
-        assert_eq!(policy.connectors, ["gitlab"]);
+        assert_eq!(
+            connected_at(dir.path()),
+            ["gitlab"],
+            "connecting names a directory and no workload, so it records per project beside the per-workload grants"
+        );
     }
 
     #[tokio::test]
@@ -1060,9 +1081,8 @@ mod tests {
         )
         .await
         .unwrap();
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
         assert_eq!(
-            policy.connectors,
+            connected_at(dir.path()),
             ["somesaas"],
             "a completed sign-in records the connector"
         );
@@ -1087,9 +1107,8 @@ mod tests {
         .await
         .unwrap_err();
         assert!(format!("{err:#}").contains("access_denied"), "got: {err:#}");
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
         assert!(
-            policy.connectors.is_empty(),
+            connected_at(dir.path()).is_empty(),
             "a failed sign-in must not record the connector"
         );
     }
@@ -1164,9 +1183,8 @@ mod tests {
         .await
         .unwrap_err();
         assert!(format!("{err:#}").contains("timed out"), "got: {err:#}");
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
         assert!(
-            policy.connectors.is_empty(),
+            connected_at(dir.path()).is_empty(),
             "a failed bind must not record the connector"
         );
     }
@@ -1244,8 +1262,7 @@ mod tests {
             &mut Vec::new(),
         )
         .unwrap();
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
-        assert!(policy.connectors.is_empty());
+        assert!(connected_at(dir.path()).is_empty());
     }
 
     #[test]
@@ -1326,12 +1343,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(
-            Policy::load_or_default(&dir.path().join("lns-policy.yaml"))
-                .unwrap()
-                .connectors,
-            ["gitlab"]
-        );
+        assert_eq!(connected_at(dir.path()), ["gitlab"]);
         run(
             &ConnectorCommand::Disconnect(DisconnectArgs {
                 id: "gitlab".into(),
@@ -1345,11 +1357,6 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(
-            Policy::load_or_default(&dir.path().join("lns-policy.yaml"))
-                .unwrap()
-                .connectors
-                .is_empty()
-        );
+        assert!(connected_at(dir.path()).is_empty());
     }
 }

--- a/crates/lns-cli/tests/behaviours/connector_cli.feature
+++ b/crates/lns-cli/tests/behaviours/connector_cli.feature
@@ -21,7 +21,7 @@ Feature: connecting connectors from the CLI
     And the background service is available to sign in
     When the developer runs "lns connector connect some-provider"
     Then the output describes binding a credential value
-    And "some-provider" is recorded under connectors in lns-policy.yaml
+    And "some-provider" is recorded as connected for this project
     And lns-policy.yaml carries no credential material
 
   Scenario: Connecting a credential connector fails clearly when the service is unavailable
@@ -29,20 +29,20 @@ Feature: connecting connectors from the CLI
     And the background service is not available
     When the developer runs "lns connector connect some-provider"
     Then the command fails noting the service is needed to bind
-    And "some-provider" is not recorded in lns-policy.yaml
+    And "some-provider" is not recorded as connected
 
   Scenario: Connecting an oauth connector signs in and then records it
     Given the background service is available to sign in
     When the developer runs "lns connector connect some-oauth"
     Then a verification URL and user code are shown
-    And "some-oauth" is recorded under connectors in lns-policy.yaml
+    And "some-oauth" is recorded as connected for this project
     And lns-policy.yaml carries no token material
 
   Scenario: Connecting an oauth connector fails clearly when the service is unavailable
     Given the background service is not available
     When the developer runs "lns connector connect some-oauth"
     Then the command fails noting the service is needed to sign in
-    And "some-oauth" is not recorded in lns-policy.yaml
+    And "some-oauth" is not recorded as connected
 
   Scenario: The catalog listing shows each connector's auth kind
     When the developer runs "lns connector list"
@@ -55,7 +55,7 @@ Feature: connecting connectors from the CLI
     When the developer runs "lns connector connect some-pkce"
     Then the browser is opened to the authorization page
     And no user code is shown
-    And "some-pkce" is recorded under connectors in lns-policy.yaml
+    And "some-pkce" is recorded as connected for this project
     And lns-policy.yaml carries no credential material
 
   Scenario: Connecting a pkce connector fails clearly when the service is unavailable
@@ -63,7 +63,7 @@ Feature: connecting connectors from the CLI
     And the background service is not available
     When the developer runs "lns connector connect some-pkce"
     Then the command fails noting the service is needed to sign in
-    And "some-pkce" is not recorded in lns-policy.yaml
+    And "some-pkce" is not recorded as connected
 
   Scenario: The catalog listing shows a pkce connector as authenticating by oauth
     Given a user catalog declares the "some-pkce" pkce connector

--- a/crates/lns-cli/tests/behaviours/connector_grants.feature
+++ b/crates/lns-cli/tests/behaviours/connector_grants.feature
@@ -12,7 +12,7 @@ Feature: inspecting and forgetting per-workload connector grants
   a shipped service.
 
   Background:
-    Given this project's policy connects "some-provider"
+    Given this project connects "some-provider"
 
   Scenario: Listing shows the workload, connector, and verdict this project granted
     Given the workload "def:/work/app" was granted "some-provider"

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -4,7 +4,6 @@ use cucumber::{given, then, when};
 use lns_cli::command::parse_args;
 use lns_cli::connector::ConnectorArgs;
 use lns_cli::connector::{self, BindOutcome, ConnectorSignIn, LocalBoxFuture, SignInOutcome};
-use lns_policy::Policy;
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -316,14 +315,22 @@ fn shows_verification(world: &mut BehaviourWorld) {
     );
 }
 
-#[then(regex = r#"^"(\S+)" is recorded under connectors in lns-policy.yaml$"#)]
+#[then(regex = r#"^"(\S+)" is recorded as connected for this project$"#)]
 fn recorded(world: &mut BehaviourWorld, id: String) {
-    let policy = Policy::load_or_default(&policy_file(world)).unwrap();
+    let connected = connected_for(world);
     assert!(
-        policy.connectors.contains(&id),
-        "expected {id} recorded, got: {:?}",
-        policy.connectors
+        connected.contains(&id),
+        "connecting names a directory and no workload, so it records per project in the sidecar; got: {connected:?}"
     );
+}
+
+fn connected_for(world: &mut BehaviourWorld) -> Vec<String> {
+    use lns_policy::grants::GrantStore as _;
+    let policy = policy_file(world);
+    lns_policy::grants::JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
+        .load()
+        .expect("the sidecar reads back")
+        .connected_in(&lns_policy::grants::project_key(&policy))
 }
 
 #[then("lns-policy.yaml carries no token material")]
@@ -381,13 +388,12 @@ fn fails_needs_service(world: &mut BehaviourWorld) {
     );
 }
 
-#[then(regex = r#"^"(\S+)" is not recorded in lns-policy.yaml$"#)]
+#[then(regex = r#"^"(\S+)" is not recorded as connected$"#)]
 fn not_recorded(world: &mut BehaviourWorld, id: String) {
-    let policy = Policy::load_or_default(&policy_file(world)).unwrap();
+    let connected = connected_for(world);
     assert!(
-        !policy.connectors.contains(&id),
-        "expected {id} absent, got: {:?}",
-        policy.connectors
+        !connected.contains(&id),
+        "expected {id} absent, got: {connected:?}"
     );
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
@@ -1,6 +1,5 @@
 use crate::world::BehaviourWorld;
 use cucumber::{given, then};
-use lns_policy::Policy;
 use lns_policy::grants::{
     GrantRecord, GrantStore, JsonFileGrantStore, WorkloadGrantFile, WorkloadIdentity, project_key,
 };
@@ -48,12 +47,13 @@ fn output(world: &BehaviourWorld) -> &str {
         .output
 }
 
-#[given(regex = r#"^this project's policy connects "([^"]+)"$"#)]
-fn policy_connects(world: &mut BehaviourWorld, id: String) {
-    let path = cwd(world).join("lns-policy.yaml");
-    let mut policy = Policy::load_or_default(&path).expect("load policy");
-    policy.connect(id);
-    policy.save_atomic(&path).expect("save policy");
+#[given(regex = r#"^this project connects "([^"]+)"$"#)]
+fn project_connects(world: &mut BehaviourWorld, id: String) {
+    let project = this_project(world);
+    let store = JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"));
+    let mut file = store.load().expect("the sidecar reads back");
+    file.connect(&project, &id);
+    store.save(&file).expect("seeding the sidecar");
 }
 
 #[given(regex = r#"^the workload "([^"]+)" was granted "([^"]+)"$"#)]
@@ -94,12 +94,13 @@ fn grant_sidecar_unwritable(world: &mut BehaviourWorld) {
 
 #[then(regex = r#"^this project still connects "([^"]+)"$"#)]
 fn project_still_connects(world: &mut BehaviourWorld, id: String) {
-    let path = cwd(world).join("lns-policy.yaml");
-    let policy = Policy::load_or_default(&path).expect("load policy");
+    let connected = JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
+        .load()
+        .expect("the sidecar reads back")
+        .connected_in(&project_key(&cwd(world).join("lns-policy.yaml")));
     assert!(
-        policy.connectors.contains(&id),
-        "a disconnect that could not forget the grants must not have dropped {id} from the policy, got: {:?}",
-        policy.connectors
+        connected.contains(&id),
+        "the connection and the grants under it are one write now, so a disconnect that could not land leaves {id} connected for a retry, got: {connected:?}"
     );
 }
 

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -158,9 +158,52 @@ pub struct WorkloadGrantFile {
     pub grants: Vec<GrantRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub revocations: Vec<Revocation>,
+    /// Connectors a project connected. `lns connector connect` names a directory and no workload, so this answers for every workload run there; spending one is still the per-workload decision `grants` records.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub connected: Vec<Connection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Connection {
+    pub project: String,
+    pub connector: String,
 }
 
 impl WorkloadGrantFile {
+    pub fn is_connected(&self, project: &str, connector: &str) -> bool {
+        self.connected
+            .iter()
+            .any(|c| c.project == project && c.connector == connector)
+    }
+
+    /// Answers whether this changed anything, so a caller writes the file only when it did.
+    pub fn connect(&mut self, project: &str, connector: &str) -> bool {
+        if self.is_connected(project, connector) {
+            return false;
+        }
+        self.connected.push(Connection {
+            project: project.to_string(),
+            connector: connector.to_string(),
+        });
+        true
+    }
+
+    pub fn disconnect(&mut self, project: &str, connector: &str) -> bool {
+        let before = self.connected.len();
+        self.connected
+            .retain(|c| !(c.project == project && c.connector == connector));
+        before != self.connected.len()
+    }
+
+    /// Every connector this project connected, in the order it connected them.
+    pub fn connected_in(&self, project: &str) -> Vec<String> {
+        self.connected
+            .iter()
+            .filter(|c| c.project == project)
+            .map(|c| c.connector.clone())
+            .collect()
+    }
+
     fn triple_matches(g: &GrantRecord, project: &str, workload_key: &str, connector: &str) -> bool {
         g.project == project && g.workload == workload_key && g.connector == connector
     }
@@ -363,6 +406,30 @@ mod tests {
 
     fn mixin(name: &str) -> String {
         format!("ghcr.io/acme/{name}@sha256:{}", "d".repeat(64))
+    }
+
+    #[test]
+    fn a_connector_is_connected_for_the_project_rather_than_one_workload_in_it() {
+        let mut file = WorkloadGrantFile::default();
+        assert!(!file.is_connected("/work", "some-provider"));
+        assert!(
+            file.connect("/work", "some-provider"),
+            "connecting a connector this project had not connected is a change"
+        );
+        assert!(
+            file.is_connected("/work", "some-provider"),
+            "`lns connector connect` names a directory and no workload, so what it records has to answer for every workload run there"
+        );
+        assert!(
+            !file.is_connected("/other", "some-provider"),
+            "another project's directory decided nothing"
+        );
+        assert!(
+            !file.connect("/work", "some-provider"),
+            "connecting twice changes nothing, so nothing has to be written"
+        );
+        assert!(file.disconnect("/work", "some-provider"));
+        assert!(!file.is_connected("/work", "some-provider"));
     }
 
     #[test]

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -23,7 +23,8 @@ mod test_env;
 pub struct Policy {
     #[serde(default)]
     pub network: NetworkPolicy,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// The run's connected set, filled from the per-machine sidecar rather than this file: connecting is a per-machine risk acceptance, and a file that travels must not carry one.
+    #[serde(skip)]
     pub connectors: Vec<String>,
 }
 
@@ -430,12 +431,6 @@ impl Policy {
         if !self.connectors.contains(&id) {
             self.connectors.push(id);
         }
-    }
-
-    pub fn disconnect(&mut self, id: &str) -> bool {
-        let before = self.connectors.len();
-        self.connectors.retain(|i| i != id);
-        self.connectors.len() != before
     }
 }
 
@@ -1698,14 +1693,35 @@ network:
     }
 
     #[test]
-    fn policy_with_connectors_yaml_roundtrip_is_lossless() {
-        let mut p = Policy::default();
-        p.connect("gitlab");
-        p.connect("acme");
+    fn a_file_still_carrying_the_old_connectors_key_loads_and_decides_nothing() {
+        let p: Policy = serde_yaml::from_str(
+            "network:\n  egress:\n    http: []\nconnectors:\n  - some-provider\n",
+        )
+        .expect("a directory written before connections moved still opens");
+        assert!(
+            p.connectors.is_empty(),
+            "the key is ignored rather than read, so the connector is offered again on first use"
+        );
+    }
+
+    #[test]
+    fn the_decisions_file_never_carries_which_connectors_are_connected() {
+        let p = Policy {
+            connectors: vec!["some-provider".into()],
+            ..Policy::default()
+        };
         let yaml = serde_yaml::to_string(&p).unwrap();
-        assert!(yaml.contains("connectors"), "got:\n{yaml}");
-        let parsed: Policy = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(p, parsed);
+        assert!(
+            !yaml.contains("connectors"),
+            "connecting is a per-machine risk acceptance, and this file is meant to be committed; got:\n{yaml}"
+        );
+        assert!(
+            serde_yaml::from_str::<Policy>(&yaml)
+                .unwrap()
+                .connectors
+                .is_empty(),
+            "what a run may spend is read from the sidecar, never from a file that travels"
+        );
     }
 
     #[test]
@@ -1742,25 +1758,8 @@ credentials:
     #[test]
     fn connect_is_idempotent_and_does_not_duplicate() {
         let mut p = Policy::default();
-        p.connect("github");
-        p.connect("github");
-        assert_eq!(p.connectors, ["github"]);
-    }
-
-    #[test]
-    fn disconnect_removes_an_applied_connector_and_reports_true() {
-        let mut p = Policy::default();
-        p.connect("github");
-        p.connect("gitlab");
-        assert!(p.disconnect("github"));
-        assert_eq!(p.connectors, ["gitlab"]);
-    }
-
-    #[test]
-    fn disconnect_reports_false_when_the_id_is_not_applied() {
-        let mut p = Policy::default();
-        p.connect("gitlab");
-        assert!(!p.disconnect("github"));
-        assert_eq!(p.connectors, ["gitlab"]);
+        p.connect("some-provider");
+        p.connect("some-provider");
+        assert_eq!(p.connectors, ["some-provider"]);
     }
 }

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -26,6 +26,9 @@ pub type ConnectorRouteDeriver = Box<dyn Fn(&[String]) -> Vec<RouteRule> + Send 
 /// Invoked on a policy reload with the reloaded connected-connector ids so the credential subsystem can revoke a disconnected connector's arming.
 pub type ArmedReconciler = Box<dyn Fn(&[String]) + Send + Sync>;
 
+/// Records that this project connected a connector. Connecting is a per-machine risk acceptance, so it lands in the sidecar beside the per-workload grants rather than in a file that travels.
+pub type ConnectionRecorder = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
+
 /// A connectable connector whose routes aren't allowed yet, so a held request to one of its `patterns` offers to connect it before the plain allow/deny.
 pub struct OfferableConnector {
     pub id: String,
@@ -143,6 +146,7 @@ pub struct ApprovalSession {
     credentials_provider: OnceLock<CredentialsProvider>,
     connector_routes: OnceLock<ConnectorRouteDeriver>,
     armed_reconciler: OnceLock<ArmedReconciler>,
+    connection_recorder: OnceLock<ConnectionRecorder>,
     offerable: Vec<OfferableConnector>,
     connector: OnceLock<Arc<dyn ConnectPort>>,
     connecting: Mutex<HashSet<String>>,
@@ -176,6 +180,7 @@ impl ApprovalSession {
             credentials_provider: OnceLock::new(),
             connector_routes: OnceLock::new(),
             armed_reconciler: OnceLock::new(),
+            connection_recorder: OnceLock::new(),
             offerable: Vec::new(),
             connector: OnceLock::new(),
             connecting: Mutex::new(HashSet::new()),
@@ -198,6 +203,11 @@ impl ApprovalSession {
     /// Installs the armed-reconciler once at boot so a watcher reload revokes a disconnected connector's arming; idempotent, the first wins.
     pub fn set_armed_reconciler(&self, reconciler: ArmedReconciler) {
         let _ = self.armed_reconciler.set(reconciler);
+    }
+
+    /// Installs the port a live connect records through; idempotent, the first wins.
+    pub fn set_connection_recorder(&self, recorder: ConnectionRecorder) {
+        let _ = self.connection_recorder.set(recorder);
     }
 
     /// Installs the connector-route deriver once at boot so a watcher reload re-applies a connected connector's routes instead of dropping them; idempotent, the first wins.
@@ -667,33 +677,32 @@ impl ApprovalSession {
         }
     }
 
-    /// Connects a connector live: records the id under `connectors:` and persists only that, while the routes are applied to the in-memory policy and emitted so a held request sees them — boot re-derives the routes from the catalog, so persisting them would leave a residual allow that `disconnect` can't revoke.
+    /// Connects a connector live: records the connection where this machine keeps them, while the routes are applied to the in-memory policy and emitted so a held request sees them — boot re-derives the routes from the catalog, so persisting them would leave a residual allow that `disconnect` can't revoke.
     pub fn connect_connector(&self, id: &str, routes: Vec<RouteRule>) {
-        let (to_persist, live_network) = {
+        let live_network = {
             let mut policy = self.policy.lock().expect("policy mutex poisoned");
-            policy.connect(id);
+            policy.connect(id.to_string());
             crate::artifact::policy::splice_connector_routes(
                 &mut policy.network.egress.http,
                 routes,
             );
-            let mut persisted = self.persisted.lock().expect("persisted mutex poisoned");
-            persisted.connect(id);
-            (persisted.clone(), policy.network.clone())
+            policy.network.clone()
         };
         let credentials = self.current_credentials();
         let _ = self.sink.send(HostFrame::Policy(PolicyMessage {
             network: Some(WireNetwork::seeded(live_network)),
             credentials,
         }));
-        if let Err(e) = self.store.save(&to_persist) {
-            self.notifier.inform(&format!(
-                "connector connected in-memory but not persisted: {e}"
-            ));
-        }
         // The routes are live above, so requests held on this connector's offer proceed no matter which surface the consent came from.
         for request_id in self.drain_offer_requests(id) {
             self.notifier.dismiss(&request_id);
             self.send_decision_frame(&request_id, Decision::AllowOnce);
+        }
+        // Recorded last: the sidecar takes a lock, and a held request must not wait on disk to be released.
+        if let Some(Err(e)) = self.connection_recorder.get().map(|record| record(id)) {
+            self.notifier.inform(&format!(
+                "connector connected in-memory but not persisted: {e}"
+            ));
         }
     }
 }
@@ -1088,31 +1097,6 @@ pub(crate) mod tests {
                 "the guest still enforces the whole effective policy; {expected} missing from {published:?}"
             );
         }
-    }
-
-    #[test]
-    fn a_connect_writes_only_the_developers_own_policy_back() {
-        let (session, _n, store, _rx) = fixture_over_a_merged_run();
-        session.connect_connector(
-            "some-provider",
-            vec![RouteRule::allow_host("api.some-provider.example")],
-        );
-
-        let saved = store.saves.lock().unwrap();
-        let policy = saved.last().expect("the connect is persisted");
-        let written: Vec<&str> = policy
-            .network
-            .egress
-            .http
-            .iter()
-            .map(|rule| rule.match_pattern.as_str())
-            .collect();
-        assert_eq!(
-            written,
-            vec!["mine.example.test"],
-            "a connect records an id; the artifact's rules and the connector's own routes are re-derived at boot, so writing them would outlive `lns connector disconnect`"
-        );
-        assert_eq!(policy.connectors, vec!["some-provider".to_string()]);
     }
 
     #[test]
@@ -1766,6 +1750,29 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn a_live_connect_records_the_connection_where_the_machine_keeps_them() {
+        let (s, _n, _store, mut rx) = fixture();
+        let recorded: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
+        let seen = recorded.clone();
+        s.set_connection_recorder(Box::new(move |id| {
+            seen.lock().unwrap().push(id.to_string());
+            Ok(())
+        }));
+
+        s.connect_connector(
+            "some-oauth",
+            vec![RouteRule::allow_host("api.some-oauth.example")],
+        );
+
+        assert_eq!(
+            recorded.lock().unwrap().as_slice(),
+            &["some-oauth".to_string()],
+            "the decisions file no longer carries connections, so a connect the developer accepted mid-run would be lost on the next reload unless it is recorded per machine"
+        );
+        let _ = policy_frame(&mut rx);
+    }
+
+    #[test]
     fn apply_external_policy_reconciles_armed_ids_with_the_reloaded_connectors() {
         let (s, _n, _store, _rx) = fixture();
         let seen: Arc<StdMutex<Vec<Vec<String>>>> = Arc::new(StdMutex::new(Vec::new()));
@@ -1952,35 +1959,32 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn connect_connector_persists_only_the_id_but_emits_the_route_live() {
+    fn connect_connector_leaves_the_developers_file_alone_and_emits_the_route_live() {
         let (s, _n, store, mut rx) = fixture();
-        s.connect_connector("gitlab", vec![RouteRule::allow_host("gitlab.com")]);
-        let saves = store.saves.lock().unwrap();
-        assert_eq!(saves.len(), 1, "the connection is persisted once");
-        assert_eq!(saves[0].connectors, ["gitlab"]);
-        assert!(
-            !saves[0]
-                .network
-                .egress
-                .http
-                .iter()
-                .any(|r| r.match_pattern == "gitlab.com"),
-            "the route must not be baked into the file — boot re-derives it from the catalog, so persisting it would survive `disconnect`"
+        s.connect_connector(
+            "some-provider",
+            vec![RouteRule::allow_host("api.some-provider.example")],
         );
-        drop(saves);
+        assert!(
+            store.saves.lock().unwrap().is_empty(),
+            "the connection lives in the machine's sidecar and the route is re-derived at boot, so a connect has nothing left to write into a file the developer commits"
+        );
         let v = serde_json::to_value(rx.try_recv().expect("policy frame")).unwrap();
         assert_eq!(v["type"], "policy");
         assert_eq!(
-            v["network"]["egress"]["http"][0]["match"], "gitlab.com",
+            v["network"]["egress"]["http"][0]["match"], "api.some-provider.example",
             "the live frame still carries the route so a held request can proceed"
         );
     }
 
     #[test]
-    fn connect_connector_informs_when_persist_fails() {
-        let (s, n, store, _rx) = fixture();
-        store.fail_next(io::ErrorKind::PermissionDenied, "disk full");
-        s.connect_connector("gitlab", vec![RouteRule::allow_host("gitlab.com")]);
+    fn connect_connector_informs_when_the_connection_cannot_be_recorded() {
+        let (s, n, _store, _rx) = fixture();
+        s.set_connection_recorder(Box::new(|_| Err("disk full".to_string())));
+        s.connect_connector(
+            "some-provider",
+            vec![RouteRule::allow_host("api.some-provider.example")],
+        );
         let informed = n.informed.lock().unwrap();
         assert_eq!(informed.len(), 1);
         assert!(informed[0].contains("not persisted"), "got: {:?}", informed);

--- a/crates/lns-service/src/approval_flow/watcher.rs
+++ b/crates/lns-service/src/approval_flow/watcher.rs
@@ -4,41 +4,64 @@ use std::sync::Arc;
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 
 use crate::approval_flow::session::ApprovalSession;
-use lns_policy::Policy;
 
 pub struct PolicyWatcher {
     _watcher: notify::RecommendedWatcher,
 }
 
 impl PolicyWatcher {
-    pub fn spawn(path: PathBuf, session: Arc<ApprovalSession>) -> notify::Result<Self> {
-        let parent = path
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("."));
-
-        let mut watcher = notify::recommended_watcher(event_handler(path.clone(), session))?;
-        watcher.watch(&parent, RecursiveMode::NonRecursive)?;
+    /// Watches both files a run's effective policy is read from: the developer's decisions, and the sidecar the machine keeps its connections in — a `lns connector disconnect` touches only the second, and a live run has to see it.
+    pub fn spawn(
+        policy_path: PathBuf,
+        grants_path: PathBuf,
+        session: Arc<ApprovalSession>,
+    ) -> notify::Result<Self> {
+        let mut watcher = notify::recommended_watcher(event_handler(
+            policy_path.clone(),
+            grants_path.clone(),
+            session,
+        ))?;
+        let mut watched: Vec<PathBuf> = Vec::new();
+        for target in [&policy_path, &grants_path] {
+            let parent = parent_of(target);
+            if watched.contains(&parent) {
+                continue;
+            }
+            watcher.watch(&parent, RecursiveMode::NonRecursive)?;
+            watched.push(parent);
+        }
         Ok(Self { _watcher: watcher })
     }
 }
 
-fn event_handler(
-    target: PathBuf,
-    session: Arc<ApprovalSession>,
-) -> impl Fn(notify::Result<Event>) + Send + 'static {
-    move |res| handle_event(res, &target, session.as_ref())
+fn parent_of(path: &Path) -> PathBuf {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
 }
 
-fn handle_event(res: notify::Result<Event>, target: &Path, session: &ApprovalSession) {
+fn event_handler(
+    policy_path: PathBuf,
+    grants_path: PathBuf,
+    session: Arc<ApprovalSession>,
+) -> impl Fn(notify::Result<Event>) + Send + 'static {
+    move |res| handle_event(res, &policy_path, &grants_path, session.as_ref())
+}
+
+fn handle_event(
+    res: notify::Result<Event>,
+    policy_path: &Path,
+    grants_path: &Path,
+    session: &ApprovalSession,
+) {
     let Ok(event) = res else {
         return;
     };
-    if !is_policy_change(&event, target) {
+    if !is_policy_change(&event, policy_path) && !is_policy_change(&event, grants_path) {
         return;
     }
-    if let Ok(p) = Policy::load_or_default(target) {
+    if let Ok(p) = crate::supervisor::adapter::reload_with_connections(policy_path, grants_path) {
         session.apply_external_policy(p);
     }
 }
@@ -133,7 +156,7 @@ mod tests {
             std::time::Duration::from_secs(30),
         ));
 
-        let _w = PolicyWatcher::spawn(path, session).unwrap();
+        let _w = PolicyWatcher::spawn(path, dir.path().join("grants.json"), session).unwrap();
     }
 
     #[test]
@@ -153,7 +176,7 @@ mod tests {
             tx,
             std::time::Duration::from_secs(30),
         ));
-        let _w = PolicyWatcher::spawn(path, session).unwrap();
+        let _w = PolicyWatcher::spawn(path, dir.path().join("grants.json"), session).unwrap();
     }
 
     fn make_session() -> (
@@ -183,7 +206,11 @@ mod tests {
         updated.save_atomic(&path).unwrap();
 
         let (session, mut rx) = make_session();
-        let handler = event_handler(path.clone(), session.clone());
+        let handler = event_handler(
+            path.clone(),
+            dir.path().join("grants.json"),
+            session.clone(),
+        );
         handler(Ok(evt(EventKind::Modify(ModifyKind::Any), &path)));
 
         assert_eq!(session.current_policy().network.egress.http.len(), 1);
@@ -203,11 +230,39 @@ mod tests {
         handle_event(
             Ok(evt(EventKind::Modify(ModifyKind::Any), &path)),
             &path,
+            &dir.path().join("grants.json"),
             session.as_ref(),
         );
 
         let cur = session.current_policy();
         assert_eq!(cur.network.egress.http.len(), 1);
+        assert!(rx.try_recv().is_ok(), "expected a Policy hot-swap frame");
+    }
+
+    #[test]
+    fn a_change_to_the_sidecar_reaches_the_run() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("lns-policy.yaml");
+        Policy::default().save_atomic(&path).unwrap();
+        let grants = dir.path().join("grants.json");
+        let store = lns_policy::grants::JsonFileGrantStore::new(grants.clone());
+        let mut file = lns_policy::grants::WorkloadGrantFile::default();
+        file.connect(&lns_policy::grants::project_key(&path), "some-provider");
+        lns_policy::grants::GrantStore::save(&store, &file).unwrap();
+
+        let (session, mut rx) = make_session();
+        handle_event(
+            Ok(evt(EventKind::Modify(ModifyKind::Any), &grants)),
+            &path,
+            &grants,
+            session.as_ref(),
+        );
+
+        assert_eq!(
+            session.current_policy().connectors,
+            ["some-provider"],
+            "`lns connector disconnect` touches only the sidecar now, so a run that watched the decisions file alone would keep an armed credential the developer just revoked"
+        );
         assert!(rx.try_recv().is_ok(), "expected a Policy hot-swap frame");
     }
 
@@ -223,6 +278,7 @@ mod tests {
         handle_event(
             Ok(evt(EventKind::Modify(ModifyKind::Any), &sibling)),
             &target,
+            &dir.path().join("grants.json"),
             session.as_ref(),
         );
 
@@ -238,6 +294,7 @@ mod tests {
         handle_event(
             Err(notify::Error::generic("simulated")),
             &path,
+            &dir.path().join("grants.json"),
             session.as_ref(),
         );
 
@@ -253,6 +310,7 @@ mod tests {
         handle_event(
             Ok(evt(EventKind::Modify(ModifyKind::Any), &path)),
             &path,
+            &dir.path().join("grants.json"),
             session.as_ref(),
         );
 
@@ -270,6 +328,7 @@ mod tests {
         handle_event(
             Ok(evt(EventKind::Modify(ModifyKind::Any), &path)),
             &path,
+            &dir.path().join("grants.json"),
             session.as_ref(),
         );
 

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -604,6 +604,10 @@ async fn start_credential_subsystem(
 
     // Back-reference so the approval session's Policy emits carry the credential registry instead of `credentials: null`.
     session.set_credentials_provider(make_credentials_provider(&credential_session));
+    session.set_connection_recorder(make_connection_recorder(
+        consent.grant_store.clone(),
+        consent.project.to_string(),
+    ));
     // A policy reload re-gates the reconnected connectors through the grant snapshot, so a disconnected — or never-granted — connector's arming is revoked; granted declarations survive because they don't derive from the policy file.
     session.set_armed_reconciler(make_armed_reconciler(
         &credential_session,
@@ -623,14 +627,45 @@ async fn start_credential_subsystem(
 fn running_policies(
     policy_path: &Path,
     sandbox_policy: Option<&Policy>,
+    connected: Vec<String>,
 ) -> Result<(Policy, Policy)> {
-    let own = Policy::load_or_default(policy_path)
+    let mut own = Policy::load_or_default(policy_path)
         .with_context(|| format!("loading policy {}", policy_path.display()))?;
+    own.connectors = connected;
     let effective = match sandbox_policy {
         Some(baseline) => crate::artifact::policy::merge_effective(Some(baseline), &own),
         None => own.clone(),
     };
     Ok((effective, own))
+}
+
+/// A live connect records the project's connection where the machine keeps them, so the next reload and the next run both see it.
+fn make_connection_recorder(
+    store: Arc<dyn GrantStore>,
+    project: String,
+) -> crate::approval_flow::session::ConnectionRecorder {
+    Box::new(move |id| {
+        store
+            .update(&mut |file| file.connect(&project, id))
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    })
+}
+
+/// The decisions file as the run reads it: what the developer wrote, plus the connectors this project connected, which live per machine rather than in a file that travels.
+pub(crate) fn reload_with_connections(policy_path: &Path, grants_path: &Path) -> Result<Policy> {
+    let mut policy = Policy::load_or_default(policy_path)
+        .with_context(|| format!("reloading policy {}", policy_path.display()))?;
+    policy.connectors = connected_in(grants_path, &project_key(policy_path));
+    Ok(policy)
+}
+
+/// Every connector this project connected, read from the sidecar each time so a connect or disconnect made mid-run is seen by the next reload.
+fn connected_in(grants_path: &Path, project: &str) -> Vec<String> {
+    lns_policy::grants::JsonFileGrantStore::new(grants_path.to_path_buf())
+        .load()
+        .map(|file| file.connected_in(project))
+        .unwrap_or_default()
 }
 
 pub(super) async fn start(
@@ -644,7 +679,8 @@ pub(super) async fn start(
 ) -> Result<SupervisorSession> {
     let sandbox_credentials = consent.credentials;
     let workload = consent.workload;
-    let (mut policy, own_policy) = running_policies(policy_path, sandbox_policy)?;
+    let connected = connected_in(&default_workload_grants_path(), &project_key(policy_path));
+    let (mut policy, own_policy) = running_policies(policy_path, sandbox_policy, connected)?;
     // Applied connectors resolve against the effective catalog (bundled ∪ user) into both wire credentials and allow-routes, captured once at boot so a later edit can't reach an already-forked workload.
     let user_catalog =
         load_user_catalog_or_warn(&lns_policy::connectors::default_connectors_path());
@@ -790,12 +826,13 @@ pub(super) async fn start(
     credential_session.set_ledger_recorder(recorder);
 
     // The watcher goes up only after the armed reconciler is registered, so no reload can fire without one; then one reconcile from disk catches any disconnect landed during subsystem init (the oauth-refresh await) before the relay emits its initial frame.
-    let watcher = PolicyWatcher::spawn(policy_path.to_path_buf(), session.clone())
-        .with_context(|| format!("watching policy {}", policy_path.display()))?;
-    session.apply_external_policy(
-        Policy::load_or_default(policy_path)
-            .with_context(|| format!("reloading policy {}", policy_path.display()))?,
-    );
+    let watcher = PolicyWatcher::spawn(
+        policy_path.to_path_buf(),
+        grants_path.clone(),
+        session.clone(),
+    )
+    .with_context(|| format!("watching policy {}", policy_path.display()))?;
+    session.apply_external_policy(reload_with_connections(policy_path, &grants_path)?);
 
     let supervisor_bin = ensure().await?;
     let relay = relay::spawn(
@@ -826,6 +863,39 @@ mod tests {
     use super::*;
     use lns_policy::grants::GrantRecord;
     use std::io;
+
+    #[test]
+    fn the_connection_recorder_writes_the_project_into_the_sidecar() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("grants.json");
+        let store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(path.clone()));
+
+        let record = make_connection_recorder(store.clone(), "/work".to_string());
+        assert_eq!(record("some-provider"), Ok(()));
+
+        assert_eq!(
+            store
+                .load()
+                .expect("the sidecar reads back")
+                .connected_in("/work"),
+            ["some-provider"],
+            "a connect the developer accepted mid-run is lost on the next reload unless it lands where the machine keeps its connections"
+        );
+    }
+
+    #[test]
+    fn the_connection_recorder_surfaces_a_sidecar_it_cannot_write() {
+        let unwritable = std::path::Path::new("/no/such/dir/grants.json");
+        let store: Arc<dyn GrantStore> =
+            Arc::new(JsonFileGrantStore::new(unwritable.to_path_buf()));
+
+        let record = make_connection_recorder(store, "/work".to_string());
+
+        assert!(
+            record("some-provider").is_err(),
+            "the session tells the developer when a connection it accepted did not land, so the re-offer next run is not a surprise"
+        );
+    }
 
     fn fixture_session() -> (Arc<ApprovalSession>, mpsc::UnboundedReceiver<HostFrame>) {
         use crate::approval_flow::session::tests::{CapturingStore, RecordingNotifier};

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::relay::Relay;
 
-mod adapter;
+pub(crate) mod adapter;
 pub(crate) use adapter::revocations_before_gate;
 mod real;
 mod traits;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -344,8 +344,8 @@ Manage the credential-connector catalog — the services whose credentials reach
 workload. The catalog is machine-global (`~/.lns-connectors.yaml`). A connector
 declared in a sandbox definition's `spec.connectors` seeds its placeholder env
 var but is only offered — the workload is prompted on first use, never armed
-automatically. Connecting one records it under `connectors:` in that
-directory's `lns-policy.yaml` and binds its value on your machine; the workload
+automatically. Connecting one records the connection for that project on this
+machine and binds its value; the workload
 still meets a first-use card, and answering it is what grants that workload the
 value.
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -59,8 +59,8 @@ A connector reaches a project's workloads in any of three ways:
   route is opened and no bound value is injected on its behalf, even for a
   credential already bound on this machine. The workload is offered a live
   connect the first time it reaches the connector's domain; accepting it arms
-  the connector and records the id in this directory's
-  [`lns-policy.yaml`](policy.md). This is what keeps an untrusted published
+  the connector and records the connection for this project, per machine. This
+  is what keeps an untrusted published
   sandbox from spending a bound credential or opening a route behind your back.
   An id the machine's catalog doesn't know refuses the launch and points at
   `lns connector add`.
@@ -83,25 +83,17 @@ A connector reaches a project's workloads in any of three ways:
 - **Connected to the directory.** `lns connector connect` binds the
   connector's per-machine [value decision](credentials.md#value-decisions) —
   the approval-window card for a credential connector, the sign-in for an
-  `oauth` one — and records the id in that directory's
-  [`lns-policy.yaml`](policy.md), which is also how a directory with no
-  definition connects one:
+  `oauth` one — and records the connection for that project, which is also how a
+  directory with no definition connects one:
 
 ```bash
 lns connector connect gitlab
 lns connector disconnect gitlab
 ```
 
-The policy stores the connector by id under `connectors:`, so the definition
-resolves from the catalog at run time and the shareable policy stays small:
-
-```yaml
-network:
-  egress:
-    http: []
-connectors:
-  - gitlab
-```
+The connection is recorded by id for the project, per machine, so the
+definition resolves from the catalog at run time and nothing about which
+connectors you use travels with a file you commit.
 
 Only a connector you have **connected** to this directory opens its declared
 routes and seeds its placeholder at launch, and the first request carrying that
@@ -109,8 +101,8 @@ placeholder follows the ordinary credential
 [value decision](credentials.md#value-decisions) — where you choose to use the
 host value, store one, or deny. Connecting is a property of the directory, not
 of any one workload, so the value itself arms only where this workload holds a
-[grant](credentials.md#workload-grants); a copied policy file asks again rather
-than inheriting your approval. A **declared** id from a sandbox definition
+[grant](credentials.md#workload-grants); a clone of the project asks again
+rather than inheriting your approval. A **declared** id from a sandbox definition
 seeds its placeholder but never arms on its own; it is offered reactively on
 first use, so an untrusted published sandbox can't open a route or spend a
 bound credential without your say-so. A connector supplying a declared
@@ -152,7 +144,7 @@ and HTTP method/path `rules` for least-privilege access — beyond the bare `mat
 interactive **sign-in** the background service drives for you — `lns connector
 connect <id>` walks you through it and records the connector only once it completes,
 and the obtained credential is injected at the boundary like any other, stored per
-machine and never in `lns-policy.yaml`. An `oauth` entry carries an `oauth:` block (in
+machine and never in a file a project commits. An `oauth` entry carries an `oauth:` block (in
 place of `credential:`) whose `flow` selects one of two shapes:
 
 - **`flow: device`** (RFC 8628, the default) — `connect` prints a verification URL and
@@ -171,5 +163,5 @@ place of `credential:`) whose `flow` selects one of two shapes:
 
 - [Credentials](credentials.md) — how placeholders keep real secrets out of the
   workload, and the per-machine value decisions connectors reuse.
-- [Policy and approvals](policy.md) — the `lns-policy.yaml` file that records which
-  connectors a project has connected.
+- [Policy and approvals](policy.md) — the `lns-policy.yaml` file that records the
+  destinations a project decided.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -32,9 +32,9 @@ Declare your own for an internal API with `lns connector add`
 (see [Connectors](connectors.md)). A sandbox definition that lists a provider
 under `spec.connectors` seeds its placeholder env var but only *offers* it —
 the workload is prompted on first use, never armed automatically.
-`lns connector connect <id>` records the id under `connectors:` in that
-directory's `lns-policy.yaml` and binds the value on your machine, but that
-alone does not arm the credential for a workload — see
+`lns connector connect <id>` records the connection for that project on this
+machine and binds the value, but that alone does not arm the credential for a
+workload — see
 [Workload grants](#workload-grants) below.
 
 ## Value decisions


### PR DESCRIPTION
> Stacked on `feat/local-mixin-last` (→ #238 → #237 → #236 → #233 → #232 → #231). Base is `feat/local-mixin-last`.
>
> Settles [§8.4](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#84-open-where-a-connector-grant-goes), which the specification left open.

## The open question

> The same file records which connectors are connected today, and that record has no home here. A connector is installed **per machine** while consenting to use one is **per project** — and neither is something a mixin can say, because no kit names a connector. So the grant needs a store of its own, per project and outside the kit grammar. Where that lives is not settled.

It now lives in `~/.lns-workload-grants.json`, the machine-local sidecar that already holds what each workload may spend.

**One fork the answer did not settle.** Every existing record there is keyed `(project × workload × connector)` — and since #231, `workload` includes the mixin composition. But `lns connector connect github` names a **directory** and has no workload. So the connection is a second record kind, keyed by project alone, beside the grants rather than among them. That preserves today's semantics exactly: connecting is per-directory, spending is per-workload.

## Why the file stops carrying it

Connecting is a per-machine risk acceptance, and the decisions file is meant to be **committed**. A clone now asks again rather than inheriting an approval nobody in that clone made.

An older file that still carries `connectors:` loads fine and decides nothing — the key is ignored, and each connector is offered again on first use. That is pinned, because it is what would break silently if `deny_unknown_fields` were ever added to `Policy`.

## One write, not two

`disconnect` used to write the sidecar and then the file, with a comment explaining that a failure had to leave the connection intact for a retry. Both records now live in one file behind one `store.update`, so the property is structural rather than a comment.

## The regression review caught

Moving the record out of the file broke **mid-run `lns connector disconnect`**. The old write is what fired the `PolicyWatcher`, which disarmed the credential and dropped the routes. Writing only the sidecar meant nothing was watching: the command reported success while the workload kept the armed value — fail-open, on the credential path.

The watcher now watches both files, with the sidecar path injected rather than reached for, which also stops the watcher's unit tests reading the developer's real home directory. Pinned by `a_change_to_the_sidecar_reaches_the_run`; dropping the second target turns it red.

Review also caught that the record ran **before** the guest was released, and the sidecar takes a flock with a five-second contention wait — so a contended file could stall every held request. It records last now.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage` (100%), `make e2e` (69 scenarios) all exit 0.

Four tests moved rather than being deleted, each checked for a lost property: a connect now writes **nothing** to the developer's file; a connection that cannot be recorded still informs the developer (which is why the port is fallible rather than infallible); the roundtrip test is **inverted** to pin that the file never carries connections; and one was deleted only after confirming an identically-named test already pinned its property on the approval path.

`Policy::disconnect` had no callers left and is removed.

## Not in this PR

The grammar conversion itself — the decisions file becoming a `kind: mixin` document — and the `lns-local-mixin.yaml` rename, which land together with the rule-4 tier's caller in the next PR on this branch.
