### PR TITLE
feat!: the directory's decisions are the local mixin the specification says they are

### DIFF
--- a/.claude/skills/problem-first/SKILL.md
+++ b/.claude/skills/problem-first/SKILL.md
@@ -40,7 +40,7 @@ This is a monorepo with multiple crates. When the user describes a problem, dete
 | `lns-cli` | The `lns` developer CLI — clap-driven IPC client that drives the service. The shipping artifact. |
 | `lns-service` | Tray-resident background service — microVM lifecycle, OCI ingest, content/layer caches, supervisor relay, audit-chain writer. |
 | `lns-ipc` | Shared `Request`/`Response` types and wire codec for the lns-cli ↔ lns-service contract. |
-| `lns-policy` | Network rules and credential-provider policy (`lns-policy.yaml`) plus per-machine credential decisions. |
+| `lns-policy` | Network rules and credential-provider policy (`lns-local-mixin.yaml`) plus per-machine credential decisions. |
 | `lns-init` | Static-musl PID-1 for the guest microVM. |
 | `lns-session` | Wire-protocol types (postcard) for the host ↔ guest session channel. |
 | `lns-session-broker` | Guest-side session host — PTY allocation, per-session workload forks, vsock framing. |

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ bin/
 # Auto-created when running `lns`; a runtime artifact, not source. The e2e
 # harness boots real runs with the crate dir as cwd (make e2e-microvm), and
 # example recipes boot with their own dir as cwd (docs/examples/*).
-/lns-policy.yaml
-/crates/e2e-tests/lns-policy.yaml
-/docs/examples/**/lns-policy.yaml
+/lns-local-mixin.yaml
+/crates/e2e-tests/lns-local-mixin.yaml
+/docs/examples/**/lns-local-mixin.yaml
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Lens Sandbox is a local desktop app for running AI agents, commands, OCI images,
 
 - **Start here:** `docs/README.md` — the first-party user documentation index.
 - **Product language:** the Product Vision above and `docs/` are the source of truth for terminology and framing; keep naming consistent with them. `docs/` is user-facing documentation only — no internal sales/marketing material lives in this repo.
