### PR TITLE
feat(service): Report determinate progress while assembling the rootfs

### DIFF
--- a/crates/lns-service/src/composefs/descriptor.rs
+++ b/crates/lns-service/src/composefs/descriptor.rs
@@ -42,6 +42,7 @@ impl DescriptorBuilder {
         &self,
         content_store: &ContentStore,
         req: &DescriptorRequest<'_>,
+        progress: &dyn Fn(u64, u64),
     ) -> Result<BuiltDescriptor> {
         let runtime_digest = req.runtime_layer.map(|r| r.digest());
         let merge_hash = compute_merge_hash(req.layer_digests, runtime_digest);
@@ -50,7 +51,7 @@ impl DescriptorBuilder {
         }
         let path = self.path_for(&merge_hash);
 
-        let mut fs = oci::build_filesystem_from_layer_bytes(content_store, req.layers)
+        let mut fs = oci::build_filesystem_from_layer_bytes(content_store, req.layers, progress)
             .context("expanding OCI layers into composefs tree")?;
 
         if fs.root.lookup(std::ffi::OsStr::new("usr")).is_some() {
@@ -254,7 +255,7 @@ mod tests {
             layers: &[tar],
             runtime_layer: None,
         };
-        let r = builder.build(&store, &req).unwrap();
+        let r = builder.build(&store, &req, &|_, _| {}).unwrap();
 
         assert!(r.path.is_file());
         assert_eq!(
@@ -315,10 +316,10 @@ mod tests {
             layers: &[tar],
             runtime_layer: None,
         };
-        let a = builder.build(&store, &req).unwrap();
+        let a = builder.build(&store, &req, &|_, _| {}).unwrap();
         let mtime_a = std::fs::metadata(&a.path).unwrap().modified().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(20));
-        let b = builder.build(&store, &req).unwrap();
+        let b = builder.build(&store, &req, &|_, _| {}).unwrap();
         assert_eq!(a, b);
         let mtime_b = std::fs::metadata(&b.path).unwrap().modified().unwrap();
         assert_eq!(mtime_a, mtime_b, "cached build must not rewrite the file");
@@ -363,6 +364,7 @@ mod tests {
                     layers: std::slice::from_ref(&tar),
                     runtime_layer: Some(&rt_a),
                 },
+                &|_, _| {},
             )
             .unwrap();
         let r2 = builder
@@ -373,6 +375,7 @@ mod tests {
                     layers: std::slice::from_ref(&tar),
                     runtime_layer: Some(&rt_b),
                 },
+                &|_, _| {},
             )
             .unwrap();
         assert_ne!(r1.merge_hash, r2.merge_hash);
@@ -392,7 +395,7 @@ mod tests {
             layers: &[tar],
             runtime_layer: None,
         };
-        let r = builder.build(&store, &req).unwrap();
+        let r = builder.build(&store, &req, &|_, _| {}).unwrap();
         assert!(r.path.is_file());
         let bytes = std::fs::read(&r.path).unwrap();
         assert!(bytes.len() > 1024);
