### PR TITLE
feat!: merge the egress rules from the decisions file and show them in the run summary

### DIFF
--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -215,14 +215,8 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
     }
     spec.ports = ports.into_iter().map(|won| won.item).collect();
 
-    // A later source's entries are placed ahead of an earlier one's, so the latest entry matching a destination is the one that decides.
+    spec.egress = egress_of(sources);
     for source in sources.iter().rev() {
-        spec.egress
-            .http
-            .extend(source.spec.egress.http.iter().cloned());
-        spec.egress
-            .tcp
-            .extend(source.spec.egress.tcp.iter().cloned());
         // Egress is a union rather than a keyed replacement, so every entry is attributed and none displaces another.
         for rule in source.spec.egress.http.iter() {
             contributions.push(egress_contribution(
@@ -246,6 +240,16 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
         spec,
         contributions,
     })
+}
+
+/// The egress an ordered source list decides: a union with each later source's entries ahead of an earlier one's, so the latest entry matching a destination is the one that decides (§4.2).
+pub fn egress_of(sources: &[Source]) -> lns_policy::Egress {
+    let mut egress = lns_policy::Egress::default();
+    for source in sources.iter().rev() {
+        egress.http.extend(source.spec.egress.http.iter().cloned());
+        egress.tcp.extend(source.spec.egress.tcp.iter().cloned());
+    }
+    egress
 }
 
 /// What a document's own egress contributes when nothing merges into it, so a run that layered on nothing still discloses every rule it will enforce (§1.5).
@@ -1027,6 +1031,31 @@ mod tests {
             table[0].verdict,
             lns_policy::Verdict::Allow,
             "the gate reads first-match, so the later source's entry has to sit ahead for it to decide"
+        );
+    }
+
+    #[test]
+    fn the_egress_a_source_list_folds_to_is_the_one_the_merged_document_carries() {
+        let owned = sources(&[
+            (
+                "base",
+                r#"{"egress":{"http":[{"match":"api.example.test","verdict":"deny"}],"tcp":[{"match":"db.example.test:5432","verdict":"allow"}]}}"#,
+            ),
+            (
+                "later",
+                r#"{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}"#,
+            ),
+        ]);
+        let list = as_sources(&owned);
+        assert_eq!(
+            egress_of(&list),
+            merge(&list).expect("these sources resolve").spec.egress,
+            "the gate re-folds a prefix of this list against a live source, so the fold has to be the one that produced the document"
+        );
+        assert_eq!(
+            egress_of(&list[..1]).http.len(),
+            1,
+            "a prefix folds to what those sources alone decided, which is what makes a source that is still being edited foldable over it"
         );
     }
 

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -184,12 +184,13 @@ fn mixins_for_the_run(target: &crate::run::target::RunTarget, pinned: &[String])
     }
 }
 
-/// What the service answered for a local definition: the merged document, and the sources that produced it.
+/// What the service answered for a local definition: the merged document, the sources that produced it, and the egress baseline the run folds this directory's live decisions over.
 struct ResolvedDefinition {
     definition: String,
     mixins: Vec<String>,
     pinned_mixins: Vec<String>,
     contributions: Vec<lns_ipc::SourceContribution>,
+    authored_egress: String,
 }
 
 /// Ask the service to resolve a local definition's mixins, since only it can pull a reference and read a directory the way the run will.
@@ -222,11 +223,13 @@ async fn preflight_local(
             mixins,
             pinned_mixins,
             contributions,
+            authored_egress,
         }) => Ok(ResolvedDefinition {
             definition,
             mixins,
             pinned_mixins,
             contributions,
+            authored_egress,
         }),
         Some(Response::Error { message }) => anyhow::bail!("{message}"),
         Some(other) => anyhow::bail!("unexpected response from daemon: {other:?}"),
