### PR TITLE
feat: let a resolution carry the directory's own decisions as its last source

### DIFF
--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -53,18 +53,30 @@ pub struct Merged {
 /// The graph is walked this deep and refused beyond, so a chain nobody can read cannot stall a launch.
 pub const MAX_DEPTH: usize = 5;
 
-/// Flatten a sandbox and its mixins into the one ordered source list §3.3.2 merges: the sandbox first, then each of its `mixins` in order with that mixin's own `mixins` expanded right after it, then each extra reference in the order the user gave it.
+/// Flatten a sandbox and its mixins into the one ordered source list §3.3.2 merges: the sandbox first, then each of its `mixins` in order with that mixin's own `mixins` expanded right after it, then each extra reference in the order the user gave it, then the directory's own decisions last.
 ///
-/// A mixin's own mixins come after it, so they beat it — a mixin that pulls in another is asking for that other's version of a shared setting.
+/// A mixin's own mixins come after it, so they beat it — a mixin that pulls in another is asking for that other's version of a shared setting. The local source is the exception: §8.1 puts it after every other source outright, so what it pulled merges before it.
 /// A source many documents name appears once, at the last place it was named: an earlier appearance can decide nothing a later one does not, since either a source after it sets a key or the source itself sets it again.
 pub fn flatten<'a>(
     root: &'a SandboxSpec,
     extra: &'a [String],
+    local: Option<Source<'a>>,
     graph: &'a BTreeMap<String, SandboxSpec>,
 ) -> Result<Vec<Source<'a>>> {
-    refuse_what_sits_out_of_reach(&root.mixins, extra, graph)?;
-    let mut sources = Vec::with_capacity(1 + graph.len());
+    let reachable: Vec<String> = local
+        .iter()
+        .flat_map(|local| local.spec.mixins.iter().cloned())
+        .chain(extra.iter().cloned())
+        .collect();
+    refuse_what_sits_out_of_reach(&root.mixins, &reachable, graph)?;
+    let mut sources = Vec::with_capacity(2 + graph.len());
     let mut seen = std::collections::BTreeSet::new();
