### PR TITLE
fix: a mixin reference is a path, and an lns flag is lns's wherever it is written

### DIFF
--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -184,7 +184,7 @@ pub fn parse_mixin(config_json: &[u8]) -> Result<Definition> {
 }
 
 /// Whether a mixin entry names a directory rather than a registry coordinate — the one predicate validation, rooting and resolution all read, so they cannot disagree about which entries are local.
-pub fn names_a_local_directory(reference: &str) -> bool {
+pub fn names_a_local_path(reference: &str) -> bool {
     reference == "."
         || reference == ".."
         || reference.starts_with("./")
@@ -211,9 +211,9 @@ fn validate_mixin_reference(reference: &str) -> Result<()> {
     if reference.trim().is_empty() {
         bail!("a mixin entry must name a directory or an OCI reference");
     }
-    if !names_a_local_directory(reference) && !spec::is_digest_pinned_image(reference) {
+    if !names_a_local_path(reference) && !spec::is_digest_pinned_image(reference) {
         bail!(
-            "mixin reference {reference:?} must be digest-pinned (…@sha256:<64 hex>), so every consumer resolves the same document; a local directory starts with `./`, `../` or `/`"
+            "mixin reference {reference:?} must be digest-pinned (…@sha256:<64 hex>), so every consumer resolves the same document; a local path starts with `./`, `../` or `/`"
         );
     }
     Ok(())

--- a/crates/lns-cli/src/command.rs
+++ b/crates/lns-cli/src/command.rs
@@ -215,9 +215,11 @@ fn normalize_workload_argv(
 ) -> Vec<OsString> {
     let mut consumes = value_consuming_options(app);
     consumes.extend(value_consuming_options(cmd));
+    let mut claimed = declared_flags(app);
+    claimed.extend(declared_flags(cmd));
     let mut out = raw[..=idx].to_vec();
     let rest = &raw[idx + 1..];
-    let mut positional_seen = false;
+    let mut reference_seen = false;
     let mut i = 0;
     while i < rest.len() {
         let arg = &rest[i];
@@ -225,7 +227,10 @@ fn normalize_workload_argv(
             out.extend(rest[i..].iter().cloned());
             return out;
         }
-        if positional_seen {
+        let s = arg.to_string_lossy();
+        let named = s.split_once('=').map_or(&*s, |(name, _)| name);
+        // Past the reference a word starts the workload's command, and everything after it is the workload's; a flag lns declares is still lns's, and `--` hands the rest over whatever it looks like.
+        if reference_seen && !claimed.contains(named) && expand_it(arg).is_none() {
             out.push(OsString::from("--"));
             out.extend(rest[i..].iter().cloned());
             return out;
@@ -236,8 +241,7 @@ fn normalize_workload_argv(
             continue;
         }
         out.push(arg.clone());
-        let s = arg.to_string_lossy();
-        if consumes.contains(s.as_ref())
+        if consumes.contains(named)
             && !s.contains('=')
             && let Some(value) = rest.get(i + 1)
         {
@@ -246,11 +250,36 @@ fn normalize_workload_argv(
             continue;
         }
         if !s.starts_with('-') {
-            positional_seen = true;
+            reference_seen = true;
         }
         i += 1;
     }
     out
+}
+
+/// The flags a command declares itself, which stay its own wherever they are written; clap's `--help` and `--version` are not among them, so `lns run node --version` still asks node.
+fn declared_flags(cmd: &clap::Command) -> HashSet<String> {
+    let mut set = HashSet::new();
+    for arg in cmd.get_arguments() {
+        if arg.is_positional()
+            || matches!(
+                arg.get_action(),
+                clap::ArgAction::Help
+                    | clap::ArgAction::HelpShort
+                    | clap::ArgAction::HelpLong
+                    | clap::ArgAction::Version
+            )
+        {
+            continue;
+        }
+        for long in arg.get_long_and_visible_aliases().into_iter().flatten() {
+            set.insert(format!("--{long}"));
+        }
+        for short in arg.get_short_and_visible_aliases().into_iter().flatten() {
+            set.insert(format!("-{short}"));
+        }
+    }
+    set
 }
 
 fn expand_it(arg: &OsString) -> Option<Vec<OsString>> {
@@ -742,5 +771,92 @@ mod tests {
         let err =
             try_get_matches_from(["lns", "run", "--help"]).expect_err("--help exits through clap");
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn a_flag_lns_declares_is_lns_wherever_it_is_written() {
+        let args: crate::cli::RunArgs = parse_args([
+            "lns", "run", "alpine", "--mixin", "XYZ", "--", "echo", "hello",
+        ])
+        .expect("a flag lns declares is lns's, and `--` is what hands the rest over");
+        assert_eq!(args.image.as_deref(), Some("alpine"));
+        assert_eq!(args.mixins, ["XYZ"]);
+        assert_eq!(args.cmd, ["echo", "hello"]);
+    }
+
+    #[test]
+    fn the_workloads_command_needs_no_separator_when_it_starts_with_a_word() {
+        let args: crate::cli::RunArgs =
+            parse_args(["lns", "run", "alpine", "--mixin", "XYZ", "echo", "hello"])
+                .expect("a word is not a flag, so it starts the command");
+        assert_eq!(args.mixins, ["XYZ"]);
+        assert_eq!(args.cmd, ["echo", "hello"]);
+    }
+
+    #[test]
+    fn a_global_flag_after_the_reference_is_lns_too() {
+        let matches = try_get_matches_from(["lns", "run", "alpine", "--log-level", "debug"])
+            .expect("a flag lns declares at the top level is still lns's");
+        assert_eq!(
+            matches.get_one::<crate::cli::LogLevel>("log_level"),
+            Some(&crate::cli::LogLevel::Debug),
+            "a global flag reaches the subcommand at parse time, not at normalise time, so it is the one an argv walk forgets"
+        );
+    }
+
+    #[test]
+    fn a_flag_written_with_its_value_attached_is_lns_too() {
+        let args: crate::cli::RunArgs = parse_args(["lns", "run", "alpine", "--mixin=./x"])
+            .expect("one spelling of a flag is not more the workload's than another");
+        assert_eq!(args.mixins, ["./x"]);
+        assert!(args.cmd.is_empty());
+    }
+
+    #[test]
+    fn a_combined_it_after_the_reference_is_still_lns() {
+        let args: crate::cli::RunArgs = parse_args(["lns", "run", "alpine", "-it"])
+            .expect("-it is two flags lns declares, however they are written together");
+        assert!(
+            args.interactive && args.tty && args.cmd.is_empty(),
+            "a combined short is not a word, so it does not start the workload's command; got interactive={} tty={} cmd={:?}",
+            args.interactive,
+            args.tty,
+            args.cmd
+        );
+    }
+
+    #[test]
+    fn an_explicit_separator_still_passes_a_flag_shaped_command() {
+        let args: crate::cli::RunArgs =
+            parse_args(["lns", "run", "alpine", "--", "--mixin", "./x"]).unwrap();
+        assert_eq!(
+            args.cmd,
+            ["--mixin", "./x"],
+            "`--` is what says the rest is the workload's, so it has to survive the refusal"
+        );
+        assert!(args.mixins.is_empty());
+    }
+
+    #[test]
+    fn a_flag_lns_does_not_own_still_reaches_the_workload() {
+        for (argv, expected) in [
+            (["lns", "run", "node", "--version"], "--version"),
+            (["lns", "run", "alpine", "--help"], "--help"),
+        ] {
+            let args: crate::cli::RunArgs = parse_args(argv)
+                .unwrap_or_else(|e| panic!("`{}` asks the workload, not lns: {e}", argv.join(" ")));
+            assert_eq!(args.cmd, [expected]);
+        }
+    }
+
+    #[test]
+    fn a_flag_after_the_workloads_own_command_is_the_workloads() {
+        let args: crate::cli::RunArgs =
+            parse_args(["lns", "run", "alpine", "sh", "--mixin", "x"]).unwrap();
+        assert_eq!(
+            args.cmd,
+            ["sh", "--mixin", "x"],
+            "only the first token after the reference can be a misplaced flag; past it the workload owns every word"
+        );
     }
 }

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -146,7 +146,7 @@ pub fn root_named_directories(mixins: &[String], cwd: &Path) -> Result<Vec<Strin
     mixins
         .iter()
         .map(|reference| {
-            if !lns_artifact::sandbox::names_a_local_directory(reference) {
+            if !lns_artifact::sandbox::names_a_local_path(reference) {
                 return Ok(reference.clone());
             }
             let rooted = lns_artifact::sandbox::fold_path(&cwd.join(reference));

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -37,6 +37,7 @@ pub trait Fs {
     fn read_to_string(&self, path: &Path) -> io::Result<String>;
     fn write(&self, path: &Path, contents: &str) -> io::Result<()>;
     fn exists(&self, path: &Path) -> bool;
+    fn is_dir(&self, path: &Path) -> bool;
     fn read_limited(&self, path: &Path, max_bytes: u64) -> io::Result<Vec<u8>>;
     fn dir_entries(&self, dir: &Path) -> io::Result<Vec<DirEntry>>;
 }

--- a/crates/lns-cli/src/sandbox/fileset.rs
+++ b/crates/lns-cli/src/sandbox/fileset.rs
@@ -120,10 +120,14 @@ pub fn directory_mixin_problems<F: Fs + ?Sized>(
         .spec
         .mixins
         .iter()
-        .filter(|reference| lns_artifact::sandbox::names_a_local_directory(reference))
+        .filter(|reference| lns_artifact::sandbox::names_a_local_path(reference))
         .filter_map(|reference| {
-            let document =
-                lns_artifact::sandbox::fold_path(&project_dir.join(reference)).join("lns.yaml");
+            let named = lns_artifact::sandbox::fold_path(&project_dir.join(reference));
+            let document = if fs.is_dir(&named) {
+                named.join("lns.yaml")
+            } else {
+                named
+            };
             fs.read_to_string(&document)
                 .err()
                 .map(|e| format!("mixin {reference}: reading {}: {e}", document.display()))
@@ -147,7 +151,21 @@ mod tests {
     }
 
     #[test]
-    fn validate_names_a_mixin_directory_that_holds_no_document() {
+    fn validate_accepts_a_mixin_named_by_its_document() {
+        let fs = MapFs::with(&[("/work/mixins/pg/lns.yaml", "kind: mixin")]);
+        let problems = directory_mixin_problems(
+            &fs,
+            Path::new("/work"),
+            &definition(r#"["./mixins/pg/lns.yaml"]"#),
+        );
+        assert!(
+            problems.is_empty(),
+            "a run resolves this entry, so validate calling it broken is validate being wrong; got {problems:?}"
+        );
+    }
+
+    #[test]
+    fn validate_names_a_mixin_path_that_holds_no_document() {
         let fs = MapFs::with(&[("/work/mixins/present/lns.yaml", "kind: mixin")]);
         let problems = directory_mixin_problems(
             &fs,
@@ -160,8 +178,8 @@ mod tests {
             "a typo in a directory name is cheapest to correct at author time; got {problems:?}"
         );
         assert!(
-            problems[0].contains("/work/mixins/absent/lns.yaml"),
-            "the refusal has to name the file it looked for; got {problems:?}"
+            problems[0].contains("/work/mixins/absent"),
+            "a path that is neither a directory nor a document is named as the author wrote it, rather than as a file inside a directory that is not there; got {problems:?}"
         );
     }
 

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -312,6 +312,10 @@ fn run_author(command: &super::SandboxCommand, ctx: RunCtx<'_>) -> Result<i32> {
 pub(crate) struct RealFs;
 
 impl super::author::Fs for RealFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
     fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
         std::fs::read_to_string(path)
     }

--- a/crates/lns-cli/src/sandbox/test_support.rs
+++ b/crates/lns-cli/src/sandbox/test_support.rs
@@ -29,6 +29,13 @@ impl MapFs {
 }
 
 impl Fs for MapFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        self.files
+            .borrow()
+            .keys()
+            .any(|held| held.ancestors().skip(1).any(|dir| dir == path))
+    }
+
     fn read_to_string(&self, path: &Path) -> io::Result<String> {
         self.files
             .borrow()

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -17,6 +17,13 @@ struct StepFs {
 }
 
 impl Fs for StepFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        self.files
+            .borrow()
+            .keys()
+            .any(|held| held.ancestors().skip(1).any(|dir| dir == path))
+    }
+
     fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
         self.files
             .borrow()

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -220,6 +220,13 @@ struct StepFs {
 }
 
 impl author::Fs for StepFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        self.files
+            .borrow()
+            .keys()
+            .any(|held| held.ancestors().skip(1).any(|dir| dir == path))
+    }
+
     fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
         self.files
             .borrow()

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -21,6 +21,13 @@ struct StepFs {
 }
 
 impl Fs for StepFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        self.files
+            .borrow()
+            .keys()
+            .any(|held| held.ancestors().skip(1).any(|dir| dir == path))
+    }
+
     fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
         self.files
             .borrow()

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -8,7 +8,8 @@ use lns_artifact::sandbox::{Definition, SandboxSpec};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Locator {
     Reference(String),
-    Directory(std::path::PathBuf),
+    /// The document on this machine a source was read from. A reference it declares joins onto the directory that document sits in, the way a reference keys on the digest a registry answered with.
+    Local(std::path::PathBuf),
 }
 
 impl Locator {
@@ -16,7 +17,7 @@ impl Locator {
     pub fn key(&self) -> String {
         match self {
             Locator::Reference(reference) => reference.clone(),
-            Locator::Directory(path) => path.display().to_string(),
+            Locator::Local(path) => path.display().to_string(),
         }
     }
 }
@@ -45,29 +46,31 @@ pub fn is_a_mixin_artifact(artifact_type: Option<&str>, config_media_type: Optio
     }
 }
 
-/// Resolve one reference against the document that named it: a directory is meaningful only to a document this machine read, and it roots where that document lives.
+/// Resolve one reference against the document that named it: a path the user typed is one this machine read whatever the run is, while a path a document declares roots at that document and so needs one this machine read.
 fn locate(reference: &str, home: &Locator, the_user_named_it: bool) -> Result<Locator> {
-    if !lns_artifact::sandbox::names_a_local_directory(reference) {
+    if !lns_artifact::sandbox::names_a_local_path(reference) {
         return Ok(Locator::Reference(reference.to_string()));
     }
-    let Locator::Directory(dir) = home else {
-        bail!(
-            "mixin {reference} is a directory, and this run's sandbox is published; a directory merges only into a document this machine read, so run the definition it belongs to"
-        );
-    };
     if the_user_named_it {
         if !std::path::Path::new(reference).is_absolute() {
             bail!(
-                "mixin {reference} reached the run as a relative directory; a run merges the absolute path its preflight showed"
+                "mixin {reference} reached the run as a relative path; a run merges the absolute path its preflight showed"
             );
         }
-        return Ok(Locator::Directory(lns_artifact::sandbox::fold_path(
+        return Ok(Locator::Local(lns_artifact::sandbox::fold_path(
             std::path::Path::new(reference),
         )));
     }
-    Ok(Locator::Directory(lns_artifact::sandbox::fold_path(
-        &dir.join(reference),
-    )))
+    let Locator::Local(document) = home else {
+        bail!(
+            "mixin {reference} is a local path declared by a published document, and a consumer has no copy of the machine that wrote it; publish that mixin and name it by digest"
+        );
+    };
+    let beside = document
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join(reference);
+    Ok(Locator::Local(lns_artifact::sandbox::fold_path(&beside)))
 }
 
 /// The graph every ordering rule decides against, keyed by the identity each source resolved to, with every reference that names a source translated to the same key.
@@ -161,17 +164,15 @@ async fn visit<S: MixinSource>(
         .fetch(&locator)
         .await
         .with_context(|| format!("resolving mixin {reference}"))?;
-    let key = match &locator {
-        Locator::Reference(_) => fetched.pinned,
-        Locator::Directory(path) => path.display().to_string(),
-    };
+    // A local source keys on the document the path resolved to, exactly as a reference keys on the digest the registry answered with, so two spellings of one document are one source.
+    let key = fetched.pinned;
     walk.visited.insert(locator.key(), key.clone());
     walk.keys.insert(seen, key.clone());
     if !walk.graph.contains_key(&key) {
         let mixin = lns_artifact::sandbox::parse_mixin(fetched.document.as_bytes())
             .with_context(|| format!("reading mixin {reference}"))?;
         let child_home = match locator {
-            Locator::Directory(path) => Locator::Directory(path),
+            Locator::Local(_) => Locator::Local(std::path::PathBuf::from(&key)),
             Locator::Reference(_) => Locator::Reference(key.clone()),
         };
         walk.frontier.extend(
@@ -448,21 +449,27 @@ mod tests {
                 .lock()
                 .expect("fetch log poisoned")
                 .push(reference.clone());
+            // A local path answers under the document it names, the same as the reader this stands in for; a directory holds `lns.yaml`.
+            let pinned = match locator {
+                Locator::Local(path) if path.extension().is_none() => {
+                    path.join("lns.yaml").display().to_string()
+                }
+                _ => self.pins.get(&reference).cloned().unwrap_or(reference),
+            };
             let document = self
                 .documents
-                .get(&reference)
+                .get(&pinned)
+                .or_else(|| self.documents.get(&locator.key()))
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("no such mixin here"))?;
-            Ok(FetchedMixin {
-                pinned: self.pins.get(&reference).cloned().unwrap_or(reference),
-                document,
-            })
+            Ok(FetchedMixin { pinned, document })
         }
     }
 
     /// Every scenario here resolves a published document unless it says otherwise.
-    fn decided_in(dir: &str) -> Locator {
-        Locator::Directory(std::path::PathBuf::from(dir))
+    /// A source read from a document on this machine, which is what a local reference joins onto.
+    fn decided_in(document: &str) -> Locator {
+        Locator::Local(std::path::PathBuf::from(document))
     }
 
     fn published() -> Locator {
@@ -788,7 +795,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_local_directory_reached_from_a_published_document_refuses_the_run() {
+    async fn a_local_path_declared_by_a_published_document_refuses_the_run() {
         let err = resolve(
             &sandbox(r#"{"image":"x:1","mixins":["./mixins/postgres-tools/"]}"#),
             &[],
@@ -799,8 +806,7 @@ mod tests {
         .await
         .unwrap_err();
         assert!(
-            format!("{err:#}")
-                .contains("a directory merges only into a document this machine read"),
+            format!("{err:#}").contains("a consumer has no copy of the machine that wrote it"),
             "a directory beside the author's file is not something a consumer can resolve, and reading whatever host path it names would be worse than refusing; got: {err:#}"
         );
     }
@@ -953,33 +959,33 @@ mod tests {
         let out = resolve(
             &sandbox(r#"{"image":"x:1","mixins":["./a","./b"]}"#),
             &[],
-            &Locator::Directory(std::path::PathBuf::from("/work")),
+            &decided_in("/work/lns.yaml"),
             &source,
             None,
         )
         .await
         .expect("each mixin roots its own references");
         assert!(
-            out.mixins.contains(&"/work/a/m".to_string())
-                && out.mixins.contains(&"/work/b/m".to_string()),
+            out.mixins.contains(&"/work/a/m/lns.yaml".to_string())
+                && out.mixins.contains(&"/work/b/m/lns.yaml".to_string()),
             "`./m` means a different directory under each mixin that names it, so one identity for both would merge the wrong document; got {:?}",
             out.mixins
         );
     }
 
     #[tokio::test]
-    async fn a_relative_directory_the_user_names_refuses_rather_than_guessing_a_root() {
+    async fn a_relative_path_the_user_names_refuses_rather_than_guessing_a_root() {
         let err = resolve(
             &sandbox(r#"{"image":"x:1"}"#),
             &["./mixins/pg".to_string()],
-            &Locator::Directory(std::path::PathBuf::from("/work")),
+            &decided_in("/work/lns.yaml"),
             &Fake::new(&[]),
             None,
         )
         .await
         .unwrap_err();
         assert!(
-            format!("{err:#}").contains("relative directory"),
+            format!("{err:#}").contains("reached the run as a relative path"),
             "only the caller knows the directory the user typed it from, so rooting it here would read some other directory with the same name; got: {err:#}"
         );
     }
@@ -990,7 +996,7 @@ mod tests {
         let out = resolve(
             &sandbox(r#"{"image":"x:1"}"#),
             &["/work/mixins/./pg".to_string()],
-            &Locator::Directory(std::path::PathBuf::from("/work")),
+            &decided_in("/work/lns.yaml"),
             &source,
             None,
         )
@@ -998,8 +1004,8 @@ mod tests {
         .expect("a directory the user named beside their own definition is theirs to merge");
         assert_eq!(
             out.mixins,
-            ["/work/mixins/pg"],
-            "a directory has no digest, so the folded absolute path is the identity the disclosure names"
+            ["/work/mixins/pg/lns.yaml"],
+            "a local source has no digest, so the document it resolved to is the identity the disclosure names"
         );
     }
 
@@ -1123,7 +1129,7 @@ mod tests {
                 pinned: "lns-local-mixin.yaml".to_string(),
                 document: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"x","spec":{"image":"x:1"}}"#.to_string(),
             }),
-            decided_in("/work"),
+            decided_in("/work/lns.yaml"),
         )
         .unwrap_err();
         assert!(
@@ -1139,7 +1145,7 @@ mod tests {
                 pinned: "lns-local-mixin.yaml".to_string(),
                 document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#.to_string(),
             }),
-            decided_in("/work"),
+            decided_in("/work/lns.yaml"),
         )
         .expect("a written file reads")
         .expect("a written file contributes");
@@ -1157,7 +1163,7 @@ mod tests {
                 pinned: "lns-local-mixin.yaml".to_string(),
                 document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"mixins":["./tools"]}}"#.to_string(),
             }),
-            decided_in("/decisions"),
+            decided_in("/decisions/lns-local-mixin.yaml"),
         )
         .expect("a written file reads")
         .expect("a written file contributes");
@@ -1186,7 +1192,7 @@ mod tests {
                 pinned: "dev.yaml".to_string(),
                 document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"dev","spec":{"mixins":["./tools"]}}"#.to_string(),
             }),
-            decided_in("/decisions"),
+            decided_in("/decisions/lns-local-mixin.yaml"),
         )
         .expect("a written file reads")
         .expect("a written file contributes");
@@ -1194,7 +1200,7 @@ mod tests {
         let out = resolve(
             &sandbox(r#"{"image":"x:1"}"#),
             &[],
-            &decided_in("/projdir"),
+            &decided_in("/projdir/lns.yaml"),
             &source,
             Some(local),
         )
@@ -1204,6 +1210,67 @@ mod tests {
             String::from_utf8_lossy(&out.document).contains("ripgrep@14"),
             "rooting at the project instead would merge whatever /projdir/tools happens to hold; got: {}",
             String::from_utf8_lossy(&out.document)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_path_the_user_named_merges_into_a_published_run() {
+        let source = Fake::new(&[("/work/mixins/debug", r#"{"tools":["ripgrep@14"]}"#)]);
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1"}"#),
+            &["/work/mixins/debug".to_string()],
+            &published(),
+            &source,
+            None,
+        )
+        .await
+        .expect("a path the user typed is one this machine read, whatever the sandbox is");
+        assert!(
+            String::from_utf8_lossy(&out.document).contains("ripgrep@14"),
+            "a directory the developer names for their own run is theirs to name; only a published document may not name one, because its consumer has no copy; got: {}",
+            String::from_utf8_lossy(&out.document)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_mixin_a_document_path_names_roots_its_own_references_beside_the_document() {
+        let source = Fake::new(&[
+            ("/work/pg/lns.yaml", r#"{"mixins":["./sibling"]}"#),
+            ("/work/pg/sibling", r#"{"tools":["python@3.12"]}"#),
+        ]);
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1","mixins":["./pg/lns.yaml"]}"#),
+            &[],
+            &decided_in("/work/lns.yaml"),
+            &source,
+            None,
+        )
+        .await
+        .expect("a document names its own siblings beside itself");
+        assert!(
+            String::from_utf8_lossy(&out.document).contains("python@3.12"),
+            "§3.3.1 roots a declared entry at the directory of the document that named it, and naming that document by its own path does not move it; got: {}",
+            String::from_utf8_lossy(&out.document)
+        );
+    }
+
+    #[tokio::test]
+    async fn one_document_named_two_ways_is_one_source() {
+        let source = Fake::new(&[("/work/pg/lns.yaml", r#"{"tools":["python@3.12"]}"#)]);
+        let out = resolve(
+            &sandbox(r#"{"image":"x:1","mixins":["./pg","./pg/lns.yaml"]}"#),
+            &[],
+            &decided_in("/work/lns.yaml"),
+            &source,
+            None,
+        )
+        .await
+        .expect("both spellings resolve");
+        assert_eq!(
+            out.mixins.len(),
+            1,
+            "§3.3.2 has a source many documents name appear once, and two spellings of one path are not two sources; got {:?}",
+            out.mixins
         );
     }
 }

--- a/crates/lns-service/src/artifact/mixin_dir.rs
+++ b/crates/lns-service/src/artifact/mixin_dir.rs
@@ -4,21 +4,28 @@ use anyhow::{Context, Result};
 
 use crate::artifact::mixin::FetchedMixin;
 
-/// The file a directory means, the same one `lns run ./dir` reads.
+/// The document a directory means, the same one `lns run ./dir` reads.
 const DOCUMENT: &str = "lns.yaml";
 
-/// Reads a mixin document off this machine, so the walk can merge a directory without owning any filesystem access itself.
+/// Reads a mixin document off this machine, so the walk can merge a local kit without owning any filesystem access itself.
 pub trait MixinDir: Send + Sync {
     fn read(&self, path: &Path) -> std::io::Result<String>;
+    fn is_dir(&self, path: &Path) -> bool;
 }
 
-/// Read the document a directory holds, as the JSON every other source is parsed from.
-pub fn read_directory_mixin<D: MixinDir>(dir: &D, path: &Path) -> Result<FetchedMixin> {
-    let document = path.join(DOCUMENT);
+/// Read the document a local path names, as the JSON every other source is parsed from: a directory holds its `lns.yaml`, and a path naming the document is the document — the two spellings `lns run` takes. It answers under the document's own folded path, which is what makes the two spellings one source.
+pub fn read_path_mixin<D: MixinDir>(dir: &D, path: &Path) -> Result<FetchedMixin> {
+    let document = if dir.is_dir(path) {
+        path.join(DOCUMENT)
+    } else {
+        path.to_path_buf()
+    };
     let yaml = dir
         .read(&document)
         .with_context(|| format!("reading {}", document.display()))?;
-    parse_document(&yaml, &document, path, path.display().to_string())
+    let document = lns_artifact::sandbox::fold_path(&document);
+    let root = document.parent().unwrap_or(Path::new(".")).to_path_buf();
+    parse_document(&yaml, &document, &root, document.display().to_string())
 }
 
 /// Read the directory's own decisions, which every run there resolves without being named (`docs/sandbox-spec.md` §8.1); a directory nobody has decided anything in has none to read.
@@ -98,30 +105,59 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    struct Fake(BTreeMap<PathBuf, String>);
+    struct Fake {
+        files: BTreeMap<PathBuf, String>,
+        dirs: std::collections::BTreeSet<PathBuf>,
+    }
+
+    impl Fake {
+        fn new(files: BTreeMap<PathBuf, String>) -> Self {
+            let mut dirs = std::collections::BTreeSet::new();
+            for file in files.keys() {
+                let mut parent = file.parent();
+                while let Some(dir) = parent {
+                    dirs.insert(dir.to_path_buf());
+                    parent = dir.parent();
+                }
+            }
+            Self { files, dirs }
+        }
+
+        /// A directory that exists and holds nothing, which no map of files can express.
+        fn empty_dir(path: &str) -> Self {
+            Self {
+                files: BTreeMap::new(),
+                dirs: std::collections::BTreeSet::from([PathBuf::from(path)]),
+            }
+        }
+    }
 
     impl MixinDir for Fake {
         fn read(&self, path: &Path) -> std::io::Result<String> {
-            self.0.get(path).cloned().ok_or_else(|| {
+            self.files.get(path).cloned().ok_or_else(|| {
                 std::io::Error::new(std::io::ErrorKind::NotFound, format!("{}", path.display()))
             })
+        }
+
+        fn is_dir(&self, path: &Path) -> bool {
+            self.dirs.contains(path)
         }
     }
 
     fn holding(path: &str, yaml: &str) -> Fake {
-        Fake(BTreeMap::from([(PathBuf::from(path), yaml.to_string())]))
+        Fake::new(BTreeMap::from([(PathBuf::from(path), yaml.to_string())]))
     }
 
     #[test]
-    fn a_directory_answers_with_its_own_document_under_its_own_path() {
+    fn a_directory_answers_with_the_document_it_holds_under_its_own_path() {
         let dir = holding(
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  tools:\n    - python@3.12\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert_eq!(
-            fetched.pinned, "/work/mixins/pg",
-            "a directory has no digest, so its path is the only identity the disclosure can name it by"
+            fetched.pinned, "/work/mixins/pg/lns.yaml",
+            "a local source has no digest, so the document it resolved to is its identity — which is what makes a directory and that document one source rather than two"
         );
         assert!(
             fetched.document.contains(r#""python@3.12""#),
@@ -136,7 +172,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""/work/mixins/pg/skills""#),
             "a relative path that travelled unrooted would re-read against whichever project merged it; got: {}",
@@ -150,7 +186,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  filesets:\n    - inline:\n        notes.md: hello\n      mountPath: /root/.agent/skills\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""notes.md""#),
             "a fileset carrying its content has no path to root; got: {}",
@@ -164,7 +200,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  volumes:\n    - type: bind\n      source: ./data\n      target: /data\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""/work/mixins/pg/data""#),
             "a relative bind that travelled unrooted would mount the consumer's directory of that name instead of the mixin's own; got: {}",
@@ -178,7 +214,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  volumes:\n    - type: volume\n      source: pg-data\n      target: /data\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""pg-data""#),
             "a named volume's source is its name, not a path, and rooting it would ask for a volume nobody created; got: {}",
@@ -192,7 +228,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  volumes:\n    - type: bind\n      source: ~/.config/pg\n      target: /config\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""~/.config/pg""#),
             "`~/` already names the machine that runs it, so rooting it at the mixin would point somewhere nobody asked for; got: {}",
@@ -206,7 +242,7 @@ mod tests {
             "/work/mixins/pg/lns.yaml",
             "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  filesets:\n    - path: /etc/agent/skills\n      mountPath: /root/.agent/skills\n",
         );
-        let fetched = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap();
         assert!(
             fetched.document.contains(r#""/etc/agent/skills""#),
             "an absolute path already names one file, so rooting it again would move it; got: {}",
@@ -215,9 +251,12 @@ mod tests {
     }
 
     #[test]
-    fn a_directory_with_no_document_says_which_file_is_missing() {
-        let err =
-            read_directory_mixin(&Fake(BTreeMap::new()), Path::new("/work/mixins/pg")).unwrap_err();
+    fn a_directory_holding_no_document_says_which_file_is_missing() {
+        let err = read_path_mixin(
+            &Fake::empty_dir("/work/mixins/pg"),
+            Path::new("/work/mixins/pg"),
+        )
+        .unwrap_err();
         assert!(
             format!("{err:#}").contains("/work/mixins/pg/lns.yaml"),
             "a typo in a directory name is only correctable if the refusal names the file it looked for; got: {err:#}"
@@ -227,7 +266,7 @@ mod tests {
     #[test]
     fn a_document_that_is_not_yaml_names_the_file_it_could_not_parse() {
         let dir = holding("/work/mixins/pg/lns.yaml", "\tnot: [valid");
-        let err = read_directory_mixin(&dir, Path::new("/work/mixins/pg")).unwrap_err();
+        let err = read_path_mixin(&dir, Path::new("/work/mixins/pg")).unwrap_err();
         assert!(
             format!("{err:#}").contains("parsing /work/mixins/pg/lns.yaml"),
             "got: {err:#}"
@@ -238,7 +277,7 @@ mod tests {
     fn a_directory_nobody_has_decided_anything_in_contributes_nothing() {
         assert!(
             read_local_mixin(
-                &Fake(BTreeMap::new()),
+                &Fake::new(BTreeMap::new()),
                 Path::new("/work/lns-local-mixin.yaml")
             )
             .unwrap()
@@ -304,7 +343,16 @@ mod tests {
                     "denied",
                 ))
             }
+
+            fn is_dir(&self, _: &Path) -> bool {
+                false
+            }
         }
+        let refused = read_path_mixin(&Denied, Path::new("/work/mixins/pg")).unwrap_err();
+        assert!(
+            format!("{refused:#}").contains("/work/mixins/pg"),
+            "a path this machine cannot read is not a path that decided nothing; got: {refused:#}"
+        );
         let err = read_local_mixin(&Denied, Path::new("/work/lns-local-mixin.yaml")).unwrap_err();
         assert!(
             format!("{err:#}").contains("/work/lns-local-mixin.yaml"),
@@ -319,6 +367,34 @@ mod tests {
         assert!(
             format!("{err:#}").contains("parsing /work/lns-local-mixin.yaml"),
             "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_path_that_names_the_document_is_read_as_the_document() {
+        let dir = holding(
+            "/work/mixins/pg/lns.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  tools:\n    - python@3.12\n",
+        );
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg/lns.yaml")).unwrap();
+        assert!(
+            fetched.document.contains(r#""python@3.12""#),
+            "`lns run` takes a directory or the document inside it, and one reference grammar means one rule; got: {}",
+            fetched.document
+        );
+    }
+
+    #[test]
+    fn a_path_that_names_the_document_roots_beside_that_document() {
+        let dir = holding(
+            "/work/mixins/pg/lns.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: pg\nspec:\n  filesets:\n    - path: ./skills\n      mountPath: /root/.agent/skills\n",
+        );
+        let fetched = read_path_mixin(&dir, Path::new("/work/mixins/pg/lns.yaml")).unwrap();
+        assert!(
+            fetched.document.contains(r#""/work/mixins/pg/skills""#),
+            "a path the document writes is written against the directory it sits in, however the reference spelled it; got: {}",
+            fetched.document
         );
     }
 }

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -182,10 +182,9 @@ fn local_source(
     let Some(path) = decisions else {
         return Ok(None);
     };
-    let decided_in = path.parent().unwrap_or(std::path::Path::new("."));
     crate::artifact::mixin::LocalSource::read(
         crate::artifact::mixin_dir::read_local_mixin(&RealMixinDir, path)?,
-        crate::artifact::mixin::Locator::Directory(lns_artifact::sandbox::fold_path(decided_in)),
+        crate::artifact::mixin::Locator::Local(lns_artifact::sandbox::fold_path(path)),
     )
 }
 
@@ -193,6 +192,10 @@ fn local_source(
 pub(crate) struct RealMixinDir;
 
 impl crate::artifact::mixin_dir::MixinDir for RealMixinDir {
+    fn is_dir(&self, path: &std::path::Path) -> bool {
+        path.is_dir()
+    }
+
     fn read(&self, path: &std::path::Path) -> std::io::Result<String> {
         std::fs::read_to_string(path)
     }
@@ -211,8 +214,8 @@ impl crate::artifact::mixin::MixinSource for RegistryMixins {
                 let registry = crate::image::caching_registry_for(reference)?;
                 crate::image::pull_mixin_with(&registry, reference).await
             }
-            crate::artifact::mixin::Locator::Directory(dir) => {
-                crate::artifact::mixin_dir::read_directory_mixin(&RealMixinDir, dir)
+            crate::artifact::mixin::Locator::Local(dir) => {
+                crate::artifact::mixin_dir::read_path_mixin(&RealMixinDir, dir)
             }
         }
     }
@@ -376,7 +379,7 @@ pub(crate) async fn resolve_definition(
 ) -> Result<lns_ipc::Response> {
     let project_dir = std::path::Path::new(project_dir);
     crate::artifact::mixin::require_a_rooted_project_dir(project_dir)?;
-    let home = crate::artifact::mixin::Locator::Directory(project_dir.to_path_buf());
+    let home = crate::artifact::mixin::Locator::Local(project_dir.join("lns.yaml"));
     let resolution = crate::artifact::mixin::resolve(
         definition.as_bytes(),
         mixins,

--- a/crates/lns-service/tests/behaviours/mixin_directory.feature
+++ b/crates/lns-service/tests/behaviours/mixin_directory.feature
@@ -12,7 +12,7 @@ Feature: a mixin a document reads from a directory
     And the local definition at "/work" declares the mixin "./mixins/postgres-tools"
     When the local sandbox is resolved and launched
     Then the run installs "python@3.12"
-    And the resolution names the mixin "/work/mixins/postgres-tools"
+    And the resolution names the mixin "/work/mixins/postgres-tools/lns.yaml"
 
   Scenario: a directory a published document names still refuses
     Given the sandbox definition declares the mixin "./mixins/postgres-tools"
@@ -31,4 +31,4 @@ Feature: a mixin a document reads from a directory
     Given a mixin directory "/work/mixins/postgres-tools" declaring the tool "python@3.12"
     And the local definition at "/work" declares the mixins "./mixins/postgres-tools" and "./mixins/../mixins/postgres-tools"
     When the local sandbox is resolved and launched
-    Then the resolution names only the mixin "/work/mixins/postgres-tools"
+    Then the resolution names only the mixin "/work/mixins/postgres-tools/lns.yaml"

--- a/crates/lns-service/tests/behaviours/mixin_flag.feature
+++ b/crates/lns-service/tests/behaviours/mixin_flag.feature
@@ -24,7 +24,12 @@ Feature: a user adds their own mixins to a run
     Then the resolution reports the mixin pinned by digest
     And the resolution answers for the tag "obs-tools:2"
 
-  Scenario: a directory named for a published sandbox refuses the run
+  Scenario: a path the user names merges into a published sandbox
+    Given a mixin directory "/work/obs-tools" declaring the tool "python@3.12"
+    When the published sandbox is resolved with the user's mixin "/work/obs-tools"
+    Then the run installs "python@3.12"
+
+  Scenario: a relative path refuses rather than being rooted at a guess
     When the published sandbox is resolved with the user's mixin "./obs-tools"
     Then the launch is refused
-    And the error says a directory merges only into a document this machine read
+    And the error says the run merges the absolute path its preflight showed

--- a/crates/lns-service/tests/behaviours/steps/mixin_directory.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_directory.rs
@@ -63,7 +63,10 @@ async fn the_local_sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
             Installed::from_rig(rig),
         )
     };
-    let home = lns_service::artifact::mixin::Locator::Directory(std::path::PathBuf::from(home));
+    // A local source is named by the document it was read from, so the project's own `lns.yaml` is what its references join onto.
+    let home = lns_service::artifact::mixin::Locator::Local(
+        std::path::PathBuf::from(home).join("lns.yaml"),
+    );
     let planned = match lns_service::artifact::mixin::resolve(
         definition.as_bytes(),
         &[],
@@ -126,7 +129,7 @@ fn the_error_says_a_published_document_cannot_read_a_directory(
 ) -> Result<(), String> {
     let rig = w.declared.as_ref().ok_or("no launch happened")?;
     let error = rig.error.as_deref().ok_or("no launch error was recorded")?;
-    if error.contains("a directory merges only into a document this machine read") {
+    if error.contains("a consumer has no copy of the machine that wrote it") {
         Ok(())
     } else {
         Err(format!(

--- a/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_flag.rs
@@ -92,13 +92,11 @@ fn resolution_answers_for_the_tag(w: &mut BehaviourWorld, tag: String) -> Result
     }
 }
 
-#[then("the error says a directory merges only into a document this machine read")]
-fn error_says_a_directory_needs_a_document_this_machine_read(
-    w: &mut BehaviourWorld,
-) -> Result<(), String> {
+#[then("the error says the run merges the absolute path its preflight showed")]
+fn error_says_the_run_merges_the_absolute_path(w: &mut BehaviourWorld) -> Result<(), String> {
     let rig = w.declared.as_ref().ok_or("no launch happened")?;
     let error = rig.error.as_deref().ok_or("no launch error was recorded")?;
-    if error.contains("a directory merges only into a document this machine read") {
+    if error.contains("merges the absolute path its preflight showed") {
         Ok(())
     } else {
         Err(format!(

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -24,15 +24,24 @@ impl Installed {
 impl MixinSource for Installed {
     async fn fetch(&self, locator: &Locator) -> anyhow::Result<FetchedMixin> {
         let reference = locator.key();
+        // A local path answers under the document it names, as the reader this stands in for does; a directory holds `lns.yaml`.
+        let pinned = match locator {
+            Locator::Local(path) if path.extension().is_none() => {
+                path.join("lns.yaml").display().to_string()
+            }
+            _ => self
+                .pins
+                .get(&reference)
+                .cloned()
+                .unwrap_or(reference.clone()),
+        };
         let document = self
             .documents
-            .get(&reference)
+            .get(&pinned)
+            .or_else(|| self.documents.get(&reference))
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("nothing here answers for {reference}"))?;
-        Ok(FetchedMixin {
-            pinned: self.pins.get(&reference).cloned().unwrap_or(reference),
-            document,
-        })
+        Ok(FetchedMixin { pinned, document })
     }
 }
 
@@ -166,7 +175,7 @@ async fn sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
             pinned: "lns-local-mixin.yaml".to_string(),
             document,
         }),
-        Locator::Directory(std::path::PathBuf::from("/work")),
+        Locator::Local(std::path::PathBuf::from("/work")),
     )
     .expect("the directory's decisions read");
     let planned = match lns_service::artifact::mixin::resolve(

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -585,20 +585,27 @@ overrules what you decided here. That file's egress is the exception: it reaches
 the running sandbox live rather than through the merge, so a rule you delete
 mid-run stops applying.
 
-A directory entry is read from this machine, relative to the document that names
-it. A published sandbox may not name one — a consumer has no copy of your
+A local entry is read from this machine, relative to the document that names it.
+It may name the directory — whose `lns.yaml` is read — or the document itself,
+the same two spellings `lns run` takes. A published sandbox may not name one — a consumer has no copy of your
 working directory — so `spec.mixins` in a document you `lns push` must be
-digest-pinned. `lns validate` reports a directory that holds no `lns.yaml`.
+digest-pinned. `lns validate` reports a path that holds no document.
 
 You can add your own for a single run:
 
 ```bash
-lns run . --mixin ./mixins/debug-tools
-lns run ghcr.io/acme/agent:1 --mixin ghcr.io/acme/observability:2
+lns run --mixin ./mixins/debug-tools .
+lns run --mixin ./mixins/debug-tools/lns.yaml .
 ```
 
-A directory merges only into a document this machine read, whoever names it — so
-`--mixin ./dir` works on a local run and is refused for a published sandbox.
+**Every flag goes before the reference.** Anything after it is the workload's own
+command, exactly as in `docker run` — so `lns run <ref> --mixin ./x` runs
+`--mixin ./x` inside the sandbox rather than layering a mixin on it.
+
+`--mixin ./dir` works on any run, published or not — you typed it on this
+machine. A **document** may not name one: `spec.mixins` in something you `lns
+push` must be digest-pinned, because whoever pulls it has no copy of your
+directory.
 
 A `--mixin` may be a tag, where a document's entry may not. The run pins it
 before it reports it, so the summary names the exact bytes you approved:

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -598,9 +598,30 @@ lns run --mixin ./mixins/debug-tools .
 lns run --mixin ./mixins/debug-tools/lns.yaml .
 ```
 
-**Every flag goes before the reference.** Anything after it is the workload's own
-command, exactly as in `docker run` — so `lns run <ref> --mixin ./x` runs
-`--mixin ./x` inside the sandbox rather than layering a mixin on it.
+**`--` hands the rest to the workload.** An `lns` flag stays `lns`'s wherever you
+write it, so these are the same run:
+
+```bash
+lns run --mixin ./mixins/debug-tools alpine -- echo hello
+lns run alpine --mixin ./mixins/debug-tools -- echo hello
+```
+
+Without `--`, the workload's command starts at the first word `lns` does not
+claim, and every word after it belongs to the workload:
+
+```bash
+lns run alpine --mixin ./mixins/debug-tools echo hello   # command: echo hello
+lns run alpine sh -c 'echo hi'                           # command: sh -c 'echo hi'
+```
+
+A flag `lns run` does not declare belongs to the workload, so `lns run node
+--version` asks node for its version. Use `--` when you want to pass a flag
+`lns` does declare: `lns run alpine -- --mixin x`.
+
+After the reference, `lns` claims a short flag written apart from its value
+(`-e FOO=1`) or joined with `=` (`-e=FOO=1`); written against its value
+(`-eFOO=1`) it starts the workload's command instead. Before the reference every
+spelling is `lns`'s, as usual. Anything after `--` is the workload's, always.
 
 `--mixin ./dir` works on any run, published or not — you typed it on this
 machine. A **document** may not name one: `spec.mixins` in something you `lns

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -490,7 +490,7 @@ mixins:
 
 | Field | Type | Rules |
 |---|---|---|
-| `mixins` | list<string> | optional. A local directory or an OCI reference. A remote reference MUST be digest-pinned. |
+| `mixins` | list<string> | optional. A local path or an OCI reference. A remote reference MUST be digest-pinned. |
 
 The list **publishes as written** — `lns push` does not merge it. Each mixin is
 pulled and merged at startup, and the run presents the resolved sandbox for
@@ -810,20 +810,30 @@ lns run claude --mixin xyz --mixin zyx    # the user adds two more, in flag orde
 
 | Source | Written by | Reference form |
 |---|---|---|
-| [`spec.mixins`](#319-mixins) | The sandbox's author | A local directory, or an OCI reference that MUST be digest-pinned. A published sandbox has to resolve to the same thing for everyone. |
-| `--mixin <ref>` | The user, per run | A local directory, or a reference that resolves like a sandbox reference — a tag is fine, and preflight pins and shows the digest before boot. |
+| [`spec.mixins`](#319-mixins) | The sandbox's author | A local path, or an OCI reference that MUST be digest-pinned. A published sandbox has to resolve to the same thing for everyone. |
+| `--mixin <ref>` | The user, per run | A local path, or a reference that resolves like a sandbox reference — a tag is fine, and preflight pins and shows the digest before boot. |
 
 The asymmetry is the same one that governs a sandbox reference itself. A digest
 inside a published document is what makes it reproducible for a stranger; a
 reference the user types is their own live choice, and they see what it resolved
 to.
 
-A directory names a file on one machine, so it merges only into a document that
-machine read. A published sandbox MUST NOT name one — a consumer has no copy of
-the author's working directory — and neither may a `--mixin` on a published run.
+**A local path is a directory or the document itself.** A directory is read as
+the `lns.yaml` inside it; a path naming the document is that document. These are
+the two spellings `lns run` already takes for a local sandbox, and one reference
+grammar means one rule — nothing about the merge distinguishes them, since a
+path a document writes roots at the directory the document sits in either way.
+
+A published sandbox MUST NOT name a local path — a consumer has no copy of the
+author's working directory, so the reference resolves to nothing, or worse to
+something else. A `--mixin` may name one on any run, published or not: the user
+typed it on the machine the run happens on, and the preflight shows them what it
+resolved to.
 A declared entry roots at the directory of the document that named it; a
 `--mixin` roots where the user typed it, since no document names one. Either
-way its folded absolute path is its identity: what the graph keys on, and what
+way the folded absolute path of the **document** it resolved to is its identity —
+so a directory and the `lns.yaml` inside it are one source, not two — and that
+identity is what the graph keys on, and what
 the disclosure shows.
 
 Either way the mixin is pulled, merged, and shown in the resolved sandbox the run
@@ -1098,8 +1108,8 @@ Offline validation (`lns sandbox validate`, and every load path including
   `authKind` names and, for `oauth`, the endpoint its `flow` needs; every
   placeholder self-identifies as fake and is at least 16 characters.
 - **Mixin**: no `image`, `command`, `workdir`, `user`, or `resources`; every
-  entry in a document's `mixins` is a local directory or a digest-pinned OCI
-  reference, and a document that publishes carries no directory.
+  entry in a document's `mixins` is a local path or a digest-pinned OCI
+  reference, and a document that publishes carries no local path.
 
 Offline validation checks one document in isolation. Four checks cannot run
 there, because they depend on state no document carries — they run at launch:


### PR DESCRIPTION
Three findings from testing `--mixin` by hand against `main`. Two are fixed here; the third turned out not to be a code defect at all.

## `--mixin` insisted on a directory, for no reason

```
$ lns run --mixin ./mixins/sealed/lns.yaml
Error: … reading …/mixins/sealed/lns.yaml/lns.yaml: Not a directory (os error 20)
```

It appended `lns.yaml` to a path that already named the document.

There was no principle behind directory-only, and the codebase already argued against it: `lns run` has always taken **both** spellings — `run/target.rs` resolves `.`, `lns.yaml`, `./lns.yaml`, `./`, `/other` and `/other/lns.yaml` alike. Only `--mixin` was stricter, and nothing in the mechanism needed it: rooting uses the document's directory, which a file path has; the graph keys on the folded absolute path either way.

**Now one rule, the one `lns run` already used.** A directory is read as the `lns.yaml` inside it; a path naming the document *is* the document. `§3.3.1` says so, and the four places the specification said "a local directory" now say "a local path" — the specification was describing the directory form rather than deciding against the other, so this is a correction, not a new decision.

## `--mixin ./dir` was refused on a published sandbox

```
$ lns run --mixin ./mixins/sealed <published-ref>
Error: … a directory merges only into a document this machine read …
```

That rule was right about documents and wrong about flags, and #240 made the inconsistency visible: the directory's own decisions file may now name a directory beside itself on a published run, because §3.3.1 roots a reference at the document that named it. A `--mixin` is a path **you** typed, on the machine the run happens on, and the preflight shows you what it resolved to before boot.

So the restriction moves to where it belongs. A published *document* still may not name a local path — whoever pulls it has no copy of your directory, so the reference resolves to nothing or, worse, to something else. `locate` no longer consults the run's home for a path the user named.

## The third one changed the rule, not the docs

```
$ lns run <published-ref> --mixin ./mixins/sealed
…
[agent] starting: --mixin ./mixins/sealed
sh: 0: Illegal option --
```

`--mixin` ran as the workload's entrypoint, because everything past the reference was the workload's command — Docker parity, deliberate, and pinned since `09eea8b7` in July.

I first called this a docs defect and corrected the guide, which documented that exact invocation. That was too tidy: "working as designed" is not "working". So the flag is claimed rather than swallowed.

**A flag `lns` declares is `lns`'s wherever it is written, and `--` hands the rest to the workload.**

```bash
lns run alpine --mixin XYZ -- echo hello   # mixin XYZ, command: echo hello
lns run alpine --mixin XYZ echo hello      # same — a word lns does not claim starts the command
```

Everything already pinned survives: `lns run alpine sh -c 'echo hi'`, `lns run alpine -- --mixin ./x`, and `lns run node --version`, which asks *node* — `--help` and `--version` are clap's, not ours, so they stay the workload's.

**What it costs.** A workload whose first argument is a flag `lns` declares now needs `--`. Most such spellings fail loudly (`lns run img -v` asks for `--volume`'s value), but a boolean like `-d` is silently `lns`'s and the workload never sees it. That is why this commit is `feat!`.

`lns exec` shares the walk, so `lns exec demo -q` is its own `--quiet` now.

## What review found: identity was the reference, not the document

Accepting the file form exposed that a local source keyed on **the path the reference spelled**. Two consequences, both real:

- A mixin named `./pg/lns.yaml` whose own `spec.mixins` said `./sibling` resolved the child at `…/lns.yaml/sibling` — the exact invocation this PR ships, broken one level down.
- `./pg` and `./pg/lns.yaml` were two graph identities for one document: fetched twice, merged twice, disclosed twice, and a host port it published would refuse the run as claimed by two sources.

Both are the same defect. **A local source now keys on the document it resolved to**, the way a reference keys on the digest the registry answered with. `Locator::Local` names that document, and a reference it declares joins onto the directory the document sits in. §3.3.1's identity sentence says so.

Two test fakes could not express the model — they answered with the reference rather than the document — so they were the reason the gap survived. Both now behave like the reader they stand in for. That is what made the two new tests meaningful rather than green-on-arrival.

## `lns validate` called a valid entry broken

`directory_mixin_problems` appended `lns.yaml` unconditionally, so a definition declaring `mixins: ["./mixins/pg/lns.yaml"]` — legal, and resolvable by the service — was reported as invalid. It now applies the same rule, which needed `is_dir` on the CLI's `Fs` port.

Its message for a path that is neither a directory nor a document changed too: it names **what the author wrote**, rather than a file inside a directory that is not there.

## Names that stopped being true

- `read_directory_mixin` → `read_path_mixin`; it no longer only reads directories.
- `Locator::Directory` → `Locator::Local`, since the path may be a file.
- `names_a_local_directory` → `names_a_local_path`.
- Two refusal messages that said "is a directory" now say what is actually wrong.

## Verification

`make lint`, `make complexity`, full-workspace `make coverage`, `make test` and `make e2e` all exit 0.

Red-first for both behaviours, and every new assertion mutation-checked: making the reader always append `lns.yaml` turns the two path tests red; rooting at the reference rather than at the document turns the fileset test red; requiring a local home for a user-named path turns the published-run test red.

**One test fake was hiding a case.** `MixinDir`'s fake inferred directories from the files it held, so it could not represent a directory that exists and holds nothing — which is exactly the "directory with no `lns.yaml`" case. Adding `is_dir` to the port surfaced it: that test started passing for the wrong reason. The fake now carries an explicit directory set.