@@ -433,7 +436,7 @@ mod tests {
     #[test]
     fn build_writes_a_sha_sidecar_next_to_the_descriptor() {
         let f = fixture("sha256:1a");
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         let sidecar = sidecar_path(&built.path);
         assert_eq!(
             std::fs::read_to_string(sidecar).unwrap(),
@@ -445,14 +448,14 @@ mod tests {
     fn cached_returns_none_before_build_and_the_built_descriptor_after() {
         let f = fixture("sha256:2b");
         assert!(f.builder.cached(&f.request()).unwrap().is_none());
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         assert_eq!(f.builder.cached(&f.request()).unwrap(), Some(built));
     }
 
     #[test]
     fn cached_hit_serves_sha_from_sidecar_without_rehashing_the_descriptor() {
         let f = fixture("sha256:3c");
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         std::fs::write(&built.path, b"corrupted on disk after install").unwrap();
         let hit = f.builder.cached(&f.request()).unwrap().expect("cache hit");
         assert_eq!(
@@ -464,7 +467,7 @@ mod tests {
     #[test]
     fn cached_falls_back_to_hashing_and_self_heals_when_sidecar_is_missing() {
         let f = fixture("sha256:4d");
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         let sidecar = sidecar_path(&built.path);
         std::fs::remove_file(&sidecar).unwrap();
         let hit = f.builder.cached(&f.request()).unwrap().expect("cache hit");
@@ -479,7 +482,7 @@ mod tests {
     #[test]
     fn cached_rejects_a_corrupt_sidecar_and_rehashes() {
         let f = fixture("sha256:5e");
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         let sidecar = sidecar_path(&built.path);
         for garbage in ["not a digest", "sha256:zz", "sha256:abc"] {
             std::fs::write(&sidecar, garbage).unwrap();
@@ -509,7 +512,7 @@ mod tests {
         assert!(f.builder.cached(&f.request()).unwrap().is_none());
         let path = f.builder.path_for(&compute_merge_hash(&f.digests, None));
         std::fs::create_dir_all(sidecar_path(&path)).unwrap();
-        let built = f.builder.build(&f.store, &f.request()).unwrap();
+        let built = f.builder.build(&f.store, &f.request(), &|_, _| {}).unwrap();
         assert!(
             built.path.is_file(),
             "descriptor must land despite the sidecar failure",
@@ -530,6 +533,7 @@ mod tests {
                     layers: &[tar],
                     runtime_layer: None,
                 },
+                &|_, _| {},
             )
             .unwrap();
         let bytes = std::fs::read(&r.path).unwrap();

--- a/crates/lns-service/src/composefs/oci.rs
+++ b/crates/lns-service/src/composefs/oci.rs
@@ -28,11 +28,17 @@ pub const fn type_bits(t: libc::mode_t) -> u32 {
 pub fn build_filesystem_from_layer_bytes(
     content_store: &ContentStore,
     layers: &[Vec<u8>],
+    progress: &dyn Fn(u64, u64),
 ) -> Result<FileSystem<Sha256Digest>> {
+    let total: u64 = layers.iter().map(|l| l.len() as u64).sum();
+    progress(0, total);
     let mut fs = FileSystem::<Sha256Digest>::new(root_stat());
+    let mut applied: u64 = 0;
     for (idx, layer_bytes) in layers.iter().enumerate() {
         apply_layer_bytes(&mut fs, content_store, layer_bytes, Limits::PRODUCTION)
             .with_context(|| format!("applying layer {idx}"))?;
+        applied += layer_bytes.len() as u64;
+        progress(applied, total);
     }
     Ok(fs)
 }
@@ -566,7 +572,7 @@ mod tests {
             write_dir_entry(b, "etc/", 0o755);
             write_file_entry(b, "etc/hostname", 0o644, b"sandbox\n");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         let leaf_id = etc.leaf_id(OsStr::new("hostname")).unwrap();
         assert!(matches!(
@@ -590,7 +596,7 @@ mod tests {
         let layer2 = build_tar(|b| {
             write_file_entry(b, "etc/version", 0o644, b"v2\n");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         let leaf_id = etc.leaf_id(OsStr::new("version")).unwrap();
         assert!(matches!(
@@ -612,7 +618,7 @@ mod tests {
             write_file_entry(b, "etc/secret", 0o600, b"hush");
         });
         let layer2 = build_tar(|b| write_whiteout(b, "etc/.wh.secret"));
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("secret")).is_err());
     }
@@ -629,7 +635,7 @@ mod tests {
             write_file_entry(b, "etc/version", 0o644, b"newer");
             write_whiteout(b, "etc/.wh.version");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         let leaf_id = etc.leaf_id(OsStr::new("version")).unwrap();
         assert!(matches!(
@@ -651,7 +657,7 @@ mod tests {
             write_whiteout(b, "var/.wh..wh..opq");
             write_file_entry(b, "var/c", 0o644, b"c");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let var = fs.root.get_directory_mut(OsStr::new("var")).unwrap();
         assert!(var.leaf_id(OsStr::new("a")).is_err());
         assert!(var.leaf_id(OsStr::new("b")).is_err());
@@ -670,7 +676,7 @@ mod tests {
             write_file_entry(b, "var/new", 0o644, b"new");
             write_whiteout(b, "var/.wh..wh..opq");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let var = fs.root.get_directory_mut(OsStr::new("var")).unwrap();
         assert!(var.leaf_id(OsStr::new("old")).is_err());
         assert!(var.leaf_id(OsStr::new("new")).is_ok());
@@ -684,7 +690,7 @@ mod tests {
             write_dir_entry(b, "bin/", 0o755);
             write_symlink_entry(b, "bin/sh", "busybox");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let bin = fs.root.get_directory_mut(OsStr::new("bin")).unwrap();
         let leaf_id = bin.leaf_id(OsStr::new("sh")).unwrap();
         let content = &fs.leaves[leaf_id.0].content;
@@ -704,7 +710,7 @@ mod tests {
         let tar = build_tar(|b| {
             write_file_entry(b, "deep/nested/file", 0o644, b"x");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let nested = fs
             .root
             .get_directory_mut(OsStr::new("deep"))
@@ -721,7 +727,7 @@ mod tests {
         let tar = build_tar(|b| {
             write_file_entry(b, "./etc/hostname", 0o644, b"sandbox");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
     }
@@ -816,7 +822,7 @@ mod tests {
         let gzipped = gz.finish().unwrap();
         let d = tempdir();
         let s = store(&d);
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[gzipped]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[gzipped], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
     }
@@ -834,7 +840,7 @@ mod tests {
         let d = tempdir();
         let s = store(&d);
         let layer = build_tar(|b| write_whiteout(b, "etc/.wh."));
-        let err = build_filesystem_from_layer_bytes(&s, &[layer]).unwrap_err();
+        let err = build_filesystem_from_layer_bytes(&s, &[layer], &|_, _| {}).unwrap_err();
         assert!(format!("{err:#}").contains("whiteout path has no target"));
     }
 
@@ -845,7 +851,7 @@ mod tests {
         let tar = build_tar(|b| {
             write_typed_entry(b, "dev/myfifo", EntryType::Fifo);
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let dev = fs.root.get_directory_mut(OsStr::new("dev")).unwrap();
         let leaf_id = dev.leaf_id(OsStr::new("myfifo")).unwrap();
         let leaf = &fs.leaves[leaf_id.0];
@@ -869,7 +875,7 @@ mod tests {
             write_file_entry(b, "etc/hostname", 0o644, b"sandbox");
             write_typed_entry(b, "etc/host", EntryType::Link);
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
         assert!(
@@ -887,7 +893,7 @@ mod tests {
             write_typed_entry(b, "dev/null", EntryType::Char);
             write_typed_entry(b, "dev/sda", EntryType::Block);
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let dev = fs.root.get_directory_mut(OsStr::new("dev")).unwrap();
         assert!(
             dev.leaf_id(OsStr::new("null")).is_err(),
@@ -907,7 +913,7 @@ mod tests {
             write_dir_entry(b, "./", 0o755);
             write_file_entry(b, "etc/hostname", 0o644, b"sandbox");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
     }
@@ -920,7 +926,7 @@ mod tests {
             write_typed_entry(b, "globalmeta", EntryType::XGlobalHeader);
             write_file_entry(b, "etc/hostname", 0o644, b"sandbox");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
         assert!(
@@ -940,7 +946,7 @@ mod tests {
         let layer2 = build_tar(|b| {
             write_dir_entry(b, "etc/", 0o755);
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(
             etc.leaf_id(OsStr::new("keep")).is_ok(),
@@ -957,7 +963,7 @@ mod tests {
             write_dir_entry(b, "etc/", 0o755);
             write_file_entry(b, "etc/hostname", 0o644, b"sandbox");
         });
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let etc = fs.root.get_directory_mut(OsStr::new("etc")).unwrap();
         assert!(etc.leaf_id(OsStr::new("hostname")).is_ok());
     }
@@ -968,7 +974,7 @@ mod tests {
         let s = store(&d);
         let layer1 = build_tar(|b| write_file_entry(b, "a", 0o644, b"identical"));
         let layer2 = build_tar(|b| write_file_entry(b, "b", 0o644, b"identical"));
-        let _fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2]).unwrap();
+        let _fs = build_filesystem_from_layer_bytes(&s, &[layer1, layer2], &|_, _| {}).unwrap();
         let count = std::fs::read_dir(d.path().join("content").join("sha256"))
             .unwrap()
             .count();
@@ -985,7 +991,7 @@ mod tests {
         std::fs::set_permissions(&sha_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let tar = build_tar(|b| write_file_entry(b, "etc/hostname", 0o644, b"sandbox\n"));
-        let err = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap_err();
+        let err = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap_err();
 
         std::fs::set_permissions(&sha_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(
@@ -1000,7 +1006,7 @@ mod tests {
         let s = store(&d);
         let big = vec![0xabu8; (MAX_BUFFERED_FILE_BYTES + 1) as usize];
         let tar = build_tar(|b| write_file_entry(b, "opt/model.bin", 0o644, &big));
-        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap();
+        let mut fs = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap();
         let opt = fs.root.get_directory_mut(OsStr::new("opt")).unwrap();
         let leaf_id = opt.leaf_id(OsStr::new("model.bin")).unwrap();
         assert!(
@@ -1030,7 +1036,7 @@ mod tests {
 
         let big = vec![0x7eu8; (MAX_BUFFERED_FILE_BYTES + 1) as usize];
         let tar = build_tar(|b| write_file_entry(b, "opt/model.bin", 0o644, &big));
-        let err = build_filesystem_from_layer_bytes(&s, &[tar]).unwrap_err();
+        let err = build_filesystem_from_layer_bytes(&s, &[tar], &|_, _| {}).unwrap_err();
 
         std::fs::set_permissions(&sha_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -217,19 +217,13 @@ mod assembling_progress_tests {
     use super::*;
     use lns_ipc::{Response, WireFrame};
 
-    fn run_progress_frames(frames: Vec<WireFrame>) -> Vec<(String, String, u64, u64)> {
-        frames
-            .into_iter()
-            .filter_map(|f| match f {
-                WireFrame::Json(Response::RunProgress {
-                    verb,
-                    message,
-                    current,
-                    total,
-                }) => Some((verb, message, current, total)),
-                _ => None,
-            })
-            .collect()
+    fn assembling_frame(current: u64, total: u64) -> WireFrame {
+        WireFrame::Json(Response::RunProgress {
+            verb: "Assembling".to_string(),
+            message: "rootfs".to_string(),
+            current,
+            total,
+        })
     }
 
     #[test]
@@ -238,10 +232,7 @@ mod assembling_progress_tests {
             let sink = assembling_progress(tracing::Span::current());
             sink(3072, 8192);
         });
-        assert_eq!(
-            run_progress_frames(frames),
-            vec![("Assembling".to_string(), "rootfs".to_string(), 3072, 8192)]
-        );
+        assert_eq!(frames, vec![assembling_frame(3072, 8192)]);
     }
 
     #[test]
@@ -253,10 +244,7 @@ mod assembling_progress_tests {
                 s.spawn(move || tracing::dispatcher::with_default(&dispatch, || sink(0, 8192)));
             });
         });
-        assert_eq!(
-            run_progress_frames(frames),
-            vec![("Assembling".to_string(), "rootfs".to_string(), 0, 8192)]
-        );
+        assert_eq!(frames, vec![assembling_frame(0, 8192)]);
     }
 }
 

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -8,6 +8,13 @@ mod scratch;
 mod shutdown;
 pub use orchestrator::handle;
 
+/// The rootfs-assembly progress sink: `span` is the run span captured before `spawn_blocking`, since the blocking thread has no ambient span for the frame forwarder to find the run's channel through.
+fn assembling_progress(span: tracing::Span) -> impl Fn(u64, u64) {
+    move |current, total| {
+        span.in_scope(|| crate::log::progress("Assembling", "rootfs", current, total));
+    }
+}
+
 pub(super) async fn emit_completion(frame_tx: &Sender<WireFrame>, result: Result<i32>) -> i32 {
     let code = match result {
         Ok(code) => {
@@ -202,6 +209,54 @@ pub(super) fn workload_identity(
         anyhow::bail!(
             "this run resolved neither a definition directory nor a published digest, so it cannot hold connector grants; run a sandbox definition or a published sandbox reference, and if `lns` was upgraded while this service kept running, restart it (`lns service stop` then `lns service start`) so the two match"
         )
+    }
+}
+
+#[cfg(test)]
+mod assembling_progress_tests {
+    use super::*;
+    use lns_ipc::{Response, WireFrame};
+
+    fn run_progress_frames(frames: Vec<WireFrame>) -> Vec<(String, String, u64, u64)> {
+        frames
+            .into_iter()
+            .filter_map(|f| match f {
+                WireFrame::Json(Response::RunProgress {
+                    verb,
+                    message,
+                    current,
+                    total,
+                }) => Some((verb, message, current, total)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_sink_forwards_an_assembling_run_progress_frame() {
+        let frames = crate::log::testing::capture_run_frames(|| {
+            let sink = assembling_progress(tracing::Span::current());
+            sink(3072, 8192);
+        });
+        assert_eq!(
+            run_progress_frames(frames),
+            vec![("Assembling".to_string(), "rootfs".to_string(), 3072, 8192)]
+        );
+    }
+
+    #[test]
+    fn the_sink_forwards_from_a_blocking_thread_outside_the_run_task() {
+        let frames = crate::log::testing::capture_run_frames(|| {
+            let sink = assembling_progress(tracing::Span::current());
+            let dispatch = tracing::dispatcher::get_default(|d| d.clone());
+            std::thread::scope(|s| {
+                s.spawn(move || tracing::dispatcher::with_default(&dispatch, || sink(0, 8192)));
+            });
+        });
+        assert_eq!(
+            run_progress_frames(frames),
+            vec![("Assembling".to_string(), "rootfs".to_string(), 0, 8192)]
+        );
     }
 }
 

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -340,6 +340,7 @@ async fn orchestrate(
                         layers: &layers,
                         runtime_layer: runtime_layer.as_ref(),
                     },
+                    &|_, _| {},
                 )
             })
             .await

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -330,8 +330,8 @@ async fn orchestrate(
     let descriptor = match cached_descriptor {
         Some(hit) => hit,
         None => {
-            log::progress("Assembling", "rootfs", 0, 0);
             let descriptor_cs = content_store.clone();
+            let run_span = tracing::Span::current();
             tokio::task::spawn_blocking(move || {
                 descriptor_builder.build(
                     &descriptor_cs,
@@ -340,7 +340,7 @@ async fn orchestrate(
                         layers: &layers,
                         runtime_layer: runtime_layer.as_ref(),
                     },
-                    &|_, _| {},
+                    &super::assembling_progress(run_span),
                 )
             })
             .await

--- a/crates/lns-service/src/tools/provisioner/real.rs
+++ b/crates/lns-service/src/tools/provisioner/real.rs
@@ -159,6 +159,7 @@ async fn run_provisioner(
                         layers: &layers,
                         runtime_layer: runtime_layer.as_ref(),
                     },
+                    &|_, _| {},
                 )
             })
             .await

--- a/crates/lns-service/tests/behaviours.rs
+++ b/crates/lns-service/tests/behaviours.rs
@@ -2,6 +2,8 @@
 mod approval_rig;
 #[path = "behaviours/artifact_rig.rs"]
 mod artifact_rig;
+#[path = "behaviours/assembly_rig.rs"]
+mod assembly_rig;
 #[path = "behaviours/bind_rig.rs"]
 mod bind_rig;
 #[path = "behaviours/credential_rig.rs"]

--- a/crates/lns-service/tests/behaviours/assembly_rig.rs
+++ b/crates/lns-service/tests/behaviours/assembly_rig.rs
@@ -10,6 +10,7 @@ pub struct AssemblyRig {
     pub layers: Vec<Vec<u8>>,
     pub events: Arc<Mutex<Vec<(u64, u64)>>>,
     pub built: Option<BuiltDescriptor>,
+    pub rebuilt: Option<BuiltDescriptor>,
 }
 
 impl AssemblyRig {
@@ -24,6 +25,7 @@ impl AssemblyRig {
             layers,
             events: Arc::new(Mutex::new(Vec::new())),
             built: None,
+            rebuilt: None,
         }
     }
 

--- a/crates/lns-service/tests/behaviours/assembly_rig.rs
+++ b/crates/lns-service/tests/behaviours/assembly_rig.rs
@@ -1,0 +1,64 @@
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+
+use lns_service::composefs::descriptor::BuiltDescriptor;
+use tempfile::TempDir;
+
+#[derive(Debug)]
+pub struct AssemblyRig {
+    pub dir: TempDir,
+    pub layers: Vec<Vec<u8>>,
+    pub events: Arc<Mutex<Vec<(u64, u64)>>>,
+    pub built: Option<BuiltDescriptor>,
+}
+
+impl AssemblyRig {
+    pub fn with_layer_sizes(sizes: &[usize]) -> Self {
+        let layers = sizes
+            .iter()
+            .enumerate()
+            .map(|(i, size)| tar_layer_of(*size, &format!("file-{i}")))
+            .collect();
+        Self {
+            dir: TempDir::new().expect("create tempdir"),
+            layers,
+            events: Arc::new(Mutex::new(Vec::new())),
+            built: None,
+        }
+    }
+
+    pub fn layer_digests(&self) -> Vec<String> {
+        (0..self.layers.len())
+            .map(|i| format!("sha256:layer-{i}"))
+            .collect()
+    }
+}
+
+/// A plain tar archive of exactly `total` bytes: one 512-byte header, one content run, one 1024-byte end-of-archive marker.
+fn tar_layer_of(total: usize, name: &str) -> Vec<u8> {
+    let content_len = total - 512 - 1024;
+    let content = vec![b'x'; content_len];
+    let mut bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(Cursor::new(&mut bytes));
+        let mut header = tar::Header::new_ustar();
+        header.set_path(name).expect("tar path");
+        header.set_size(content_len as u64);
+        header.set_mode(0o644);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder
+            .append(&header, Cursor::new(&content[..]))
+            .expect("append tar entry");
+        builder.finish().expect("finish tar");
+    }
+    assert_eq!(
+        bytes.len(),
+        total,
+        "tar fixture must be exactly {total} bytes"
+    );
+    bytes
+}

--- a/crates/lns-service/tests/behaviours/rootfs_assembly_progress.feature
+++ b/crates/lns-service/tests/behaviours/rootfs_assembly_progress.feature
@@ -12,7 +12,6 @@ Feature: rootfs assembly reports determinate progress
     And the sink observes 3072 of 8192 bytes after the first layer
     And the sink observes 8192 of 8192 bytes after the last layer
 
-  @todo
   Scenario: A cached descriptor is served without any assembly progress
     Given an image whose descriptor was already assembled
     When the same rootfs is requested again with a recording progress sink

--- a/crates/lns-service/tests/behaviours/rootfs_assembly_progress.feature
+++ b/crates/lns-service/tests/behaviours/rootfs_assembly_progress.feature
@@ -1,0 +1,20 @@
+Feature: rootfs assembly reports determinate progress
+  First-run `lns run` of a large image assembles the rootfs from its
+  layers, which can take minutes. The assembly must report how many
+  layer bytes it has applied out of the total so the CLI can draw the
+  same determinate bar the pull phase already shows — an indeterminate
+  spinner reads as a hang.
+
+  Scenario: Assembling a multi-layer rootfs reports cumulative bytes per layer
+    Given an uncached image with layers of 3072 and 5120 bytes
+    When the rootfs is assembled with a recording progress sink
+    Then the sink first observes 0 of 8192 bytes
+    And the sink observes 3072 of 8192 bytes after the first layer
+    And the sink observes 8192 of 8192 bytes after the last layer
+
+  @todo
+  Scenario: A cached descriptor is served without any assembly progress
+    Given an image whose descriptor was already assembled
+    When the same rootfs is requested again with a recording progress sink
+    Then the descriptor is served from cache
+    And the sink observes no progress at all

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -15,6 +15,7 @@ pub mod mixin_resolution;
 pub mod oauth_connector;
 pub mod pkce_connector;
 pub mod policy_guardrail;
+pub mod rootfs_assembly;
 pub mod run_as_env;
 pub mod run_lifecycle;
 pub mod run_naming;

--- a/crates/lns-service/tests/behaviours/steps/rootfs_assembly.rs
+++ b/crates/lns-service/tests/behaviours/steps/rootfs_assembly.rs
@@ -1,0 +1,52 @@
+use crate::assembly_rig::AssemblyRig;
+use crate::world::BehaviourWorld;
+use cucumber::{given, then, when};
+use lns_service::composefs::descriptor::{DescriptorBuilder, DescriptorRequest};
+use lns_service::content_store::ContentStore;
+
+#[given(regex = r"^an uncached image with layers of (\d+) and (\d+) bytes$")]
+fn uncached_image(world: &mut BehaviourWorld, first: usize, second: usize) {
+    world.assembly = Some(AssemblyRig::with_layer_sizes(&[first, second]));
+}
+
+#[when("the rootfs is assembled with a recording progress sink")]
+fn assemble_with_recording_sink(world: &mut BehaviourWorld) {
+    let rig = world.assembly.as_mut().expect("assembly rig");
+    let events = rig.events.clone();
+    let sink = move |current: u64, total: u64| events.lock().unwrap().push((current, total));
+    let store = ContentStore::new(rig.dir.path().join("content"));
+    let builder = DescriptorBuilder::new(rig.dir.path());
+    let digests = rig.layer_digests();
+    let built = builder
+        .build(
+            &store,
+            &DescriptorRequest {
+                layer_digests: &digests,
+                layers: &rig.layers,
+                runtime_layer: None,
+            },
+            &sink,
+        )
+        .expect("descriptor build");
+    rig.built = Some(built);
+}
+
+#[then(regex = r"^the sink first observes (\d+) of (\d+) bytes$")]
+fn sink_first_observes(world: &mut BehaviourWorld, current: u64, total: u64) {
+    assert_eq!(observed(world).first(), Some(&(current, total)));
+}
+
+#[then(regex = r"^the sink observes (\d+) of (\d+) bytes after the first layer$")]
+fn sink_observes_after_first_layer(world: &mut BehaviourWorld, current: u64, total: u64) {
+    assert_eq!(observed(world).get(1), Some(&(current, total)));
+}
+
+#[then(regex = r"^the sink observes (\d+) of (\d+) bytes after the last layer$")]
+fn sink_observes_after_last_layer(world: &mut BehaviourWorld, current: u64, total: u64) {
+    assert_eq!(observed(world).last(), Some(&(current, total)));
+}
+
+fn observed(world: &BehaviourWorld) -> Vec<(u64, u64)> {
+    let rig = world.assembly.as_ref().expect("assembly rig");
+    rig.events.lock().unwrap().clone()
+}

--- a/crates/lns-service/tests/behaviours/steps/rootfs_assembly.rs
+++ b/crates/lns-service/tests/behaviours/steps/rootfs_assembly.rs
@@ -14,10 +14,43 @@ fn assemble_with_recording_sink(world: &mut BehaviourWorld) {
     let rig = world.assembly.as_mut().expect("assembly rig");
     let events = rig.events.clone();
     let sink = move |current: u64, total: u64| events.lock().unwrap().push((current, total));
+    rig.built = Some(build_descriptor(rig, &sink));
+}
+
+#[given("an image whose descriptor was already assembled")]
+fn already_assembled_image(world: &mut BehaviourWorld) {
+    let mut rig = AssemblyRig::with_layer_sizes(&[3072, 5120]);
+    rig.built = Some(build_descriptor(&rig, &|_, _| {}));
+    world.assembly = Some(rig);
+}
+
+#[when("the same rootfs is requested again with a recording progress sink")]
+fn request_again_with_recording_sink(world: &mut BehaviourWorld) {
+    let rig = world.assembly.as_mut().expect("assembly rig");
+    let events = rig.events.clone();
+    let sink = move |current: u64, total: u64| events.lock().unwrap().push((current, total));
+    rig.rebuilt = Some(build_descriptor(rig, &sink));
+}
+
+#[then("the descriptor is served from cache")]
+fn descriptor_served_from_cache(world: &mut BehaviourWorld) {
+    let rig = world.assembly.as_ref().expect("assembly rig");
+    assert_eq!(rig.rebuilt, rig.built);
+}
+
+#[then("the sink observes no progress at all")]
+fn sink_observes_nothing(world: &mut BehaviourWorld) {
+    assert_eq!(observed(world), Vec::<(u64, u64)>::new());
+}
+
+fn build_descriptor(
+    rig: &AssemblyRig,
+    progress: &dyn Fn(u64, u64),
+) -> lns_service::composefs::descriptor::BuiltDescriptor {
     let store = ContentStore::new(rig.dir.path().join("content"));
     let builder = DescriptorBuilder::new(rig.dir.path());
     let digests = rig.layer_digests();
-    let built = builder
+    builder
         .build(
             &store,
             &DescriptorRequest {
@@ -25,10 +58,9 @@ fn assemble_with_recording_sink(world: &mut BehaviourWorld) {
                 layers: &rig.layers,
                 runtime_layer: None,
             },
-            &sink,
+            progress,
         )
-        .expect("descriptor build");
-    rig.built = Some(built);
+        .expect("descriptor build")
 }
 
 #[then(regex = r"^the sink first observes (\d+) of (\d+) bytes$")]

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use crate::approval_rig::ApprovalRig;
 use crate::artifact_rig::ArtifactRig;
+use crate::assembly_rig::AssemblyRig;
 use crate::bind_rig::BindRig;
 use crate::credential_rig::CredentialRig;
 use crate::declared_rig::DeclaredRig;
@@ -58,6 +59,8 @@ pub struct BehaviourWorld {
     pub image: Option<ImageRig>,
 
     pub artifact: Option<ArtifactRig>,
+
+    pub assembly: Option<AssemblyRig>,
 
     pub policy: Option<PolicyRig>,
 


### PR DESCRIPTION
## Summary

Before this change, `lns run` showed only a spinner with the text "Assembling rootfs…" during the first run of an image. For a large image, this step can be slow. We measured 226 seconds for a 26-layer, 1.2 GiB image. The spinner did not move or show numbers. Users thought that the run stopped.

After this change, `lns run` shows a progress bar during this step. The bar shows the applied bytes, the total bytes, and a percentage. The pull step already shows the same type of bar.

## What the user sees

The user starts a large image for the first time:

```
$ lns run ghcr.io/lensapp/prism-agent
```

**Before this change** — the spinner does not change for minutes:

```
⠧ Assembling rootfs
```

**After this change** — the bar moves after each layer:

```
⠧ Assembling rootfs  [████████░░░░░░░░░░░░]  312 MiB / 1.2 GiB 26%
```

The second run of the same image does not show this bar. The service gets the result from its cache and the boot starts immediately.

## How it works

1. The composefs build function receives a progress callback. The function sends `(0, total)` before the first layer. The function sends the sum of the applied layer bytes after each layer. The total is the sum of all layer bytes in memory.
2. The run orchestrator connects this callback to the run status line. The orchestrator records the run span before `spawn_blocking` starts. The callback enters this span and sends the values through `log::progress`. This is necessary because the blocking thread has no span of its own.
3. The wire protocol and the CLI did not change. The CLI already shows a bar when the total is more than zero.
4. The tools provisioner uses a callback that does nothing. Provisioner progress is not part of this change.

Known limit: the bar changes only after each full layer. One very large layer keeps the bar at the same value until that layer is complete. A change to report progress in one layer is possible in the future.

## Screenshots
<!-- Add a recording of a first run that shows the progress bar -->

## Test instructions

1. Select a multi-layer image that is not in the cache. Start it: `lns run ghcr.io/lensapp/prism-agent -- true`. Make sure that the status line shows a bar with `X MiB / Y MiB NN%`. Make sure that the bar moves and stops at 100%.
2. Start the same image again. Make sure that no bar for assembly shows. The boot must start immediately.
3. Run the behaviour tests: `cargo test -p lns-service --test behaviours`. See `rootfs_assembly_progress.feature` for the two scenarios.
4. Run the unit tests for the callback: `cargo test -p lns-service --lib assembling`. These tests include one test that sends progress from a different thread.