@@ -280,6 +283,7 @@ pub async fn run_image(
     args.mixins = crate::run::target::root_named_directories(&args.mixins, &cwd)?;
     // §8.1 has every run in a directory resolve its decisions, so a directory that decided something needs the preflight even when nothing declared a mixin.
     let decisions = crate::run::summary::policy_path(args.policy.as_deref(), &cwd);
+    let mut authored_egress = None;
     if let crate::run::target::RunTarget::Local {
         def,
         json,
@@ -292,6 +296,7 @@ pub async fn run_image(
         **def = lns_artifact::sandbox::parse(resolved.definition.as_bytes())
             .context("reading the resolved definition")?;
         *json = resolved.definition;
+        authored_egress = Some(resolved.authored_egress);
         crate::run::summary::adopt_pinned_mixins(
             &mut args,
             &resolved.mixins,
@@ -467,6 +472,7 @@ pub async fn run_image(
         definition_dir: target
             .project_dir()
             .map(|p| p.to_string_lossy().into_owned()),
+        authored_egress,
     }));
     let frame = encode_frame(&request).context("encoding RunImage request")?;
     stream

--- a/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
+++ b/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
@@ -1,0 +1,23 @@
+Feature: the disclosure names what this directory decided
+  A run in a directory that has decided something resolves those decisions as the
+  last source of its document, so the summary printed before boot lists their
+  rules the way it lists every other source's: each entry named by the source that
+  decided it, the developer's own ahead of what it overruled. An override nobody
+  intended is visible while the run can still be refused.
+
+  Scenario: a rule this directory decided is listed with the file that decided it
+    Given the sandbox denies "docs.some-vendor.example" and this directory allows it
+    When the run summary is composed before boot
+    Then the run summary attributes "allow docs.some-vendor.example" to "lns-local-mixin.yaml"
+    And the run summary attributes "deny docs.some-vendor.example" to "the sandbox"
+
+  Scenario: the decisions file is named among the sources the run resolved
+    Given the sandbox denies "docs.some-vendor.example" and this directory allows it
+    When the run summary is composed before boot
+    Then the run summary lists "Mixins:    lns-local-mixin.yaml"
+
+  Scenario: a directory that decided nothing has no second author to name
+    Given the sandbox denies "docs.some-vendor.example" and this directory decided nothing
+    When the run summary is composed before boot
+    Then the run summary lists "Rules:     deny docs.some-vendor.example"
+    And the run summary does not contain "[from"

--- a/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
+++ b/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use cucumber::{given, then, when};
+use lns_cli::cli::RunArgs;
+use lns_cli::command::parse_args;
+use lns_cli::run::summary::{PolicySource, adopt_pinned_mixins, format_summary, resolved_size};
+use lns_policy::Policy;
+
+use crate::world::BehaviourWorld;
+
+/// What the service answers for a directory whose decisions the resolution reached: every egress entry of the merged document, in the order a first-match gate reads them.
+fn resolution(w: &mut BehaviourWorld, sources: &[&str], entries: &[(&str, &str)]) {
+    w.decisions.sources = sources.iter().map(|s| (*s).to_string()).collect();
+    w.decisions.contributions = entries
+        .iter()
+        .map(|(key, source)| lns_ipc::SourceContribution {
+            block: lns_ipc::ContributionBlock::Egress,
+            key: (*key).to_string(),
+            source: (*source).to_string(),
+            displaced: Vec::new(),
+        })
+        .collect();
+}
+
+#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory allows it$"#)]
+fn the_directory_allows_what_the_sandbox_denies(w: &mut BehaviourWorld, host: String) {
+    resolution(
+        w,
+        &["lns-local-mixin.yaml"],
+        &[
+            (&format!("allow {host}"), "lns-local-mixin.yaml"),
+            (&format!("deny {host}"), "the sandbox"),
+        ],
+    );
+}
+
+#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory decided nothing$"#)]
+fn the_directory_decided_nothing(w: &mut BehaviourWorld, host: String) {
+    resolution(w, &[], &[(&format!("deny {host}"), "the sandbox")]);
+}
+
+#[when("the run summary is composed before boot")]
+fn compose_the_summary(w: &mut BehaviourWorld) {
+    let mut args: RunArgs = parse_args(&[
+        "lns".to_string(),
+        "run".to_string(),
+        "ghcr.io/team/hermes:1".to_string(),
+    ])
+    .expect("argv must parse against the CLI grammar");
+    let sources = std::mem::take(&mut w.decisions.sources);
+    let contributions = std::mem::take(&mut w.decisions.contributions);
+    adopt_pinned_mixins(&mut args, &sources, &[], &contributions);
+    w.summary_output = format_summary(
+        &args,
+        resolved_size(Default::default(), &args),
+        &Policy::default(),
+        Path::new("./lns-local-mixin.yaml"),
+        &PolicySource::FoundInCwd,
+    );
+}
+
+#[then(regex = r#"^the run summary lists "([^"]+)"$"#)]
+fn summary_lists(w: &mut BehaviourWorld, line: String) -> Result<(), String> {
+    if w.summary_output.contains(&line) {
+        Ok(())
+    } else {
+        Err(format!("expected {line:?} in:\n{}", w.summary_output))
+    }
+}
+
+#[then(regex = r#"^the run summary attributes "([^"]+)" to "([^"]+)"$"#)]
+fn summary_attributes(w: &mut BehaviourWorld, entry: String, source: String) -> Result<(), String> {
+    let needle = format!("{entry}  [from {source}]");
+    if w.summary_output.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "a rule this directory decided that the disclosure cannot attribute leaves an override nobody intended invisible; expected {needle:?} in:\n{}",
+            w.summary_output
+        ))
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -9,6 +9,7 @@ pub mod declared_tools;
 pub mod definition_selection;
 pub mod env_file;
 pub mod host_bind;
+pub mod local_decisions;
 pub mod machine_output;
 pub mod policy_cli;
 pub mod publish;

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -57,6 +57,14 @@ pub struct BehaviourWorld {
     pub author_files: std::collections::HashMap<std::path::PathBuf, String>,
     /// Request sequence each shortcut-equivalence invocation sent, in invocation order.
     pub equivalence_requests: Vec<Vec<lns_ipc::Request>>,
+    pub decisions: LocalDecisionsRig,
+}
+
+/// What the service answered when a run resolved this directory's decisions: the sources the merge reached, and which of them decided each entry.
+#[derive(Debug, Default)]
+pub struct LocalDecisionsRig {
+    pub sources: Vec<String>,
+    pub contributions: Vec<lns_ipc::SourceContribution>,
 }
 
 use lns_policy::host_bind_decisions::SecretDisposition;

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -246,6 +246,9 @@ pub enum Response {
         /// Which source decided each entry of the merged document, so the disclosure can attribute every line it shows.
         #[serde(default)]
         contributions: Vec<SourceContribution>,
+        /// The egress every source but this directory's own decided, as JSON: the run folds the live decisions file over it rather than over the copy the merged document carries, so a rule deleted mid-run retracts.
+        #[serde(default)]
+        authored_egress: String,
     },
     ImageTagged {
         from: String,
@@ -604,6 +607,9 @@ pub struct RunImageArgs {
     /// The local definition's absolute directory, keying its per-workload connector grants; absent for a published reference (which keys by repo@digest instead).
     #[serde(default)]
     pub definition_dir: Option<String>,
+    /// What the preflight resolved from every source but this directory's own, as JSON egress: the gate folds the live decisions file over it, so a rule deleted mid-run retracts. Absent when the definition is the only source there was, and unread for a published reference (which the service resolves itself).
+    #[serde(default)]
+    pub authored_egress: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -939,6 +945,7 @@ mod tests {
             verify_sandbox: false,
             definition: None,
             definition_dir: None,
+            authored_egress: None,
         }));
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
@@ -987,6 +994,7 @@ mod tests {
             verify_sandbox: false,
             definition: None,
             definition_dir: None,
+            authored_egress: None,
         };
         let frame = crate::encode_frame(&args).unwrap();
         let decoded: RunImageArgs = crate::decode_frame(&mut &frame[..]).unwrap();
@@ -1123,6 +1131,7 @@ mod tests {
             verify_sandbox: false,
             definition: Some(r#"{"kind":"sandbox"}"#.into()),
             definition_dir: Some("/work/proj".into()),
+            authored_egress: Some(r#"{"http":[],"tcp":[]}"#.into()),
         }
     }
 

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -215,7 +215,7 @@ impl ApprovalSession {
         let _ = self.connector_routes.set(deriver);
     }
 
-    /// Installs a sandbox's shipped policy as the earlier source every reload re-merges under, so a watcher reload of the local decisions carries the sandbox's rules along rather than replacing them; idempotent, the first wins.
+    /// Installs the baseline every reload folds the decisions file over — what every source *but* this directory's own decided, since a copy of that file frozen here would outlive a rule the developer deletes; idempotent, the first wins.
     pub fn set_shipped_policy(&self, shipped: Policy) {
         let _ = self.shipped.set(shipped);
     }
@@ -1745,6 +1745,33 @@ pub(crate) mod tests {
         assert!(
             allow_idx < deny_idx,
             "the developer's decisions file is the last source, so an approval they just made must decide rather than be dropped by the document under it: {routes:?}"
+        );
+        let _ = policy_frame(&mut rx);
+    }
+
+    #[test]
+    fn a_destination_the_developer_deleted_mid_run_stops_being_decided() {
+        let (s, _n, _store, mut rx) = fixture();
+        let mut authored = Policy::default();
+        authored.add_rule(RouteRule::deny_host("*"));
+        s.set_shipped_policy(authored);
+        let mut decided = Policy::default();
+        decided.add_rule(RouteRule::allow_host("docs.some-vendor.example"));
+        s.apply_external_policy(decided);
+        let _ = policy_frame(&mut rx);
+
+        s.apply_external_policy(Policy::default());
+
+        assert_eq!(
+            s.current_policy()
+                .network
+                .egress
+                .http
+                .iter()
+                .map(|rule| (rule.match_pattern.clone(), rule.verdict))
+                .collect::<Vec<_>>(),
+            [("*".to_string(), Verdict::Deny)],
+            "the baseline is what every source but this directory's own decided, so deleting the rule is what retracts it — a copy frozen at boot would keep the host open for the rest of the run"
         );
         let _ = policy_frame(&mut rx);
     }

--- a/crates/lns-service/src/artifact/inspect.rs
+++ b/crates/lns-service/src/artifact/inspect.rs
@@ -172,6 +172,7 @@ mod tests {
             mixins: mixins.to_vec(),
             pinned_extra: Vec::new(),
             contributions: Vec::new(),
+            authored_egress: Default::default(),
         }
     }
 
@@ -342,12 +343,7 @@ mod tests {
             digest(),
             Some(&fileset.artifact_type()),
             &fileset.config_media_type(),
-            &crate::artifact::mixin::Resolution {
-                document: b"{}".to_vec(),
-                mixins: Vec::new(),
-                pinned_extra: Vec::new(),
-                contributions: Vec::new(),
-            },
+            &resolution("{}", &[]),
             None,
         )
         .unwrap_err();
@@ -368,12 +364,7 @@ mod tests {
             digest(),
             Some(&lns_artifact::spec::Kind::Mixin.artifact_type()),
             &lns_artifact::spec::Kind::Mixin.config_media_type(),
-            &crate::artifact::mixin::Resolution {
-                document: document.into_bytes(),
-                mixins: Vec::new(),
-                pinned_extra: Vec::new(),
-                contributions: Vec::new(),
-            },
+            &resolution(&document, &[]),
             None,
         )
         .unwrap();
@@ -402,12 +393,10 @@ mod tests {
             digest(),
             Some(&lns_artifact::spec::Kind::Mixin.artifact_type()),
             &lns_artifact::spec::Kind::Mixin.config_media_type(),
-            &crate::artifact::mixin::Resolution {
-                document: br#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"obs","spec":{"image":"x:1"}}"#.to_vec(),
-                mixins: Vec::new(),
-                pinned_extra: Vec::new(),
-                contributions: Vec::new(),
-            },
+            &resolution(
+                r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"obs","spec":{"image":"x:1"}}"#,
+                &[],
+            ),
             None,
         )
         .unwrap_err();