-- **Concepts:** approvals drive policy authoring; a per-directory decisions file (today `lns-policy.yaml`, auto-created empty; a destination no rule decides is asked about) holds network rules and the ids of connected connectors, while custom credential-provider declarations live in a separate user catalog (`~/.lns-connectors.yaml`) and per-machine credential values are stored separately again so secrets aren't committed; `Vz` on macOS / `KVM` on Linux is the only runtime; real secrets stay outside the workload via credential-shaped placeholders.
+- **Concepts:** approvals drive policy authoring; a per-directory decisions file (`lns-local-mixin.yaml`, a `kind: mixin` document auto-created empty; a destination no rule decides is asked about) holds the network rules, while which connectors a project connected is per machine and lives in the grant sidecar, custom credential-provider declarations live in a separate user catalog (`~/.lns-connectors.yaml`), and per-machine credential values are stored separately again so secrets aren't committed; `Vz` on macOS / `KVM` on Linux is the only runtime; real secrets stay outside the workload via credential-shaped placeholders.
 - **Target format:** `docs/sandbox-spec.md` is the normative specification for the `lns.run/v1` document format and the decisions behind it. **The code does not implement all of it** — see [Transitional mode](#transitional-mode) before you touch a document-format surface.
 - **Sibling product:** Lens Agents is the centrally managed counterpart for IT teams. Same policy model.
 
@@ -32,8 +32,6 @@ Never edit the specification to match the code. A divergence is work to be done,
 3. **The guides describe what ships.** Do not rewrite a user guide to describe unimplemented behaviour, and do not annotate one with what the target says instead — a guide answers "how do I use this today".
 4. **Closing a gap is behaviour work, so it starts with a failing test** in the layer that owns it (see [Workflow](#workflow)). A format change with no red test first is not done.
 5. **Read the code for what ships.** This repository does not carry a list of where the two disagree, so do not add one and do not trust a stale summary: before changing a format surface, read the code that owns it and read the section of the specification that decides it.
-
-Two questions the specification leaves open, so do not settle them in code by accident: what the local decisions file is called, and where a per-project connector grant lives ([§8.3](docs/sandbox-spec.md#83-open-the-name), [§8.4](docs/sandbox-spec.md#84-open-where-a-connector-grant-goes)).
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ lns run
   Flags:     -i -t
   Ports:     127.0.0.1:8642 -> 8642, 127.0.0.1:9119 -> 9119
   Policy:
-    file: /Users/you/dev/my-app/lns-policy.yaml
+    file: /Users/you/dev/my-app/lns-local-mixin.yaml
     default verdict: ask
     rules: none defined; anything else asks
     source: auto-created (no policy in this directory)
 ```
 
-When the workload opens a connection no rule covers, the background service raises an approval prompt showing the host and action (e.g. `CONNECT api.linear.app:443`). You choose allow/deny — once, or always. "Always" writes a matching rule to `lns-policy.yaml`, so future runs load the decision automatically.
+When the workload opens a connection no rule covers, the background service raises an approval prompt showing the host and action (e.g. `CONNECT api.linear.app:443`). You choose allow/deny — once, or always. "Always" writes a matching rule to `lns-local-mixin.yaml`, so future runs load the decision automatically.
 
 ## What it does
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ Security-sensitive areas include:
 
 - Guest/host isolation — the microVM boundary (Vz on macOS, KVM on Linux) and the host-side service that owns its lifecycle
 - Policy enforcement — whether a workload can reach a network gate, port, or credential-backed action that policy did not approve
-- The approval flow — decisions written to `lns-policy.yaml`, and whether a denied request can be silently turned into an allowed one
+- The approval flow — decisions written to `lns-local-mixin.yaml`, and whether a denied request can be silently turned into an allowed one
 - Credential handling — placeholder substitution and boundary credential exchange, and whether any real secret can reach the guest VM
 - The audit chain — tamper-evidence of the recorded run history, and the `lns audit` verifier
 - The host IPC surface — the local Unix socket between `lns` and `lns-service`

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -186,8 +186,8 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
     );
     std::fs::write(root.join("lns.yaml"), definition).expect("write project lns.yaml");
     std::fs::write(
-        root.join("lns-policy.yaml"),
-        "network:\n  egress:\n    http: []\n",
+        root.join("lns-local-mixin.yaml"),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n",
     )
     .expect("write the project policy");
     root
@@ -254,7 +254,7 @@ fn last_run(world: &E2eWorld) -> Result<String, String> {
 
 fn write_policy(world: &mut E2eWorld, yaml: &str) {
     let dir = tempfile::TempDir::new().expect("tempdir for policy");
-    let path = dir.path().join("lns-policy.yaml");
+    let path = dir.path().join("lns-local-mixin.yaml");
     std::fs::write(&path, yaml).expect("write policy file");
     world.policy_dir = Some(dir);
     world.policy_path = Some(path);
@@ -753,8 +753,8 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
     std::fs::write(consumer.join("consumer-marker"), "consumer project\n")
         .expect("write consumer marker");
     std::fs::write(
-        consumer.join("lns-policy.yaml"),
-        "network:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        consumer.join("lns-local-mixin.yaml"),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     )
     .expect("write consumer policy");
     track_volume(world, &volume);
@@ -1136,8 +1136,8 @@ fn run_pulled_sandbox_offline(world: &mut E2eWorld, cmd_line: &str) {
         .path()
         .to_path_buf();
     std::fs::write(
-        consumer.join("lns-policy.yaml"),
-        "network:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        consumer.join("lns-local-mixin.yaml"),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     )
     .expect("write consumer policy");
     let mut args = vec![
@@ -1541,7 +1541,7 @@ fn output_lists_that_run(world: &mut E2eWorld) -> Result<(), String> {
 fn policy_ask_with_direct_route(world: &mut E2eWorld) {
     write_policy(
         world,
-        "network:\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n        transport: direct\n",
+        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n        transport: direct\n",
     );
 }
 
@@ -1549,7 +1549,7 @@ fn policy_ask_with_direct_route(world: &mut E2eWorld) {
 fn policy_deny_all(world: &mut E2eWorld) {
     write_policy(
         world,
-        "network:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     );
 }
 

--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -581,7 +581,7 @@ mod tests {
             &root,
             &extra,
             Some(Source {
-                label: "lns-policy.yaml",
+                label: "lns-local-mixin.yaml",
                 spec: &local,
             }),
             &graph,
@@ -589,7 +589,7 @@ mod tests {
         .expect("every reference resolves");
         assert_eq!(
             labels(&sources),
-            [ROOT_LABEL, "own", "flag", "lns-policy.yaml"],
+            [ROOT_LABEL, "own", "flag", "lns-local-mixin.yaml"],
             "the developer's own decisions are last, so nothing they pulled can overrule them (docs/sandbox-spec.md §8.1)"
         );
     }
@@ -603,7 +603,7 @@ mod tests {
             &root,
             &[],
             Some(Source {
-                label: "lns-policy.yaml",
+                label: "lns-local-mixin.yaml",
                 spec: &local,
             }),
             &graph,
@@ -611,7 +611,7 @@ mod tests {
         .expect("every reference resolves");
         assert_eq!(
             labels(&sources),
-            [ROOT_LABEL, "locals-own", "lns-policy.yaml"],
+            [ROOT_LABEL, "locals-own", "lns-local-mixin.yaml"],
             "§3.3.2 puts a mixin's own mixins after it, but §8.1 says the local one is last outright, and what it pulled is still something pulled"
         );
     }

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -77,7 +77,7 @@ pub struct RunArgs {
 
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory, auto-created with no rules if absent."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory, auto-created with no rules if absent."
     )]
     pub policy: Option<PathBuf>,
 

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -82,7 +82,7 @@ pub struct ConnectArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
 }
@@ -93,7 +93,7 @@ pub struct DisconnectArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
 }
@@ -108,7 +108,7 @@ pub struct ConnectorListArgs {
 pub struct GrantsArgs {
     #[arg(
         long,
-        help = "Policy file path whose project the grants are listed for; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path whose project the grants are listed for; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
     #[arg(
@@ -126,7 +126,7 @@ pub struct RevokeArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path whose project the grant is revoked from; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path whose project the grant is revoked from; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
 }
@@ -600,7 +600,7 @@ mod tests {
         JsonFileGrantStore::new(dir.join("grants.json"))
             .load()
             .expect("the sidecar reads back")
-            .connected_in(&project_key(&dir.join("lns-policy.yaml")))
+            .connected_in(&project_key(&dir.join("lns-local-mixin.yaml")))
     }
 
     #[test]

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -54,7 +54,7 @@ pub struct PolicyRuleArgs {
     pub description: Option<String>,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
 }
@@ -63,7 +63,7 @@ pub struct PolicyRuleArgs {
 pub struct PolicyScopeArgs {
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
     #[command(flatten)]
@@ -76,7 +76,7 @@ pub struct PolicyRemoveArgs {
     pub pattern: String,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-policy.yaml` in the current directory."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
     )]
     pub policy: Option<PathBuf>,
 }
@@ -722,7 +722,7 @@ mod tests {
     }
 
     fn seeded(dir: &Path, rules: Vec<RouteRule>) -> PathBuf {
-        let path = dir.join("lns-policy.yaml");
+        let path = dir.join("lns-local-mixin.yaml");
         let mut policy = Policy::default();
         policy.network.egress.http = rules;
         policy.save_atomic(&path).unwrap();
@@ -808,7 +808,7 @@ mod tests {
         seeded.add_rule(RouteRule::deny_host("*"));
         seeded.add_rule(RouteRule::allow_host("*"));
         seeded
-            .save_atomic(&dir.path().join("lns-policy.yaml"))
+            .save_atomic(&dir.path().join("lns-local-mixin.yaml"))
             .unwrap();
 
         let mut out = Vec::new();
@@ -821,7 +821,7 @@ mod tests {
         )
         .unwrap();
 
-        let held = Policy::load_or_default(&dir.path().join("lns-policy.yaml"))
+        let held = Policy::load_or_default(&dir.path().join("lns-local-mixin.yaml"))
             .unwrap()
             .network
             .egress
@@ -886,7 +886,7 @@ mod tests {
             text.contains("is already in"),
             "nothing about the rule changed, so reporting an edit would be a lie:\n{text}"
         );
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-local-mixin.yaml")).unwrap();
         assert_eq!(policy.network.egress.http.len(), 1);
     }
 
@@ -897,7 +897,7 @@ mod tests {
         let mut out = Vec::new();
         let code = add_rule(&args, Verdict::Allow, &[], dir.path(), &mut out).unwrap();
         assert_eq!(code, 0);
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-local-mixin.yaml")).unwrap();
         assert_eq!(policy.network.egress.http.len(), 1);
         assert_eq!(policy.network.egress.http[0].verdict, Verdict::Allow);
         assert_eq!(policy.network.egress.http[0].transport, Transport::Direct);
@@ -914,7 +914,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(code, 0);
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-local-mixin.yaml")).unwrap();
         assert!(
             policy
                 .network
@@ -941,7 +941,7 @@ mod tests {
             out: &mut out,
         };
         assert_eq!(run_command(sub, ctx).await.unwrap(), 0);
-        let policy = Policy::load_or_default(&dir.path().join("lns-policy.yaml")).unwrap();
+        let policy = Policy::load_or_default(&dir.path().join("lns-local-mixin.yaml")).unwrap();
         assert!(
             policy
                 .network
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     fn list_reports_each_verdict_and_its_description() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let mut policy = Policy::default();
         policy.add_rule(RouteRule {
             match_pattern: "blocked.example".into(),
@@ -998,7 +998,7 @@ mod tests {
     #[test]
     fn remove_on_a_missing_rule_errors_and_leaves_the_file_untouched() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let mut policy = Policy::default();
         policy.add_rule(RouteRule::allow_host("keep.example"));
         policy.save_atomic(&path).unwrap();
@@ -1021,8 +1021,8 @@ mod tests {
     #[test]
     fn add_surfaces_a_clear_error_for_a_malformed_policy_file() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        std::fs::write(&path, "network: not-a-map\n").unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        std::fs::write(&path, "apiVersion: [\n").unwrap();
         let mut out = Vec::new();
         let err = add_rule(
             &rule_args("x", None),

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -14,13 +14,7 @@ pub enum PolicySource {
     AutoCreated,
 }
 
-const DEFAULT_POLICY_FILENAME: &str = "lns-policy.yaml";
-const DEFAULT_POLICY_YAML: &str = "\
-network:
-  egress:
-    http: []
-    tcp: []
-";
+const DEFAULT_POLICY_FILENAME: &str = "lns-local-mixin.yaml";
 
 pub fn policy_path(explicit: Option<&Path>, cwd: &Path) -> PathBuf {
     match explicit {
@@ -45,7 +39,8 @@ pub fn resolve_policy(explicit: Option<&Path>, cwd: &Path) -> Result<(PathBuf, P
             path.display()
         ),
         Err(_) => {
-            std::fs::write(&path, DEFAULT_POLICY_YAML)
+            lns_policy::Policy::default()
+                .save_atomic(&path)
                 .with_context(|| format!("creating default policy at {}", path.display()))?;
             Ok((path, PolicySource::AutoCreated))
         }
@@ -580,7 +575,7 @@ mod tests {
         summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         )
     }
@@ -797,7 +792,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -807,7 +802,7 @@ mod tests {
         let authored = summary_of(
             &run_args(Some("prism")),
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(!authored.contains("Mixins:"), "got: {authored}");
@@ -854,7 +849,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -887,7 +882,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -926,7 +921,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -947,7 +942,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -978,7 +973,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1011,7 +1006,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1048,7 +1043,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1081,7 +1076,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         let first = s
@@ -1115,7 +1110,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1131,7 +1126,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Tools:     node@22\n"), "got: {s}");
@@ -1182,7 +1177,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1238,7 +1233,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/home/dev/my-app/lns-policy.yaml"),
+            Path::new("/home/dev/my-app/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Image:"), "missing Image line: {s}");
@@ -1265,7 +1260,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1291,7 +1286,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1313,7 +1308,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1355,7 +1350,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Workdir:   /app"), "missing workdir line: {s}");
@@ -1366,7 +1361,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(!s.contains("Workdir:"), "no workdir line expected: {s}");
@@ -1377,7 +1372,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(!s.contains("Volume:"), "no volume line expected: {s}");
@@ -1389,7 +1384,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("ubuntu (resolving…)"), "no placeholder: {s}");
@@ -1401,7 +1396,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("./lns.yaml (resolving…)"), "got: {s}");
@@ -1418,7 +1413,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("lns.dev.yaml (resolving…)"), "got: {s}");
@@ -1430,7 +1425,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("1 vCPU · 512 MiB"), "resources line wrong: {s}");
@@ -1450,7 +1445,7 @@ mod tests {
                 mem_mib: 6144,
             },
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("3 vCPU · 6144 MiB"), "resources line wrong: {s}");
@@ -1465,7 +1460,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Flags:     -i -t"), "flags line wrong: {s}");
@@ -1480,7 +1475,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Flags:     -d"), "flags line wrong: {s}");
@@ -1493,7 +1488,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Flags:     -i -t --rm"), "flags line wrong: {s}");
@@ -1508,7 +1503,7 @@ mod tests {
         let s = summary_of(
             &args,
             &Policy::default(),
-            Path::new("/x/lns-policy.yaml"),
+            Path::new("/x/lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("Flags:     (none)"), "flags line wrong: {s}");
@@ -1524,7 +1519,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1544,10 +1539,10 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
-        assert!(s.contains("file: ./lns-policy.yaml"));
+        assert!(s.contains("file: ./lns-local-mixin.yaml"));
         assert!(
             s.contains("unmatched destinations: ask"),
             "the default is no longer a field the file varies, so the summary states the rule: {s}"
@@ -1570,7 +1565,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1590,7 +1585,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1604,7 +1599,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(
@@ -1621,7 +1616,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &policy,
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("1 allow, 1 deny, anything else asks"));
@@ -1632,7 +1627,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         );
         assert!(s.contains("source: found in this directory"));
@@ -1643,7 +1638,7 @@ mod tests {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::AutoCreated,
         );
         assert!(s.contains("source: auto-created (no policy in this directory)"));
@@ -1691,7 +1686,7 @@ mod tests {
     fn resolve_policy_finds_existing_default_file_in_cwd() {
         let dir = tempfile::TempDir::new().unwrap();
         let preexisting = dir.path().join(DEFAULT_POLICY_FILENAME);
-        std::fs::write(&preexisting, "network:\n  egress:\n    http: []\n").unwrap();
+        Policy::default().save_atomic(&preexisting).unwrap();
         let (resolved, source) = resolve_policy(None, dir.path()).unwrap();
         assert_eq!(resolved, preexisting);
         assert_eq!(source, PolicySource::FoundInCwd);

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -484,6 +484,7 @@ where
         .one_shot(Request::InspectImage {
             image: args.reference.clone(),
             mixins: Vec::new(),
+            decisions: None,
         })
         .await?;
     // A mixin pull installs nothing: it caches documents, so there is no effect to consent to and its tools are disclosed where they are installed.
@@ -929,6 +930,7 @@ async fn inspect_cached<W: std::io::Write>(
         .one_shot(Request::InspectImage {
             image: reference.to_string(),
             mixins: mixins.to_vec(),
+            decisions: None,
         })
         .await?
     {

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -2075,7 +2075,7 @@ mod tests {
                     started: "2026-01-01T00:00:00Z".into(),
                 },
                 config: lns_ipc::RunConfig {
-                    policy_path: Some("/work/lns-policy.yaml".into()),
+                    policy_path: Some("/work/lns-local-mixin.yaml".into()),
                     ..Default::default()
                 },
             }),
@@ -2607,7 +2607,7 @@ mod tests {
                     started: "2026-01-01T00:00:00Z".into(),
                 },
                 config: lns_ipc::RunConfig {
-                    policy_path: Some("/work/lns-policy.yaml".into()),
+                    policy_path: Some("/work/lns-local-mixin.yaml".into()),
                     ..Default::default()
                 },
             }),
@@ -2624,15 +2624,15 @@ mod tests {
 
     #[test]
     fn policy_doc_marks_an_unreadable_file() {
-        let doc = policy_doc("/work/lns-policy.yaml", None);
-        assert_eq!(doc["path"], "/work/lns-policy.yaml");
+        let doc = policy_doc("/work/lns-local-mixin.yaml", None);
+        assert_eq!(doc["path"], "/work/lns-local-mixin.yaml");
         assert!(doc["error"].as_str().unwrap().contains("could not be read"));
     }
 
     #[test]
     fn policy_doc_embeds_a_parsed_policy() {
         let doc = policy_doc(
-            "/work/lns-policy.yaml",
+            "/work/lns-local-mixin.yaml",
             Some(serde_json::json!({"network": {"egress": {"http": []}}})),
         );
         assert_eq!(

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -198,11 +198,13 @@ async fn preflight_local(
     definition: &str,
     project_dir: &Path,
     mixins: &[String],
+    decisions: &Path,
 ) -> Result<ResolvedDefinition> {
     let request = Request::ResolveDefinition {
         definition: definition.to_string(),
         project_dir: project_dir.display().to_string(),
         mixins: mixins.to_vec(),
+        decisions: Some(decisions.display().to_string()),
     };
     match timeout(
         PUBLISHED_PREFLIGHT_TIMEOUT,
@@ -238,10 +240,12 @@ async fn preflight_published(
     socket: &Path,
     reference: &str,
     mixins: &[String],
+    decisions: &Path,
 ) -> Result<PublishedTarget> {
     let request = Request::InspectImage {
         image: reference.to_string(),
         mixins: mixins.to_vec(),
+        decisions: Some(decisions.display().to_string()),
     };
     await_published_preflight(reference, real::send_request(socket, &request)).await
 }
@@ -274,14 +278,17 @@ pub async fn run_image(
 ) -> Result<i32> {
     let client = real_client()?;
     args.mixins = crate::run::target::root_named_directories(&args.mixins, &cwd)?;
+    // §8.1 has every run in a directory resolve its decisions, so a directory that decided something needs the preflight even when nothing declared a mixin.
+    let decisions = crate::run::summary::policy_path(args.policy.as_deref(), &cwd);
     if let crate::run::target::RunTarget::Local {
         def,
         json,
         project_dir,
     } = &mut target
-        && (!def.spec.mixins.is_empty() || !args.mixins.is_empty())
+        && (!def.spec.mixins.is_empty() || !args.mixins.is_empty() || decisions.is_file())
     {
-        let resolved = preflight_local(client.socket(), json, project_dir, &args.mixins).await?;
+        let resolved =
+            preflight_local(client.socket(), json, project_dir, &args.mixins, &decisions).await?;
         **def = lns_artifact::sandbox::parse(resolved.definition.as_bytes())
             .context("reading the resolved definition")?;
         *json = resolved.definition;
@@ -294,7 +301,7 @@ pub async fn run_image(
     }
     let published = match &target {
         crate::run::target::RunTarget::Reference(reference) => {
-            Some(preflight_published(client.socket(), reference, &args.mixins).await?)
+            Some(preflight_published(client.socket(), reference, &args.mixins, &decisions).await?)
         }
         crate::run::target::RunTarget::Local { .. } => {
             // A path-shaped REF resolved to a definition; the summary names its image, not the path.

--- a/crates/lns-cli/tests/behaviours/connector_cli.feature
+++ b/crates/lns-cli/tests/behaviours/connector_cli.feature
@@ -5,8 +5,8 @@ Feature: connecting connectors from the CLI
   connector by an interactive sign-in the background service drives, so
   connecting one shows the verification URL and code. Either way the
   decision lands in the per-machine credential store, never in
-  `lns-policy.yaml`; the id is recorded under `connectors:` in that
-  directory's policy only once the bind or sign-in completes.
+  `lns-local-mixin.yaml`; the connection is recorded for the directory in
+  the per-machine sidecar only once the bind or sign-in completes.
   `lns connector list` shows, per connector, whether it authenticates
   by sign-in or a value.
 
@@ -22,7 +22,7 @@ Feature: connecting connectors from the CLI
     When the developer runs "lns connector connect some-provider"
     Then the output describes binding a credential value
     And "some-provider" is recorded as connected for this project
-    And lns-policy.yaml carries no credential material
+    And lns-local-mixin.yaml carries no credential material
 
   Scenario: Connecting a credential connector fails clearly when the service is unavailable
     Given a user catalog declares the "some-provider" credential connector
@@ -36,7 +36,7 @@ Feature: connecting connectors from the CLI
     When the developer runs "lns connector connect some-oauth"
     Then a verification URL and user code are shown
     And "some-oauth" is recorded as connected for this project
-    And lns-policy.yaml carries no token material
+    And lns-local-mixin.yaml carries no token material
 
   Scenario: Connecting an oauth connector fails clearly when the service is unavailable
     Given the background service is not available
@@ -56,7 +56,7 @@ Feature: connecting connectors from the CLI
     Then the browser is opened to the authorization page
     And no user code is shown
     And "some-pkce" is recorded as connected for this project
-    And lns-policy.yaml carries no credential material
+    And lns-local-mixin.yaml carries no credential material
 
   Scenario: Connecting a pkce connector fails clearly when the service is unavailable
     Given a user catalog declares the "some-pkce" pkce connector

--- a/crates/lns-cli/tests/behaviours/connector_grants.feature
+++ b/crates/lns-cli/tests/behaviours/connector_grants.feature
@@ -7,7 +7,7 @@ Feature: inspecting and forgetting per-workload connector grants
   connector's next use asks again. `lns connector disconnect` forgets the
   connector's grants here as part of dropping it from the policy.
 
-  Grants are per-machine, so no grant data reaches `lns-policy.yaml`; these
+  Grants are per-machine, so no grant data reaches `lns-local-mixin.yaml`; these
   scenarios use an arbitrary user-declared connector, so nothing here pins
   a shipped service.
 

--- a/crates/lns-cli/tests/behaviours/policy_cli.feature
+++ b/crates/lns-cli/tests/behaviours/policy_cli.feature
@@ -2,7 +2,7 @@ Feature: shaping network rules from the CLI
   The approval window is the interactive way to decide network rules,
   but it needs a running workload and a human clicking. The CLI is the
   non-interactive counterpart: it writes rules straight into the policy
-  file in use — the same `lns-policy.yaml` that `lns run` loads and that
+  file in use — the same `lns-local-mixin.yaml` that `lns run` loads and that
   `--policy` selects — so a developer can pre-seed rules before a run or
   adjust them while one is in flight. The CLI writes the file directly;
   the running sandbox's file watcher hot-swaps the change, so these
@@ -10,8 +10,8 @@ Feature: shaping network rules from the CLI
 
   Scenario: Adding an allow rule writes it to the policy file in use
     Given no sandbox is running
-    When the developer adds an allow rule for "api.linear.app" to "lns-policy.yaml"
-    Then "lns-policy.yaml" contains an allow rule for "api.linear.app"
+    When the developer adds an allow rule for "api.linear.app" to "lns-local-mixin.yaml"
+    Then "lns-local-mixin.yaml" contains an allow rule for "api.linear.app"
 
   # The CLI's job is to write the rule into the file the running sandbox loaded;
   # the running sandbox then hot-swaps that external write via its PolicyWatcher.
@@ -19,314 +19,314 @@ Feature: shaping network rules from the CLI
   # ("A manual edit to the policy file hot-swaps the running policy"), so here we
   # pin only the CLI half: a no-flag add targets the in-use cwd policy file.
   Scenario: Adding a rule while a sandbox is running targets the policy file it loaded
-    Given a sandbox is running with "lns-policy.yaml" loaded in the current directory
+    Given a sandbox is running with "lns-local-mixin.yaml" loaded in the current directory
     When the developer adds an allow rule for "api.linear.app" without passing --policy
-    Then "lns-policy.yaml" in the current directory contains an allow rule for "api.linear.app"
+    Then "lns-local-mixin.yaml" in the current directory contains an allow rule for "api.linear.app"
 
-  Scenario: --policy defaults to lns-policy.yaml in the current directory
-    Given the developer is in a directory with no "lns-policy.yaml"
+  Scenario: --policy defaults to lns-local-mixin.yaml in the current directory
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer adds an allow rule for "api.linear.app" without passing --policy
-    Then "lns-policy.yaml" is created in the current directory
+    Then "lns-local-mixin.yaml" is created in the current directory
     And it contains an allow rule for "api.linear.app"
 
   Scenario: --policy can point at any path
     When the developer adds an allow rule for "api.linear.app" with --policy "/tmp/team-policy.yaml"
     Then "/tmp/team-policy.yaml" contains the allow rule
-    And "./lns-policy.yaml" is not created
+    And "./lns-local-mixin.yaml" is not created
 
   Scenario: Adding a rule with a description records it in the policy file
     When the developer adds an allow rule for "api.linear.app" with description "Linear API for issue sync"
-    Then "lns-policy.yaml" contains the allow rule with the description
+    Then "lns-local-mixin.yaml" contains the allow rule with the description
 
   # The note is not part of the grant, so annotating a rule the file already holds is an edit of that rule, not a second one to place in front of it.
   Scenario: Annotating a rule the file already holds edits it in place
-    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" with description "issue sync"
-    Then "lns-policy.yaml" still holds 1 rule
-    And "lns-policy.yaml" contains the allow rule with the description
+    Then "lns-local-mixin.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" contains the allow rule with the description
     And the output says the description was updated
 
   Scenario: Annotating a deny rule the file already holds edits it in place
-    Given "lns-policy.yaml" has a deny rule for "evil.example"
+    Given "lns-local-mixin.yaml" has a deny rule for "evil.example"
     When the developer denies "evil.example" with description "phishing kit"
-    Then "lns-policy.yaml" still holds 1 rule
+    Then "lns-local-mixin.yaml" still holds 1 rule
     And the output says the description was updated
 
   Scenario: Re-adding a rule without a description leaves the note it already carries
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" described as "issue sync"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" described as "issue sync"
     When the developer adds an allow rule for "api.example.test" without passing --policy
-    Then "lns-policy.yaml" still holds 1 rule
-    And "lns-policy.yaml" contains the allow rule with the description
+    Then "lns-local-mixin.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" contains the allow rule with the description
     And the output says the rule is already there
 
   # A scoped rule claims the destination and fails closed, denying every caller off the list rather than falling through, which is why the flag exists only for allow.
   Scenario: Scoping an allow rule to one binary records it in the policy file
     When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
-    Then "lns-policy.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git"
+    Then "lns-local-mixin.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git"
 
   Scenario: Repeating the flag scopes one rule to several binaries
     When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git" and "/usr/bin/curl"
-    Then "lns-policy.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git,/usr/bin/curl"
+    Then "lns-local-mixin.yaml" scopes the allow rule for "git.example.test" to "/usr/bin/git,/usr/bin/curl"
 
   # The scoping is what denies without asking, not where the rule landed, so the one case a developer meets first — a fresh file with nothing to sit in front of — must say so too.
   Scenario: Scoping a destination no other rule covers still says who it now denies
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
     Then the output says every other caller is now denied "git.example.test"
 
   Scenario: Adding an unscoped rule claims nothing about other callers
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the output does not claim any caller is denied
 
   Scenario: A relative binary path is refused before anything is written
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer adds an allow rule for "git.example.test" scoped to "git"
     Then the command fails with an exit code other than 0
     And the failure says a relative path can never match the kernel-resolved path
-    And "./lns-policy.yaml" is not created
+    And "./lns-local-mixin.yaml" is not created
 
   Scenario: A binary path climbing through .. is refused before anything is written
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/../bin/git"
     Then the command fails with an exit code other than 0
     And the failure says a .. segment can never match the kernel-resolved path
-    And "./lns-policy.yaml" is not created
+    And "./lns-local-mixin.yaml" is not created
 
   # The gate stops at the first matching rule, so a narrowing rule written after an open one would never fire — the CLI puts it where it does what the developer asked and says so.
   Scenario: Narrowing a destination an open rule already allows puts the scoped rule first
-    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
-    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "api.example.test"
+    Then "lns-local-mixin.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "api.example.test"
     And the output says it was placed before the rule for "api.example.test"
     And the output says every other caller is now denied "api.example.test"
 
   Scenario: A wildcard allow covering the destination is what the scoped rule goes in front of
-    Given "lns-policy.yaml" has an allow rule for "*.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "*.example.test"
     When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
-    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "*.example.test"
+    Then "lns-local-mixin.yaml" lists the rule scoped to "/usr/bin/curl" before the rule for "*.example.test"
 
   Scenario: Scoping a whole suffix behind a catch-all allow puts the scoped rule first
-    Given "lns-policy.yaml" has an allow rule for "*"
+    Given "lns-local-mixin.yaml" has an allow rule for "*"
     When the developer adds an allow rule for "*.example.test" scoped to "/usr/bin/git"
-    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/git" before the rule for "*"
+    Then "lns-local-mixin.yaml" lists the rule scoped to "/usr/bin/git" before the rule for "*"
     And the output says it was placed before the rule for "*"
 
   # The only place an open rule reaches the callers a scoped rule excludes is in front of it, which opens the destination to everyone — the same widening the CLI refuses to perform behind a deny.
   Scenario: Re-opening a destination a scoped rule claimed is refused rather than reordered
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
     When the developer adds an allow rule for "git.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the failure says the rule would open the destination to every caller
     And the error names "/usr/bin/git"
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   Scenario: The refusal names the covering rule when it is a wildcard the developer did not type
-    Given "lns-policy.yaml" has an allow rule for "*.example.test" scoped to "/usr/bin/git"
+    Given "lns-local-mixin.yaml" has an allow rule for "*.example.test" scoped to "/usr/bin/git"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the error names "*.example.test"
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   # A narrowing rule is not a widening: the caller it names already reaches the destination through the rule it goes in front of.
   Scenario: Narrowing a scoped rule to fewer of its binaries is placed in front of it
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" and "/usr/bin/curl"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" and "/usr/bin/curl"
     When the developer adds an allow rule for "git.example.test" scoped to "/usr/bin/git"
-    Then "lns-policy.yaml" lists the rule scoped to "/usr/bin/git" before the rule scoped to "/usr/bin/git,/usr/bin/curl"
+    Then "lns-local-mixin.yaml" lists the rule scoped to "/usr/bin/git" before the rule scoped to "/usr/bin/git,/usr/bin/curl"
     And the output does not claim any scoping is spent
 
   # A catch-all deny is the file's backstop, not a decision about any one destination
   # — and it is what closes a directory now that no default can. Refusing to widen it
   # would leave a closed policy editable only by hand, since it raises no cards either.
   Scenario: Allowing a destination in a closed policy puts the allow ahead of the catch-all
-    Given "lns-policy.yaml" has a deny rule for "*"
+    Given "lns-local-mixin.yaml" has a deny rule for "*"
     When the developer adds an allow rule for "api.example.test" without passing --policy
-    Then "lns-policy.yaml" lists the allow rule for "api.example.test" before the rule for "*"
+    Then "lns-local-mixin.yaml" lists the allow rule for "api.example.test" before the rule for "*"
     And the output says it was placed before the rule for "*"
 
   # The catch-all already blocks it, so a second deny naming one destination adds
   # nothing — the same answer the file gives for any deny behind a covering deny.
   Scenario: Denying a destination in a closed policy reports the catch-all already blocks it
-    Given "lns-policy.yaml" has a deny rule for "*"
+    Given "lns-local-mixin.yaml" has a deny rule for "*"
     When the developer denies "evil.example"
     Then the output says the broader deny already blocks it
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   # Two catch-alls cannot both be in force: the second decides everything the first
   # would have, so the file would carry a line the gate never reaches.
   Scenario: Opening a closed policy replaces its catch-all rather than stranding it
-    Given "lns-policy.yaml" has a deny rule for "*"
+    Given "lns-local-mixin.yaml" has a deny rule for "*"
     When the developer adds an allow rule for "*" without passing --policy
-    Then "lns-policy.yaml" holds only the allow rule for "*"
+    Then "lns-local-mixin.yaml" holds only the allow rule for "*"
     And the output says the catch-all it replaced
 
   Scenario: Closing an open policy replaces its catch-all rather than stranding it
-    Given "lns-policy.yaml" has an allow rule for "*"
+    Given "lns-local-mixin.yaml" has an allow rule for "*"
     When the developer denies "*"
-    Then "lns-policy.yaml" holds only the deny rule for "*"
+    Then "lns-local-mixin.yaml" holds only the deny rule for "*"
     And the output says the catch-all it replaced
 
   # A deny blocks the request before there is anything to intercept, so terminating
   # TLS on one is a dead flag — not a treatment the rule replacing or fronting it
   # takes on.
   Scenario: Opening a closed policy does not take up the catch-all deny's TLS termination
-    Given "lns-policy.yaml" has a TLS-terminating deny rule for "*"
+    Given "lns-local-mixin.yaml" has a TLS-terminating deny rule for "*"
     When the developer adds an allow rule for "*" without passing --policy
-    Then "lns-policy.yaml" does not terminate TLS on the allow rule for "*"
+    Then "lns-local-mixin.yaml" does not terminate TLS on the allow rule for "*"
     And the output does not claim the rule terminates TLS
 
   Scenario: An allow placed in front of a catch-all deny does not take up its TLS termination
-    Given "lns-policy.yaml" has a TLS-terminating deny rule for "*"
+    Given "lns-local-mixin.yaml" has a TLS-terminating deny rule for "*"
     When the developer adds an allow rule for "api.example.test" without passing --policy
-    Then "lns-policy.yaml" does not terminate TLS on the allow rule for "api.example.test"
+    Then "lns-local-mixin.yaml" does not terminate TLS on the allow rule for "api.example.test"
     And the output does not claim the rule terminates TLS
 
   # A deny the author aimed at a destination is a decision, so an allow behind it is
   # still refused rather than quietly reordered.
   Scenario: Allowing a destination a narrower deny names is still refused
-    Given "lns-policy.yaml" has a deny rule for "*.example.test"
+    Given "lns-local-mixin.yaml" has a deny rule for "*.example.test"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the failure says the deny already blocks it
 
   Scenario: Denying a destination a scoped allow claimed puts the deny in front of it
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
     When the developer denies "git.example.test"
-    Then "lns-policy.yaml" lists the deny rule for "git.example.test" before the rule scoped to "/usr/bin/git"
+    Then "lns-local-mixin.yaml" lists the deny rule for "git.example.test" before the rule scoped to "/usr/bin/git"
     And the output says the scoped rule for "git.example.test" no longer applies
 
   # A narrowing of who may reach a destination is not a request to stop intercepting it, so the rule going in front carries the fronted rule's TLS termination with it.
   Scenario: A rule placed in front of a TLS-terminating rule keeps terminating TLS
-    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has a TLS-terminating allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
-    Then "lns-policy.yaml" terminates TLS on the rule scoped to "/usr/bin/curl"
+    Then "lns-local-mixin.yaml" terminates TLS on the rule scoped to "/usr/bin/curl"
     And the output says the placed rule terminates TLS too
 
   Scenario: A deny placed in front of a TLS-terminating rule does not take up terminating TLS
-    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has a TLS-terminating allow rule for "api.example.test"
     When the developer denies "api.example.test"
-    Then "lns-policy.yaml" does not terminate TLS on the deny rule for "api.example.test"
+    Then "lns-local-mixin.yaml" does not terminate TLS on the deny rule for "api.example.test"
 
   # Inheriting the termination makes the new rule the one the file already holds, so it is an annotation of that rule — not a second copy of it that drops its note.
   Scenario: Re-adding a rule the file holds as a TLS-terminating one keeps its note
-    Given "lns-policy.yaml" has a TLS-terminating allow rule for "api.example.test" described as "issue sync"
+    Given "lns-local-mixin.yaml" has a TLS-terminating allow rule for "api.example.test" described as "issue sync"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the output says the rule is already there
-    And "lns-policy.yaml" still holds 1 rule
-    And "lns-policy.yaml" describes the allow rule for "api.example.test" as "issue sync"
+    And "lns-local-mixin.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" describes the allow rule for "api.example.test" as "issue sync"
 
   # A rule carrying an http `rules` list allows only the requests it names and denies the rest, so getting in front of it hands the new rule's callers every method and path.
   Scenario: Fronting a rule that restricts which requests it allows is refused
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" restricted to GET requests
     When the developer adds an allow rule for "api.example.test" scoped to "/usr/bin/curl"
     Then the command fails with an exit code other than 0
     And the failure says the rule would lift the request restriction
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   Scenario: Denying a destination whose rule restricts requests is still placed in front of it
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" restricted to GET requests
     When the developer denies "api.example.test"
-    Then "lns-policy.yaml" lists the deny rule for "api.example.test" before the rule restricted to GET requests
+    Then "lns-local-mixin.yaml" lists the deny rule for "api.example.test" before the rule restricted to GET requests
 
   # Removing the deny would widen egress for every destination it covers, so the refusal must not send the developer there.
   Scenario: A destination an earlier deny already blocks is refused rather than reordered
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" and a deny rule for "evil.example"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" and a deny rule for "evil.example"
     When the developer adds an allow rule for "evil.example" scoped to "/usr/bin/curl"
     Then the command fails with an exit code other than 0
     And the failure does not tell the developer to remove the deny
     And the error names "evil.example"
-    And "lns-policy.yaml" still holds 2 rules
+    And "lns-local-mixin.yaml" still holds 2 rules
 
   Scenario: Adding a rule the file already holds changes nothing
-    Given "lns-policy.yaml" has an allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the output says the rule is already there
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   # The file holding a grant and the gate reaching it are different things: a copy stranded behind a rule that pre-empts it is not the rule to report as already in force.
   Scenario: A grant the file holds but a deny pre-empts is refused, not reported as already there
-    Given "lns-policy.yaml" has a deny rule for "*.example.test" ahead of an allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has a deny rule for "*.example.test" ahead of an allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the error names "*.example.test"
-    And "lns-policy.yaml" still holds 2 rules
+    And "lns-local-mixin.yaml" still holds 2 rules
 
   Scenario: A deny the file holds but an allow pre-empts is moved in front of that allow
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test"
     When the developer denies "api.example.test"
-    Then "lns-policy.yaml" lists the deny rule for "api.example.test" before the allow rule for "api.example.test"
-    And "lns-policy.yaml" still holds 2 rules
+    Then "lns-local-mixin.yaml" lists the deny rule for "api.example.test" before the allow rule for "api.example.test"
+    And "lns-local-mixin.yaml" still holds 2 rules
 
   Scenario: Moving a stranded rule into force keeps the note it was carrying
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test" described as "phishing kit"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" ahead of a deny rule for "api.example.test" described as "phishing kit"
     When the developer denies "api.example.test"
-    Then "lns-policy.yaml" still holds 2 rules
-    And "lns-policy.yaml" describes the deny rule for "api.example.test" as "phishing kit"
+    Then "lns-local-mixin.yaml" still holds 2 rules
+    And "lns-local-mixin.yaml" describes the deny rule for "api.example.test" as "phishing kit"
 
   # A same-verdict rule can pre-empt by scope or by request filter as surely as a deny pre-empts by verdict, and a copy stranded behind one of those is no more in force.
   Scenario: A grant a binary-scoped rule pre-empts is refused, not reported as already there
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
     When the developer adds an allow rule for "git.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the failure says the rule would open the destination to every caller
-    And "lns-policy.yaml" still holds 2 rules
+    And "lns-local-mixin.yaml" still holds 2 rules
 
   Scenario: A grant a request-filtered rule pre-empts is refused, not reported as already there
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" restricted to GET requests ahead of an unrestricted allow rule for "api.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" restricted to GET requests ahead of an unrestricted allow rule for "api.example.test"
     When the developer adds an allow rule for "api.example.test" without passing --policy
     Then the command fails with an exit code other than 0
     And the failure says the rule would lift the request restriction
-    And "lns-policy.yaml" still holds 2 rules
+    And "lns-local-mixin.yaml" still holds 2 rules
 
   # A deny behind a deny is the one shadowed rule that is not a mistake: the destination is already blocked, which is what the developer asked for.
   Scenario: Denying a destination a broader deny already blocks succeeds and changes nothing
-    Given "lns-policy.yaml" has a deny rule for "*.example.test"
+    Given "lns-local-mixin.yaml" has a deny rule for "*.example.test"
     When the developer denies "api.example.test"
     Then the command succeeds
     And the output says the deny adds nothing
-    And "lns-policy.yaml" still holds 1 rule
+    And "lns-local-mixin.yaml" still holds 1 rule
 
   # `lns policy remove` deletes every rule carrying the pattern, scoped or not, so the scoping has to be visible before removing anything.
   Scenario: Listing shows which binaries a rule is scoped to
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git"
     When the developer lists rules
     Then the output shows the rule scoped to "/usr/bin/git"
 
   Scenario: Listing as JSON tells a script which rules are binary-scoped
-    Given "lns-policy.yaml" has an allow rule for "api.example.test" and a scoped allow rule for "git.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.example.test" and a scoped allow rule for "git.example.test"
     When the developer lists rules as JSON
     Then JSON row 0 has a null "binaries"
     And JSON row 1 has "binaries" set to the list "/usr/bin/git"
 
   Scenario: Listing rules shows what is currently in the policy file
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app" and a deny rule for "evil.example"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app" and a deny rule for "evil.example"
     When the developer lists rules
     Then the output shows both rules with their verdicts
 
   Scenario: Listing rules from a policy file naming the removed allowedRoutes key fails loudly
-    Given "lns-policy.yaml" uses the removed allowedRoutes key for "api.linear.app"
+    Given "lns-local-mixin.yaml" uses the removed allowedRoutes key for "api.linear.app"
     When the developer lists rules
     Then the command fails with an exit code other than 0
     And the error names "allowedRoutes"
 
   Scenario: Removing a rule by pattern deletes it from the policy file
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app"
     When the developer removes the rule matching "api.linear.app"
-    Then "lns-policy.yaml" no longer contains a rule for "api.linear.app"
+    Then "lns-local-mixin.yaml" no longer contains a rule for "api.linear.app"
 
   # Removal goes by pattern alone, so a scoped rule can go with the one the developer meant; the report has to name the count or a silent extra deletion reads as a single-rule removal.
   Scenario: Removing a destination several rules carry says how many went
-    Given "lns-policy.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
+    Given "lns-local-mixin.yaml" has an allow rule for "git.example.test" scoped to "/usr/bin/git" ahead of an unscoped allow rule for "git.example.test"
     When the developer removes the rule matching "git.example.test"
     Then the output says 2 rules were removed for "git.example.test"
 
   Scenario: Removing a destination one rule carries reports it in the singular
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app"
     When the developer removes the rule matching "api.linear.app"
     Then the output says 1 rule was removed for "api.linear.app"
 
   Scenario: Removing a rule that does not exist surfaces a clear error
-    Given "lns-policy.yaml" has no rule for "ghost.example"
+    Given "lns-local-mixin.yaml" has no rule for "ghost.example"
     When the developer tries to remove a rule for "ghost.example"
     Then the command fails with an exit code other than 0
     And the policy file is unchanged
@@ -337,25 +337,25 @@ Feature: shaping network rules from the CLI
   # traffic is passed through unread, so "any port on this host" is not a grant we offer.
   Scenario: Allowing a raw TCP destination writes it to the raw table
     When the developer allows the raw destination "db.internal:5432"
-    Then "lns-policy.yaml" contains a raw allow rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a raw allow rule for "db.internal:5432"
 
   Scenario: Denying a raw TCP destination writes it to the raw table
     When the developer denies the raw destination "db.internal:5432"
-    Then "lns-policy.yaml" contains a raw deny rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a raw deny rule for "db.internal:5432"
 
   # A portless raw rule fails the whole policy closed inside the guest, so it is
   # refused here rather than at the next run.
   Scenario: A raw destination with no port is refused before anything is written
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer allows the raw destination "db.internal"
     Then the command fails with an exit code other than 0
     And the error explains that a raw destination needs a port
-    And "./lns-policy.yaml" is not created
+    And "./lns-local-mixin.yaml" is not created
 
   # The raw table is first-match-wins too, so the same placement the HTTP verbs do
   # applies here: a rule that would never be reached is not quietly written.
   Scenario: A raw allow behind a raw deny for the same destination is refused
-    Given "lns-policy.yaml" has a raw deny rule for "10.0.0.0/8:5432"
+    Given "lns-local-mixin.yaml" has a raw deny rule for "10.0.0.0/8:5432"
     When the developer allows the raw destination "10.0.0.5:5432"
     Then the command fails with an exit code other than 0
     And the error explains the raw rule would never fire
@@ -365,14 +365,14 @@ Feature: shaping network rules from the CLI
   # its list, so placing an unscoped rule in front widens the file's own grant —
   # the developer's call to make, not the tool's.
   Scenario: An unscoped raw allow in front of a binaries-scoped raw rule is refused
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
     When the developer allows the raw destination "db.internal:5432"
     Then the command fails with an exit code other than 0
     And the error explains it would open the raw destination to every caller
     And the policy file is unchanged
 
   Scenario: An unscoped raw allow behind a scoped raw range names the range to narrow
-    Given "lns-policy.yaml" has a raw allow rule for "10.0.0.0/24:5432" scoped to "/usr/bin/psql"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "10.0.0.0/24:5432" scoped to "/usr/bin/psql"
     When the developer allows the raw destination "10.0.0.5:5432"
     Then the command fails with an exit code other than 0
     And the error tells the developer to narrow the raw rule for "10.0.0.0/24:5432"
@@ -381,103 +381,103 @@ Feature: shaping network rules from the CLI
   # rule — which then decides nobody, and the file would otherwise still read as if
   # that one binary could open the destination.
   Scenario: A raw deny placed in front of a scoped raw allow says the scoping stopped applying
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
     When the developer denies the raw destination "db.internal:5432"
-    Then "lns-policy.yaml" contains a raw deny rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a raw deny rule for "db.internal:5432"
     And the output says the scoping of the rule behind it no longer applies
 
   Scenario: A raw deny a broader raw deny already covers adds nothing
-    Given "lns-policy.yaml" has a raw deny rule for "10.0.0.0/8:5432"
+    Given "lns-local-mixin.yaml" has a raw deny rule for "10.0.0.0/8:5432"
     When the developer denies the raw destination "10.0.0.5:5432"
     Then the output says the broader raw deny already blocks it
-    And "lns-policy.yaml" has exactly one raw rule for "10.0.0.0/8:5432"
+    And "lns-local-mixin.yaml" has exactly one raw rule for "10.0.0.0/8:5432"
 
   Scenario: Annotating a raw rule the file already holds edits it in place
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432"
     When the developer allows the raw destination "db.internal:5432" with description "project database"
-    Then "lns-policy.yaml" has exactly one raw rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" has exactly one raw rule for "db.internal:5432"
     And the output says the description was updated
 
   # A copy of the grant stranded behind the rule that pre-empts it is the same rule,
   # not a second one to keep: moving it into force is the whole of what was asked for,
   # and leaving the old line behind grows the file with rules the gate never reaches.
   Scenario: A raw allow the file holds but a broader rule pre-empts is moved in front of it
-    Given "lns-policy.yaml" has a raw allow rule for "10.0.0.0/24:5432" ahead of a raw allow rule for "10.0.0.5:5432"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "10.0.0.0/24:5432" ahead of a raw allow rule for "10.0.0.5:5432"
     When the developer allows the raw destination "10.0.0.5:5432"
     Then the raw allow rule for "10.0.0.5:5432" sits ahead of the raw rule for "10.0.0.0/24:5432"
-    And "lns-policy.yaml" has exactly one raw allow rule for "10.0.0.5:5432"
+    And "lns-local-mixin.yaml" has exactly one raw allow rule for "10.0.0.5:5432"
 
   Scenario: Moving a stranded raw rule into force keeps the note it was carrying
-    Given "lns-policy.yaml" has a raw allow rule for "10.0.0.0/24:5432" ahead of a raw allow rule for "10.0.0.5:5432" described as "project database"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "10.0.0.0/24:5432" ahead of a raw allow rule for "10.0.0.5:5432" described as "project database"
     When the developer allows the raw destination "10.0.0.5:5432"
-    Then "lns-policy.yaml" describes the raw allow rule for "10.0.0.5:5432" as "project database"
-    And "lns-policy.yaml" has exactly one raw allow rule for "10.0.0.5:5432"
+    Then "lns-local-mixin.yaml" describes the raw allow rule for "10.0.0.5:5432" as "project database"
+    And "lns-local-mixin.yaml" has exactly one raw allow rule for "10.0.0.5:5432"
 
   Scenario: Adding the same raw rule twice reports it rather than duplicating it
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432"
     When the developer allows the raw destination "db.internal:5432"
     Then the output says the raw rule is already present
-    And "lns-policy.yaml" has exactly one raw rule for "db.internal:5432"
+    And "lns-local-mixin.yaml" has exactly one raw rule for "db.internal:5432"
 
   # Nothing between the workload and a raw destination can read the traffic, so naming
   # the one caller that may open it is the narrowest the grant gets — and the flag is on
   # the verbs whose scoping changes the outcome, which a deny's never does.
   Scenario: Scoping a raw allow to one binary records it in the policy file
     When the developer allows the raw destination "db.internal:5432" scoped to "/usr/bin/psql"
-    Then "lns-policy.yaml" contains a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
+    Then "lns-local-mixin.yaml" contains a raw allow rule for "db.internal:5432" scoped to "/usr/bin/psql"
     And the output says every other caller is now denied "db.internal:5432"
 
   Scenario: A relative binary path is refused before any raw rule is written
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer allows the raw destination "db.internal:5432" scoped to "psql"
     Then the command fails with an exit code other than 0
-    And "./lns-policy.yaml" is not created
+    And "./lns-local-mixin.yaml" is not created
 
   # Narrowing who may open a destination the file already splices for everyone only takes
   # effect in front of that rule, since the gate stops at the first match.
   Scenario: Narrowing a raw destination an open raw rule already splices puts the scoped rule first
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432"
     When the developer allows the raw destination "db.internal:5432" scoped to "/usr/bin/psql"
-    Then "lns-policy.yaml" lists the raw rule scoped to "/usr/bin/psql" before the raw rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" lists the raw rule scoped to "/usr/bin/psql" before the raw rule for "db.internal:5432"
     And the output says every other caller is now denied "db.internal:5432"
 
   # The raw table is consulted before the HTTP one, so a raw rule takes its destination
   # over from every HTTP rule naming that host on that port. Lifting a deny that way is
   # a widening of the file's own block, which is the developer's call to make, not ours.
   Scenario: A raw allow that would lift an existing HTTP deny is refused
-    Given "lns-policy.yaml" has a deny rule for "db.internal"
+    Given "lns-local-mixin.yaml" has a deny rule for "db.internal"
     When the developer allows the raw destination "db.internal:5432"
     Then the command fails with an exit code other than 0
     And the error explains the HTTP deny would stop applying
-    And "lns-policy.yaml" no longer contains a raw rule for "db.internal:5432"
+    And "lns-local-mixin.yaml" no longer contains a raw rule for "db.internal:5432"
 
   # The refusal is about what writing the rule would change; a rule the file already
   # holds changes nothing, and the deny it displaces is already displaced.
   Scenario: Re-adding a raw allow the file already holds is not refused by the deny it already pre-empts
-    Given "lns-policy.yaml" has a raw allow rule for "db.internal:5432" and a deny rule for "db.internal"
+    Given "lns-local-mixin.yaml" has a raw allow rule for "db.internal:5432" and a deny rule for "db.internal"
     When the developer allows the raw destination "db.internal:5432"
     Then the command succeeds
     And the output says the raw rule is already present
 
   Scenario: A raw allow says which HTTP rule it takes the destination over from
-    Given "lns-policy.yaml" has an allow rule for "db.internal"
+    Given "lns-local-mixin.yaml" has an allow rule for "db.internal"
     When the developer allows the raw destination "db.internal:5432"
-    Then "lns-policy.yaml" contains a raw allow rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a raw allow rule for "db.internal:5432"
     And the output says the HTTP rule for "db.internal" no longer applies
 
   Scenario: Listing rules shows which table each rule is in
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app" and a raw allow rule for "db.internal:5432"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app" and a raw allow rule for "db.internal:5432"
     When the developer lists rules
     Then the output shows "api.linear.app" in the "http" table and "db.internal:5432" in the "tcp" table
 
   Scenario: Removing a raw rule by pattern deletes it from the raw table
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app" and a raw allow rule for "db.internal:5432"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app" and a raw allow rule for "db.internal:5432"
     When the developer removes the rule matching "db.internal:5432"
-    Then "lns-policy.yaml" no longer contains a raw rule for "db.internal:5432"
-    And "lns-policy.yaml" contains an allow rule for "api.linear.app"
+    Then "lns-local-mixin.yaml" no longer contains a raw rule for "db.internal:5432"
+    And "lns-local-mixin.yaml" contains an allow rule for "api.linear.app"
 
   Scenario: Listing rules as JSON gives a script the verdict and pattern per rule
-    Given "lns-policy.yaml" has an allow rule for "api.linear.app" and a deny rule for "evil.example"
+    Given "lns-local-mixin.yaml" has an allow rule for "api.linear.app" and a deny rule for "evil.example"
     When the developer lists rules as JSON
     Then the output is a JSON array of 2 rows
     And JSON row 0 has "verdict" set to "allow"
@@ -486,6 +486,6 @@ Feature: shaping network rules from the CLI
     And JSON row 1 has "pattern" set to "evil.example"
 
   Scenario: An empty policy lists as an empty JSON array, not prose
-    Given the developer is in a directory with no "lns-policy.yaml"
+    Given the developer is in a directory with no "lns-local-mixin.yaml"
     When the developer lists rules as JSON
     Then the output is an empty JSON array

--- a/crates/lns-cli/tests/behaviours/run_visibility.feature
+++ b/crates/lns-cli/tests/behaviours/run_visibility.feature
@@ -18,7 +18,7 @@ Feature: users see what `lns run` is doing from the moment they hit Enter
     And fields not yet known to the CLI are shown as "(resolving…)"
 
   Scenario: Policy block answers what and why
-    Given the working directory contains `./lns-policy.yaml`
+    Given the working directory contains `./lns-local-mixin.yaml`
     And that policy has 3 allow rules, and 1 deny rule
     When the summary is printed
     Then the Policy block shows the file path
@@ -27,7 +27,7 @@ Feature: users see what `lns run` is doing from the moment they hit Enter
     And the provenance line: "source: found in this directory"
 
   Scenario: Auto-created policy is called out in the source line
-    Given no `lns-policy.yaml` exists in the working directory
+    Given no `lns-local-mixin.yaml` exists in the working directory
     When the run starts
     Then the Policy block source line reads "auto-created (no policy in this directory)"
     And a destination no rule names is "ask"ed

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -90,15 +90,15 @@ Feature: managing running sandboxes from the CLI
     And the output contains "memMib"
 
   Scenario: inspect embeds the policy file when it is readable
-    Given the service reports run 3 with policy path "/work/lns-policy.yaml"
+    Given the service reports run 3 with policy path "/work/lns-local-mixin.yaml"
     And the policy file parses with one allow rule
     When the user runs sandbox command "inspect 3"
     Then the exit code is 0
     And the output contains "egress"
-    And the output contains "/work/lns-policy.yaml"
+    And the output contains "/work/lns-local-mixin.yaml"
 
   Scenario: inspect marks an unreadable policy file instead of failing
-    Given the service reports run 3 with policy path "/work/lns-policy.yaml"
+    Given the service reports run 3 with policy path "/work/lns-local-mixin.yaml"
     When the user runs sandbox command "inspect 3"
     Then the exit code is 0
     And the output contains "policy file could not be read"

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -15,7 +15,7 @@ fn cwd(world: &mut BehaviourWorld) -> PathBuf {
 }
 
 fn policy_file(world: &mut BehaviourWorld) -> PathBuf {
-    cwd(world).join("lns-policy.yaml")
+    cwd(world).join("lns-local-mixin.yaml")
 }
 
 /// Stands in for the running service: renders the sign-in prompt the CLI would show and returns the scripted outcome.
@@ -333,7 +333,7 @@ fn connected_for(world: &mut BehaviourWorld) -> Vec<String> {
         .connected_in(&lns_policy::grants::project_key(&policy))
 }
 
-#[then("lns-policy.yaml carries no token material")]
+#[then("lns-local-mixin.yaml carries no token material")]
 fn no_token_material(world: &mut BehaviourWorld) {
     let text = std::fs::read_to_string(policy_file(world)).unwrap_or_default();
     assert!(
@@ -368,7 +368,7 @@ fn shows_no_user_code(world: &mut BehaviourWorld) {
     );
 }
 
-#[then("lns-policy.yaml carries no credential material")]
+#[then("lns-local-mixin.yaml carries no credential material")]
 fn no_credential_material(world: &mut BehaviourWorld) {
     let text = std::fs::read_to_string(policy_file(world)).unwrap_or_default();
     assert!(

--- a/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
@@ -18,7 +18,7 @@ fn store(world: &mut BehaviourWorld) -> JsonFileGrantStore {
 
 /// Derived the same way the commands derive it, so a seeded grant keys identically to one a real run would have left.
 fn this_project(world: &mut BehaviourWorld) -> String {
-    project_key(&cwd(world).join("lns-policy.yaml"))
+    project_key(&cwd(world).join("lns-local-mixin.yaml"))
 }
 
 fn workload_of(key: &str) -> WorkloadIdentity {
@@ -97,7 +97,7 @@ fn project_still_connects(world: &mut BehaviourWorld, id: String) {
     let connected = JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
         .load()
         .expect("the sidecar reads back")
-        .connected_in(&project_key(&cwd(world).join("lns-policy.yaml")));
+        .connected_in(&project_key(&cwd(world).join("lns-local-mixin.yaml")));
     assert!(
         connected.contains(&id),
         "the connection and the grants under it are one write now, so a disconnect that could not land leaves {id} connected for a retry, got: {connected:?}"

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -146,7 +146,7 @@ fn compose_summary(world: &mut BehaviourWorld, defaults: Defaults, flags: &str) 
             &args,
             size,
             &lns_policy::Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &lns_cli::run::summary::PolicySource::FoundInCwd,
         ),
         ..Default::default()

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -139,7 +139,7 @@ fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
                 &args,
                 lns_cli::run::summary::resolved_size(Default::default(), &args),
                 &Policy::default(),
-                Path::new("./lns-policy.yaml"),
+                Path::new("./lns-local-mixin.yaml"),
                 &PolicySource::FoundInCwd,
             );
             text.push_str(&format_bind_dispositions(resolved));

--- a/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/policy_cli.rs
@@ -79,10 +79,10 @@ fn sandbox_running_with_policy(world: &mut BehaviourWorld) {
     let _ = cwd(world);
 }
 
-#[given(regex = r#"^the developer is in a directory with no "lns-policy\.yaml"$"#)]
+#[given(regex = r#"^the developer is in a directory with no "lns-local-mixin\.yaml"$"#)]
 fn directory_without_policy(world: &mut BehaviourWorld) {
     let dir = cwd(world);
-    assert!(!dir.join("lns-policy.yaml").exists());
+    assert!(!dir.join("lns-local-mixin.yaml").exists());
 }
 
 #[given(regex = r#"^"([^"]+)" has an allow rule for "([^"]+)" and a deny rule for "([^"]+)"$"#)]
@@ -183,7 +183,7 @@ fn raw_allow_precedes_raw_rule(
     first: String,
     second: String,
 ) -> Result<(), String> {
-    let policy = load(world, "lns-policy.yaml");
+    let policy = load(world, "lns-local-mixin.yaml");
     let patterns: Vec<&str> = policy
         .network
         .egress
@@ -431,9 +431,11 @@ fn policy_uses_the_removed_key(world: &mut BehaviourWorld, file: String, pattern
     let dir = cwd(world);
     std::fs::write(
         dir.join(file),
-        format!("network:\n  allowedRoutes:\n    - match: {pattern}\n      verdict: allow\n"),
+        format!(
+            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    allowedRoutes:\n      - match: {pattern}\n        verdict: allow\n"
+        ),
     )
-    .expect("seed a policy file in the pre-egress shape");
+    .expect("seed a decisions file naming a table nothing reads");
 }
 
 #[given(regex = r#"^"([^"]+)" has no rule for "([^"]+)"$"#)]
@@ -671,7 +673,7 @@ fn file_is_created(world: &mut BehaviourWorld, file: String) -> Result<(), Strin
 
 #[then(regex = r#"^it contains an allow rule for "([^"]+)"$"#)]
 fn it_contains_allow(world: &mut BehaviourWorld, pattern: String) -> Result<(), String> {
-    file_contains_allow(world, "lns-policy.yaml".to_string(), pattern)
+    file_contains_allow(world, "lns-local-mixin.yaml".to_string(), pattern)
 }
 
 #[then(regex = r#"^"([^"]+)" contains the allow rule$"#)]
@@ -689,11 +691,11 @@ fn explicit_file_contains_rule(world: &mut BehaviourWorld, path: String) -> Resu
     }
 }
 
-#[then(regex = r#"^"\./lns-policy\.yaml" is not created$"#)]
+#[then(regex = r#"^"\./lns-local-mixin\.yaml" is not created$"#)]
 fn default_file_not_created(world: &mut BehaviourWorld) -> Result<(), String> {
     let dir = cwd(world);
-    if dir.join("lns-policy.yaml").exists() {
-        Err("default lns-policy.yaml should not have been created".to_string())
+    if dir.join("lns-local-mixin.yaml").exists() {
+        Err("default lns-local-mixin.yaml should not have been created".to_string())
     } else {
         Ok(())
     }
@@ -1576,7 +1578,7 @@ fn command_fails(world: &mut BehaviourWorld) -> Result<(), String> {
 
 #[then(regex = r"^the policy file is unchanged$")]
 fn policy_file_unchanged(world: &mut BehaviourWorld) -> Result<(), String> {
-    let policy = load(world, "lns-policy.yaml");
+    let policy = load(world, "lns-local-mixin.yaml");
     if policy.network.egress.http.is_empty() {
         Ok(())
     } else {

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -155,7 +155,7 @@ fn user_invokes_lns_run(world: &mut BehaviourWorld, image_and_flags: String) {
 #[given(regex = r"^the working directory is `[^`]+`$")]
 fn working_directory_is(_world: &mut BehaviourWorld) {}
 
-#[given(regex = r"^the working directory contains `\./lns-policy\.yaml`$")]
+#[given(regex = r"^the working directory contains `\./lns-local-mixin\.yaml`$")]
 fn cwd_contains_policy_file(world: &mut BehaviourWorld) {
     let _ = require_cwd(world);
 }
@@ -171,11 +171,11 @@ fn that_policy_has(world: &mut BehaviourWorld, allows: usize, denies: usize) {
         policy.add_rule(RouteRule::deny_host(format!("deny-{i}.example")));
     }
     policy
-        .save_atomic(&cwd.join("lns-policy.yaml"))
+        .save_atomic(&cwd.join("lns-local-mixin.yaml"))
         .expect("save_atomic");
 }
 
-#[given(regex = r"^no `lns-policy\.yaml` exists in the working directory$")]
+#[given(regex = r"^no `lns-local-mixin\.yaml` exists in the working directory$")]
 fn no_policy_in_cwd(_world: &mut BehaviourWorld) {}
 
 #[given(regex = r"^the command is `lns run ([^`]+)`$")]
@@ -284,7 +284,7 @@ fn resolving_placeholder_present(world: &mut BehaviourWorld) -> Result<(), Strin
 #[then(regex = r"^the Policy block shows the file path$")]
 fn policy_block_shows_file_path(world: &mut BehaviourWorld) -> Result<(), String> {
     let cwd = require_cwd(world);
-    let expected = cwd.join("lns-policy.yaml");
+    let expected = cwd.join("lns-local-mixin.yaml");
     let needle = format!("file: {}", expected.display());
     if world.summary_output.contains(&needle) {
         Ok(())

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -27,7 +27,7 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
             &resolved,
             lns_cli::run::summary::resolved_size(Default::default(), &resolved),
             &Policy::default(),
-            Path::new("./lns-policy.yaml"),
+            Path::new("./lns-local-mixin.yaml"),
             &PolicySource::FoundInCwd,
         ),
         ..Default::default()

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -94,12 +94,18 @@ pub enum Request {
         project_dir: String,
         #[serde(default)]
         mixins: Vec<String>,
+        /// The decisions file this run reads, so what the preflight resolves is what the boot resolves.
+        #[serde(default)]
+        decisions: Option<String>,
     },
     InspectImage {
         image: String,
         /// The mixin references the user named on the command line, in flag order, so the preflight describes the document that will boot.
         #[serde(default)]
         mixins: Vec<String>,
+        /// The decisions file this run reads, absent when the question is about the artifact rather than about a run in some directory.
+        #[serde(default)]
+        decisions: Option<String>,
     },
     TagImage {
         from: String,
@@ -1439,6 +1445,7 @@ mod tests {
         let req = Request::InspectImage {
             image: "registry.example.test/team/sandbox:1".into(),
             mixins: vec!["ghcr.io/acme/obs-tools:2".into()],
+            decisions: Some("/work/lns-local-mixin.yaml".into()),
         };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -1082,7 +1082,7 @@ mod tests {
             mem: 1024,
             cpus_explicit: true,
             mem_explicit: true,
-            policy_path: Some("/work/lns-policy.yaml".into()),
+            policy_path: Some("/work/lns-local-mixin.yaml".into()),
             sandbox_user: Some("sandbox".into()),
             sandbox_uid: Some(65534),
             entrypoint: Some("/bin/sh".into()),
@@ -1126,7 +1126,10 @@ mod tests {
         let config = RunConfig::from_run_args(&args);
         assert_eq!(config.cpus, 2);
         assert_eq!(config.mem_mib, 1024);
-        assert_eq!(config.policy_path.as_deref(), Some("/work/lns-policy.yaml"));
+        assert_eq!(
+            config.policy_path.as_deref(),
+            Some("/work/lns-local-mixin.yaml")
+        );
         assert_eq!(config.sandbox_user.as_deref(), Some("sandbox"));
         assert_eq!(config.entrypoint.as_deref(), Some("/bin/sh"));
         assert_eq!(config.hostname.as_deref(), Some("demo"));

--- a/crates/lns-policy/src/credentials.rs
+++ b/crates/lns-policy/src/credentials.rs
@@ -1,4 +1,4 @@
-//! Credential rules live in `~/.lns-credentials.json`, not `lns-policy.yaml`, to keep the shareable policy file free of per-machine state.
+//! Credential rules live in `~/.lns-credentials.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine state.
 
 use std::collections::HashMap;
 use std::fs;

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -956,8 +956,8 @@ mod tests {
     #[test]
     fn project_key_canonicalizes_an_existing_policy_path() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        fs::write(&path, "network: {}\n").unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(&path, "").unwrap();
         assert_eq!(
             project_key(&path),
             fs::canonicalize(&path).unwrap().to_string_lossy()
@@ -966,8 +966,8 @@ mod tests {
 
     #[test]
     fn project_key_falls_back_to_the_raw_path_when_it_cannot_be_canonicalized() {
-        let path = Path::new("/no/such/dir/lns-policy.yaml");
-        assert_eq!(project_key(path), "/no/such/dir/lns-policy.yaml");
+        let path = Path::new("/no/such/dir/lns-local-mixin.yaml");
+        assert_eq!(project_key(path), "/no/such/dir/lns-local-mixin.yaml");
     }
 
     #[test]

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -18,7 +18,7 @@ mod secure_file;
 #[cfg(test)]
 mod test_env;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Policy {
     #[serde(default)]
@@ -26,60 +26,74 @@ pub struct Policy {
     /// The run's connected set, filled from the per-machine sidecar rather than this file: connecting is a per-machine risk acceptance, and a file that travels must not carry one.
     #[serde(skip)]
     pub connectors: Vec<String>,
+    /// What the document on disk called itself, kept so writing a decision back does not rename the developer's own file.
+    #[serde(skip)]
+    pub name: Option<String>,
+    /// Every block of that document the run does not write, kept verbatim so an approval cannot delete what somebody wrote by hand.
+    #[serde(skip)]
+    pub rest: serde_yaml::Mapping,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(
-    rename_all = "camelCase",
-    deny_unknown_fields,
-    try_from = "NetworkPolicyRaw"
-)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NetworkPolicy {
     #[serde(default)]
     pub egress: Egress,
 }
 
-/// Deserialization shim for the two fields that left the file: one restating the new behavior is dropped, one that decided something is refused.
-#[derive(Deserialize)]
+/// The document format every kit is written in (`docs/sandbox-spec.md` §2), which the directory's own decisions are written in too.
+pub const API_VERSION: &str = "lns.run/v1";
+
+/// The kind §8.1 records a decision as, so it merges under the same rules as anything the developer pulled.
+pub const KIND: &str = "mixin";
+
+/// The decisions file on disk. Its envelope is restated here rather than read through the crate that parses a kit, which depends on this one; only the block a run writes back is modelled, and every other one travels in [`LocalMixinSpec::rest`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct NetworkPolicyRaw {
+struct LocalMixinDocument {
+    api_version: String,
+    kind: String,
+    name: String,
     #[serde(default)]
-    egress: Egress,
-    #[serde(default)]
-    default_verdict: Option<String>,
-    #[serde(default)]
-    default_transport: Option<String>,
+    spec: LocalMixinSpec,
 }
 
-impl TryFrom<NetworkPolicyRaw> for NetworkPolicy {
-    type Error = String;
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LocalMixinSpec {
+    #[serde(default)]
+    egress: Egress,
+    #[serde(flatten)]
+    rest: serde_yaml::Mapping,
+}
 
-    fn try_from(raw: NetworkPolicyRaw) -> Result<Self, Self::Error> {
-        match raw.default_verdict.as_deref() {
-            None | Some("ask") => {}
-            Some(verdict @ ("allow" | "deny")) => {
-                return Err(format!(
-                    "defaultVerdict is no longer part of a policy file, and `{verdict}` decided what a rule now has to say: delete the line, then end `egress.http` with a catch-all instead — `lns policy {verdict} '*'`. {raw}",
-                    raw = match verdict {
-                        "deny" =>
-                            "That rule governs raw destinations too, so `egress.tcp` needs no counterpart",
-                        // A catch-all allow leaves a connection nothing can read still asking, since a default was never consent to splice one.
-                        _ => "A raw destination nothing can inspect will still ask on first use",
-                    }
-                ));
-            }
-            Some(other) => {
-                return Err(format!(
-                    "defaultVerdict is no longer part of a policy file, and `{other}` was never one of its values: delete the line"
-                ));
-            }
-        }
-        if let Some(transport) = raw.default_transport.as_deref().filter(|t| *t != "direct") {
-            return Err(format!(
-                "defaultTransport is no longer part of a policy file, and `{transport}` isn't supported in the local sandbox: delete the line"
-            ));
-        }
-        Ok(Self { egress: raw.egress })
+/// The shape §2 requires of a document's name, restated here for the same reason the envelope is: a document this crate accepts has to be one the resolver accepts.
+fn is_dns_label(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    let alnum = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    !bytes.is_empty()
+        && bytes.len() <= 63
+        && alnum(bytes[0])
+        && alnum(bytes[bytes.len() - 1])
+        && bytes.iter().all(|&b| alnum(b) || b == b'-')
+}
+
+/// Name a written document after the file it lands in, since nobody is present to choose one.
+fn dns_label_for(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let spelled: String = stem
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let label: String = spelled.trim_matches('-').chars().take(63).collect();
+    let label = label.trim_end_matches('-');
+    if is_dns_label(label) {
+        label.to_string()
+    } else {
+        "local".to_string()
     }
 }
 
@@ -376,20 +390,60 @@ pub enum Scheme {
 impl Policy {
     pub fn load_or_default(path: &Path) -> io::Result<Self> {
         match fs::read_to_string(path) {
-            Ok(text) => {
-                let policy: Self = serde_yaml::from_str(&text)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                policy.network.validate_local_transport()?;
-                policy.network.validate_binary_scopes()?;
-                Ok(policy)
-            }
+            // §8.1 has the mixin exist whether or not anyone wrote it, and an editor truncates a file before it writes one.
+            Ok(text) if text.trim().is_empty() => Ok(Self::default()),
+            Ok(text) => Self::from_document(&text),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
             Err(e) => Err(e),
         }
     }
 
+    fn from_document(text: &str) -> io::Result<Self> {
+        let invalid = |message: String| io::Error::new(io::ErrorKind::InvalidData, message);
+        let doc: LocalMixinDocument =
+            serde_yaml::from_str(text).map_err(|e| invalid(e.to_string()))?;
+        if doc.api_version != API_VERSION {
+            return Err(invalid(format!(
+                "this document says apiVersion {}, and a directory's decisions are written in {API_VERSION}",
+                doc.api_version
+            )));
+        }
+        if doc.kind != KIND {
+            return Err(invalid(format!(
+                "this document says kind {}, and a directory's decisions are a {KIND}",
+                doc.kind
+            )));
+        }
+        if !is_dns_label(&doc.name) {
+            return Err(invalid(format!(
+                "this document is named {}, and a document is named with lowercase letters, digits and dashes, starting and ending with a letter or a digit",
+                doc.name
+            )));
+        }
+        let policy = Self {
+            network: NetworkPolicy {
+                egress: doc.spec.egress,
+            },
+            connectors: Vec::new(),
+            name: Some(doc.name),
+            rest: doc.spec.rest,
+        };
+        policy.network.validate_local_transport()?;
+        policy.network.validate_binary_scopes()?;
+        Ok(policy)
+    }
+
     pub fn save_atomic(&self, path: &Path) -> io::Result<()> {
-        let yaml = serde_yaml::to_string(self)
+        let document = LocalMixinDocument {
+            api_version: API_VERSION.to_string(),
+            kind: KIND.to_string(),
+            name: self.name.clone().unwrap_or_else(|| dns_label_for(path)),
+            spec: LocalMixinSpec {
+                egress: self.network.egress.clone(),
+                rest: self.rest.clone(),
+            },
+        };
+        let yaml = serde_yaml::to_string(&document)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
@@ -588,6 +642,20 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Write a decisions file whose spec holds the given blocks, so a fixture states the one thing it is about.
+    fn decisions_file(dir: &TempDir, spec: &str) -> PathBuf {
+        let path = dir.path().join("lns-local-mixin.yaml");
+        let body: String = spec.lines().map(|line| format!("  {line}\n")).collect();
+        fs::write(
+            &path,
+            format!(
+                "apiVersion: {API_VERSION}\nkind: {KIND}\nname: lns-local-mixin\nspec:\n{body}"
+            ),
+        )
+        .unwrap();
+        path
+    }
+
     #[test]
     fn a_default_policy_decides_nothing_and_so_holds_no_rules() {
         // The file is the decisions the developer has made. A fresh one has made
@@ -595,92 +663,6 @@ mod tests {
         let p = Policy::default();
         assert!(p.network.egress.http.is_empty());
         assert!(p.network.egress.tcp.is_empty());
-    }
-
-    #[test]
-    fn the_removed_defaults_are_dropped_where_they_only_restated_the_new_behavior() {
-        // Every file created before this change carries both, and both spell what
-        // the runtime now does unconditionally — refusing them would brick every
-        // existing project to tell it nothing.
-        let net: NetworkPolicy = serde_yaml::from_str(
-            "egress:\n  http: []\ndefaultVerdict: ask\ndefaultTransport: direct\n",
-        )
-        .expect("the values that restate the new behavior must load");
-        assert!(net.egress.http.is_empty());
-        let yaml = serde_yaml::to_string(&Policy::default()).unwrap();
-        assert!(
-            !yaml.contains("defaultVerdict") && !yaml.contains("defaultTransport"),
-            "a rewritten file must not put the keys back:\n{yaml}"
-        );
-    }
-
-    #[test]
-    fn a_default_verdict_that_decided_something_is_refused_with_the_rule_to_write_instead() {
-        // These two changed a file's meaning, and no rule the loader could invent
-        // would preserve it — so it says what to write rather than guessing.
-        for (value, tail, absent) in [
-            (
-                "deny",
-                "`egress.tcp` needs no counterpart",
-                "still ask on first use",
-            ),
-            ("allow", "still ask on first use", "needs no counterpart"),
-        ] {
-            let err = serde_yaml::from_str::<NetworkPolicy>(&format!(
-                "egress:\n  http: []\ndefaultVerdict: {value}\n"
-            ))
-            .expect_err("a default that decided something must be refused");
-            let msg = err.to_string();
-            assert!(
-                msg.contains("defaultVerdict") && msg.contains(value),
-                "the error must name the key and the verdict; got {msg}"
-            );
-            // Only a catch-all deny reaches raw destinations, so only that branch may
-            // promise it; an allow leaves an unreadable connection still asking.
-            assert!(msg.contains(tail), "expected {tail:?} in {msg}");
-            assert!(!msg.contains(absent), "unexpected {absent:?} in {msg}");
-        }
-    }
-
-    #[test]
-    fn the_refusal_says_delete_the_line_before_the_command_that_needs_it_gone() {
-        // `lns policy deny '*'` loads the file first, so it stops on this same error.
-        // Prescribed in the other order the fix is a loop the reader cannot leave.
-        let err =
-            serde_yaml::from_str::<NetworkPolicy>("egress:\n  http: []\ndefaultVerdict: deny\n")
-                .expect_err("a default that decided something must be refused");
-        let msg = err.to_string();
-        let (delete, command) = (
-            msg.find("delete the line")
-                .expect("the message must say to delete it"),
-            msg.find("lns policy deny")
-                .expect("the message must name the command"),
-        );
-        assert!(
-            delete < command,
-            "the command cannot run until the line is gone: {msg}"
-        );
-    }
-
-    #[test]
-    fn a_default_verdict_that_was_never_a_value_is_refused_without_inventing_a_command() {
-        let err =
-            serde_yaml::from_str::<NetworkPolicy>("egress:\n  http: []\ndefaultVerdict: bananas\n")
-                .expect_err("an unknown value must be refused");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("never one of its values") && !msg.contains("lns policy bananas"),
-            "the fix-it must not echo a value back as a verb: {msg}"
-        );
-    }
-
-    #[test]
-    fn an_upstream_default_transport_keeps_the_error_it_always_had() {
-        let err = serde_yaml::from_str::<NetworkPolicy>(
-            "egress:\n  http: []\ndefaultTransport: upstream\n",
-        )
-        .expect_err("upstream must stay refused");
-        assert!(err.to_string().contains("upstream"), "got {err}");
     }
 
     #[test]
@@ -830,18 +812,17 @@ mod tests {
     #[test]
     fn load_or_default_accepts_a_rule_scoped_to_an_absolute_binary() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  egress:
-    http:
-      - match: git.example.test
-        verdict: allow
-        binaries:
-          - /usr/bin/git
-  defaultVerdict: ask
-";
-        fs::write(&path, yaml).unwrap();
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
+  http:
+    - match: git.example.test
+      verdict: allow
+      binaries:
+        - /usr/bin/git
+",
+        );
         let p = Policy::load_or_default(&path).unwrap();
         assert_eq!(
             p.network.egress.http[0].binaries,
@@ -852,17 +833,16 @@ network:
     #[test]
     fn load_or_default_rejects_an_empty_binaries_filter() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  egress:
-    http:
-      - match: git.example.test
-        verdict: allow
-        binaries: []
-  defaultVerdict: ask
-";
-        fs::write(&path, yaml).unwrap();
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
+  http:
+    - match: git.example.test
+      verdict: allow
+      binaries: []
+",
+        );
         let err = Policy::load_or_default(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
@@ -875,19 +855,18 @@ network:
     #[test]
     fn load_or_default_rejects_a_relative_binary_path() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  egress:
-    http:
-      - match: git.example.test
-        verdict: allow
-        binaries:
-          - /usr/bin/git
-          - git
-  defaultVerdict: ask
-";
-        fs::write(&path, yaml).unwrap();
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
+  http:
+    - match: git.example.test
+      verdict: allow
+      binaries:
+        - /usr/bin/git
+        - git
+",
+        );
         let err = Policy::load_or_default(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
@@ -987,16 +966,15 @@ network:
     #[test]
     fn load_or_default_reads_existing_yaml() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  egress:
-    http:
-      - match: api.linear.app
-        verdict: allow
-  defaultVerdict: ask
-";
-        fs::write(&path, yaml).unwrap();
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
+  http:
+    - match: api.linear.app
+      verdict: allow
+",
+        );
         let p = Policy::load_or_default(&path).unwrap();
         assert_eq!(p.network.egress.http.len(), 1);
         assert_eq!(p.network.egress.http[0].match_pattern, "api.linear.app");
@@ -1004,22 +982,22 @@ network:
     }
 
     #[test]
-    fn load_or_default_rejects_a_file_still_naming_the_removed_allowed_routes_key() {
+    fn load_or_default_rejects_a_stale_key_inside_egress_rather_than_reading_zero_rules() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
   allowedRoutes:
     - match: api.linear.app
       verdict: allow
-  defaultVerdict: ask
-";
-        fs::write(&path, yaml).unwrap();
+",
+        );
         let err = Policy::load_or_default(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
             err.to_string().contains("allowedRoutes"),
-            "a stale key must name itself in the error, not load as a policy with zero rules: {err}"
+            "a key nothing reads must name itself in the error, not load as a decision that decides nothing: {err}"
         );
     }
 
@@ -1090,12 +1068,10 @@ network:
     #[test]
     fn load_or_default_reads_a_tcp_rule() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        fs::write(
-            &path,
-            "network:\n  egress:\n    tcp:\n      - match: db.internal:5432\n        verdict: allow\n  defaultVerdict: ask\n",
-        )
-        .unwrap();
+        let path = decisions_file(
+            &dir,
+            "egress:\n  tcp:\n    - match: db.internal:5432\n      verdict: allow\n",
+        );
         let p = Policy::load_or_default(&path).unwrap();
         assert_eq!(p.network.egress.tcp, vec![tcp_allow("db.internal:5432")]);
     }
@@ -1513,38 +1489,18 @@ network:
     }
 
     #[test]
-    fn load_or_default_rejects_an_upstream_default_transport() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  defaultVerdict: ask
-  defaultTransport: upstream
-";
-        fs::write(&path, yaml).unwrap();
-        let err = Policy::load_or_default(&path).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-        assert!(
-            err.to_string()
-                .contains("defaultTransport is no longer part of a policy file")
-                && err.to_string().contains("upstream"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
     fn load_or_default_rejects_an_upstream_route_transport() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
-        let yaml = "\
-network:
-  egress:
-    http:
-      - match: api.example.test
-        verdict: allow
-        transport: upstream
-";
-        fs::write(&path, yaml).unwrap();
+        let path = decisions_file(
+            &dir,
+            "\
+egress:
+  http:
+    - match: api.example.test
+      verdict: allow
+      transport: upstream
+",
+        );
         let err = Policy::load_or_default(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
@@ -1567,7 +1523,7 @@ network:
     fn load_or_default_surfaces_invalid_yaml_as_io_error() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("broken.yaml");
-        fs::write(&path, "network: not-a-map\n").unwrap();
+        fs::write(&path, "apiVersion: [\n").unwrap();
         let err = Policy::load_or_default(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
@@ -1575,19 +1531,19 @@ network:
     #[test]
     fn save_atomic_writes_file_readable_by_load_or_default() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("api.linear.app"));
 
         p.save_atomic(&path).unwrap();
         let reloaded = Policy::load_or_default(&path).unwrap();
-        assert_eq!(p, reloaded);
+        assert_eq!(p.network, reloaded.network);
     }
 
     #[test]
     fn save_atomic_creates_parent_directory() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("nested/dir/lns-policy.yaml");
+        let path = dir.path().join("nested/dir/lns-local-mixin.yaml");
         Policy::default().save_atomic(&path).unwrap();
         assert!(path.exists());
     }
@@ -1595,7 +1551,7 @@ network:
     #[test]
     fn save_atomic_leaves_no_tmp_file_on_success() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         Policy::default().save_atomic(&path).unwrap();
         let tmp = path.with_extension("yaml.tmp");
         assert!(!tmp.exists(), "tmp file should be renamed away");
@@ -1604,7 +1560,7 @@ network:
     #[test]
     fn file_policy_store_save_writes_yaml_readable_by_load_or_default() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let store = FilePolicyStore::new(path.clone());
 
         let mut p = Policy::default();
@@ -1612,7 +1568,7 @@ network:
         store.save(&p).unwrap();
 
         let reloaded = Policy::load_or_default(&path).unwrap();
-        assert_eq!(reloaded, p);
+        assert_eq!(reloaded.network, p.network);
     }
 
     #[test]
@@ -1620,7 +1576,7 @@ network:
         let dir = TempDir::new().unwrap();
         let unwritable = dir.path().join("file-not-a-dir");
         fs::write(&unwritable, b"").unwrap();
-        let path = unwritable.join("nested/lns-policy.yaml");
+        let path = unwritable.join("nested/lns-local-mixin.yaml");
         let store = FilePolicyStore::new(path);
 
         let err = store.save(&Policy::default()).unwrap_err();
@@ -1671,80 +1627,26 @@ network:
     }
 
     #[test]
-    fn legacy_network_only_yaml_parses_with_empty_connectors() {
-        let yaml = "\
-network:
-  egress:
-    http: []
-  defaultVerdict: ask
-  defaultTransport: direct
-";
-        let p: Policy = serde_yaml::from_str(yaml).unwrap();
-        assert!(p.connectors.is_empty());
-    }
-
-    #[test]
-    fn default_policy_omits_the_connectors_key() {
-        let yaml = serde_yaml::to_string(&Policy::default()).unwrap();
-        assert!(
-            !yaml.contains("connectors"),
-            "an empty connectors list must not clutter the shareable file:\n{yaml}"
-        );
-    }
-
-    #[test]
-    fn a_file_still_carrying_the_old_connectors_key_loads_and_decides_nothing() {
-        let p: Policy = serde_yaml::from_str(
-            "network:\n  egress:\n    http: []\nconnectors:\n  - some-provider\n",
-        )
-        .expect("a directory written before connections moved still opens");
-        assert!(
-            p.connectors.is_empty(),
-            "the key is ignored rather than read, so the connector is offered again on first use"
-        );
-    }
-
-    #[test]
     fn the_decisions_file_never_carries_which_connectors_are_connected() {
-        let p = Policy {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        Policy {
             connectors: vec!["some-provider".into()],
             ..Policy::default()
-        };
-        let yaml = serde_yaml::to_string(&p).unwrap();
+        }
+        .save_atomic(&path)
+        .unwrap();
+        let text = fs::read_to_string(&path).unwrap();
         assert!(
-            !yaml.contains("connectors"),
-            "connecting is a per-machine risk acceptance, and this file is meant to be committed; got:\n{yaml}"
+            !text.contains("connectors"),
+            "connecting is a per-machine risk acceptance, and this file is meant to be committed; got:\n{text}"
         );
         assert!(
-            serde_yaml::from_str::<Policy>(&yaml)
+            Policy::load_or_default(&path)
                 .unwrap()
                 .connectors
                 .is_empty(),
             "what a run may spend is read from the sidecar, never from a file that travels"
-        );
-    }
-
-    #[test]
-    fn a_legacy_policy_carrying_the_removed_credentials_section_still_loads() {
-        let yaml = "\
-network:
-  egress:
-    http: []
-  defaultVerdict: ask
-  defaultTransport: direct
-credentials:
-  customProviders:
-    - id: acme
-      envVar: ACME_API_KEY
-      placeholder: acme_LNSPLACEHOLDER0000000000000000000000
-      injections:
-        - kind: bearer_header
-          domain: api.acme.corp
-";
-        let p: Policy = serde_yaml::from_str(yaml).unwrap();
-        assert!(
-            p.connectors.is_empty(),
-            "the now-unknown credentials section is ignored, not an error"
         );
     }
 
@@ -1761,5 +1663,175 @@ credentials:
         p.connect("some-provider");
         p.connect("some-provider");
         assert_eq!(p.connectors, ["some-provider"]);
+    }
+
+    #[test]
+    fn the_decisions_file_is_the_mixin_the_specification_says_it_is() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("docs.some-vendor.example"));
+        p.save_atomic(&path).unwrap();
+
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(
+            text.contains("apiVersion: lns.run/v1") && text.contains("kind: mixin"),
+            "§8.1 records a decision in the grammar the rest of the document already defines; got:\n{text}"
+        );
+        assert!(
+            text.contains("egress:") && !text.contains("network:"),
+            "§3.1.6 names the block `egress`, directly under `spec`; got:\n{text}"
+        );
+        assert_eq!(
+            Policy::load_or_default(&path).unwrap().network.egress.http,
+            p.network.egress.http,
+            "what the run wrote back is what the next run reads"
+        );
+    }
+
+    #[test]
+    fn the_document_is_named_for_the_file_it_is_written_to() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        Policy::default().save_atomic(&path).unwrap();
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("name: lns-local-mixin"),
+            "§2 requires a name on every document, and nobody is here to choose one"
+        );
+    }
+
+    #[test]
+    fn a_name_no_dns_label_could_be_is_written_as_one() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("My_Decisions.yaml");
+        Policy::default().save_atomic(&path).unwrap();
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("name: my-decisions"),
+            "a `--policy` path the developer chose still has to produce a document §2 accepts"
+        );
+    }
+
+    #[test]
+    fn a_file_stem_holding_no_label_character_still_produces_a_name() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("__.yaml");
+        Policy::default().save_atomic(&path).unwrap();
+        assert!(
+            fs::read_to_string(&path).unwrap().contains("name: local"),
+            "§2 requires a name, so a file whose stem spells none has to fall back to one"
+        );
+    }
+
+    #[test]
+    fn a_file_stem_longer_than_a_label_is_cut_to_one() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(format!("{}-tail.yaml", "a".repeat(70)));
+        Policy::default().save_atomic(&path).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        let name = text
+            .lines()
+            .find_map(|line| line.strip_prefix("name: "))
+            .expect("the document names itself");
+        assert_eq!(
+            name,
+            "a".repeat(63),
+            "§2 caps a label at 63 characters, and a path the developer chose can be longer"
+        );
+    }
+
+    #[test]
+    fn a_block_the_run_never_writes_survives_the_run_writing_one_it_does() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(
+            &path,
+            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  mixins:\n    - ghcr.io/team/base@sha256:abc\n  egress:\n    http: []\n",
+        )
+        .unwrap();
+
+        let mut p = Policy::load_or_default(&path).unwrap();
+        p.add_rule(RouteRule::allow_host("api.example.test"));
+        p.save_atomic(&path).unwrap();
+
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(
+            text.contains("ghcr.io/team/base@sha256:abc"),
+            "an approval appends an egress entry; it must not delete what the developer wrote by hand:\n{text}"
+        );
+        assert!(text.contains("api.example.test"), "got:\n{text}");
+    }
+
+    #[test]
+    fn a_document_of_another_kind_is_refused_rather_than_read_as_decisions() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(
+            &path,
+            "apiVersion: lns.run/v1\nkind: sandbox\nname: something-else\nspec:\n  egress:\n    http: []\n",
+        )
+        .unwrap();
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("mixin"),
+            "the file is the developer's own, so a wrong kind is loud rather than silently empty: {err}"
+        );
+    }
+
+    #[test]
+    fn a_document_named_what_no_document_may_be_named_is_refused() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(
+            &path,
+            "apiVersion: lns.run/v1\nkind: mixin\nname: Not_A_Label!\nspec:\n  egress:\n    http: []\n",
+        )
+        .unwrap();
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("Not_A_Label!"),
+            "the resolver refuses this document too, so the two readers of one grammar have to agree: {err}"
+        );
+    }
+
+    #[test]
+    fn a_name_is_a_label_or_it_is_not_a_name() {
+        for valid in ["a", "9", "lns-local-mixin", &"a".repeat(63)] {
+            assert!(is_dns_label(valid), "{valid} is a label");
+        }
+        for invalid in ["", "-a", "a-", "aBc", "a_b", "a.b", &"a".repeat(64)] {
+            assert!(!is_dns_label(invalid), "{invalid} is not a label");
+        }
+    }
+
+    #[test]
+    fn a_document_of_another_api_version_is_refused() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(
+            &path,
+            "apiVersion: lns.run/v2\nkind: mixin\nname: local\nspec:\n  egress:\n    http: []\n",
+        )
+        .unwrap();
+        let err = Policy::load_or_default(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("lns.run/v1"), "got: {err}");
+    }
+
+    #[test]
+    fn an_empty_file_is_the_mixin_nobody_wrote() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        fs::write(&path, "  \n").unwrap();
+        assert_eq!(
+            Policy::load_or_default(&path).unwrap().network,
+            NetworkPolicy::default(),
+            "§8.1 has the mixin exist whether or not anyone wrote it, and an editor truncates before it writes"
+        );
     }
 }

--- a/crates/lns-policy/src/registry_auth.rs
+++ b/crates/lns-policy/src/registry_auth.rs
@@ -1,4 +1,4 @@
-//! Registry logins live in `~/.lns-registry-auth.json`, not `lns-policy.yaml`, to keep the shareable policy file free of per-machine secrets.
+//! Registry logins live in `~/.lns-registry-auth.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine secrets.
 
 use std::collections::HashMap;
 use std::fs;

--- a/crates/lns-service/Cargo.toml
+++ b/crates/lns-service/Cargo.toml
@@ -75,7 +75,7 @@ tracing            = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "ansi"] }
 anstyle = "1"
 
-# Approval-flow deps. serde_yaml: lns-policy.yaml load/save. notify:
+# Approval-flow deps. serde_yaml: lns-local-mixin.yaml load/save. notify:
 # filesystem watcher for hot-swap on manual policy edits. The
 # approval UI itself is rendered by the eframe/egui setup above —
 # no HTTP stack is involved.

--- a/crates/lns-service/src/approval_flow/watcher.rs
+++ b/crates/lns-service/src/approval_flow/watcher.rs
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_modify_on_target_path() {
-        let target = Path::new("/tmp/lns-policy.yaml");
+        let target = Path::new("/tmp/lns-local-mixin.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Modify(ModifyKind::Any), target),
             target
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_create_on_target_path() {
-        let target = Path::new("/tmp/lns-policy.yaml");
+        let target = Path::new("/tmp/lns-local-mixin.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Create(CreateKind::Any), target),
             target
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_remove_on_target_path() {
-        let target = Path::new("/tmp/lns-policy.yaml");
+        let target = Path::new("/tmp/lns-local-mixin.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Remove(RemoveKind::Any), target),
             target
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_rejects_event_on_sibling_path() {
-        let target = Path::new("/tmp/lns-policy.yaml");
+        let target = Path::new("/tmp/lns-local-mixin.yaml");
         let sibling = Path::new("/tmp/something-else.yaml");
         assert!(!is_policy_change(
             &evt(EventKind::Modify(ModifyKind::Any), sibling),
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_rejects_uninteresting_event_kinds() {
-        let target = Path::new("/tmp/lns-policy.yaml");
+        let target = Path::new("/tmp/lns-local-mixin.yaml");
         assert!(!is_policy_change(
             &evt(EventKind::Access(notify::event::AccessKind::Any), target),
             target
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn spawn_returns_ok_for_existing_parent_dir() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         Policy::default().save_atomic(&path).unwrap();
 
         let notifier = Arc::new(crate::approval_flow::session::tests::RecordingNotifier::default());
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn spawn_with_path_that_has_no_parent_uses_cwd() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         Policy::default().save_atomic(&path).unwrap();
 
         let notifier = Arc::new(crate::approval_flow::session::tests::RecordingNotifier::default());
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn event_handler_closure_reloads_policy_on_matching_event() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let mut updated = Policy::default();
         updated.add_rule(RouteRule::allow_host("api.linear.app"));
         updated.save_atomic(&path).unwrap();
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn handle_event_for_matching_modify_reloads_and_applies_policy() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let mut updated = Policy::default();
         updated.add_rule(RouteRule::allow_host("api.linear.app"));
         updated.save_atomic(&path).unwrap();
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn a_change_to_the_sidecar_reaches_the_run() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         Policy::default().save_atomic(&path).unwrap();
         let grants = dir.path().join("grants.json");
         let store = lns_policy::grants::JsonFileGrantStore::new(grants.clone());
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn handle_event_for_unrelated_path_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let target = dir.path().join("lns-policy.yaml");
+        let target = dir.path().join("lns-local-mixin.yaml");
         let sibling = dir.path().join("other.yaml");
         Policy::default().save_atomic(&target).unwrap();
 
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn handle_event_with_notify_error_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         let (session, mut rx) = make_session();
 
         handle_event(
@@ -321,7 +321,7 @@ mod tests {
     #[test]
     fn handle_event_with_malformed_policy_file_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-policy.yaml");
+        let path = dir.path().join("lns-local-mixin.yaml");
         std::fs::write(&path, "this is: not\n  - a: valid\npolicy: [").unwrap();
         let (session, mut rx) = make_session();
 

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -75,6 +75,7 @@ struct Fetched {
     graph: BTreeMap<String, SandboxSpec>,
     pinned_roots: Vec<String>,
     pinned_extra: Vec<String>,
+    pinned_local: Vec<String>,
 }
 
 /// What one walk of the graph carries: the sources fetched so far, what each reference resolved to under the document that named it, and the references still to visit.
@@ -89,6 +90,7 @@ struct Walk {
 async fn collect<S: MixinSource>(
     roots: &[String],
     extra: &[String],
+    local: Option<(&[String], &Locator)>,
     home: &Locator,
     source: &S,
 ) -> Result<Fetched> {
@@ -101,6 +103,12 @@ async fn collect<S: MixinSource>(
     let mut pinned_extra = Vec::new();
     for reference in extra {
         pinned_extra.push(visit(&mut walk, reference, home, true, source).await?);
+    }
+    let mut pinned_local = Vec::new();
+    if let Some((references, decided_in)) = local {
+        for reference in references {
+            pinned_local.push(visit(&mut walk, reference, decided_in, false, source).await?);
+        }
     }
     let mut pinned_roots = Vec::new();
     for reference in roots {
@@ -130,6 +138,7 @@ async fn collect<S: MixinSource>(
         graph,
         pinned_roots,
         pinned_extra,
+        pinned_local,
     })
 }
 
@@ -185,6 +194,7 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
     extra: &[String],
     home: &Locator,
     source: &S,
+    local: Option<LocalSource>,
 ) -> Result<Resolution> {
     if !matches!(
         crate::artifact::dispatch(artifact_type, config_media_type),
@@ -198,7 +208,7 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
             contributions: Vec::new(),
         });
     }
-    resolve(config_json, extra, home, source).await
+    resolve(config_json, extra, home, source, local).await
 }
 
 /// What a run boots, and the mixins that produced it — the merged document declares none of its own, so the references travel beside it.
@@ -212,15 +222,49 @@ pub struct Resolution {
     pub contributions: Vec<lns_artifact::merge::Contribution>,
 }
 
+/// What the directory decided, as the merge reads it: the label a disclosure names it by, and everything but the egress it decided. Egress is left out because it reaches the guest live — an approval made mid-run applies and a rule deleted mid-run retracts, and a copy frozen into the booted document could do neither.
+#[derive(Debug)]
+pub struct LocalSource {
+    pub label: String,
+    /// The directory this file was read from, which is what any directory it names roots at (§3.3.1) — not the directory the run happens to be about.
+    home: Locator,
+    spec: SandboxSpec,
+}
+
+impl LocalSource {
+    /// Read the directory's decisions as one merge source; a file nobody has written has nothing to contribute.
+    pub fn read(fetched: Option<FetchedMixin>, home: Locator) -> Result<Option<Self>> {
+        let Some(fetched) = fetched else {
+            return Ok(None);
+        };
+        let document = lns_artifact::sandbox::parse_mixin(fetched.document.as_bytes())
+            .with_context(|| format!("reading {}", fetched.pinned))?;
+        Ok(Some(Self {
+            label: fetched.pinned,
+            home,
+            spec: SandboxSpec {
+                egress: Default::default(),
+                ..document.spec
+            },
+        }))
+    }
+
+    fn decides_nothing(&self) -> bool {
+        self.spec == SandboxSpec::default()
+    }
+}
+
 /// Resolve a published definition and every mixin it layers on into the one document a run boots (`docs/sandbox-spec.md` §3.3), returned as a definition the rest of the plan path reads exactly as it reads an authored one.
 pub async fn resolve<S: MixinSource>(
     config_json: &[u8],
     extra: &[String],
     home: &Locator,
     source: &S,
+    local: Option<LocalSource>,
 ) -> Result<Resolution> {
     let def = lns_artifact::sandbox::parse(config_json).context("reading the sandbox document")?;
-    if def.spec.mixins.is_empty() && extra.is_empty() {
+    let local = local.filter(|local| !local.decides_nothing());
+    if def.spec.mixins.is_empty() && extra.is_empty() && local.is_none() {
         return Ok(Resolution {
             document: config_json.to_vec(),
             mixins: Vec::new(),
@@ -228,10 +272,34 @@ pub async fn resolve<S: MixinSource>(
             contributions: lns_artifact::merge::own_egress(&def.spec),
         });
     }
-    let fetched = collect(&def.spec.mixins, extra, home, source).await?;
+    let decided = local
+        .as_ref()
+        .map(|local| (local.spec.mixins.clone(), local.home.clone()));
+    let fetched = collect(
+        &def.spec.mixins,
+        extra,
+        decided
+            .as_ref()
+            .map(|(references, decided_in)| (references.as_slice(), decided_in)),
+        home,
+        source,
+    )
+    .await?;
     let mut root = def.spec.clone();
     root.mixins = fetched.pinned_roots;
-    let sources = flatten(&root, &fetched.pinned_extra, None, &fetched.graph)?;
+    let local = local.map(|mut local| {
+        local.spec.mixins = fetched.pinned_local.clone();
+        local
+    });
+    let sources = flatten(
+        &root,
+        &fetched.pinned_extra,
+        local.as_ref().map(|local| Source {
+            label: &local.label,
+            spec: &local.spec,
+        }),
+        &fetched.graph,
+    )?;
     let merged = merge(&sources)?;
     let document = document(&def, &merged.spec)?;
     refuse_what_no_sandbox_could_be(&document, &sources)?;
@@ -289,7 +357,7 @@ pub fn refuse_mixins_without_a_document(extra: &[String]) -> Result<()> {
 /// Cache every mixin a pulled one names, so a digest-pinned graph pulled once resolves offline afterwards; answers with how many documents it read.
 pub async fn warm<S: MixinSource>(roots: &[String], source: &S) -> Result<usize> {
     let home = Locator::Reference(String::new());
-    let fetched = collect(roots, &[], &home, source).await?;
+    let fetched = collect(roots, &[], None, &home, source).await?;
     Ok(fetched.graph.len())
 }
 
@@ -393,6 +461,10 @@ mod tests {
     }
 
     /// Every scenario here resolves a published document unless it says otherwise.
+    fn decided_in(dir: &str) -> Locator {
+        Locator::Directory(std::path::PathBuf::from(dir))
+    }
+
     fn published() -> Locator {
         Locator::Reference("registry.example.test/team/sandbox:1".to_string())
     }
@@ -434,7 +506,7 @@ mod tests {
             .iter()
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
-        let out = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs)).await?;
+        let out = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs), None).await?;
         lns_artifact::sandbox::parse(&out.document)
     }
 
@@ -448,7 +520,7 @@ mod tests {
             .iter()
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
-        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs), None)
             .await
             .expect("a declared mixin resolves");
         let wire = on_the_wire(&resolution.contributions);
@@ -480,7 +552,7 @@ mod tests {
             .iter()
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
-        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+        let resolution = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs), None)
             .await
             .expect("a mixin declaring every block resolves");
         let wire = on_the_wire(&resolution.contributions);
@@ -511,6 +583,7 @@ mod tests {
             &[],
             &published(),
             &source,
+            None,
         )
         .await
         .expect_err("a tag a published document declares resolves differently for each consumer");
@@ -538,7 +611,7 @@ mod tests {
             .iter()
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
-        let err = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs))
+        let err = resolve(&sandbox(&spec), &[], &published(), &Fake::new(&refs), None)
             .await
             .expect_err("a pinned mixin naming a tag reopens exactly what pinning it closed");
         assert!(
@@ -551,7 +624,7 @@ mod tests {
     async fn a_document_with_no_mixins_is_returned_untouched() {
         let source = Fake::new(&[]);
         let original = sandbox(r#"{"image":"x:1"}"#);
-        let out = resolve(&original, &[], &published(), &source)
+        let out = resolve(&original, &[], &published(), &source, None)
             .await
             .unwrap();
         assert_eq!(
@@ -572,7 +645,7 @@ mod tests {
     #[tokio::test]
     async fn a_plain_image_is_passed_through_without_a_fetch() {
         let source = Fake::new(&[]);
-        let out = resolve_if_a_sandbox(None, None, b"{}", &[], &published(), &source)
+        let out = resolve_if_a_sandbox(None, None, b"{}", &[], &published(), &source, None)
             .await
             .expect("an image has no document to merge");
         assert_eq!(out.document, b"{}");
@@ -595,6 +668,7 @@ mod tests {
             &[],
             &published(),
             &Fake::new(&[]),
+            None,
         )
         .await
         .expect("a sandbox resolves");
@@ -652,7 +726,7 @@ mod tests {
             .map(|(r, b)| (r.as_str(), b.as_str()))
             .collect();
         let source = Fake::new(&refs);
-        let resolution = resolve(&sandbox(&spec), &[], &published(), &source)
+        let resolution = resolve(&sandbox(&spec), &[], &published(), &source, None)
             .await
             .expect("a diamond resolves");
         let shared = pinned("shared");
@@ -677,6 +751,7 @@ mod tests {
             &[],
             &published(),
             &Fake::new(&[]),
+            None,
         )
         .await
         .unwrap_err();
@@ -702,6 +777,7 @@ mod tests {
             &[],
             &published(),
             &source,
+            None,
         )
         .await
         .unwrap_err();
@@ -718,6 +794,7 @@ mod tests {
             &[],
             &published(),
             &Fake::new(&[]),
+            None,
         )
         .await
         .unwrap_err();
@@ -765,7 +842,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_document_that_will_not_parse_is_blamed_on_itself_and_not_on_its_mixins() {
-        let err = resolve(b"{}", &[], &published(), &Fake::new(&[]))
+        let err = resolve(b"{}", &[], &published(), &Fake::new(&[]), None)
             .await
             .unwrap_err();
         assert!(
@@ -797,6 +874,7 @@ mod tests {
             &[pinned("m")],
             &published(),
             &Fake::new(&[]),
+            None,
         )
         .await
         .unwrap_err();
@@ -817,6 +895,7 @@ mod tests {
             &[],
             &published(),
             &source,
+            None,
         )
         .await
         .expect("a document may pin a mixin in any form the registry accepts");
@@ -837,6 +916,7 @@ mod tests {
             &[tagged.to_string()],
             &published(),
             &source,
+            None,
         )
         .await
         .expect("a tag resolves");
@@ -875,6 +955,7 @@ mod tests {
             &[],
             &Locator::Directory(std::path::PathBuf::from("/work")),
             &source,
+            None,
         )
         .await
         .expect("each mixin roots its own references");
@@ -893,6 +974,7 @@ mod tests {
             &["./mixins/pg".to_string()],
             &Locator::Directory(std::path::PathBuf::from("/work")),
             &Fake::new(&[]),
+            None,
         )
         .await
         .unwrap_err();
@@ -910,6 +992,7 @@ mod tests {
             &["/work/mixins/./pg".to_string()],
             &Locator::Directory(std::path::PathBuf::from("/work")),
             &source,
+            None,
         )
         .await
         .expect("a directory the user named beside their own definition is theirs to merge");
@@ -1016,6 +1099,7 @@ mod tests {
             &[],
             &published(),
             &Fake::new(&[]),
+            None,
         )
         .await
         .expect("a document with no mixins resolves to itself");
@@ -1029,6 +1113,97 @@ mod tests {
                 lns_artifact::merge::ROOT_LABEL
             )],
             "§1.5 has a run disclose every rule it will enforce, and a run that pulled no mixin enforces these"
+        );
+    }
+
+    #[test]
+    fn a_decisions_file_that_is_no_mixin_refuses_the_run_naming_the_file() {
+        let err = LocalSource::read(
+            Some(FetchedMixin {
+                pinned: "lns-local-mixin.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"x","spec":{"image":"x:1"}}"#.to_string(),
+            }),
+            decided_in("/work"),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("lns-local-mixin.yaml"),
+            "a run that dropped a decisions file it could not read would boot without what the developer decided; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_directory_that_decided_only_destinations_contributes_nothing_to_the_merge() {
+        let local = LocalSource::read(
+            Some(FetchedMixin {
+                pinned: "lns-local-mixin.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#.to_string(),
+            }),
+            decided_in("/work"),
+        )
+        .expect("a written file reads")
+        .expect("a written file contributes");
+        assert!(
+            local.decides_nothing(),
+            "egress reaches the guest live, so a file holding only egress leaves the merge with nothing to do"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_directory_the_decisions_file_names_is_read_beside_that_file() {
+        let source = Fake::new(&[("/decisions/tools", r#"{"tools":["ripgrep@14"]}"#)]);
+        let local = LocalSource::read(
+            Some(FetchedMixin {
+                pinned: "lns-local-mixin.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"mixins":["./tools"]}}"#.to_string(),
+            }),
+            decided_in("/decisions"),
+        )
+        .expect("a written file reads")
+        .expect("a written file contributes");
+
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1"}"#),
+            &[],
+            &published(),
+            &source,
+            Some(local),
+        )
+        .await
+        .expect("a directory beside the decisions file is one this machine read");
+        assert!(
+            String::from_utf8_lossy(&out.document).contains("ripgrep@14"),
+            "§3.3.1 roots a declared entry at the directory of the document that named it, and that document is the decisions file; got: {}",
+            String::from_utf8_lossy(&out.document)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_decisions_file_kept_outside_the_project_still_roots_its_own_references() {
+        let source = Fake::new(&[("/decisions/tools", r#"{"tools":["ripgrep@14"]}"#)]);
+        let local = LocalSource::read(
+            Some(FetchedMixin {
+                pinned: "dev.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"dev","spec":{"mixins":["./tools"]}}"#.to_string(),
+            }),
+            decided_in("/decisions"),
+        )
+        .expect("a written file reads")
+        .expect("a written file contributes");
+
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1"}"#),
+            &[],
+            &decided_in("/projdir"),
+            &source,
+            Some(local),
+        )
+        .await
+        .expect("a --policy file elsewhere still names directories beside itself");
+        assert!(
+            String::from_utf8_lossy(&out.document).contains("ripgrep@14"),
+            "rooting at the project instead would merge whatever /projdir/tools happens to hold; got: {}",
+            String::from_utf8_lossy(&out.document)
         );
     }
 }

--- a/crates/lns-service/src/artifact/mixin_dir.rs
+++ b/crates/lns-service/src/artifact/mixin_dir.rs
@@ -18,11 +18,38 @@ pub fn read_directory_mixin<D: MixinDir>(dir: &D, path: &Path) -> Result<Fetched
     let yaml = dir
         .read(&document)
         .with_context(|| format!("reading {}", document.display()))?;
+    parse_document(&yaml, &document, path, path.display().to_string())
+}
+
+/// Read the directory's own decisions, which every run there resolves without being named (`docs/sandbox-spec.md` §8.1); a directory nobody has decided anything in has none to read.
+pub fn read_local_mixin<D: MixinDir>(dir: &D, file: &Path) -> Result<Option<FetchedMixin>> {
+    let yaml = match dir.read(file) {
+        Ok(yaml) => yaml,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(anyhow::Error::new(e).context(format!("reading {}", file.display()))),
+    };
+    if yaml.trim().is_empty() {
+        return Ok(None);
+    }
+    let label = file
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| file.display().to_string());
+    parse_document(&yaml, file, file.parent().unwrap_or(Path::new(".")), label).map(Some)
+}
+
+/// Parse one document off this machine, rooting the paths it writes against the directory it was written in.
+fn parse_document(
+    yaml: &str,
+    document: &Path,
+    root: &Path,
+    pinned: String,
+) -> Result<FetchedMixin> {
     let mut parsed: serde_json::Value =
-        serde_yaml::from_str(&yaml).with_context(|| format!("parsing {}", document.display()))?;
-    root_relative_paths(&mut parsed, path);
+        serde_yaml::from_str(yaml).with_context(|| format!("parsing {}", document.display()))?;
+    root_relative_paths(&mut parsed, root);
     Ok(FetchedMixin {
-        pinned: path.display().to_string(),
+        pinned,
         document: serde_json::to_string(&parsed).context("serializing the mixin")?,
     })
 }
@@ -203,6 +230,94 @@ mod tests {
         let err = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap_err();
         assert!(
             format!("{err:#}").contains("parsing /work/mixins/pg/lns.yaml"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_directory_nobody_has_decided_anything_in_contributes_nothing() {
+        assert!(
+            read_local_mixin(
+                &Fake(BTreeMap::new()),
+                Path::new("/work/lns-local-mixin.yaml")
+            )
+            .unwrap()
+            .is_none(),
+            "§8.1 has the mixin exist whether or not anyone created it, so an absent file is not an error"
+        );
+    }
+
+    #[test]
+    fn a_decisions_file_an_editor_has_truncated_contributes_nothing() {
+        let dir = holding("/work/lns-local-mixin.yaml", "  \n");
+        assert!(
+            read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+                .unwrap()
+                .is_none(),
+            "an editor truncates a file before it writes one, and a run that caught it mid-write must not refuse"
+        );
+    }
+
+    #[test]
+    fn the_decisions_file_is_named_by_the_file_it_is() {
+        let dir = holding(
+            "/work/lns-local-mixin.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  tools:\n    - ripgrep@14\n",
+        );
+        let fetched = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+            .unwrap()
+            .expect("a written file contributes");
+        assert_eq!(
+            fetched.pinned, "lns-local-mixin.yaml",
+            "nothing names this source, so a disclosure attributes it by the file it is"
+        );
+        assert!(
+            fetched.document.contains(r#""ripgrep@14""#),
+            "got: {}",
+            fetched.document
+        );
+    }
+
+    #[test]
+    fn a_path_the_decisions_file_writes_is_rooted_in_its_own_directory() {
+        let dir = holding(
+            "/work/lns-local-mixin.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  filesets:\n    - path: ./notes\n      mountPath: /home/agent/notes\n",
+        );
+        let fetched = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+            .unwrap()
+            .expect("a written file contributes");
+        assert!(
+            fetched.document.contains(r#""/work/notes""#),
+            "a relative path is written against the directory the file sits in; got: {}",
+            fetched.document
+        );
+    }
+
+    #[test]
+    fn a_decisions_file_that_cannot_be_read_says_so_rather_than_deciding_nothing() {
+        struct Denied;
+        impl MixinDir for Denied {
+            fn read(&self, _: &Path) -> std::io::Result<String> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "denied",
+                ))
+            }
+        }
+        let err = read_local_mixin(&Denied, Path::new("/work/lns-local-mixin.yaml")).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("/work/lns-local-mixin.yaml"),
+            "a file that exists and cannot be read is not a directory that decided nothing; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_decisions_file_that_is_not_yaml_names_the_file_it_could_not_parse() {
+        let dir = holding("/work/lns-local-mixin.yaml", "\tnot: [valid");
+        let err = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml")).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("parsing /work/lns-local-mixin.yaml"),
             "got: {err:#}"
         );
     }

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -141,6 +141,7 @@ pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> Resolve
                 egress: def.spec.egress.clone(),
             },
             connectors: def.spec.connectors.clone(),
+            ..lns_policy::Policy::default()
         }),
         credentials: def.spec.credentials.clone(),
         tools: def.spec.tools.clone(),

--- a/crates/lns-service/src/artifact/policy.rs
+++ b/crates/lns-service/src/artifact/policy.rs
@@ -128,6 +128,7 @@ pub fn merge_effective(baseline: Option<&Policy>, overlay: &Policy) -> Policy {
             },
         },
         connectors: overlay.connectors.clone(),
+        ..Policy::default()
     }
 }
 

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -334,7 +334,7 @@ fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     if policy.network != lns_policy::NetworkPolicy::default() {
         crate::log::info!(
             "policy",
-            "this sandbox ships a network policy; it governs the run except where your own lns-policy.yaml decides otherwise"
+            "this sandbox ships a network policy; it governs the run except where your own lns-local-mixin.yaml decides otherwise"
         );
         let summary =
             crate::artifact::policy::run_summary(&crate::artifact::policy::guardrail_flags(policy));

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -22,6 +22,7 @@ pub(crate) async fn peek_and_plan(
     mixins: &[String],
     run_id: &str,
     microvm: &str,
+    decisions: Option<&std::path::Path>,
 ) -> Result<Option<SandboxPlan>> {
     let reference: Reference = image_ref
         .parse()
@@ -50,6 +51,7 @@ pub(crate) async fn peek_and_plan(
                 mixins,
                 &crate::artifact::mixin::Locator::Reference(image_ref.to_string()),
                 &RegistryMixins,
+                local_source(decisions)?,
             )
             .await
             .with_context(|| format!("resolving {image_ref}"))?
@@ -171,6 +173,20 @@ pub(crate) fn refuse_unknown_connectors(policy: Option<&lns_policy::Policy>) -> 
         return Ok(());
     }
     anyhow::bail!(crate::credential_flow::connectors::unknown_connectors_refusal(&unknown))
+}
+
+/// The directory's own decisions as a merge source, read off this machine; a run that named no decisions file resolves without one.
+fn local_source(
+    decisions: Option<&std::path::Path>,
+) -> Result<Option<crate::artifact::mixin::LocalSource>> {
+    let Some(path) = decisions else {
+        return Ok(None);
+    };
+    let decided_in = path.parent().unwrap_or(std::path::Path::new("."));
+    crate::artifact::mixin::LocalSource::read(
+        crate::artifact::mixin_dir::read_local_mixin(&RealMixinDir, path)?,
+        crate::artifact::mixin::Locator::Directory(lns_artifact::sandbox::fold_path(decided_in)),
+    )
 }
 
 /// Reads a directory mixin off this machine's filesystem.
@@ -356,14 +372,20 @@ pub(crate) async fn resolve_definition(
     definition: &str,
     project_dir: &str,
     mixins: &[String],
+    decisions: Option<&std::path::Path>,
 ) -> Result<lns_ipc::Response> {
     let project_dir = std::path::Path::new(project_dir);
     crate::artifact::mixin::require_a_rooted_project_dir(project_dir)?;
     let home = crate::artifact::mixin::Locator::Directory(project_dir.to_path_buf());
-    let resolution =
-        crate::artifact::mixin::resolve(definition.as_bytes(), mixins, &home, &RegistryMixins)
-            .await
-            .with_context(|| format!("resolving the definition in {}", project_dir.display()))?;
+    let resolution = crate::artifact::mixin::resolve(
+        definition.as_bytes(),
+        mixins,
+        &home,
+        &RegistryMixins,
+        local_source(decisions)?,
+    )
+    .await
+    .with_context(|| format!("resolving the definition in {}", project_dir.display()))?;
     Ok(lns_ipc::Response::DefinitionResolved {
         definition: String::from_utf8(resolution.document)
             .context("the resolved definition is not utf-8")?,
@@ -373,7 +395,11 @@ pub(crate) async fn resolve_definition(
     })
 }
 
-pub(crate) async fn inspect(image_ref: &str, mixins: &[String]) -> Result<ArtifactInspection> {
+pub(crate) async fn inspect(
+    image_ref: &str,
+    mixins: &[String],
+    decisions: Option<&std::path::Path>,
+) -> Result<ArtifactInspection> {
     let reference: Reference = image_ref
         .parse()
         .with_context(|| format!("invalid image reference {image_ref}"))?;
@@ -391,6 +417,7 @@ pub(crate) async fn inspect(image_ref: &str, mixins: &[String]) -> Result<Artifa
         mixins,
         &crate::artifact::mixin::Locator::Reference(image_ref.to_string()),
         &RegistryMixins,
+        local_source(decisions)?,
     )
     .await
     .with_context(|| format!("resolving {image_ref}"))?;

--- a/crates/lns-service/src/credential_flow/connectors.rs
+++ b/crates/lns-service/src/credential_flow/connectors.rs
@@ -75,7 +75,7 @@ pub fn applied_connector_routes(ids: &[String], catalog: &[Connector]) -> Vec<Ro
         .collect()
 }
 
-/// Definition-declared ids the effective catalog cannot arm; each refuses the launch, unlike a stale `lns-policy.yaml` id which stays a tolerant skip.
+/// Definition-declared ids the effective catalog cannot arm; each refuses the launch, unlike a stale `lns-local-mixin.yaml` id which stays a tolerant skip.
 pub fn unknown_connector_ids(declared: &[String], catalog: &[Connector]) -> Vec<String> {
     let known: HashSet<&str> = catalog.iter().map(|i| i.id.as_str()).collect();
     declared

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -1,4 +1,4 @@
-//! The credential-rule source of truth lives in `~/.lns-credentials.json`, not `lns-policy.yaml`.
+//! The credential-rule source of truth lives in `~/.lns-credentials.json`, not `lns-local-mixin.yaml`.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -340,7 +340,7 @@ impl CredentialSession {
         self
     }
 
-    /// The value keys of the run's artifact-declared credentials, which `lns-policy.yaml` has no authority over — a policy reload retains their live arming rather than revoking it, whether the credential was granted at boot or consented at first use.
+    /// The value keys of the run's artifact-declared credentials, which `lns-local-mixin.yaml` has no authority over — a policy reload retains their live arming rather than revoking it, whether the credential was granted at boot or consented at first use.
     pub fn with_declared_ids(mut self, declared: HashSet<String>) -> Self {
         self.declared_ids = declared;
         self
@@ -4252,7 +4252,7 @@ mod tests {
                 )),
             "while connected, the stored value arms"
         );
-        // `lns connector disconnect` drops the id from lns-policy.yaml; the reload reconciles with the remaining connectors.
+        // `lns connector disconnect` drops the connection from the sidecar; the reload reconciles with the remaining connectors.
         session.reconcile_armed(&[], &[]);
         assert!(
             wire_injections(&session, "some-provider")

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -226,13 +226,28 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             definition,
             project_dir,
             mixins,
+            decisions,
         } => image_response(
-            crate::artifact::real::resolve_definition(definition, project_dir, mixins).await,
+            crate::artifact::real::resolve_definition(
+                definition,
+                project_dir,
+                mixins,
+                decisions.as_deref().map(std::path::Path::new),
+            )
+            .await,
         ),
-        Request::InspectImage { image, mixins } => image_response(
-            crate::artifact::real::inspect(image, mixins)
-                .await
-                .map(|inspection| Response::ImageInspected { inspection }),
+        Request::InspectImage {
+            image,
+            mixins,
+            decisions,
+        } => image_response(
+            crate::artifact::real::inspect(
+                image,
+                mixins,
+                decisions.as_deref().map(std::path::Path::new),
+            )
+            .await
+            .map(|inspection| Response::ImageInspected { inspection }),
         ),
         Request::TagImage { from, to } => {
             image_response(crate::image_store::tag(from, to).await.map(|()| {
@@ -2122,6 +2137,7 @@ mod tests {
                     definition: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1"}}"#.into(),
                     project_dir: "/work".into(),
                     mixins: Vec::new(),
+                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -2150,6 +2166,7 @@ mod tests {
                     definition: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1","mixins":["./mixins/pg"]}}"#.into(),
                     project_dir: "work".into(),
                     mixins: Vec::new(),
+                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -2173,6 +2190,7 @@ mod tests {
                     definition: "{}".into(),
                     project_dir: "/work".into(),
                     mixins: Vec::new(),
+                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -2195,6 +2213,7 @@ mod tests {
                 &Request::InspectImage {
                     image: "###".into(),
                     mixins: Vec::new(),
+                    decisions: None,
                 },
                 Instant::now(),
             )

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -90,6 +90,7 @@ async fn orchestrate(
                 &args.mixins,
                 &run_id,
                 &microvm,
+                policy.as_deref(),
             )
             .await?
         }

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -1383,7 +1383,7 @@ mod tests {
     }
 
     fn seeded_sidecar(dir: &std::path::Path, policy_path: &Path) -> JsonFileGrantStore {
-        std::fs::write(policy_path, "network: {}\n").expect("policy");
+        Policy::default().save_atomic(policy_path).expect("policy");
         let store = JsonFileGrantStore::new(dir.join("grants.json"));
         store
             .update(&mut |file| {
@@ -1400,7 +1400,7 @@ mod tests {
     #[serial_test::serial(env)]
     fn revocations_before_gate_reads_only_this_projects_counts() {
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let policy_path = dir.path().join("lns-policy.yaml");
+        let policy_path = dir.path().join("lns-local-mixin.yaml");
         seeded_sidecar(dir.path(), &policy_path);
         let _g = crate::test_env::EnvVarGuard::set(
             "LNS_WORKLOAD_GRANTS_PATH",
@@ -1425,7 +1425,7 @@ mod tests {
         let _g = crate::test_env::EnvVarGuard::set("LNS_WORKLOAD_GRANTS_PATH", &sidecar);
 
         assert!(
-            revocations_before_gate(&dir.path().join("lns-policy.yaml")).is_empty(),
+            revocations_before_gate(&dir.path().join("lns-local-mixin.yaml")).is_empty(),
             "a corrupt sidecar must not stop a launch here; the write that follows surfaces the same corruption with something the developer can act on"
         );
     }

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -569,8 +569,8 @@ mod tests {
             EnvVarGuard::unset("LNS_WORKLOAD_GRANTS_PATH"),
             EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin),
         ];
-        let policy_path = dir.path().join("lns-policy.yaml");
-        std::fs::write(&policy_path, "network:\n  egress:\n    http: []\n").expect("policy");
+        let policy_path = dir.path().join("lns-local-mixin.yaml");
+        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n").expect("policy");
         lns_policy::connectors::Catalog {
             connectors: vec![lns_policy::connectors::Connector {
                 id: "some-oauth".into(),
@@ -701,8 +701,8 @@ mod tests {
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);
-        let policy_path = d.path().join("lns-policy.yaml");
-        std::fs::write(&policy_path, "network:\n  egress:\n    http: []\n").expect("policy");
+        let policy_path = d.path().join("lns-local-mixin.yaml");
+        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n").expect("policy");
 
         let result = SupervisorSession::start(
             "deadbeef00000000000000000000aa99".to_string(),
@@ -732,8 +732,8 @@ mod tests {
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);
-        let policy_path = d.path().join("lns-policy.yaml");
-        std::fs::write(&policy_path, "network:\n  egress:\n    http: []\n").expect("policy");
+        let policy_path = d.path().join("lns-local-mixin.yaml");
+        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n").expect("policy");
         let mut sandbox_policy = lns_policy::Policy::default();
         sandbox_policy.add_rule(lns_policy::RouteRule::deny_host("api.example.test"));
 

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -192,7 +192,7 @@ pub fn run_headless(
     ipc_handle: JoinHandle<anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
     crate::log::warn!(
-        "no display detected — running headless without the tray; interactive approval prompts can't be shown, so pre-authorize access in lns-policy.yaml"
+        "no display detected — running headless without the tray; interactive approval prompts can't be shown, so pre-authorize access in lns-local-mixin.yaml"
     );
     shutdown.wait_sync();
     match ipc_handle.join() {

--- a/crates/lns-service/tests/behaviours/approval_flow.feature
+++ b/crates/lns-service/tests/behaviours/approval_flow.feature
@@ -28,11 +28,11 @@ Feature: lns-service approval flow
     And a future request to "api.linear.app" prompts again
 
   Scenario: Always allow writes a rule to the policy file and hot-swaps the running policy
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And the policy has no rule for "api.linear.app"
     And an approval entry is visible for a request to "api.linear.app"
     When the developer picks "always allow"
-    Then "lns-policy.yaml" contains a new allow rule for "api.linear.app"
+    Then "lns-local-mixin.yaml" contains a new allow rule for "api.linear.app"
     And the running policy contains the same rule
     And the workload's request proceeds
     And a future request to "api.linear.app" is allowed without prompting
@@ -55,11 +55,11 @@ Feature: lns-service approval flow
     And a future request to "api.linear.app" prompts again
 
   Scenario: Always deny writes a deny rule to the policy file and hot-swaps the running policy
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And the policy has no rule for "api.linear.app"
     And an approval entry is visible for a request to "api.linear.app"
     When the developer picks "always deny"
-    Then "lns-policy.yaml" contains a new deny rule for "api.linear.app"
+    Then "lns-local-mixin.yaml" contains a new deny rule for "api.linear.app"
     And the running policy contains the same rule
     And the workload's request is denied always
     And a future request to "api.linear.app" is denied without prompting
@@ -93,8 +93,8 @@ Feature: lns-service approval flow
     And no restart of the workload is required
 
   Scenario: A manual edit to the policy file hot-swaps the running policy
-    Given a workload is running with "lns-policy.yaml" loaded
-    When the developer edits "lns-policy.yaml" to add an allow rule for "api.linear.app"
+    Given a workload is running with "lns-local-mixin.yaml" loaded
+    When the developer edits "lns-local-mixin.yaml" to add an allow rule for "api.linear.app"
     Then a subsequent request from the workload to "api.linear.app" is allowed without prompting
     And no restart of the workload is required
 
@@ -103,29 +103,29 @@ Feature: lns-service approval flow
   # match, so writing the second answer behind it would be a line that never fires —
   # and silence would leave the developer believing their deny stuck.
   Scenario: A second, contradicting always-decision is not written behind the rule the first one wrote
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And an approval entry is visible for a request to "api.example.test"
     When the developer picks "always allow"
     And the workload makes a request to "api.example.test"
     And the developer picks "always deny"
-    Then "lns-policy.yaml" contains a new allow rule for "api.example.test"
-    And "lns-policy.yaml" holds no deny rule for "api.example.test"
+    Then "lns-local-mixin.yaml" contains a new allow rule for "api.example.test"
+    And "lns-local-mixin.yaml" holds no deny rule for "api.example.test"
     And the approval window informs the developer that a rule already decides the destination
 
   # A raw splice is passed through untouched, so the rule has to name the port the
   # developer was shown; the bare host would grant every other port on that host too.
   Scenario: Always allow on a raw splice writes the port-scoped destination to the raw table
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always allow"
-    Then "lns-policy.yaml" contains a new raw allow rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a new raw allow rule for "db.internal:5432"
     And the workload's request proceeds
 
   Scenario: Always deny on a raw splice writes a raw deny rule
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always deny"
-    Then "lns-policy.yaml" contains a new raw deny rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a new raw deny rule for "db.internal:5432"
     And the workload's request is denied always
 
   # The developer's own file can already hold the answer they just gave, stranded behind
@@ -133,7 +133,7 @@ Feature: lns-service approval flow
   # bigger surprise, so the card keeps coming back — but they have to be told why, or
   # "always allow" reads as remembered while nothing changed.
   Scenario: An always-decision the file already holds behind another rule is reported, not silently dropped
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And the policy denies "*.example.test" and holds an allow rule for "api.example.test" behind that
     And an approval entry is visible for a request to "api.example.test"
     When the developer picks "always allow"
@@ -143,21 +143,21 @@ Feature: lns-service approval flow
   # The raw table is the pre-filter, so an approved splice takes the destination over
   # from the HTTP rules naming that host — silently, unless the card says so.
   Scenario: Approving a raw splice says which HTTP rule stops applying to it
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And the policy allows "db.internal"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always allow"
-    Then "lns-policy.yaml" contains a new raw allow rule for "db.internal:5432"
+    Then "lns-local-mixin.yaml" contains a new raw allow rule for "db.internal:5432"
     And the approval window informs the developer that the HTTP rule for "db.internal" no longer applies
 
   # One unparseable rule force-denies the whole policy inside the guest, so a
   # destination we cannot express has to leave the file alone and say so.
   Scenario: A raw destination that cannot be expressed as a rule is not written to the policy file
-    Given the sandbox was launched with --policy "lns-policy.yaml"
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
     And an approval entry is visible for a raw splice to "db.internal"
     When the developer picks "always allow"
     Then the workload's request proceeds
-    And the raw table in "lns-policy.yaml" stays empty
+    And the raw table in "lns-local-mixin.yaml" stays empty
     And the approval window informs the developer that the destination could not be turned into a rule
 
   Scenario: A failed policy-file write keeps the rule in memory and notifies the developer

--- a/crates/lns-service/tests/behaviours/approval_rig.rs
+++ b/crates/lns-service/tests/behaviours/approval_rig.rs
@@ -77,7 +77,7 @@ pub struct ApprovalRig {
 impl ApprovalRig {
     pub fn new() -> Self {
         let dir = TempDir::new().expect("create tempdir");
-        let policy_path = dir.path().join("lns-policy.yaml");
+        let policy_path = dir.path().join("lns-local-mixin.yaml");
         let notifier = Arc::new(TestNotifier::default());
         let store = Arc::new(FlakyStore::new(policy_path.clone()));
         let (tx, rx) = mpsc::unbounded_channel();

--- a/crates/lns-service/tests/behaviours/credential_flow.feature
+++ b/crates/lns-service/tests/behaviours/credential_flow.feature
@@ -14,7 +14,7 @@ Feature: lns-service credential flow
   dismissing a card is not a decision and settles nothing.
   Decisions and any typed values land in `~/.lns-credentials.json` (a
   pluggable host-side store, JSON-file v1). They do NOT live in
-  `lns-policy.yaml`: the shareable policy file stays free of
+  `lns-local-mixin.yaml`: the shareable policy file stays free of
   per-machine credential state. Manual edits to
   `~/.lns-credentials.json` are picked up live and double as the
   revocation mechanism.
@@ -61,7 +61,7 @@ Feature: lns-service credential flow
     And the workload's request leaves the boundary with the host-detected some-provider credential substituted in
     And the workload still sees only the placeholder
     And a future request carrying the some-provider placeholder is exchanged silently using the currently host-detected value
-    And "lns-policy.yaml" is unchanged
+    And "lns-local-mixin.yaml" is unchanged
 
   Scenario: A typed value arms the credential at the boundary and persists a stored rule
     Given a credential card for "some-provider" is visible
@@ -69,7 +69,7 @@ Feature: lns-service credential flow
     Then "~/.lns-credentials.json" gains an entry for "some-provider" with kind "stored" carrying the typed value
     And the workload's request leaves the boundary with the typed value substituted for the placeholder
     And a future request carrying the some-provider placeholder is exchanged silently using the stored value
-    And "lns-policy.yaml" is unchanged
+    And "lns-local-mixin.yaml" is unchanged
 
   Scenario: A value already bound on this machine is granted without binding it again
     Given a value for "some-provider" is bound on this machine but this workload holds no grant
@@ -94,7 +94,7 @@ Feature: lns-service credential flow
     Then the workload grant sidecar records a deny for "some-provider"
     And the workload's held request is failed at the boundary
     And a future request carrying the some-provider placeholder is failed at the boundary without prompting
-    And "lns-policy.yaml" is unchanged
+    And "lns-local-mixin.yaml" is unchanged
 
   Scenario: Closing a credential card decides nothing and asks again on the next use
     Given a credential card for "some-provider" is visible

--- a/crates/lns-service/tests/behaviours/declared_connectors.feature
+++ b/crates/lns-service/tests/behaviours/declared_connectors.feature
@@ -8,7 +8,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   stays reactive and per-directory: the first time the workload reaches
   the connector's domain it is offered a live connect, and accepting it
   arms the connector and records the id in this directory's
-  `lns-policy.yaml`. Only a connector the user has connected in this
+  `lns-local-mixin.yaml`. Only a connector the user has connected in this
   directory (the overlay) arms at launch. A sandbox that must have a
   credential declares a `spec.credentials` slot instead (see
   credential_at_boot.feature). Real secrets never enter the artifact or the
@@ -17,7 +17,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A declared connector seeds its placeholder but is not armed, only offered
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     When the sandbox is launched
     Then the workload's environment contains the "SOME_TOKEN" placeholder
     And the running policy does not allow the "api.some-provider.example" route
@@ -26,7 +26,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A published sandbox's declared connectors seed their placeholder, offered not armed
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN"
     And a published sandbox artifact declares connector "some-provider"
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     When the published sandbox is launched
     Then the workload's environment contains the "SOME_TOKEN" placeholder
     And "some-provider" is offered for a reactive connect
@@ -35,7 +35,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the machine catalog has a credential connector "other-provider" managing "OTHER_TOKEN" with a route to "api.other.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     When the sandbox is launched
     Then the workload's environment does not seed the "OTHER_TOKEN" placeholder
     And "other-provider" is offered for a reactive connect
@@ -43,7 +43,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A connector connected in this directory still arms at launch
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects "some-provider"
+    And the directory's lns-local-mixin.yaml connects "some-provider"
     When the sandbox is launched
     Then the workload's environment contains the "SOME_TOKEN" placeholder
     And the running policy allows the "api.some-provider.example" route
@@ -51,7 +51,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A connected connector's machine-stored value arms at the boundary at launch
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects "some-provider"
+    And the directory's lns-local-mixin.yaml connects "some-provider"
     And the per-machine credential store has a stored value for "some-provider"
     When the sandbox is launched
     Then the boundary injection for "some-provider" is armed with the stored value
@@ -59,7 +59,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A committed overlay this workload never granted does not arm the machine-stored value
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects "some-provider"
+    And the directory's lns-local-mixin.yaml connects "some-provider"
     And the per-machine credential store has a stored value for "some-provider"
     And this workload has no grant for "some-provider"
     When the sandbox is launched
@@ -69,7 +69,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A grant the bare run earned does not arm a run that layers a mixin onto it
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects "some-provider"
+    And the directory's lns-local-mixin.yaml connects "some-provider"
     And the per-machine credential store has a stored value for "some-provider"
     And the run composes the mixin "ghcr.io/acme/obs-tools"
     When the sandbox is launched
@@ -79,7 +79,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A declared connector's machine-stored value stays unarmed until connected
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider" and allows the "api.some-provider.example" route
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     And the per-machine credential store has a stored value for "some-provider"
     When the sandbox is launched
     Then the workload's environment contains the "SOME_TOKEN" placeholder
@@ -91,7 +91,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the machine catalog has a credential connector "other-provider" managing "OTHER_TOKEN" with a route to "api.other.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     And the per-machine credential store has a stored value for "other-provider"
     When the sandbox is launched
     Then the boundary injection for "other-provider" stays unarmed
@@ -99,7 +99,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: A declared connector does not open a route past a local deny-by-default
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares connector "some-provider"
-    And the directory's lns-policy.yaml denies all by default
+    And the directory's lns-local-mixin.yaml denies all by default
     When the sandbox is launched
     Then a workload request to "api.some-provider.example" is denied by policy
 
@@ -114,13 +114,13 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
   Scenario: Accepting a reactive connect persists to the directory policy, never the definition
     Given a launched sandbox whose definition declares connector "some-provider"
     When the developer approves a new destination "api.example.test" with "always allow"
-    Then the allow rule is written to the directory's lns-policy.yaml
+    Then the allow rule is written to the directory's lns-local-mixin.yaml
     And the sandbox definition is not modified
 
   Scenario: A declared credential does not open a route past a local deny-by-default
     Given the machine catalog has a credential connector "some-provider" managing "SOME_TOKEN" with a route to "api.some-provider.example"
     And the sandbox definition declares a credential "SOME_TOKEN" for "api.some-provider.example"
-    And the directory's lns-policy.yaml denies all by default
+    And the directory's lns-local-mixin.yaml denies all by default
     When the sandbox is launched
     Then a workload request to "api.some-provider.example" is denied by policy
 
@@ -128,7 +128,7 @@ Feature: a sandbox definition's declared connectors seed their placeholder but s
     Given the machine catalog has a credential connector "some-primary" managing "PRIMARY_TOKEN" with a route to "api.shared.example"
     And the machine catalog has a credential connector "some-secondary" managing "SECONDARY_TOKEN" with a route to "api.shared.example"
     And the sandbox definition declares connector "some-primary"
-    And the directory's lns-policy.yaml connects no connectors
+    And the directory's lns-local-mixin.yaml connects no connectors
     When the sandbox is launched
     Then "some-secondary" is not offered for a reactive connect
 

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -31,6 +31,10 @@ pub struct DeclaredRig {
     pub definition_snapshot: Option<String>,
     /// Mixin documents this machine can resolve, keyed by reference.
     pub mixins: std::collections::BTreeMap<String, String>,
+    /// The document the directory's own decisions file holds, for a scenario about the source §3.3.2 puts last.
+    pub local_mixin: Option<String>,
+    /// The document the resolution produced, so a scenario can see what did and did not get merged into it.
+    pub resolved_document: Option<String>,
     /// Pinned `--mixin` references this run is composed of; the rig grants the bare identity, so a composed launch models a grant an earlier bare run earned.
     pub composed_mixins: Vec<String>,
     /// The tools the resolved document asks for, so a scenario can see what a mixin contributed.

--- a/crates/lns-service/tests/behaviours/mixin_resolution.feature
+++ b/crates/lns-service/tests/behaviours/mixin_resolution.feature
@@ -33,7 +33,7 @@ Feature: a run resolves the mixins its document declares
   Scenario: a mixin cannot open a directory that denies by default
     Given a mixin allowing "api.some-provider.example"
     And the sandbox definition declares that mixin
-    And the directory's lns-policy.yaml denies all by default
+    And the directory's lns-local-mixin.yaml denies all by default
     When the published sandbox is resolved and launched
     Then a workload request to "api.some-provider.example" is denied by policy
 

--- a/crates/lns-service/tests/behaviours/mixin_resolution.feature
+++ b/crates/lns-service/tests/behaviours/mixin_resolution.feature
@@ -24,6 +24,34 @@ Feature: a run resolves the mixins its document declares
     When the published sandbox is resolved and launched
     Then the run installs "node@22"
 
+  Scenario: what the directory decided reaches the run, after everything it pulled
+    Given a mixin declaring the tool "python@3.11"
+    And the sandbox definition declares that mixin
+    And the directory's own decisions declare the tool "python@3.12"
+    When the published sandbox is resolved and launched
+    Then the run installs "python@3.12"
+
+  Scenario: the directory's egress stays live rather than being frozen into the document
+    Given the sandbox definition declares nothing but its image
+    And the directory's own decisions allow "api.some-provider.example"
+    When the published sandbox is resolved and launched
+    Then the run installs "curl@8"
+    And the resolved document decides nothing about "api.some-provider.example"
+
+  Scenario: a directory that decided only destinations leaves the document alone
+    Given the sandbox definition declares nothing but its image
+    And the directory's own decisions allow "api.some-provider.example" and nothing else
+    When the published sandbox is resolved and launched
+    Then the run resolved no source but the sandbox itself
+
+  Scenario: a mixin the directory's decisions name merges before them
+    Given a mixin declaring the tools "node@22" and "python@3.11"
+    And the sandbox definition declares nothing but its image
+    And the directory's own decisions declare the tool "python@3.12" and that mixin
+    When the published sandbox is resolved and launched
+    Then the run installs "node@22"
+    And the run installs "python@3.12"
+
   Scenario: a mixin's egress is enforced like the sandbox's own
     Given a mixin allowing "api.some-provider.example"
     And the sandbox definition declares that mixin

--- a/crates/lns-service/tests/behaviours/steps/credential_flow.rs
+++ b/crates/lns-service/tests/behaviours/steps/credential_flow.rs
@@ -739,7 +739,7 @@ fn then_future_request_failed(world: &mut BehaviourWorld) -> Result<(), String> 
     Ok(())
 }
 
-#[then(r#""lns-policy.yaml" is unchanged"#)]
+#[then(r#""lns-local-mixin.yaml" is unchanged"#)]
 fn then_lns_policy_yaml_unchanged(_w: &mut BehaviourWorld) -> Result<(), String> {
     // no-op: no code path runs from CredentialSession to the policy file, so this holds by construction.
     Ok(())

--- a/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_connectors.rs
@@ -205,13 +205,13 @@ fn definition_declares_with_allowed_route(w: &mut BehaviourWorld, id: String, ho
     ));
 }
 
-#[given("the directory's lns-policy.yaml connects no connectors")]
+#[given("the directory's lns-local-mixin.yaml connects no connectors")]
 fn overlay_connects_nothing(w: &mut BehaviourWorld) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.overlay = Policy::default();
 }
 
-#[given(regex = r#"^the directory's lns-policy.yaml connects "([^"]+)"$"#)]
+#[given(regex = r#"^the directory's lns-local-mixin.yaml connects "([^"]+)"$"#)]
 fn overlay_connects(w: &mut BehaviourWorld, id: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.overlay.connectors.push(id);
@@ -465,7 +465,7 @@ fn launched_sandbox_declaring(w: &mut BehaviourWorld, id: String) {
     w.approval();
 }
 
-#[given("the directory's lns-policy.yaml denies all by default")]
+#[given("the directory's lns-local-mixin.yaml denies all by default")]
 fn overlay_denies_by_default(w: &mut BehaviourWorld) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.overlay.add_rule(lns_policy::RouteRule::deny_host("*"));
@@ -513,7 +513,7 @@ fn request_denied_by_policy(w: &mut BehaviourWorld, host: String) -> Result<(), 
     }
 }
 
-#[then("the allow rule is written to the directory's lns-policy.yaml")]
+#[then("the allow rule is written to the directory's lns-local-mixin.yaml")]
 fn allow_rule_written_to_policy_file(w: &mut BehaviourWorld) -> Result<(), String> {
     let rig = w.approval();
     let on_disk = Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())?;

--- a/crates/lns-service/tests/behaviours/steps/mixin_directory.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_directory.rs
@@ -64,17 +64,22 @@ async fn the_local_sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
         )
     };
     let home = lns_service::artifact::mixin::Locator::Directory(std::path::PathBuf::from(home));
-    let planned =
-        match lns_service::artifact::mixin::resolve(definition.as_bytes(), &[], &home, &installed)
-            .await
-        {
-            Ok(resolution) => {
-                let rig = w.declared.get_or_insert_with(Default::default);
-                rig.resolved_mixins.clone_from(&resolution.mixins);
-                lns_service::artifact::plan_local_sandbox(&resolution.document)
-            }
-            Err(e) => Err(e),
-        };
+    let planned = match lns_service::artifact::mixin::resolve(
+        definition.as_bytes(),
+        &[],
+        &home,
+        &installed,
+        None,
+    )
+    .await
+    {
+        Ok(resolution) => {
+            let rig = w.declared.get_or_insert_with(Default::default);
+            rig.resolved_mixins.clone_from(&resolution.mixins);
+            lns_service::artifact::plan_local_sandbox(&resolution.document)
+        }
+        Err(e) => Err(e),
+    };
     crate::steps::declared_connectors::launch_resolved(w, planned);
 }
 

--- a/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
@@ -45,6 +45,7 @@ async fn resolve_with(w: &mut BehaviourWorld, extra: &[String]) {
         extra,
         &published(),
         &installed,
+        None,
     )
     .await
     {

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -65,6 +65,11 @@ fn mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
     install(w, &format!(r#"{{"tools":["{tool}"]}}"#));
 }
 
+#[given(regex = r#"^a mixin declaring the tools "([^"]+)" and "([^"]+)"$"#)]
+fn mixin_declaring_two_tools(w: &mut BehaviourWorld, first: String, second: String) {
+    install(w, &format!(r#"{{"tools":["{first}","{second}"]}}"#));
+}
+
 #[given(regex = r#"^a mixin allowing "([^"]+)"$"#)]
 fn mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
     install(
@@ -81,6 +86,43 @@ fn mixin_declaring_a_credential(w: &mut BehaviourWorld, env_var: String, domain:
             r#"{{"credentials":[{{"envVar":"{env_var}","placeholder":"lns-placeholder-{env_var}","injections":[{{"kind":"bearer_header","domain":"{domain}"}}]}}]}}"#
         ),
     );
+}
+
+#[given(regex = r#"^the directory's own decisions declare the tool "([^"]+)"$"#)]
+fn local_mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.local_mixin = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["{tool}"]}}}}"#
+    ));
+}
+
+#[given(regex = r#"^the directory's own decisions allow "([^"]+)"$"#)]
+fn local_mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.local_mixin = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["curl@8"],"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
+    ));
+}
+
+#[given(regex = r#"^the directory's own decisions allow "([^"]+)" and nothing else$"#)]
+fn local_mixin_allowing_only_a_destination(w: &mut BehaviourWorld, host: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.local_mixin = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
+    ));
+}
+
+#[given(regex = r#"^the directory's own decisions declare the tool "([^"]+)" and that mixin$"#)]
+fn local_mixin_declaring_a_tool_and_that_mixin(w: &mut BehaviourWorld, tool: String) {
+    let rig = w.declared.get_or_insert_with(Default::default);
+    rig.local_mixin = Some(format!(
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["{tool}"],"mixins":["{MIXIN}"]}}}}"#
+    ));
+}
+
+#[given("the sandbox definition declares nothing but its image")]
+fn definition_declares_only_its_image(w: &mut BehaviourWorld) {
+    definition(w, r#"{"image":"ghcr.io/team/base:1"}"#);
 }
 
 #[given("the sandbox definition declares that mixin")]
@@ -109,27 +151,43 @@ fn definition_declares_an_unresolvable_mixin(w: &mut BehaviourWorld) {
 
 #[when("the published sandbox is resolved and launched")]
 async fn sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
-    let (definition, installed) = {
+    let (definition, installed, local) = {
         let rig = w.declared.get_or_insert_with(Default::default);
         (
             rig.definition
                 .clone()
                 .expect("a Given step must declare the definition"),
             Installed::from_rig(rig),
+            rig.local_mixin.clone(),
         )
     };
+    let local = lns_service::artifact::mixin::LocalSource::read(
+        local.map(|document| FetchedMixin {
+            pinned: "lns-local-mixin.yaml".to_string(),
+            document,
+        }),
+        Locator::Directory(std::path::PathBuf::from("/work")),
+    )
+    .expect("the directory's decisions read");
     let planned = match lns_service::artifact::mixin::resolve(
         definition.as_bytes(),
         &[],
         &published(),
         &installed,
+        local,
     )
     .await
     {
-        Ok(resolution) => lns_service::artifact::plan_published_sandbox(
-            &resolution.document,
-            "registry.example.test/some-sandbox:1",
-        ),
+        Ok(resolution) => {
+            let rig = w.declared.get_or_insert_with(Default::default);
+            rig.resolved_document =
+                Some(String::from_utf8_lossy(&resolution.document).into_owned());
+            rig.resolved_mixins.clone_from(&resolution.mixins);
+            lns_service::artifact::plan_published_sandbox(
+                &resolution.document,
+                "registry.example.test/some-sandbox:1",
+            )
+        }
         Err(e) => Err(e),
     };
     crate::steps::declared_connectors::launch_resolved(w, planned);
@@ -202,6 +260,34 @@ fn error_says_the_definition_reached_the_plan_unresolved(
     } else {
         Err(format!(
             "a run whose document still declares a mixin never merged it, so booting would drop what it contributes without a word: {error}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the resolved document decides nothing about "([^"]+)"$"#)]
+fn resolved_document_decides_nothing(w: &mut BehaviourWorld, host: String) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    let document = rig
+        .resolved_document
+        .as_ref()
+        .ok_or("the resolution produced no document")?;
+    if document.contains(&host) {
+        return Err(format!(
+            "the directory's egress reaches the gate live, so freezing a copy into the booted document would survive the developer deleting the rule; got: {document}"
+        ));
+    }
+    Ok(())
+}
+
+#[then("the run resolved no source but the sandbox itself")]
+fn run_resolved_no_other_source(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if rig.resolved_mixins.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "a directory that decided only destinations decides them live, so the merge has nothing to do and the bytes that boot are the ones that were published; got {:?}",
+            rig.resolved_mixins
         ))
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ You drive everything through one binary: the `lns` CLI.
   ports, interactive vs. detached sessions.
 - **[Example: Claude Code](examples/claude-code/)** — a complete agent recipe:
   manifest, seed config, network allowlist, and credential wiring.
-- **[Policy and approvals](policy.md)** — the `lns-policy.yaml` file, being asked
+- **[Policy and approvals](policy.md)** — the `lns-local-mixin.yaml` file, being asked
   about what no rule decides, closing a directory, the approval window, and editing
   rules with `lns policy`.
 - **[Credentials](credentials.md)** — how placeholders keep real secrets out of

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -100,7 +100,7 @@ the `./lns.yaml` definition with its command overridden.
 | `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory roots the definition's relative binds and filesets. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |
-| `--policy <PATH>`            | `lns-policy.yaml`| Policy file; auto-created with no rules if absent.                      |
+| `--policy <PATH>`            | `lns-local-mixin.yaml`| Policy file; auto-created with no rules if absent.                      |
 | `--mixin <REF>`              |                  | Merge a mixin into this run, after the ones the document declares (repeatable, in flag order — a later one wins). Takes a reference or a directory. A tag is allowed and is pinned before the run reports it; the summary shows `tag → digest`, and a directory shows its absolute path. |
 | `-w`, `--workdir <DIR>`      | `spec.workdir`, then image `WORKDIR` | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |
@@ -294,7 +294,7 @@ lns update [--force] [--dry-run]
 ## `lns policy`
 
 Edit network rules in a policy file. All subcommands accept `--policy <PATH>`
-(default `lns-policy.yaml` in the current directory).
+(default `lns-local-mixin.yaml` in the current directory).
 
 ```bash
 lns policy allow     <PATTERN> [--description <TEXT>] [--binary <PATH>]…

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -163,5 +163,5 @@ place of `credential:`) whose `flow` selects one of two shapes:
 
 - [Credentials](credentials.md) — how placeholders keep real secrets out of the
   workload, and the per-machine value decisions connectors reuse.
-- [Policy and approvals](policy.md) — the `lns-policy.yaml` file that records the
+- [Policy and approvals](policy.md) — the `lns-local-mixin.yaml` file that records the
   destinations a project decided.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -41,7 +41,7 @@ workload — see
 
 A provider's *value decision* is per-machine — it's how the real secret is bound
 on your machine. It's stored in `~/.lns-credentials.json`, separate from the
-shareable `lns-policy.yaml`, so secrets are never committed.
+shareable `lns-local-mixin.yaml`, so secrets are never committed.
 
 Decisions are made interactively, at either of two moments:
 
@@ -70,7 +70,7 @@ remembered as a per-workload deny instead — see
 Having a value bound on your machine is not the same as letting a *particular*
 workload spend it. Binding is machine-wide; the decision to spend is per
 workload. So a connector arms only where you have granted it — a copied
-`lns-policy.yaml`, or a sandbox definition that declares a connector you happen
+`lns-local-mixin.yaml`, or a sandbox definition that declares a connector you happen
 to have connected, still meets a first-use card rather than silently reaching
 for the real secret.
 
@@ -112,7 +112,7 @@ than a pasted secret it's obtained by an interactive **sign-in**
 **token set**, refreshed automatically and re-prompted when the grant can no longer be
 refreshed; a pkce connector yields a **durable key** captured through your browser,
 with no refresh or expiry. Either way it lives in the same per-machine file and is
-never written to `lns-policy.yaml`.
+never written to `lns-local-mixin.yaml`.
 
 When a workload asks for an `oauth` connector you are already signed in to, the
 card offers both: grant the connection you have, or **reconnect** — sign in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,14 +96,14 @@ lns run
   Flags:     -i -t
   Ports:     (none)
   Policy:
-    file: /Users/you/dev/my-app/lns-policy.yaml
+    file: /Users/you/dev/my-app/lns-local-mixin.yaml
     unmatched destinations: ask
     rules: none defined; anything else asks
     source: auto-created (no policy in this directory)
 ```
 
 You run Lens Sandbox from a project directory — that's where it looks for
-`lns-policy.yaml`, creating an empty one the first time. To
+`lns-local-mixin.yaml`, creating an empty one the first time. To
 give the workload your actual project files, bind-mount the directory with
 `-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for a
 portable definition use a declarative bind with `source: .`; for scratch
@@ -183,7 +183,7 @@ action (for example `CONNECT api.github.com:443`). You choose:
 
 - **Allow once** / **Deny once** — applies to this request only.
 - **Allow always** / **Deny always** — also writes a matching rule to
-  `lns-policy.yaml`, so the same question isn't asked again.
+  `lns-local-mixin.yaml`, so the same question isn't asked again.
 
 A denied request fails at the boundary the way a real network failure would — a
 refused connection or a failed DNS lookup — never a silent success.
@@ -211,7 +211,7 @@ lns uninstall --purge
 ```
 
 `--purge` keeps only files you authored yourself, such as your
-`~/.lns-connectors.yaml` catalog and each project's `lns-policy.yaml`, and prints
+`~/.lns-connectors.yaml` catalog and each project's `lns-local-mixin.yaml`, and prints
 what it left behind.
 
 ## Where to go next

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -7,12 +7,15 @@ three things: **allow** it, **deny** it at the boundary, or — when no rule mat
 
 ## The policy file
 
-Policy lives in a human-readable YAML file. By default that's `lns-policy.yaml` in
+Policy lives in a human-readable YAML file. By default that's `lns-local-mixin.yaml` in
 the directory you run from; the first `lns run` in a directory without one creates
 it:
 
 ```yaml
-network:
+apiVersion: lns.run/v1
+kind: mixin
+name: lns-local-mixin
+spec:
   egress:
     http: []
     tcp: []
@@ -20,6 +23,10 @@ network:
 
 `lns run` writes this starter file for you, so you only deal with it by hand if you
 choose to edit the file directly.
+
+The file is a **mixin** — the same document format a
+[sandbox definition](running-workloads.md#defining-a-sandbox) layers on. Your
+decisions merge after every other source, so nothing you pulled overrules them.
 
 One directory, one policy file — it sits next to the project it governs. Point a
 run at a different file with `--policy <path>`:
@@ -51,7 +58,7 @@ That rule governs raw destinations too, so `egress.tcp` needs no counterpart. Se
 Each entry in `egress.http` is a rule:
 
 ```yaml
-network:
+spec:
   egress:
     http:
       - match: api.github.com
@@ -78,10 +85,6 @@ A `match` pattern can be:
 - a CIDR block — `10.0.0.0/8`
 - a host with a port — `registry.internal:5000`
 
-`egress.http` used to be a top-level `allowedRoutes:` list. That key is gone: a
-policy file still naming it is refused with an error rather than loaded as a
-policy with no rules. Move the list under `egress: http:`.
-
 ### Raw TCP destinations
 
 Not everything a workload connects to speaks HTTP. A Postgres client, a Redis
@@ -90,7 +93,7 @@ client, an SSH session — Lens Sandbox cannot read those, so it cannot apply
 allow anyway:
 
 ```yaml
-network:
+spec:
   egress:
     http:
       - match: api.github.com
@@ -144,7 +147,7 @@ a rule that grants uninspected traffic is the right way round.
 denied that host:
 
 ```yaml
-network:
+spec:
   egress:
     http:
       - match: git.example.test
@@ -190,7 +193,7 @@ section before using it.
 ## Editing rules from the CLI
 
 You can hand-edit the YAML, but `lns policy` edits it for you and keeps it
-well-formed. All subcommands default to `lns-policy.yaml` in the current directory;
+well-formed. All subcommands default to `lns-local-mixin.yaml` in the current directory;
 pass `--policy <path>` to target another file.
 
 ### Add an allow or deny rule
@@ -218,7 +221,7 @@ effect ahead of the broader rule it narrows. `lns policy allow` places it there 
 says so:
 
 ```
-Added allow rule for "api.example.test" to lns-policy.yaml
+Added allow rule for "api.example.test" to lns-local-mixin.yaml
 Placed it before the existing rule for "*.example.test", which covers the same
 destination and would otherwise pre-empt it. Every other caller is now denied
 "api.example.test" without being asked, and that rule no longer serves them.
@@ -230,7 +233,7 @@ destination. A scoped rule for a destination no other rule covers has nothing to
 in front of, so it is appended — and still reports what it now denies:
 
 ```
-Added allow rule for "git.example.test" to lns-policy.yaml
+Added allow rule for "git.example.test" to lns-local-mixin.yaml
 Every other caller is now denied "git.example.test" without being asked.
 ```
 
@@ -394,7 +397,7 @@ If no one responds, the request times out and is treated as a denial.
 
 ## Sharing policy
 
-Because policy is a plain file, it travels. Commit `lns-policy.yaml` to the repo so
+Because policy is a plain file, it travels. Commit `lns-local-mixin.yaml` to the repo so
 everyone running the project shares the same rules, hand it to a teammate, or keep
 a curated file somewhere central and point runs at it with `--policy`. A run loads
 the file at startup, so shared approvals are already in place — no one has to

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -25,8 +25,25 @@ spec:
 choose to edit the file directly.
 
 The file is a **mixin** — the same document format a
-[sandbox definition](running-workloads.md#defining-a-sandbox) layers on. Your
-decisions merge after every other source, so nothing you pulled overrules them.
+[sandbox definition](running-workloads.md#defining-a-sandbox) layers on. Every
+run in the directory resolves it without being named, after every other source,
+so nothing you pulled overrules what you decided.
+
+Being a mixin also means the file is not limited to `egress`. Any block a mixin
+can declare, this one can declare too — a tool, a mount, another mixin to layer
+on — and it reaches every run in this directory:
+
+```yaml
+apiVersion: lns.run/v1
+kind: mixin
+name: lns-local-mixin
+spec:
+  tools:
+    - ripgrep@14
+  egress:
+    http: []
+    tcp: []
+```
 
 One directory, one policy file — it sits next to the project it governs. Point a
 run at a different file with `--policy <path>`:

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -578,7 +578,12 @@ lns pull ghcr.io/acme/observability:2      # cache it and the mixins it names
 
 **The last source to say something about a thing wins.** Sources are ordered:
 the sandbox first, then each entry in `spec.mixins` in order with that mixin's
-own mixins expanded right after it, then each `--mixin` the user passed.
+own mixins expanded right after it, then each `--mixin` the user passed, and
+last the directory's own
+[`lns-local-mixin.yaml`](policy.md#the-policy-file) — so nothing you pulled
+overrules what you decided here. That file's egress is the exception: it reaches
+the running sandbox live rather than through the merge, so a rule you delete
+mid-run stops applying.
 
 A directory entry is read from this machine, relative to the document that names
 it. A published sandbox may not name one — a consumer has no copy of your

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -115,7 +115,7 @@ lns run ghcr.io/acme/agent:latest        # run a published sandbox by reference
 ```
 
 You run `lns run` from a project directory; that's where Lens Sandbox looks for the
-`lns-policy.yaml` that governs the run. To expose your actual host files to the
+`lns-local-mixin.yaml` that governs the run. To expose your actual host files to the
 workload, bind-mount a directory with `-v /host/path:/guest/path` (see
 [Host bind mounts](#host-bind-mounts)); for scratch space that persists across runs,
 attach a named volume instead.

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -1217,7 +1217,7 @@ decision is the same question again tomorrow — so the run writes it down, as a
 ```yaml
 apiVersion: lns.run/v1
 kind: mixin
-name: reviewer-local
+name: lns-local-mixin
 spec:
   egress:
     http:
@@ -1266,20 +1266,26 @@ parser, its own documentation, and its own answer to every question
 It also stops the file being egress-only. If a decision ever needs to record
 something other than a destination, the blocks are already defined.
 
-### 8.3 Open: the name
+### 8.3 The name
 
-`lns-policy.yaml` described a file that held policy. It holds decisions now, in
-mixin grammar, and may hold more than egress. The name has to change; what it
-changes to is not settled.
+The file is `lns-local-mixin.yaml`. The old name described a file that held
+policy; this one holds decisions, in mixin grammar, and may hold more than
+egress — so it says what the file **is** rather than what it once carried, and it
+sorts beside the `lns.yaml` it layers on.
 
-### 8.4 Open: where a connector grant goes
+Its `name` is the file's own stem, because nobody is present to choose one.
 
-The same file records which connectors are connected today, and that record has no
-home here. A connector is installed **per machine**
+### 8.4 Where a connector grant goes
+
+A connector grant does not live here. A connector is installed **per machine**
 ([§7.1](#71-connectors)), while consenting to use one is **per project** — and
 neither is something a mixin can say, because no kit names a connector
-([§1.4](#14-credentials-and-what-a-connector-adds)). So the grant needs a store of
-its own, per project and outside the kit grammar. Where that lives is not settled.
+([§1.4](#14-credentials-and-what-a-connector-adds)).
+
+So it lives in the per-workload grant store the machine already keeps, keyed by
+project alone: `lns connector connect` names a directory and no workload. Keeping it out of this file is what lets the file be committed — a
+clone asks for its own consent rather than inheriting one nobody in that clone
+gave.
 
 ---
 
@@ -1287,7 +1293,7 @@ its own, per project and outside the kit grammar. Where that lives is not settle
 
 - [Running workloads](running-workloads.md) — the authoring guide for this format.
 - [Policy and approvals](policy.md) — the `match` pattern grammar and the
-  per-directory `lns-policy.yaml`.
+  per-directory `lns-local-mixin.yaml`.
 - [Credentials](credentials.md) — placeholders, and the per-machine values a
   credential resolves against.
 - [Connectors](connectors.md) — connecting a workload to an external service.

--- a/docs/service.md
+++ b/docs/service.md
@@ -37,7 +37,7 @@ Two environment variables override the defaults (mostly useful for development):
 - `LNS_SERVICE_BIN` — use a specific `lns-service` binary.
 - `LNS_HEADLESS=1` — run without the tray or approval window even when a
   display is present. Interactive prompts can't be shown headless: approvals
-  need pre-authorized rules in `lns-policy.yaml`, and `lns connector
+  need pre-authorized rules in `lns-local-mixin.yaml`, and `lns connector
   connect` for a credential connector fails immediately instead of waiting
   on a card that can never appear.
 


### PR DESCRIPTION
> Stacked on #239 (→ #238 → #237 → #236 → #233 → #232 → #231). Base is `feat/connected-out-of-the-file`.
>
> The last PR of the mixin stack. It closes what remains of [§8](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#8-the-local-mixin): the directory's decisions become the `mixin` document the specification says they are, the file gets the name §8.3 left open, and §3.3.2's fourth tier finally gets its caller.

## The divergence

§8 says a directory's decisions are a `mixin` document — "the same grammar as §3.3, so a decision is recorded in the shape the rest of the document already defines" — resolved by every run there "without being named", "last in the merge".

None of that was true. The file was a bespoke `network: { egress: … }` shape only this file used, it was called `lns-policy.yaml`, and `flatten`'s local tier (added in the preceding commit) had no caller at all: every call site passed `None`.

## Three commits

**1. `docs:` settle the two open questions.** §8.3 (the name) and §8.4 (where a connector grant lives). §8.4 was settled in code by #239; this states it. Spec changes land as decisions in their own commit.

**2. `feat!:` the decisions file becomes the local mixin.** `apiVersion`, `kind`, `name`, and `spec.egress`, in `lns-local-mixin.yaml`.

**3. `feat:` resolution carries the directory's own decisions.** The rule-4 tier's caller.

## The old file is not read

The user's call, and it makes the change simpler than it looks: an old `lns-policy.yaml` is never read, never migrated, never mentioned. Under the new name it cannot exist, so there is nothing to carry and no message to write. `NetworkPolicyRaw` — the shim that produced migration errors for `defaultVerdict` / `defaultTransport` — is deleted with its five tests.

**Two things a reader should know this costs:**

- **Every project re-asks connector consent once.** `grants::project_key` canonicalises the *policy path*, so the key embeds the filename. Pre-1.0; not worth a key migration the no-migration rule would forbid in spirit anyway.
- **A file in the old shape now fails to load rather than being explained.** That is the whole point of the instruction, but it is worth saying out loud.

## A block the run does not write survives an approval

`lns-policy` cannot call `lns_artifact::parse_mixin` — lns-artifact depends on lns-policy, not the reverse — so the envelope is restated in `lns-policy`. That makes it a second reader of one grammar, and the risk is that the approval writer (load → mutate → save) quietly deletes anything it does not model.

It does not: `LocalMixinSpec` carries `#[serde(flatten)] rest`, so a hand-written `spec.mixins` is still there after an approval appends an egress rule. Review verified the round-trip against nested maps, sequences, deep nesting, block scalars, and integer/float/bool edges. Comments are not preserved — equally true of the whole-file rewrite this replaces.

One consequence of the split reader, stated deliberately: a typo'd key under `spec` (`egres:`) is preserved-and-inert here rather than refused. The full-grammar parser refuses it at resolution, which is commit 3.

## The local egress does not travel through the merge — because it already outranks it

**Read this before the rest.** The decisions file's egress is fully enforced, and at the *highest* precedence in the gate. Nothing here weakens it. What this PR removes is a duplicate.

There are two roads to the guest gate, and egress was already on one of them:

| Road | Carries | Updates |
|---|---|---|
| The **merge** — `resolve` → the resolved document | the artifact's egress, and every mixin's | frozen at boot |
| The **overlay** — `Policy::load_or_default(policy_path)` | the decisions file's egress | live; re-read on every change to the file |

`supervisor/adapter.rs:636` calls `merge_effective(Some(baseline), &own)` with the decisions file as `own`, and that builds `layers = [overlay, baseline]`. The local rules are placed **ahead** of everything the artifact shipped, and the gate is first-match-wins. So this block already had precisely the rule-4 precedence §3.3.2 asks for, before this PR existed.

Sending it down the merge road as well would put a second copy in the resolved document, which lands in the session's baseline floor (`approval_flow/session.rs:550`). A floor is not re-read from the file, so an approval the developer deletes mid-run would stay in force until reboot. Stripping removes the duplicate; the rule keeps deciding.

So the merge takes the local file's tools, mounts, filesets, ports, credentials and `spec.mixins` — the blocks that had no road before — and egress keeps the road it had. Pinned by *the directory's egress stays live rather than being frozen into the document*, which turns red if the strip is removed.

A file that holds **only** egress therefore contributes nothing to the *merge*, and the run takes the untouched-bytes fast path — so the common case does not change shape at all.

## What the caller needed

- `Request::ResolveDefinition` and `Request::InspectImage` carry the decisions-file path. Both additive and `#[serde(default)]`.
- `peek_and_plan` takes it from `RunImageArgs.policy_path`, which the run already carried.
- The CLI's local preflight now also fires when the directory has a decisions file, not only when something declared a mixin — §8.1 resolves it "without being named".
- `collect` seeds the local file's own references, so a chain it reaches is bounded and digest-pinned like any other.
- `resolve`'s early return no longer skips a local source that contributes something.

`lns sandbox inspect <ref>` passes no decisions file: it answers "what is this artifact", not "what would boot here". The run preflight passes one, so §1.5's disclosure still describes what boots.

A directory the decisions file names roots at **that file's** directory, not the run's — §3.3.1 roots a declared entry at the document that named it, and the document that named it is the decisions file. Review caught this: without it a committed `mixins: ["./team-tools"]` worked for `lns run ./` and hard-refused `lns run ghcr.io/…` in the same directory, and a `--policy` file kept outside the project silently merged whatever `<project>/team-tools` happened to hold.

**Two follow-ups, not fixed here:**

- A connector grant keys on the composition of `--mixin` flags, so a mixin the local file names does not change the grant key.
- The retraction property is about the file's **own** `egress` block. A mixin the file *names* is an ordinary source, so its egress is baked into the booted document and deleting that reference mid-run does not retract its rules until the next boot.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage`, `make test` and `make e2e` all exit 0.

Every new assertion was mutation-checked. Four of them did not bite on the first attempt and were rewritten:

- the local-mixin scenarios asserted against `resolved_mixins`, which the resolution step never recorded — a `cargo fmt` reflow had silently defeated the edit that was meant to record it;
- *a mixin the directory's decisions name merges before them* proved nothing until the named mixin contributed a tool the local file does not, since the local file's own tool won either way.

The reviewer's blocking finding on commit 2 was that `from_document` accepted a `name` §2 refuses and wrote it back verbatim, so the two readers of one grammar disagreed on the envelope. Fixed test-first: `is_dns_label` is restated beside the envelope, the loader refuses, and `dns_label_for` now ends in the same predicate, so the generator cannot emit a name the loader would reject.
