### PR TITLE
feat: say why a destination is in the file, and show it before boot

### DIFF
--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -33,6 +33,8 @@ pub struct Contribution {
     pub block: Block,
     pub key: String,
     pub source: String,
+    /// What the entry says about itself, when it says anything (§4.2), so the disclosure explains an entry the way its own document does.
+    pub note: Option<String>,
     pub displaced: Vec<Displaced>,
 }
 
@@ -233,6 +235,7 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
             contributions.push(egress_contribution(
                 rule.verdict,
                 &rule.match_pattern,
+                rule.description.as_deref(),
                 source.label,
             ));
         }
@@ -240,6 +243,7 @@ pub fn merge(sources: &[Source]) -> Result<Merged> {
             contributions.push(egress_contribution(
                 rule.verdict,
                 &rule.match_pattern,
+                rule.description.as_deref(),
                 source.label,
             ));
         }
@@ -285,22 +289,30 @@ pub fn path_filesets(spec: &SandboxSpec) -> impl Iterator<Item = (usize, &Filese
 
 /// What a document's own egress contributes when nothing merges into it, so a run that layered on nothing still discloses every rule it will enforce (§1.5).
 pub fn own_egress(spec: &SandboxSpec) -> Vec<Contribution> {
-    let http = spec.egress.http.iter();
-    let tcp = spec
-        .egress
-        .tcp
-        .iter()
-        .map(|rule| (rule.verdict, &rule.match_pattern));
-    http.map(|rule| (rule.verdict, &rule.match_pattern))
-        .chain(tcp)
-        .map(|(verdict, pattern)| egress_contribution(verdict, pattern, ROOT_LABEL))
-        .collect()
+    let http = spec.egress.http.iter().map(|rule| {
+        egress_contribution(
+            rule.verdict,
+            &rule.match_pattern,
+            rule.description.as_deref(),
+            ROOT_LABEL,
+        )
+    });
+    let tcp = spec.egress.tcp.iter().map(|rule| {
+        egress_contribution(
+            rule.verdict,
+            &rule.match_pattern,
+            rule.description.as_deref(),
+            ROOT_LABEL,
+        )
+    });
+    http.chain(tcp).collect()
 }
 
 /// A rule is its verdict and its pattern together, because the verdict is the half that decides and two sources may disagree about one destination.
 fn egress_contribution(
     verdict: lns_policy::Verdict,
     match_pattern: &str,
+    note: Option<&str>,
     source: &str,
 ) -> Contribution {
     let verdict = match verdict {
@@ -311,6 +323,7 @@ fn egress_contribution(
         block: Block::Egress,
         key: format!("{verdict} {match_pattern}"),
         source: source.to_string(),
+        note: note.map(str::to_string),
         displaced: Vec::new(),
     }
 }
@@ -416,6 +429,7 @@ impl<T> Won<T> {
             block,
             key: self.key.clone(),
             source: self.source.clone(),
+            note: None,
             displaced: self.displaced.clone(),
         }
     }
@@ -829,6 +843,43 @@ mod tests {
         assert_eq!(
             found.source, "obs",
             "a credential the sandbox never asked for is exactly what a reader has to be able to trace to its mixin"
+        );
+    }
+
+    const EXPLAINED_EGRESS: &str = r#"{"egress":{"http":[{"match":"api.base.example","verdict":"allow","description":"approved during a run"}],"tcp":[{"match":"db.base.example:5432","verdict":"allow","description":"the project database"}]}}"#;
+
+    #[test]
+    fn an_egress_entry_carries_what_its_own_rule_says_about_itself() {
+        // §4.2 shows a description wherever the entry is explained, and the disclosure before boot is where a reader meets the entry.
+        let owned = sources(&[(ROOT_LABEL, EXPLAINED_EGRESS)]);
+        let noted = |key: &str| {
+            contribution(&owned, Block::Egress, key)
+                .note
+                .unwrap_or_default()
+        };
+        assert_eq!(noted("allow api.base.example"), "approved during a run");
+        assert_eq!(noted("allow db.base.example:5432"), "the project database");
+    }
+
+    #[test]
+    fn a_document_that_layers_on_nothing_still_carries_what_its_rules_explain() {
+        // The uncomposed run reports through own_egress rather than the merge, so an explanation dropped here is one no reader of that run ever sees.
+        let explained: Vec<(String, Option<String>)> = own_egress(&spec(EXPLAINED_EGRESS))
+            .into_iter()
+            .map(|c| (c.key, c.note))
+            .collect();
+        assert_eq!(
+            explained,
+            [
+                (
+                    "allow api.base.example".to_string(),
+                    Some("approved during a run".to_string())
+                ),
+                (
+                    "allow db.base.example:5432".to_string(),
+                    Some("the project database".to_string())
+                ),
+            ]
         );
     }
 

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -186,32 +186,25 @@ fn write_block(
     let heading = format!("  {label}:");
     let pad = COLUMN.saturating_sub(heading.len()).max(1);
     let value_column = heading.len() + pad;
-    writeln!(
-        s,
-        "{heading}{:pad$}{}{}",
-        "",
-        first.key,
-        if attributed {
-            attribution_of(first)
-        } else {
-            String::new()
-        }
-    )
-    .unwrap();
+    writeln!(s, "{heading}{:pad$}{}", "", entry_line(first, attributed)).unwrap();
     for entry in rest {
-        writeln!(
-            s,
-            "{:value_column$}{}{}",
-            "",
-            entry.key,
-            if attributed {
-                attribution_of(entry)
-            } else {
-                String::new()
-            }
-        )
-        .unwrap();
+        writeln!(s, "{:value_column$}{}", "", entry_line(entry, attributed)).unwrap();
     }
+}
+
+/// One entry as the disclosure reads it: what it decided, the source that decided it, and whatever the entry says about itself.
+fn entry_line(entry: &lns_ipc::SourceContribution, attributed: bool) -> String {
+    let attribution = if attributed {
+        attribution_of(entry)
+    } else {
+        String::new()
+    };
+    let note = entry
+        .note
+        .as_deref()
+        .map(|note| format!("  {note}"))
+        .unwrap_or_default();
+    format!("{}{attribution}{note}", entry.key)
 }
 
 pub fn format_summary(
@@ -779,6 +772,7 @@ mod tests {
             block,
             key: key.to_string(),
             source: source.to_string(),
+            note: None,
             displaced: displaced
                 .iter()
                 .map(|(source, summary)| lns_ipc::DisplacedEntry {
@@ -1106,6 +1100,7 @@ mod tests {
                 block: lns_ipc::ContributionBlock::Egress,
                 key: key.into(),
                 source: "the sandbox".into(),
+                note: None,
                 displaced: Vec::new(),
             })
             .collect();

--- a/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
+++ b/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
@@ -21,3 +21,14 @@ Feature: the disclosure names what this directory decided
     When the run summary is composed before boot
     Then the run summary lists "Rules:     deny docs.some-vendor.example"
     And the run summary does not contain "[from"
+
+  Scenario: a rule that says why it is in the file says so before boot too
+    Given the sandbox denies "docs.some-vendor.example" and this directory allowed it during a run
+    When the run summary is composed before boot
+    Then the run summary lists "allow docs.some-vendor.example  [from lns-local-mixin.yaml]  approved during a run"
+
+  Scenario: a rule the sandbox explains says so even where there is no source to name
+    Given the sandbox denies "docs.some-vendor.example" with a note and this directory decided nothing
+    When the run summary is composed before boot
+    Then the run summary lists "deny docs.some-vendor.example  the vendor mirrors the API here"
+    And the run summary does not contain "[from"

--- a/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
+++ b/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
@@ -17,6 +17,7 @@ fn resolution(w: &mut BehaviourWorld, sources: &[&str], entries: &[(&str, &str)]
             block: lns_ipc::ContributionBlock::Egress,
             key: (*key).to_string(),
             source: (*source).to_string(),
+            note: None,
             displaced: Vec::new(),
         })
         .collect();
@@ -34,9 +35,31 @@ fn the_directory_allows_what_the_sandbox_denies(w: &mut BehaviourWorld, host: St
     );
 }
 
+#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory allowed it during a run$"#)]
+fn the_directory_allowed_it_during_a_run(w: &mut BehaviourWorld, host: String) {
+    the_directory_allows_what_the_sandbox_denies(w, host.clone());
+    let approved = format!("allow {host}");
+    for entry in w
+        .decisions
+        .contributions
+        .iter_mut()
+        .filter(|c| c.key == approved)
+    {
+        entry.note = Some("approved during a run".to_string());
+    }
+}
+
 #[given(regex = r#"^the sandbox denies "([^"]+)" and this directory decided nothing$"#)]
 fn the_directory_decided_nothing(w: &mut BehaviourWorld, host: String) {
     resolution(w, &[], &[(&format!("deny {host}"), "the sandbox")]);
+}
+
+#[given(regex = r#"^the sandbox denies "([^"]+)" with a note and this directory decided nothing$"#)]
+fn the_sandbox_explains_what_it_denies(w: &mut BehaviourWorld, host: String) {
+    the_directory_decided_nothing(w, host);
+    for entry in w.decisions.contributions.iter_mut() {
+        entry.note = Some("the vendor mirrors the API here".to_string());
+    }
 }
 
 #[when("the run summary is composed before boot")]

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -347,6 +347,8 @@ pub struct SourceContribution {
     pub block: ContributionBlock,
     pub key: String,
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub displaced: Vec<DisplacedEntry>,
 }

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -47,6 +47,9 @@ pub const API_VERSION: &str = "lns.run/v1";
 /// The kind §8.1 records a decision as, so it merges under the same rules as anything the developer pulled.
 pub const KIND: &str = "mixin";
 
+/// What §4.2's `description` says about the one entry nobody typed, so a destination the run wrote down does not read as one somebody chose on purpose.
+const APPROVED_NOTE: &str = "approved during a run";
+
 /// The decisions file on disk. Its envelope is restated here rather than read through the crate that parses a kit, which depends on this one; only the block a run writes back is modelled, and every other one travels in [`LocalMixinSpec::rest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -228,6 +231,11 @@ impl TcpEgressRule {
             binaries: None,
             description: None,
         }
+    }
+
+    pub fn approved(mut self) -> Self {
+        self.description = Some(APPROVED_NOTE.to_string());
+        self
     }
 
     /// Rejects everything lens-sandbox-core's `parse_tcp_egress` rejects — one rule it refuses force-denies the whole policy inside the guest — plus the scopes that parse there but can never match a caller.