@@ -428,10 +417,11 @@ mod tests {
                 Some(&lns_artifact::spec::Kind::Sandbox.artifact_type()),
                 &lns_artifact::spec::Kind::Sandbox.config_media_type(),
                 &crate::artifact::mixin::Resolution {
-                    document: br#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"some-sandbox","spec":{"image":"registry.example.test/runtime:1"}}"#.to_vec(),
-                    mixins: vec![declared.clone(), pinned.clone()],
                     pinned_extra: vec![pinned.clone()],
-                    contributions: Vec::new(),
+                    ..resolution(
+                        r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"some-sandbox","spec":{"image":"registry.example.test/runtime:1"}}"#,
+                        &[declared.clone(), pinned.clone()],
+                    )
                 },
                 None,
             )

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -207,6 +207,7 @@ pub async fn resolve_if_a_sandbox<S: MixinSource>(
             mixins: Vec::new(),
             pinned_extra: Vec::new(),
             contributions: Vec::new(),
+            authored_egress: lns_policy::Egress::default(),
         });
     }
     resolve(config_json, extra, home, source, local).await
@@ -221,9 +222,11 @@ pub struct Resolution {
     pub pinned_extra: Vec<String>,
     /// Which source decided each entry of the merged document, and what that decision replaced.
     pub contributions: Vec<lns_artifact::merge::Contribution>,
+    /// What every source but the directory's own decided about egress: the run folds the decisions file over this live, so an approval made mid-run applies and a rule deleted mid-run retracts.
+    pub authored_egress: lns_policy::Egress,
 }
 
-/// What the directory decided, as the merge reads it: the label a disclosure names it by, and everything but the egress it decided. Egress is left out because it reaches the guest live — an approval made mid-run applies and a rule deleted mid-run retracts, and a copy frozen into the booted document could do neither.
+/// What the directory decided, as the merge reads it: the label a disclosure names it by, and everything it decided.
 #[derive(Debug)]
 pub struct LocalSource {
     pub label: String,
@@ -243,10 +246,7 @@ impl LocalSource {
         Ok(Some(Self {
             label: fetched.pinned,
             home,
-            spec: SandboxSpec {
-                egress: Default::default(),
-                ..document.spec
-            },
+            spec: document.spec,
         }))
     }
 
@@ -271,6 +271,7 @@ pub async fn resolve<S: MixinSource>(
             mixins: Vec::new(),
             pinned_extra: Vec::new(),
             contributions: lns_artifact::merge::own_egress(&def.spec),
+            authored_egress: def.spec.egress.clone(),
         });
     }
     let decided = local
@@ -304,16 +305,24 @@ pub async fn resolve<S: MixinSource>(
     let merged = merge(&sources)?;
     let document = document(&def, &merged.spec)?;
     refuse_what_no_sandbox_could_be(&document, &sources)?;
+    let authored_egress = authored_egress(&sources, local.is_some());
+    let mixins = sources
+        .iter()
+        .skip(1)
+        .map(|source| source.label.to_string())
+        .collect();
     Ok(Resolution {
         document,
-        mixins: sources
-            .iter()
-            .skip(1)
-            .map(|source| source.label.to_string())
-            .collect(),
+        mixins,
         pinned_extra: fetched.pinned_extra,
         contributions: merged.contributions,
+        authored_egress,
     })
+}
+
+/// The egress every source but the directory's own decided, which is what the gate folds the live decisions file over; §8.1 puts that source last, so it is the one the fold leaves out.
+fn authored_egress(sources: &[Source], the_directory_decided: bool) -> lns_policy::Egress {
+    lns_artifact::merge::egress_of(&sources[..sources.len() - usize::from(the_directory_decided)])
 }
 
 /// Restate a merge's attribution for the wire, since lns-ipc names the document format without depending on the crate that merges it.
