### PR TITLE
fix: write a directory's decisions as carefully as the sidecars beside them

### DIFF
--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -224,15 +224,7 @@ impl Catalog {
     pub fn save_atomic(&self, path: &Path) -> io::Result<()> {
         let yaml = serde_yaml::to_string(self)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent)?;
-        }
-        let tmp = path.with_extension("yaml.tmp");
-        fs::write(&tmp, yaml)?;
-        fs::rename(&tmp, path)?;
-        Ok(())
+        crate::secure_file::write_yaml_document_atomic(path, yaml.as_bytes())
     }
 }
 
@@ -1265,6 +1257,28 @@ mod tests {
         assert!(path.exists());
         assert!(!path.with_extension("yaml.tmp").exists());
         assert_eq!(Catalog::load_or_default(&path).unwrap(), c);
+    }
+
+    #[test]
+    fn save_atomic_does_not_follow_a_symlink_planted_at_the_tmp_path() {
+        // This catalog declares where a credential is injected, so a write redirected out of it is a write of whatever the symlink names.
+        let dir = tempfile::TempDir::new().unwrap();
+        let victim = dir.path().join("victim");
+        let victim_contents = b"victim-data-must-survive";
+        fs::write(&victim, victim_contents).unwrap();
+        let path = dir.path().join(".lns-connectors.yaml");
+        std::os::unix::fs::symlink(&victim, path.with_extension("yaml.tmp")).unwrap();
+
+        let _ = Catalog {
+            connectors: vec![sample_connector()],
+        }
+        .save_atomic(&path);
+
+        assert_eq!(
+            fs::read(&victim).unwrap(),
+            victim_contents,
+            "a symlink at the tmp path must not redirect the catalog write"
+        );
     }
 
     #[test]

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -445,15 +445,7 @@ impl Policy {
         };
         let yaml = serde_yaml::to_string(&document)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent)?;
-        }
-        let tmp = path.with_extension("yaml.tmp");
-        fs::write(&tmp, yaml)?;
-        fs::rename(&tmp, path)?;
-        Ok(())
+        crate::secure_file::write_yaml_document_atomic(path, yaml.as_bytes())
     }
 
     pub fn add_rule(&mut self, rule: RouteRule) {
@@ -1555,6 +1547,45 @@ egress:
         Policy::default().save_atomic(&path).unwrap();
         let tmp = path.with_extension("yaml.tmp");
         assert!(!tmp.exists(), "tmp file should be renamed away");
+    }
+
+    #[test]
+    fn save_atomic_does_not_follow_a_symlink_planted_at_the_tmp_path() {
+        // The service writes this file unattended on every approval, so a symlink planted at the tmp path would turn a click into a write of whatever it points at.
+        let dir = TempDir::new().unwrap();
+        let victim = dir.path().join("victim");
+        let victim_contents = b"victim-data-must-survive";
+        fs::write(&victim, victim_contents).unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+        std::os::unix::fs::symlink(&victim, path.with_extension("yaml.tmp")).unwrap();
+
+        let _ = Policy::default().save_atomic(&path);
+
+        assert_eq!(
+            fs::read(&victim).unwrap(),
+            victim_contents,
+            "a symlink at the tmp path must not redirect the decisions write"
+        );
+    }
+
+    #[test]
+    fn save_atomic_leaves_the_mode_umask_gives_a_file_the_developer_commits() {
+        // §8.2 makes this a file a project commits and shares, so the 0600 a secret sidecar takes would lock out a second account for no gain — compared against a plain write in the same directory, so the assertion holds under any umask.
+        let dir = TempDir::new().unwrap();
+        let reference = dir.path().join("reference");
+        fs::write(&reference, b"").unwrap();
+        let path = dir.path().join("lns-local-mixin.yaml");
+
+        Policy::default().save_atomic(&path).unwrap();
+
+        let mode = |p: &Path| {
+            std::os::unix::fs::PermissionsExt::mode(&fs::metadata(p).unwrap().permissions()) & 0o777
+        };
+        assert_eq!(
+            mode(&path),
+            mode(&reference),
+            "the decisions file must be as readable as any file the developer writes here"
+        );
     }
 
     #[test]

--- a/crates/lns-policy/src/secure_file.rs
+++ b/crates/lns-policy/src/secure_file.rs
@@ -24,17 +24,26 @@ fn write_atomic_at(path: &Path, tmp: &Path, contents: &[u8], mode: u32) -> io::R
         Err(e) if e.kind() == io::ErrorKind::NotFound => {}
         Err(e) => return Err(e),
     }
-    let mut f = fs::OpenOptions::new()
+    let f = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .mode(mode)
         .custom_flags(libc::O_NOFOLLOW)
         .open(tmp)?;
+    match fill_and_rename(f, tmp, path, contents) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(tmp);
+            Err(e)
+        }
+    }
+}
+
+fn fill_and_rename(mut f: fs::File, tmp: &Path, path: &Path, contents: &[u8]) -> io::Result<()> {
     f.write_all(contents)?;
     f.sync_all()?;
     drop(f);
-    fs::rename(tmp, path)?;
-    Ok(())
+    fs::rename(tmp, path)
 }
 
 pub struct SidecarLock {
@@ -129,6 +138,22 @@ mod tests {
         assert!(
             !path.with_extension("json.tmp").exists(),
             "tmp must be renamed away, not left in place"
+        );
+    }
+
+    #[test]
+    fn an_install_that_cannot_land_leaves_no_tmp_behind() {
+        // A tmp the writer created and could not install is untracked noise the developer then finds beside their own file, and only the next write of the same path clears it.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("secret.json");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("occupant"), b"x").unwrap();
+
+        write_json_secret_atomic(&path, b"{}").unwrap_err();
+
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "a write that cannot reach its target must take its tmp with it"
         );
     }
 