+    // Pushed first because the list is built in reverse, so this is what lands last.
+    if let Some(local) = local {
+        let own = &local.spec.mixins;
+        sources.push(local);
+        expand(own, graph, &mut seen, &mut sources)?;
+    }
     expand(extra, graph, &mut seen, &mut sources)?;
     expand(&root.mixins, graph, &mut seen, &mut sources)?;
     sources.push(Source {
@@ -517,7 +529,7 @@ mod tests {
         let (root, graph) = a_chain_the_sandbox_names_flat(5_000);
         let walked = std::thread::Builder::new()
             .stack_size(256 * 1024)
-            .spawn(move || flatten(&root, &[], &graph).map(|sources| sources.len()))
+            .spawn(move || flatten(&root, &[], None, &graph).map(|sources| sources.len()))
             .expect("the walk gets its own thread")
             .join()
             .expect(
@@ -533,7 +545,7 @@ mod tests {
     #[test]
     fn a_mixin_many_documents_reach_is_one_source_and_not_one_per_path() {
         let (root, graph) = wide_dag();
-        let sources = flatten(&root, &[], &graph).expect("every reference resolves");
+        let sources = flatten(&root, &[], None, &graph).expect("every reference resolves");
         assert_eq!(
             labels(&sources).len(),
             1 + graph.len(),
@@ -551,11 +563,56 @@ mod tests {
             ("firsts-own", r#"{}"#),
             ("second", r#"{}"#),
         ]);
-        let sources = flatten(&root, &extra, &graph).expect("every reference resolves");
+        let sources = flatten(&root, &extra, None, &graph).expect("every reference resolves");
         assert_eq!(
             labels(&sources),
             [ROOT_LABEL, "own", "first", "firsts-own", "second"],
             "a mixin's own mixins follow it, and the user's flags are appended last, so each beats what came before it"
+        );
+    }
+
+    #[test]
+    fn the_source_list_ends_with_the_local_mixin_after_every_flag() {
+        let root = spec(r#"{"image":"x:1","mixins":["own"]}"#);
+        let extra = ["flag".to_string()];
+        let local = spec(r#"{"tools":["ripgrep@14"]}"#);
+        let graph = graph(&[("own", r#"{}"#), ("flag", r#"{}"#)]);
+        let sources = flatten(
+            &root,
+            &extra,
+            Some(Source {
+                label: "lns-policy.yaml",
+                spec: &local,
+            }),
+            &graph,
+        )
+        .expect("every reference resolves");
+        assert_eq!(
+            labels(&sources),
+            [ROOT_LABEL, "own", "flag", "lns-policy.yaml"],
+            "the developer's own decisions are last, so nothing they pulled can overrule them (docs/sandbox-spec.md §8.1)"
+        );
+    }
+
+    #[test]
+    fn a_local_mixins_own_mixins_are_expanded_before_it() {
+        let root = spec(r#"{"image":"x:1"}"#);
+        let local = spec(r#"{"mixins":["locals-own"]}"#);
+        let graph = graph(&[("locals-own", r#"{}"#)]);
+        let sources = flatten(
+            &root,
+            &[],
+            Some(Source {
+                label: "lns-policy.yaml",
+                spec: &local,
+            }),
+            &graph,
+        )
+        .expect("every reference resolves");
+        assert_eq!(
+            labels(&sources),
+            [ROOT_LABEL, "locals-own", "lns-policy.yaml"],
+            "§3.3.2 puts a mixin's own mixins after it, but §8.1 says the local one is last outright, and what it pulled is still something pulled"
         );
     }
 
@@ -569,12 +626,12 @@ mod tests {
             ("m5", r#"{}"#),
         ];
         let root = spec(r#"{"image":"x:1","mixins":["m1"]}"#);
-        assert_eq!(flatten(&root, &[], &graph(&chain)).unwrap().len(), 6);
+        assert_eq!(flatten(&root, &[], None, &graph(&chain)).unwrap().len(), 6);
 
         let mut deeper = chain;
         deeper[4] = ("m5", r#"{"mixins":["m6"]}"#);
         deeper.push(("m6", r#"{}"#));
-        let err = flatten(&root, &[], &graph(&deeper)).unwrap_err();
+        let err = flatten(&root, &[], None, &graph(&deeper)).unwrap_err();
         assert!(
             format!("{err:#}").contains("deeper than 5 mixins"),
             "got: {err:#}"
@@ -587,6 +644,7 @@ mod tests {
         let err = flatten(
             &root,
             &[],
+            None,
             &graph(&[("a", r#"{"mixins":["b"]}"#), ("b", r#"{"mixins":["a"]}"#)]),
         )
         .unwrap_err();
@@ -599,7 +657,7 @@ mod tests {
     #[test]
     fn a_reference_nothing_pulled_refuses_rather_than_being_skipped() {
         let root = spec(r#"{"image":"x:1","mixins":["absent"]}"#);
-        let err = flatten(&root, &[], &BTreeMap::new()).unwrap_err();
+        let err = flatten(&root, &[], None, &BTreeMap::new()).unwrap_err();
         assert!(
             format!("{err:#}").contains("is not resolved"),
             "skipping it would boot a sandbox without what its own document declared; got: {err:#}"

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -231,7 +231,7 @@ pub async fn resolve<S: MixinSource>(
     let fetched = collect(&def.spec.mixins, extra, home, source).await?;
     let mut root = def.spec.clone();
     root.mixins = fetched.pinned_roots;
-    let sources = flatten(&root, &fetched.pinned_extra, &fetched.graph)?;
+    let sources = flatten(&root, &fetched.pinned_extra, None, &fetched.graph)?;
     let merged = merge(&sources)?;
     let document = document(&def, &merged.spec)?;
     refuse_what_no_sandbox_could_be(&document, &sources)?;

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -1244,7 +1244,9 @@ spec:
   by digest, and this one is a working file on disk.
 - **Last in the merge.** It is the developer's own, so it sits after every other
   source in [§3.3.2](#332-merge-rules) — including a `--mixin`. Nothing they pulled
-  can overrule what they decided.
+  can overrule what they decided, and that includes what this file itself pulls: a
+  mixin it names merges **before** it, not after, so the general rule that a mixin's
+  own mixins beat it stops at this one.
 
 The developer does not approve this file. [§1.5](#15-one-disclosure) has a run
 disclose what it resolved before booting, which protects them from documents they


### PR DESCRIPTION
> Stacked on #238 (→ #237 → #236 → #233 → #232 → #231). Base is `feat/top-level-name`.
>
> This PR was missing from the chain. #239 was opened with this branch as its *base*, so these two commits sat in no pull request at all and would have reached `main` through the merge chain without ever being reviewed on GitHub. Opening it now closes that hole.

Two commits, one decision and one mechanism, both about the tier [§3.3.2](https://github.com/lensapp/lens-sandbox/blob/main/docs/sandbox-spec.md#332-merge-rules) numbers 4: the directory's own mixin, last in the merge.

## `docs:` say which way the local mixin's own mixins merge

§3.3.2's numbered list gives items 2 and 3 an explicit clause — a mixin's own mixins expand **after** it, so they beat it — and gives item 4 nothing. The diagram ends at the local source. That left the ordering of what the local mixin itself pulls genuinely undecided.

§8.1 now says it: a mixin the local file names merges **before** it, not after. The general rule that a mixin's own mixins beat it stops at this one, because §8.1's whole point is that nothing the developer pulled can overrule what they decided — and a document they pulled is still a document they pulled, however they reached it.

## `feat:` let a resolution carry the directory's own decisions as its last source

`flatten` takes the local source as its own input rather than as a reference in the graph. Nothing names it — no document declares it and no flag passes it — so it has no identity to key on, and a directory locator for the project would name the sandbox file instead.

Its own mixins expand before it, per the clarification above. Its references seed the depth check, so a chain it reaches is bounded like any other.

**Every caller passes `None` in this PR.** That is deliberate, not an oversight: at this point in the stack the decisions file is still a bespoke `network:` document whose egress reaches the guest live, and merging that into the resolved document would freeze a second copy no reload could withdraw. The caller arrives in #240, once the file is mixin grammar and its egress is stripped for exactly that reason.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage`, `make test` and `make e2e` all exit 0.

The ordering is pinned by a unit test that puts a mixin the local source names ahead of the local source itself in the flattened list; reversing the push order in `flatten` turns it red.