@@ -1139,7 +1148,7 @@ mod tests {
     }
 
     #[test]
-    fn a_directory_that_decided_only_destinations_contributes_nothing_to_the_merge() {
+    fn a_directory_that_decided_only_destinations_is_still_a_source_of_the_merge() {
         let local = LocalSource::read(
             Some(FetchedMixin {
                 pinned: "lns-local-mixin.yaml".to_string(),
@@ -1150,8 +1159,143 @@ mod tests {
         .expect("a written file reads")
         .expect("a written file contributes");
         assert!(
-            local.decides_nothing(),
-            "egress reaches the guest live, so a file holding only egress leaves the merge with nothing to do"
+            !local.decides_nothing(),
+            "§3.3.2 merges this file's egress like any other source's, so a file holding only egress still decides something"
+        );
+    }
+
+    /// The decisions file as the run reads it, holding whatever `spec` a scenario is about.
+    fn decided(spec: &str) -> Option<LocalSource> {
+        LocalSource::read(
+            Some(FetchedMixin {
+                pinned: "lns-local-mixin.yaml".to_string(),
+                document: format!(
+                    r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{spec}}}"#
+                ),
+            }),
+            decided_in("/work"),
+        )
+        .expect("a written file reads")
+    }
+
+    #[tokio::test]
+    async fn what_the_directory_decided_reaches_the_document_that_boots_attributed_to_the_file() {
+        let out = resolve(
+            &sandbox(
+                r#"{"image":"x:1","egress":{"http":[{"match":"docs.some-vendor.example","verdict":"deny"}]}}"#,
+            ),
+            &[],
+            &published(),
+            &Fake::new(&[]),
+            decided(
+                r#"{"egress":{"http":[{"match":"docs.some-vendor.example","verdict":"allow"}]}}"#,
+            ),
+        )
+        .await
+        .expect("a directory that decided a destination resolves");
+        let def = lns_artifact::sandbox::parse(&out.document).expect("the merge is a sandbox");
+        assert_eq!(
+            def.spec
+                .egress
+                .http
+                .iter()
+                .map(|rule| (rule.match_pattern.as_str(), rule.verdict))
+                .collect::<Vec<_>>(),
+            [
+                ("docs.some-vendor.example", lns_policy::Verdict::Allow),
+                ("docs.some-vendor.example", lns_policy::Verdict::Deny)
+            ],
+            "§8.1 puts the directory's decisions last, and §4.2 places a later source ahead, so the developer's allow is what a first-match gate reaches"
+        );
+        assert_eq!(
+            out.contributions
+                .iter()
+                .map(|c| (c.key.as_str(), c.source.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                ("allow docs.some-vendor.example", "lns-local-mixin.yaml"),
+                (
+                    "deny docs.some-vendor.example",
+                    lns_artifact::merge::ROOT_LABEL
+                )
+            ],
+            "§1.5 has the disclosure name what each source contributed, so an allow beating a pulled deny is visible while it can still be refused"
+        );
+        assert_eq!(
+            out.mixins,
+            ["lns-local-mixin.yaml"],
+            "a source the run merged is one the disclosure names"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_gates_baseline_leaves_out_what_the_directory_decided() {
+        let out = resolve(
+            &sandbox(
+                r#"{"image":"x:1","egress":{"http":[{"match":"api.some-vendor.example","verdict":"allow"}],"tcp":[{"match":"db.some-vendor.example:5432","verdict":"allow"}]}}"#,
+            ),
+            &[],
+            &published(),
+            &Fake::new(&[]),
+            decided(
+                r#"{"egress":{"http":[{"match":"docs.some-vendor.example","verdict":"allow"}],"tcp":[{"match":"cache.some-vendor.example:6379","verdict":"allow"}]}}"#,
+            ),
+        )
+        .await
+        .expect("a directory that decided a destination resolves");
+        assert_eq!(
+            out.authored_egress
+                .http
+                .iter()
+                .map(|rule| rule.match_pattern.as_str())
+                .collect::<Vec<_>>(),
+            ["api.some-vendor.example"],
+            "the run folds the live decisions file over this baseline, and a frozen copy of the file in it would outlive a rule the developer deletes mid-run"
+        );
+        assert_eq!(
+            out.authored_egress
+                .tcp
+                .iter()
+                .map(|rule| rule.match_pattern.as_str())
+                .collect::<Vec<_>>(),
+            ["db.some-vendor.example:5432"],
+            "the raw table is folded live by the same rule as the inspected one"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_run_that_layered_on_nothing_hands_the_gate_its_own_egress_as_the_baseline() {
+        let out = resolve(
+            &sandbox(
+                r#"{"image":"x:1","egress":{"http":[{"match":"api.some-vendor.example","verdict":"allow"}]}}"#,
+            ),
+            &[],
+            &published(),
+            &Fake::new(&[]),
+            None,
+        )
+        .await
+        .expect("a document with no mixins resolves to itself");
+        assert_eq!(
+            out.authored_egress
+                .http
+                .iter()
+                .map(|rule| rule.match_pattern.as_str())
+                .collect::<Vec<_>>(),
+            ["api.some-vendor.example"],
+            "a run that resolved nothing still enforces what its own document said, so a baseline of nothing would drop it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plain_image_hands_the_gate_no_baseline_at_all() {
+        let out = resolve_if_a_sandbox(None, None, b"{}", &[], &published(), &Fake::new(&[]), None)
+            .await
+            .expect("an image has no document to merge");
+        assert_eq!(
+            out.authored_egress,
+            lns_policy::Egress::default(),
+            "an image declares no egress, so the directory's decisions govern it verbatim"
         );
     }
 

--- a/crates/lns-service/src/artifact/mod.rs
+++ b/crates/lns-service/src/artifact/mod.rs
@@ -67,10 +67,42 @@ pub fn dispatch_run(
     Ok(path)
 }
 
-/// Map a flat `kind: sandbox` definition onto a resolved run: its base image plus the inline config, with no component graph to assemble. A definition that ships neither a network policy nor connectors plans with no policy baseline, so the directory's overlay governs verbatim.
+/// The baseline the guest's gate folds this directory's live decisions over. A source that ships neither egress nor connectors leaves no baseline at all, so the directory's decisions govern verbatim.
+fn baseline_policy(
+    egress: &lns_policy::Egress,
+    connectors: &[String],
+) -> Option<lns_policy::Policy> {
+    let ships_policy = *egress != lns_policy::Egress::default() || !connectors.is_empty();
+    ships_policy.then(|| lns_policy::Policy {
+        network: lns_policy::NetworkPolicy {
+            egress: egress.clone(),
+        },
+        connectors: connectors.to_vec(),
+        ..lns_policy::Policy::default()
+    })
+}
+
+/// Re-base a plan's policy on the egress every source but the directory's own decided, because the gate folds this directory's live decisions over that baseline rather than over the copy of them the resolved document carries (`docs/sandbox-spec.md` §8.1).
+pub fn with_authored_baseline(
+    mut resolved: ResolvedSandbox,
+    authored: &lns_policy::Egress,
+) -> ResolvedSandbox {
+    let connectors = resolved
+        .policy
+        .as_ref()
+        .map(|policy| policy.connectors.clone())
+        .unwrap_or_default();
+    resolved.policy = baseline_policy(authored, &connectors);
+    resolved
+}
+
+/// The baseline a preflight resolved, as it travelled to the run that boots it.
+pub fn authored_egress(json: &str) -> Result<lns_policy::Egress> {
+    serde_json::from_str(json).context("reading the egress this run's preflight resolved")
+}
+
+/// Map a flat `kind: sandbox` definition onto a resolved run: its base image plus the inline config, with no component graph to assemble.
 pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> ResolvedSandbox {
-    let ships_policy =
-        def.spec.egress != lns_policy::Egress::default() || !def.spec.connectors.is_empty();
     ResolvedSandbox {
         base_image: def.spec.image.clone(),
         user: def.spec.user.clone(),
@@ -136,13 +168,7 @@ pub fn resolved_from_sandbox(def: &lns_artifact::sandbox::Definition) -> Resolve
         command: def.spec.command.clone(),
         env: def.spec.env.clone(),
         resources: def.spec.resources.clone(),
-        policy: ships_policy.then(|| lns_policy::Policy {
-            network: lns_policy::NetworkPolicy {
-                egress: def.spec.egress.clone(),
-            },
-            connectors: def.spec.connectors.clone(),
-            ..lns_policy::Policy::default()
-        }),
+        policy: baseline_policy(&def.spec.egress, &def.spec.connectors),
         credentials: def.spec.credentials.clone(),
         tools: def.spec.tools.clone(),
     }
@@ -301,6 +327,78 @@ mod tests {
             "the baseline's lockdown is a catch-all deny it carries in the table"
         );
         assert_eq!(policy.connectors, vec!["some-provider".to_string()]);
+    }
+
+    #[test]
+    fn a_plan_re_based_on_the_authored_egress_leaves_out_what_the_directory_decided() {
+        let def = lns_artifact::sandbox::parse(
+            br#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1","connectors":["some-provider"],"egress":{"http":[{"match":"docs.some-vendor.example","verdict":"allow"},{"match":"api.some-vendor.example","verdict":"deny"}]}}}"#,
+        )
+        .unwrap();
+        let authored = authored_egress(
+            r#"{"http":[{"match":"api.some-vendor.example","verdict":"deny"}],"tcp":[]}"#,
+        )
+        .expect("the baseline a preflight resolved parses");
+
+        let policy = with_authored_baseline(resolved_from_sandbox(&def), &authored)
+            .policy
+            .expect("a sandbox that ships egress keeps a baseline");
+
+        assert_eq!(
+            policy
+                .network
+                .egress
+                .http
+                .iter()
+                .map(|rule| rule.match_pattern.as_str())
+                .collect::<Vec<_>>(),
+            ["api.some-vendor.example"],
+            "the gate folds the live decisions file over this, and the developer's own allow frozen into it would outlive them deleting the rule"
+        );
+        assert_eq!(
+            policy.connectors,
+            vec!["some-provider".to_string()],
+            "no mixin can name a connector, so re-basing the egress must not drop the list the sandbox itself declared"
+        );
+    }
+
+    #[test]
+    fn a_plan_whose_only_egress_was_the_directorys_own_leaves_the_gate_no_baseline() {
+        let def = lns_artifact::sandbox::parse(
+            br#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1","egress":{"http":[{"match":"docs.some-vendor.example","verdict":"allow"}]}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            with_authored_baseline(resolved_from_sandbox(&def), &lns_policy::Egress::default())
+                .policy,
+            None,
+            "nothing but the developer decided anything here, so the file governs verbatim rather than through a merge with itself"
+        );
+    }
+
+    #[test]
+    fn a_definition_that_shipped_nothing_still_leaves_the_gate_no_baseline_to_fold_over() {
+        let def = lns_artifact::sandbox::parse(
+            br#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            with_authored_baseline(resolved_from_sandbox(&def), &lns_policy::Egress::default())
+                .policy,
+            None,
+            "a directory whose decisions are the only word on the network has nothing to layer them over, and inventing an empty baseline would merge the file with itself"
+        );
+    }
+
+    #[test]
+    fn a_baseline_that_is_not_an_egress_table_refuses_rather_than_governing_as_nothing() {
+        let err = authored_egress("not json").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("the egress this run's preflight resolved"),
+            "a baseline read as empty would silently drop every rule the sandbox ships; got: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -46,7 +46,7 @@ pub(crate) async fn peek_and_plan(
         }
         RunPath::Sandbox => {
             crate::artifact::mixin::require_pinned_extras(mixins)?;
-            let document = crate::artifact::mixin::resolve(
+            let resolution = crate::artifact::mixin::resolve(
                 config_json.as_bytes(),
                 mixins,
                 &crate::artifact::mixin::Locator::Reference(image_ref.to_string()),
@@ -54,9 +54,11 @@ pub(crate) async fn peek_and_plan(
                 local_source(decisions)?,
             )
             .await
-            .with_context(|| format!("resolving {image_ref}"))?
-            .document;
-            let resolved = crate::artifact::plan_published_sandbox(&document, image_ref)?;
+            .with_context(|| format!("resolving {image_ref}"))?;
+            let resolved = crate::artifact::with_authored_baseline(
+                crate::artifact::plan_published_sandbox(&resolution.document, image_ref)?,
+                &resolution.authored_egress,
+            );
             record_sandbox_run(run_id, microvm, image_ref, &digest, &resolved);
             crate::image_store::record_artifact_run(image_ref, &digest, &resolved.base_image)
                 .await
@@ -82,9 +84,18 @@ pub(crate) async fn peek_and_plan(
     }
 }
 
-/// Plan a local `lns.yaml` definition into a bootable workload, disclosing its shipped policy exactly like a published sandbox run.
-pub(crate) async fn plan_local(definition_json: &str) -> Result<SandboxPlan> {
-    let resolved = crate::artifact::plan_local_sandbox(definition_json.as_bytes())?;
+/// Plan a local `lns.yaml` definition into a bootable workload, disclosing its shipped policy exactly like a published sandbox run. `authored_egress` is what the preflight resolved from every source but this directory's own, absent when the run resolved nothing to layer on.
+pub(crate) async fn plan_local(
+    definition_json: &str,
+    authored_egress: Option<&str>,
+) -> Result<SandboxPlan> {
+    let mut resolved = crate::artifact::plan_local_sandbox(definition_json.as_bytes())?;
+    if let Some(authored) = authored_egress {
+        resolved = crate::artifact::with_authored_baseline(
+            resolved,
+            &crate::artifact::authored_egress(authored)?,
+        );
+    }
     disclose_effective_policy(resolved.policy.as_ref());
     let mut materialized = materialize_filesets(&resolved).await?;
     crate::artifact::fileset::local_fileset_specs(
@@ -395,6 +406,8 @@ pub(crate) async fn resolve_definition(
         mixins: resolution.mixins,
         pinned_mixins: resolution.pinned_extra,
         contributions: crate::artifact::mixin::on_the_wire(&resolution.contributions),
+        authored_egress: serde_json::to_string(&resolution.authored_egress)
+            .context("serializing the egress this run resolved")?,
     })
 }
 

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -605,6 +605,7 @@ mod tests {
                 verify_sandbox: false,
                 definition: None,
                 definition_dir: None,
+                authored_egress: None,
             })),
             Instant::now(),
         )

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -81,7 +81,10 @@ async fn orchestrate(
     let sandbox_plan = match (args.definition.as_deref(), resolved_image) {
         (Some(definition), _) => {
             crate::artifact::mixin::refuse_mixins_without_a_document(&args.mixins)?;
-            Some(crate::artifact::real::plan_local(definition).await?)
+            Some(
+                crate::artifact::real::plan_local(definition, args.authored_egress.as_deref())
+                    .await?,
+            )
         }
         (None, Some(image_ref)) => {
             crate::artifact::real::peek_and_plan(

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -43,6 +43,8 @@ pub struct DeclaredRig {
     pub mixin_pins: std::collections::BTreeMap<String, String>,
     /// Every source the resolution merged, as the disclosure names them.
     pub resolved_mixins: Vec<String>,
+    /// Which source decided each entry of the merged document, as the disclosure reads them.
+    pub contributions: Vec<lns_ipc::SourceContribution>,
     /// The pins for the references the user named, in the order they named them.
     pub pinned_extra: Vec<String>,
     /// Where a local definition sits, since a directory it names roots there.

--- a/crates/lns-service/tests/behaviours/mixin_resolution.feature
+++ b/crates/lns-service/tests/behaviours/mixin_resolution.feature
@@ -12,6 +12,11 @@ Feature: a run resolves the mixins its document declares
   an entry never went through it and is refused rather than booted without what
   it contributes.
 
+  The directory's own decisions are the last source in that list, so they merge
+  into the document like any other and the disclosure attributes them to the
+  file. What the guest enforces is folded from that file live, so a rule the
+  developer deletes mid-run stops applying.
+
   Scenario: what a mixin declares reaches the run
     Given a mixin declaring the tool "python@3.12"
     And the sandbox definition declares that mixin
@@ -31,18 +36,33 @@ Feature: a run resolves the mixins its document declares
     When the published sandbox is resolved and launched
     Then the run installs "python@3.12"
 
-  Scenario: the directory's egress stays live rather than being frozen into the document
+  Scenario: what the directory decided merges into the document that boots
     Given the sandbox definition declares nothing but its image
     And the directory's own decisions allow "api.some-provider.example"
     When the published sandbox is resolved and launched
     Then the run installs "curl@8"
-    And the resolved document decides nothing about "api.some-provider.example"
+    And the resolved document allows "api.some-provider.example"
+    And the disclosure attributes "allow api.some-provider.example" to "lns-local-mixin.yaml"
 
-  Scenario: a directory that decided only destinations leaves the document alone
+  Scenario: a directory that decided only destinations is a source the disclosure names
     Given the sandbox definition declares nothing but its image
     And the directory's own decisions allow "api.some-provider.example" and nothing else
     When the published sandbox is resolved and launched
-    Then the run resolved no source but the sandbox itself
+    Then the run resolved the directory's own decisions as a source
+
+  Scenario: what the directory decided outranks a destination the sandbox denies
+    Given the sandbox definition denies "docs.some-vendor.example"
+    And the directory's own decisions allow "docs.some-vendor.example" and nothing else
+    When the published sandbox is resolved and launched
+    Then a workload request to "docs.some-vendor.example" is allowed by policy
+    And the disclosure attributes "allow docs.some-vendor.example" to "lns-local-mixin.yaml"
+    And the disclosure attributes "deny docs.some-vendor.example" to "the sandbox"
+
+  Scenario: a destination the developer never decided stays the sandbox's to deny
+    Given the sandbox definition denies "docs.some-vendor.example"
+    And the directory's own decisions allow "api.some-provider.example" and nothing else
+    When the published sandbox is resolved and launched
+    Then a workload request to "docs.some-vendor.example" is denied by policy
 
   Scenario: a mixin the directory's decisions name merges before them
     Given a mixin declaring the tools "node@22" and "python@3.11"

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -105,20 +105,34 @@ fn local_mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
     ));
 }
 
-#[given(regex = r#"^the directory's own decisions allow "([^"]+)"$"#)]
-fn local_mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
+/// The decisions file in both the roles it plays: the merge's last source, and the live table the guest's gate folds over what the run pulled.
+fn decided(w: &mut BehaviourWorld, spec: &str, allowing: &str) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.local_mixin = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["curl@8"],"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{spec}}}"#
     ));
+    rig.overlay
+        .add_rule(lns_policy::RouteRule::allow_host(allowing));
+}
+
+#[given(regex = r#"^the directory's own decisions allow "([^"]+)"$"#)]
+fn local_mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
+    decided(
+        w,
+        &format!(
+            r#"{{"tools":["curl@8"],"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}"#
+        ),
+        &host,
+    );
 }
 
 #[given(regex = r#"^the directory's own decisions allow "([^"]+)" and nothing else$"#)]
 fn local_mixin_allowing_only_a_destination(w: &mut BehaviourWorld, host: String) {
-    let rig = w.declared.get_or_insert_with(Default::default);
-    rig.local_mixin = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}}}"#
-    ));
+    decided(
+        w,
+        &format!(r#"{{"egress":{{"http":[{{"match":"{host}","verdict":"allow"}}]}}}}"#),
+        &host,
+    );
 }
 
 #[given(regex = r#"^the directory's own decisions declare the tool "([^"]+)" and that mixin$"#)]
@@ -132,6 +146,16 @@ fn local_mixin_declaring_a_tool_and_that_mixin(w: &mut BehaviourWorld, tool: Str
 #[given("the sandbox definition declares nothing but its image")]
 fn definition_declares_only_its_image(w: &mut BehaviourWorld) {
     definition(w, r#"{"image":"ghcr.io/team/base:1"}"#);
+}
+
+#[given(regex = r#"^the sandbox definition denies "([^"]+)"$"#)]
+fn definition_denying_a_destination(w: &mut BehaviourWorld, host: String) {
+    definition(
+        w,
+        &format!(
+            r#"{{"image":"ghcr.io/team/base:1","egress":{{"http":[{{"match":"{host}","verdict":"deny"}}]}}}}"#
+        ),
+    );
 }
 
 #[given("the sandbox definition declares that mixin")]
@@ -192,10 +216,15 @@ async fn sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
             rig.resolved_document =
                 Some(String::from_utf8_lossy(&resolution.document).into_owned());
             rig.resolved_mixins.clone_from(&resolution.mixins);
+            rig.contributions =
+                lns_service::artifact::mixin::on_the_wire(&resolution.contributions);
             lns_service::artifact::plan_published_sandbox(
                 &resolution.document,
                 "registry.example.test/some-sandbox:1",
             )
+            .map(|resolved| {
+                lns_service::artifact::with_authored_baseline(resolved, &resolution.authored_egress)
+            })
         }
         Err(e) => Err(e),
     };
@@ -273,29 +302,63 @@ fn error_says_the_definition_reached_the_plan_unresolved(
     }
 }
 
-#[then(regex = r#"^the resolved document decides nothing about "([^"]+)"$"#)]
-fn resolved_document_decides_nothing(w: &mut BehaviourWorld, host: String) -> Result<(), String> {
+#[then(regex = r#"^the resolved document allows "([^"]+)"$"#)]
+fn resolved_document_allows(w: &mut BehaviourWorld, host: String) -> Result<(), String> {
     let rig = w.declared.as_ref().ok_or("no launch happened")?;
     let document = rig
         .resolved_document
         .as_ref()
         .ok_or("the resolution produced no document")?;
-    if document.contains(&host) {
-        return Err(format!(
-            "the directory's egress reaches the gate live, so freezing a copy into the booted document would survive the developer deleting the rule; got: {document}"
-        ));
+    let def = lns_artifact::sandbox::parse(document.as_bytes()).map_err(|e| format!("{e:#}"))?;
+    match super::mixin_resolution::gate_verdict(
+        &lns_policy::Policy {
+            network: lns_policy::NetworkPolicy {
+                egress: def.spec.egress,
+            },
+            ..lns_policy::Policy::default()
+        },
+        &host,
+    ) {
+        Some(lns_policy::Verdict::Allow) => Ok(()),
+        other => Err(format!(
+            "the document a run boots is the whole merge, and a decision missing from it has nowhere to be disclosed; the document's first match for {host} gave {other:?}: {document}"
+        )),
     }
-    Ok(())
 }
 
-#[then("the run resolved no source but the sandbox itself")]
-fn run_resolved_no_other_source(w: &mut BehaviourWorld) -> Result<(), String> {
+#[then(regex = r#"^the disclosure attributes "([^"]+)" to "([^"]+)"$"#)]
+fn disclosure_attributes(
+    w: &mut BehaviourWorld,
+    entry: String,
+    source: String,
+) -> Result<(), String> {
     let rig = w.declared.as_ref().ok_or("no launch happened")?;
-    if rig.resolved_mixins.is_empty() {
+    let found: Vec<(&str, &str)> = rig
+        .contributions
+        .iter()
+        .map(|c| (c.key.as_str(), c.source.as_str()))
+        .collect();
+    if found.contains(&(entry.as_str(), source.as_str())) {
         Ok(())
     } else {
         Err(format!(
-            "a directory that decided only destinations decides them live, so the merge has nothing to do and the bytes that boot are the ones that were published; got {:?}",
+            "§1.5 has the disclosure name what each source contributed, so an override nobody intended has to be visible before boot; got {found:?}"
+        ))
+    }
+}
+
+#[then("the run resolved the directory's own decisions as a source")]
+fn run_resolved_the_directorys_decisions(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.declared.as_ref().ok_or("no launch happened")?;
+    if rig
+        .resolved_mixins
+        .iter()
+        .any(|source| source == "lns-local-mixin.yaml")
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "a file holding only destinations still decides them, so a run that named no source for them leaves 'why did this run reach that host' unanswered; got {:?}",
             rig.resolved_mixins
         ))
     }

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -27,7 +27,14 @@ choose to edit the file directly.
 The file is a **mixin** — the same document format a
 [sandbox definition](running-workloads.md#defining-a-sandbox) layers on. Every
 run in the directory resolves it without being named, after every other source,
-so nothing you pulled overrules what you decided.
+so nothing you pulled overrules what you decided. Because it is a source like any
+other, the summary a run prints before booting lists its rules and names the file
+they came from — so a rule of yours that overrules one the sandbox shipped is
+visible while you can still stop the run.
+
+The rules the run enforces are folded from this file as it stands, not from a copy
+taken at launch: a rule an approval appends mid-run applies at once, and one you
+delete mid-run stops applying.
 
 Being a mixin also means the file is not limited to `egress`. Any block a mixin
 can declare, this one can declare too — a tool, a mount, another mixin to layer

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -581,9 +581,10 @@ the sandbox first, then each entry in `spec.mixins` in order with that mixin's
 own mixins expanded right after it, then each `--mixin` the user passed, and
 last the directory's own
 [`lns-local-mixin.yaml`](policy.md#the-policy-file) — so nothing you pulled
-overrules what you decided here. That file's egress is the exception: it reaches
-the running sandbox live rather than through the merge, so a rule you delete
-mid-run stops applying.
+overrules what you decided here. Every block of that file merges like any other
+source's, including its `egress`, so the summary lists your rules beside the ones
+they overruled. What the running sandbox enforces is folded from the file itself,
+so a rule you add or delete mid-run applies or stops applying at once.
 
 A local entry is read from this machine, relative to the document that names it.
 It may name the directory — whose `lns.yaml` is read — or the document itself,
@@ -640,15 +641,20 @@ where each line came from — and lists the rules and credentials the merge
 produced, which an uncomposed run has no second author to attribute:
 
 ```
+  Mixins:    /work/mixins/debug-tools, lns-local-mixin.yaml
   Volume:    cache → /home/agent/.cache  [from /work/mixins/debug-tools]
   Tools:     node@22  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…, replaced node@20 from the sandbox]
-  Rules:     allow api.vendor.example  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
-             deny proxy.vendor.example  [from the sandbox]
+  Rules:     allow docs.vendor.example  [from lns-local-mixin.yaml]
+             allow api.vendor.example  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
+             deny docs.vendor.example  [from the sandbox]
   Credentials: SOME_TOKEN  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
 ```
 
-A run that resolved no mixin prints what it always has: one author, nothing to
-attribute.
+A directory that has decided something is one of those sources, so its file is
+named too — and because it is the last one, its rules read first: the `allow`
+above is what the gate reaches, and the `deny` it overruled is still listed under
+it. A run in a directory that decided nothing prints what it always has: one
+author, nothing to attribute.
 
 `lns inspect <REF> --mixin <REF>` shows the same composition without starting a
 run.


### PR DESCRIPTION
## The problem

The specification (`docs/sandbox-spec.md` §3.3.2, §8.1, §1.5) gives these rules:

- The decisions file `lns-local-mixin.yaml` is the last source of the merge.
- The run summary must show each rule and the source of that rule.
- An override must be visible before the run starts.

The code did not follow these rules for egress:

- `LocalSource::read` removed the `egress` block from the decisions file before the merge.
- The rules went to the guest gate through a different path (`merge_effective`).
- The merged document did not contain the rules from the decisions file.
- The run summary showed those rules only as counts in the `Policy:` footer.
- A local `allow` rule could cancel a pulled `deny` rule with no line in the summary. The summary showed the `deny` rule as active. The gate applied the `allow` rule.
- A decisions file with only egress rules was dropped from the resolution, because `decides_nothing()` was true for it.

## The change

- The `egress` block of the decisions file merges the same as each other block. It is the last source. Its entries go before the entries they cancel.
- The merged document contains these entries. The attribution list names the decisions file for each one.
- The run summary shows each rule with its source.
- A decisions file with only egress rules is a source. The resolution names it.
- An empty decisions file adds nothing. A run in a directory with no decisions shows the same summary as before.

## The result

Example: the sandbox denies `docs.some-vendor.example`. The developer allowed it in this directory. The run summary now shows:

```
  Mixins:    lns-local-mixin.yaml
  Rules:     allow docs.some-vendor.example  [from lns-local-mixin.yaml]
             deny docs.some-vendor.example  [from the sandbox]
```

The first rule that matches a destination wins. The developer sees the override before the run starts.

## The file stays live

The old code removed the egress block for one reason: the file is live. A rule added while the sandbox runs must apply. A rule deleted while the sandbox runs must stop. A frozen copy in the booted document can not do this.

The new code keeps this property with a baseline:

- `mixin::Resolution` returns `authored_egress`. This is the merged egress of every source except the decisions file. The same `lns_artifact::merge::egress_of` builds it and the document's table.
- `with_authored_baseline` sets this baseline on the plan's policy.
- `merge_effective` folds the live file over the baseline at boot (`running_policies`) and at each reload (`ApprovalSession::apply_external_policy`).
- At boot, the result is equal to the egress table of the merged document.
- While the sandbox runs, the fold reads the file again. An added rule applies. A deleted rule stops.

`merge_effective` stays the only mechanism that makes the guest table. Only its baseline changed: the baseline is now "every source except this directory".

## The wire change

For a local `lns.yaml`, the CLI sends the merged document to the service. This keeps one property: the service boots the document that the summary showed. Because of this, only the CLI preflight knows which entries came from the decisions file. So `Response::DefinitionResolved` and `RunImageArgs` carry a new field: `authored_egress` (JSON, `#[serde(default)]`). The CLI moves it and does not read it. A published reference does not use the field. The service resolves a published reference at boot and computes the baseline there.

The rejected alternative: send the unresolved definition and resolve again at boot. This adds no wire surface. But then the booted document is not the shown document, and the change becomes much larger.

## Tests

- **Layer 2 (lns-service)**: the scenarios that pinned the old behavior are inverted ("merges into the document that boots", "is a source the disclosure names"). New scenarios: a local allow that outranks a pulled deny, with both attributions; a destination the developer did not decide keeps the sandbox's deny. The test rig's decisions step sets both roles of the file (merge source and live overlay).
- **Layer 2 (lns-cli)**: new `local_decisions_disclosure.feature`. The override is listed and attributed. The file is named in the sources. A directory with no decisions shows no `[from …]` text.
- **Layer 3**: tests for `Resolution.authored_egress` (with and without a decisions file, plain image, no-mixins early return), `with_authored_baseline` (keeps the sandbox's connectors, drops the file's rules, gives no baseline when the file was the only source), the baseline parse refusal, `egress_of` equal to the merged document's table, and a mid-run retraction regression on `apply_external_policy`. The `decides_nothing` unit test is inverted, not deleted.

## Docs

`docs/policy.md` and `docs/running-workloads.md` described the old exception. They now describe what ships: each block merges, the summary attributes the rules of the file, and a mid-run add or delete takes effect at once. The summary example shows the decisions file. `docs/sandbox-spec.md` is not changed.

## Out of scope

These known gaps stay:

- A plain-image run does not resolve the decisions file as a source.
- The effects-consent prompt of a published run does not include local contributions.
- The `--policy` relocation semantics.