@@ -495,6 +503,8 @@ pub enum Approval {
 trait Placed: PartialEq {
     fn verdict(&self) -> Verdict;
     fn match_pattern(&self) -> &str;
+    /// Whether the file already holds this entry, disregarding the note beside it: a note says how an entry got there, never what it decides.
+    fn already_held_as(&self, other: &Self) -> bool;
 }
 
 impl Placed for RouteRule {
@@ -504,6 +514,14 @@ impl Placed for RouteRule {
 
     fn match_pattern(&self) -> &str {
         &self.match_pattern
+    }
+
+    fn already_held_as(&self, other: &Self) -> bool {
+        let unnoted = |rule: &Self| Self {
+            description: None,
+            ..rule.clone()
+        };
+        unnoted(self) == unnoted(other)
     }
 }
 
@@ -515,6 +533,14 @@ impl Placed for TcpEgressRule {
     fn match_pattern(&self) -> &str {
         &self.match_pattern
     }
+
+    fn already_held_as(&self, other: &Self) -> bool {
+        let unnoted = |rule: &Self| Self {
+            description: None,
+            ..rule.clone()
+        };
+        unnoted(self) == unnoted(other)
+    }
 }
 
 /// Places an approval-derived rule where the gate reaches it: appended when nothing covers the destination, and otherwise written neither ahead of the rule that already decides it — that would grant more than the card showed — nor behind it, where it would never fire.
@@ -523,7 +549,9 @@ fn place_approved<R: Placed>(
     rule: R,
     shadowing: Option<(usize, R)>,
 ) -> Approval {
-    let held = table.iter().position(|existing| *existing == rule);
+    let held = table
+        .iter()
+        .position(|existing| existing.already_held_as(&rule));
     let Some((index, shadowing)) = shadowing else {
         if held.is_none() {
             table.push(rule);
@@ -597,6 +625,11 @@ impl RouteRule {
             rules: Vec::new(),
             binaries: None,
         }
+    }
+
+    pub fn approved(mut self) -> Self {
+        self.description = Some(APPROVED_NOTE.to_string());
+        self
     }
 
     pub fn validate_binaries(&self) -> io::Result<()> {
@@ -1547,6 +1580,44 @@ egress:
         Policy::default().save_atomic(&path).unwrap();
         let tmp = path.with_extension("yaml.tmp");
         assert!(!tmp.exists(), "tmp file should be renamed away");
+    }
+
+    #[test]
+    fn an_approval_for_a_host_the_developer_already_allowed_keeps_their_own_entry() {
+        // The note belongs to the run, so an entry somebody typed without one has to still read as the answer they already gave rather than as a near-duplicate to append.
+        let mut p = Policy::default();
+        p.add_rule(RouteRule::allow_host("docs.some-vendor.example"));
+
+        let approval =
+            p.add_approved_rule(RouteRule::allow_host("docs.some-vendor.example").approved());
+
+        assert_eq!(approval, Approval::Stands);
+        assert_eq!(
+            p.network.egress.http,
+            [RouteRule::allow_host("docs.some-vendor.example")],
+            "the entry they wrote keeps its own words, and nothing is written beside it"
+        );
+    }
+
+    #[test]
+    fn an_approval_for_a_raw_destination_the_developer_already_allowed_keeps_their_own_entry() {
+        let mut p = Policy::default();
+        p.network.egress.tcp.push(TcpEgressRule::allow_destination(
+            "db.some-vendor.example:5432",
+        ));
+
+        let approval = p.add_approved_tcp_rule(
+            TcpEgressRule::allow_destination("db.some-vendor.example:5432").approved(),
+        );
+
+        assert_eq!(approval, Approval::Stands);
+        assert_eq!(
+            p.network.egress.tcp,
+            [TcpEgressRule::allow_destination(
+                "db.some-vendor.example:5432"
+            )],
+            "the entry they wrote keeps its own words, and nothing is written beside it"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -716,8 +716,8 @@ fn offers_connector(entry: &PendingEntry, connector_id: &str) -> bool {
 
 fn rule_for_always_decision(host: &str, decision: Decision) -> Option<RouteRule> {
     match decision {
-        Decision::AllowAlways => Some(RouteRule::allow_host(host)),
-        Decision::DenyAlways => Some(RouteRule::deny_host(host)),
+        Decision::AllowAlways => Some(RouteRule::allow_host(host).approved()),
+        Decision::DenyAlways => Some(RouteRule::deny_host(host).approved()),
         Decision::AllowOnce | Decision::DenyOnce | Decision::Timeout => None,
     }
 }
@@ -733,8 +733,8 @@ fn pre_empted_http_patterns(policy: &Policy, rule: &TcpEgressRule) -> Vec<String
 
 fn tcp_rule_for_always_decision(destination: &str, decision: Decision) -> Option<TcpEgressRule> {
     match decision {
-        Decision::AllowAlways => Some(TcpEgressRule::allow_destination(destination)),
-        Decision::DenyAlways => Some(TcpEgressRule::deny_destination(destination)),
+        Decision::AllowAlways => Some(TcpEgressRule::allow_destination(destination).approved()),
+        Decision::DenyAlways => Some(TcpEgressRule::deny_destination(destination).approved()),
         Decision::AllowOnce | Decision::DenyOnce | Decision::Timeout => None,
     }
 }
@@ -1108,7 +1108,7 @@ pub(crate) mod tests {
         let policy = saved.last().expect("the decision is persisted");
         assert_eq!(
             policy.network.egress.tcp,
-            vec![TcpEgressRule::allow_destination("db.internal:5432")]
+            vec![TcpEgressRule::allow_destination("db.internal:5432").approved()]
         );
         assert!(
             policy.network.egress.http.is_empty(),
@@ -1124,7 +1124,7 @@ pub(crate) mod tests {
         let saved = store.saves.lock().unwrap();
         assert_eq!(
             saved.last().expect("saved").network.egress.tcp,
-            vec![TcpEgressRule::allow_destination("[2001:db8::1]:5432")],
+            vec![TcpEgressRule::allow_destination("[2001:db8::1]:5432").approved()],
             "re-deriving the pattern from host and port is how a bracketed literal gets mangled"
         );
     }
@@ -1226,7 +1226,7 @@ pub(crate) mod tests {
         let saved = store.saves.lock().unwrap();
         assert_eq!(
             saved.last().expect("saved").network.egress.tcp,
-            vec![TcpEgressRule::deny_destination("db.internal:5432")]
+            vec![TcpEgressRule::deny_destination("db.internal:5432").approved()]
         );
     }
 

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -387,6 +387,7 @@ pub fn on_the_wire(
             },
             key: c.key.clone(),
             source: c.source.clone(),
+            note: c.note.clone(),
             displaced: c
                 .displaced
                 .iter()
@@ -632,7 +633,7 @@ mod tests {
             r#"{"image":"x:1","mixins":["obs"]}"#,
             &[(
                 "obs",
-                r#"{"tools":["node@22"],"volumes":[{"type":"volume","name":"cache","target":"/cache"}],"ports":[{"container":8080}],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}],"egress":{"http":[{"match":"api.some-provider.example","verdict":"allow"}]}}"#,
+                r#"{"tools":["node@22"],"volumes":[{"type":"volume","name":"cache","target":"/cache"}],"ports":[{"container":8080}],"credentials":[{"envVar":"SOME_TOKEN","placeholder":"lns-placeholder-some","injections":[{"kind":"bearer_header","domain":"api.some-provider.example"}]}],"egress":{"http":[{"match":"api.some-provider.example","verdict":"allow","description":"approved during a run"}]}}"#,
             )],
         );
         let refs: Vec<(&str, &str)> = documents
@@ -660,6 +661,15 @@ mod tests {
                 "§1.5 names every rule, mount, tool and credential, so a block that never reaches the wire is a line the disclosure cannot attribute; missing {expected:?} from {found:?}"
             );
         }
+        let noted = wire
+            .iter()
+            .find(|c| c.key == "allow api.some-provider.example")
+            .expect("the egress entry reaches the wire");
+        assert_eq!(
+            noted.note.as_deref(),
+            Some("approved during a run"),
+            "an entry that explains itself has to keep saying so across the wire, or the disclosure loses the explanation"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-service/tests/behaviours/approval_flow.feature
+++ b/crates/lns-service/tests/behaviours/approval_flow.feature
@@ -168,3 +168,19 @@ Feature: lns-service approval flow
     And the running policy contains the new allow rule
     And the approval window informs the developer that the rule could not be persisted
     And a future request to "api.linear.app" is allowed without prompting until the sandbox exits
+
+  # A destination sitting in this file with nothing beside it reads as one the project
+  # decided on purpose. §4.2 gives an entry a description for saying otherwise, and the
+  # entry nobody typed is the one that needs it.
+  Scenario: An entry an always-decision writes says how it got there
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    And the policy has no rule for "docs.some-vendor.example"
+    And an approval entry is visible for a request to "docs.some-vendor.example"
+    When the developer picks "always allow"
+    Then the rule for "docs.some-vendor.example" in "lns-local-mixin.yaml" is noted as approved during a run
+
+  Scenario: A raw entry an always-decision writes says how it got there
+    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    And an approval entry is visible for a raw splice to "db.internal:5432"
+    When the developer picks "always allow"
+    Then the raw rule for "db.internal:5432" in "lns-local-mixin.yaml" is noted as approved during a run

--- a/crates/lns-service/tests/behaviours/steps/approval_flow.rs
+++ b/crates/lns-service/tests/behaviours/steps/approval_flow.rs
@@ -683,6 +683,49 @@ fn then_inform_underivable_rule(world: &mut BehaviourWorld) -> Result<(), String
     ))
 }
 
+#[then(regex = r#"^the rule for "([^"]+)" in "([^"]+)" is noted as approved during a run$"#)]
+fn then_file_rule_says_how_it_got_there(
+    world: &mut BehaviourWorld,
+    host: String,
+    _filename: String,
+) -> Result<(), String> {
+    let on_disk = on_disk_policy(world)?;
+    let matched = on_disk
+        .network
+        .egress
+        .http
+        .iter()
+        .find(|r| r.match_pattern == host)
+        .ok_or_else(|| format!("no rule for {host} in the policy file"))?;
+    assert_approval_note(matched.description.as_deref(), &host)
+}
+
+#[then(regex = r#"^the raw rule for "([^"]+)" in "([^"]+)" is noted as approved during a run$"#)]
+fn then_raw_file_rule_says_how_it_got_there(
+    world: &mut BehaviourWorld,
+    destination: String,
+    _filename: String,
+) -> Result<(), String> {
+    let on_disk = on_disk_policy(world)?;
+    let matched = on_disk
+        .network
+        .egress
+        .tcp
+        .iter()
+        .find(|r| r.match_pattern == destination)
+        .ok_or_else(|| format!("no raw rule for {destination} in the policy file"))?;
+    assert_approval_note(matched.description.as_deref(), &destination)
+}
+
+fn assert_approval_note(note: Option<&str>, destination: &str) -> Result<(), String> {
+    match note {
+        Some("approved during a run") => Ok(()),
+        other => Err(format!(
+            "an entry nobody typed has to say how it got there, or the file reads as though somebody chose {destination} on purpose; got {other:?}"
+        )),
+    }
+}
+
 fn on_disk_policy(world: &mut BehaviourWorld) -> Result<Policy, String> {
     let rig = world.approval();
     Policy::load_or_default(&rig.policy_path).map_err(|e| e.to_string())

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -397,7 +397,9 @@ background service shows an approval window with the host and the action — for
 - **Allow once** / **Deny once** — apply to this request only; nothing is written
   to the policy file.
 - **Allow always** / **Deny always** — apply now *and* write a matching rule to
-  the policy file, so the same question isn't asked again.
+  the policy file, so the same question isn't asked again. The rule carries the
+  note `approved during a run`, so a destination you answered for reads
+  differently from one somebody wrote by hand.
 
 **Always** writes a rule only where the guest would reach it. If some rule already
 decides that destination — an earlier answer, or a rule you wrote — the gate stops

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -650,7 +650,7 @@ produced, which an uncomposed run has no second author to attribute:
   Mixins:    /work/mixins/debug-tools, lns-local-mixin.yaml
   Volume:    cache → /home/agent/.cache  [from /work/mixins/debug-tools]
   Tools:     node@22  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…, replaced node@20 from the sandbox]
-  Rules:     allow docs.vendor.example  [from lns-local-mixin.yaml]
+  Rules:     allow docs.vendor.example  [from lns-local-mixin.yaml]  approved during a run
              allow api.vendor.example  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
              deny docs.vendor.example  [from the sandbox]
   Credentials: SOME_TOKEN  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
@@ -661,6 +661,10 @@ named too — and because it is the last one, its rules read first: the `allow`
 above is what the gate reaches, and the `deny` it overruled is still listed under
 it. A run in a directory that decided nothing prints what it always has: one
 author, nothing to attribute.
+
+An entry that says anything about itself says it here too, after the source that
+decided it: the note an approval writes, or the one you gave a rule yourself with
+`lns policy allow --description`.
 
 `lns inspect <REF> --mixin <REF>` shows the same composition without starting a
 run.


### PR DESCRIPTION
Stacked on #252 — review that one first; the base will retarget to `main` when it merges.

`docs/sandbox-spec.md` §8 makes `lns-local-mixin.yaml` the file the run writes as the developer answers, and §4.2 gives every egress entry a `description` that is "shown wherever the entry is explained". Neither half was true: an approval wrote a bare rule, and the pre-boot disclosure never showed a note even when one existed.

### 1. An entry the run wrote down says how it got there

An always-decision now writes `approved during a run` beside the rule it appends, on the http table and the raw one alike. A destination sitting in that file with nothing beside it used to read as one somebody chose on purpose.

The note belongs to the run, never to the developer, so it stays out of what an entry *decides*. `place_approved` now asks whether the file already holds a rule with the description normalised away (`Placed::already_held_as`). Without that the note broke a pinned behaviour: a host the developer had allowed by hand stopped matching the rule an approval would write, and the approval window reported *their own* rule as shadowed by the covering deny instead of telling them it sits where the gate never reaches. That regression was caught by the existing scenario, watched red, and is green again.

### 2. The disclosure shows what a rule says about itself

```
  Rules:     allow docs.vendor.example  [from lns-local-mixin.yaml]  approved during a run
```

The note travels on `merge::Contribution` and `lns_ipc::SourceContribution` rather than being appended to the contribution's `key`, which is an identity-ish `"{verdict} {match_pattern}"` that the summary looks entries up by. Every source's note renders the same way, including on a run that layered on nothing and therefore names no source: a note says how an entry got there, which is different information from which file it came from.

### On YAML comments, deliberately not done

The gap this closes was framed as "§8's annotated example is unimplementable against this writer". Read literally, §8 requires no such thing: the single `#` line in its example annotates the first of two entries and reads as prose for the specification's reader, and no sentence anywhere requires a writer to preserve comments. The grammar's own mechanism for explaining an entry is `description`, which is what these commits fill in and show. So no comment-preserving YAML writer was built — there is no crate in the lock file that attaches comments to nodes, `save_atomic` is also the create-from-nothing path, and `lns policy` needs insert-at-index and delete rather than append — and no spec edit is due.

Key order is still normalised on save. Nothing in the specification requires preserving it, and the loss is one-time: after the first save the file is in writer-normal form and every later approval is an append at the end.

### Verification

`cargo test -p lns-policy --lib` 309 pass · `-p lns-artifact --lib` 239 pass · `-p lns-ipc --lib` 151 pass · `lns-cli` behaviours 413 scenarios · `lns-service` behaviours 230 scenarios · `lns-service --lib` 2203 pass. `make lint`-equivalent clippy and `cargo fmt --check` clean.

Six pre-existing failures in `lns-service --lib` and one in `coverage-strip-ast` are environment-caused, not from this branch: they simulate "cannot write" with file permissions, which uid 0 defeats, or they want the network.

Two scenarios could not be watched failing first, because the step that seeds a note does not compile until the field exists. Both were mutation-tested instead: reverting the renderer, `own_egress`'s pass-through, and the merge loop's tcp arm each turns the corresponding test red, and restoring each turns it green.