--- a/crates/lns-policy/src/secure_file.rs
+++ b/crates/lns-policy/src/secure_file.rs
@@ -6,12 +6,20 @@ use std::time::{Duration, Instant};
 
 /// Atomically installs `contents` at a `.json` `path` with mode 0600 via a NOFOLLOW create-new tmp + rename, so a stale tmp or planted symlink cannot leak the secret through broader perms.
 pub fn write_json_secret_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
+    write_atomic_at(path, &path.with_extension("json.tmp"), contents, 0o600)
+}
+
+/// The same install for a `.yaml` document the developer commits, whose mode umask decides rather than the 0600 a secret takes.
+pub fn write_yaml_document_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
+    write_atomic_at(path, &path.with_extension("yaml.tmp"), contents, 0o666)
+}
+
+fn write_atomic_at(path: &Path, tmp: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
     if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension("json.tmp");
-    // Drop any leftover tmp so the next open is create_new — `.mode(0o600)` is ignored on an existing file, so a stale tmp with broader perms (or a planted symlink) would otherwise carry through the rename and leave the secret world-readable.
-    match fs::remove_file(&tmp) {
+    // Drop any leftover tmp so the next open is create_new — `.mode()` is ignored on an existing file, so a stale tmp with broader perms (or a planted symlink) would otherwise carry through the rename.
+    match fs::remove_file(tmp) {
         Ok(()) => {}
         Err(e) if e.kind() == io::ErrorKind::NotFound => {}
         Err(e) => return Err(e),
@@ -19,13 +27,13 @@ pub fn write_json_secret_atomic(path: &Path, contents: &[u8]) -> io::Result<()> 
     let mut f = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .mode(0o600)
+        .mode(mode)
         .custom_flags(libc::O_NOFOLLOW)
-        .open(&tmp)?;
+        .open(tmp)?;
     f.write_all(contents)?;
     f.sync_all()?;
     drop(f);
-    fs::rename(&tmp, path)?;
+    fs::rename(tmp, path)?;
     Ok(())
 }
 


### PR DESCRIPTION
`docs/sandbox-spec.md` §8 makes `lns-local-mixin.yaml` a file the run writes on the developer's behalf and the project commits. It was the one store in `lns-policy` still installed by a plain `fs::write` of a fixed tmp plus a rename, while every JSON sidecar in the same crate already opened its tmp with `create_new` and `O_NOFOLLOW` and fsynced it before the rename.

Three commits, each with its red test watched failing first:

1. **A symlink at the tmp path no longer redirects a decision.** The install those sidecars use is one function now (`write_atomic_at`); `write_json_secret_atomic` keeps its `json.tmp` and 0600, and the new `write_yaml_document_atomic` takes a `yaml.tmp`. The service writes this file unattended on every approval, so the old writer turned a click into a write of whatever a planted `lns-local-mixin.yaml.tmp` symlink named.
2. **A write that cannot reach its target takes its tmp with it.** One cleanup arm covers the write, the fsync and the rename. It sits after the `create_new` deliberately, so the writer only removes a tmp it owns — an open that lost the create to another writer, or refused a planted symlink, leaves what it found.
3. **The connector catalog rides the same install.** `~/.lns-connectors.yaml` had the identical three-line sequence and the identical hole. Leaving it would have replaced "every JSON store hardened, no YAML store hardened" with a new one-of-two split.

### Two decisions worth stating

**The mode stays what umask gives it, not the 0600 a secret takes.** §8.2 makes this a file the developer commits and reviews in a pull request, and §8.4 keeps every secret and every per-machine consent out of it — `Policy::connectors` is `#[serde(skip)]`, with a test that fails if the connected set ever reaches the file. A 0600 decisions file would break a group-readable checkout, a second account on one machine, and the shared file `--policy` is documented to accept. `0o666` is byte-identical to the `fs::write` it replaces under any umask, and a test pins it against a plain write in the same directory so it holds under any umask.

**No parent-directory fsync.** It was considered and dropped: `sync_all` before the rename already closes the "a crash leaves an empty file, which reads as the mixin nobody wrote" hazard, the sibling JSON writer does not fsync the parent either, and no test in this crate can tell its presence from its absence without an injected `Fs` port. It would have been an unpinned change to four secret stores in a commit whose test cannot see it.

### Out of scope, deliberately

Concurrent read-modify-write of this file (`lns policy allow` versus the service's approval persist) is a pre-existing hazard this PR neither fixes nor worsens. Closing it needs read-under-lock, and the lock would put a `.lock` companion file in a project directory that the specification does not describe.

### Verification

`make lint`, `make complexity` clean. Full workspace tests pass, except one pre-existing failure unrelated to this change: `coverage-strip-ast::run_surfaces_write_failure_with_path_context` sets a file to `0o444` and expects the write to fail, which does not hold when the suite runs as uid 0. `crates/lns-policy/src/secure_file.rs` and `connectors.rs` are both at 100% line coverage.