### PR TITLE
feat!: govern a run by the decisions of the project it runs

### DIFF
--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -77,7 +77,7 @@ pub struct RunArgs {
 
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory, auto-created with no rules if absent."
+        help = "Policy file path; defaults to `lns-local-mixin.yaml` beside the definition being run, auto-created with no rules if absent. A relative path roots where you typed it."
     )]
     pub policy: Option<PathBuf>,
 

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -402,7 +402,10 @@ pub async fn connect(
             BindOutcome::Completed(decision) => bind_message(&args.id, decision),
         }
     };
-    let path = policy_path(args.policy.as_deref(), cwd);
+    let path = policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    );
     connect_project(grants_path, &project_key(&path), &args.id)?;
     writeln!(writer, "{closing}")?;
     // Binding the value cannot lift a workload's decline, so say what will: otherwise the connect reports success and the workload goes on being refused with nothing on screen explaining it.
@@ -448,7 +451,10 @@ pub fn disconnect(
     grants_path: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let path = policy_path(args.policy.as_deref(), cwd);
+    let path = policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    );
     let project = project_key(&path);
     let cleared = disconnect_project(grants_path, &project, &args.id)?
         .ok_or_else(|| anyhow::anyhow!("{:?} is not connected in {project}", args.id))?;
@@ -507,7 +513,10 @@ fn grants(
     let file = store
         .load()
         .with_context(|| format!("reading grants from {}", grants_path.display()))?;
-    let project = project_key(&policy_path(args.policy.as_deref(), cwd));
+    let project = project_key(&policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    ));
     let rows: Vec<&GrantRecord> = if args.all {
         file.grants.iter().collect()
     } else {
@@ -573,7 +582,10 @@ fn revoke(
     grants_path: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let project = project_key(&policy_path(args.policy.as_deref(), cwd));
+    let project = project_key(&policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    ));
     let cleared = clear_project_grants(grants_path, &project, &args.id)?;
     if cleared == 0 {
         bail!(

--- a/crates/lns-cli/src/policy/mod.rs
+++ b/crates/lns-cli/src/policy/mod.rs
@@ -385,7 +385,10 @@ fn add<R: Placeable>(
     cwd: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let path = policy_path(args.policy.as_deref(), cwd);
+    let path = policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    );
     let mut policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
     let announced = R::WORDS.announced;
@@ -586,7 +589,10 @@ fn placement_note<R: Placeable>(shadowing: &R, rule: &R) -> String {
 }
 
 fn list_rules(args: &PolicyScopeArgs, cwd: &Path, writer: &mut impl Write) -> Result<i32> {
-    let path = policy_path(args.policy.as_deref(), cwd);
+    let path = policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    );
     let policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
     let rows: Vec<RuleRow> = policy
@@ -654,7 +660,10 @@ impl crate::output::TableRow for RuleRow {
 }
 
 fn remove_rule(args: &PolicyRemoveArgs, cwd: &Path, writer: &mut impl Write) -> Result<i32> {
-    let path = policy_path(args.policy.as_deref(), cwd);
+    let path = policy_path(
+        args.policy.as_deref(),
+        crate::run::summary::DecisionsSite::one_directory(cwd),
+    );
     let mut policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
     let before = policy.network.egress.http.len() + policy.network.egress.tcp.len();

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -10,30 +10,57 @@ use crate::cli::RunArgs;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PolicySource {
     Explicit(PathBuf),
-    FoundInCwd,
+    Found,
     AutoCreated,
 }
 
 const DEFAULT_POLICY_FILENAME: &str = "lns-local-mixin.yaml";
 
-pub fn policy_path(explicit: Option<&Path>, cwd: &Path) -> PathBuf {
-    match explicit {
-        Some(p) if p.is_absolute() => p.to_path_buf(),
-        Some(p) => cwd.join(p),
-        None => cwd.join(DEFAULT_POLICY_FILENAME),
+/// The two directories a decisions file can root at, which are the same one until a definition somewhere else is run: the default file belongs to the project (§8.1), while a path the developer typed roots where they typed it, as a `--mixin` does (§3.3.1).
+#[derive(Debug, Clone, Copy)]
+pub struct DecisionsSite<'a> {
+    pub typed_in: &'a Path,
+    pub project: &'a Path,
+}
+
+impl<'a> DecisionsSite<'a> {
+    pub fn one_directory(dir: &'a Path) -> Self {
+        Self {
+            typed_in: dir,
+            project: dir,
+        }
+    }
+
+    /// A run's site: a local definition's own directory is the project, and a published reference has none of its own, so the directory the run was started in is.
+    pub fn for_run(typed_in: &'a Path, project: Option<&'a Path>) -> Self {
+        Self {
+            typed_in,
+            project: project.unwrap_or(typed_in),
+        }
     }
 }
 
-pub fn resolve_policy(explicit: Option<&Path>, cwd: &Path) -> Result<(PathBuf, PolicySource)> {
+pub fn policy_path(explicit: Option<&Path>, site: DecisionsSite<'_>) -> PathBuf {
+    match explicit {
+        Some(p) if p.is_absolute() => p.to_path_buf(),
+        Some(p) => site.typed_in.join(p),
+        None => site.project.join(DEFAULT_POLICY_FILENAME),
+    }
+}
+
+pub fn resolve_policy(
+    explicit: Option<&Path>,
+    site: DecisionsSite<'_>,
+) -> Result<(PathBuf, PolicySource)> {
     if let Some(p) = explicit {
         return Ok((
-            policy_path(Some(p), cwd),
+            policy_path(Some(p), site),
             PolicySource::Explicit(p.to_path_buf()),
         ));
     }
-    let path = policy_path(None, cwd);
+    let path = policy_path(None, site);
     match std::fs::metadata(&path) {
-        Ok(md) if md.is_file() => Ok((path, PolicySource::FoundInCwd)),
+        Ok(md) if md.is_file() => Ok((path, PolicySource::Found)),
         Ok(_) => anyhow::bail!(
             "{} exists but is not a regular file; remove it or pass `--policy <path>`",
             path.display()
@@ -100,10 +127,10 @@ pub fn drop_overridden_mounts(args: &mut RunArgs, overridden: &[String]) {
 pub fn print_run_summary(
     args: &RunArgs,
     size: lns_artifact::resources::VmSize,
-    cwd: &Path,
+    site: DecisionsSite<'_>,
     writer: &mut impl io::Write,
 ) -> Result<PathBuf> {
-    let (path, source) = resolve_policy(args.policy.as_deref(), cwd)?;
+    let (path, source) = resolve_policy(args.policy.as_deref(), site)?;
     let policy = Policy::load_or_default(&path)
         .with_context(|| format!("loading policy from {}", path.display()))?;
     let body = format_summary(args, size, &policy, &path, &source);
@@ -482,8 +509,10 @@ fn tally(verdicts: impl Iterator<Item = Verdict>) -> (u32, u32) {
 
 fn source_line(source: &PolicySource) -> String {
     match source {
-        PolicySource::FoundInCwd => "found in this directory".to_string(),
-        PolicySource::AutoCreated => "auto-created (no policy in this directory)".to_string(),
+        PolicySource::Found => "found in the project directory".to_string(),
+        PolicySource::AutoCreated => {
+            "auto-created (no policy in the project directory)".to_string()
+        }
         PolicySource::Explicit(p) => format!("--policy {}", p.display()),
     }
 }
@@ -557,7 +586,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         )
     }
 
@@ -747,7 +776,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Mixins:    ghcr.io/acme/postgres-tools@sha256:c41e8b7d"),
@@ -757,7 +786,7 @@ mod tests {
             &run_args(Some("prism")),
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(!authored.contains("Mixins:"), "got: {authored}");
     }
@@ -805,7 +834,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("node@22  [from ghcr.io/acme/obs@sha256:cccccccccccc…, replaced node@20 from the sandbox]"),
@@ -838,7 +867,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains(
@@ -877,7 +906,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("\n             proxy.vendor.example  [from the sandbox]\n"),
@@ -898,7 +927,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Volume:    scratch \u{2192} /scratch\n"),
@@ -929,7 +958,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Volume:    mine \u{2192} /scratch\n"),
@@ -962,7 +991,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains(
@@ -999,7 +1028,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("[from ghcr.io/acme/obs@sha256:cccccccccccc…]"),
@@ -1032,7 +1061,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         let first = s
             .lines()
@@ -1066,7 +1095,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("some/dir@sha256:a\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{2026}"),
@@ -1082,7 +1111,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Tools:     node@22\n"), "got: {s}");
         assert!(
@@ -1111,7 +1140,7 @@ mod tests {
             &args,
             &closed,
             Path::new("./lns-policy.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
 
         assert!(
@@ -1134,7 +1163,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Tools:     node@22.11.0, python@3.12.6"),
@@ -1190,7 +1219,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/home/dev/my-app/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Image:"), "missing Image line: {s}");
         assert!(s.contains("Resources:"), "missing Resources line: {s}");
@@ -1217,7 +1246,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Volume:    prism-data → /data"),
@@ -1243,7 +1272,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Bind:      /Users/me/proj → /work (read-write)"),
@@ -1265,7 +1294,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("Bind:      /Users/me/cfg → /cfg (read-only)"),
@@ -1307,7 +1336,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Workdir:   /app"), "missing workdir line: {s}");
     }
@@ -1318,7 +1347,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(!s.contains("Workdir:"), "no workdir line expected: {s}");
     }
@@ -1329,7 +1358,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(!s.contains("Volume:"), "no volume line expected: {s}");
     }
@@ -1341,7 +1370,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("ubuntu (resolving…)"), "no placeholder: {s}");
     }
@@ -1353,7 +1382,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("./lns.yaml (resolving…)"), "got: {s}");
         assert!(
@@ -1370,7 +1399,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("lns.dev.yaml (resolving…)"), "got: {s}");
         assert!(!s.contains("./lns.yaml"), "got: {s}");
@@ -1382,7 +1411,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("1 vCPU · 512 MiB"), "resources line wrong: {s}");
     }
@@ -1402,7 +1431,7 @@ mod tests {
             },
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("3 vCPU · 6144 MiB"), "resources line wrong: {s}");
     }
@@ -1417,7 +1446,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Flags:     -i -t"), "flags line wrong: {s}");
     }
@@ -1432,7 +1461,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Flags:     -d"), "flags line wrong: {s}");
     }
@@ -1445,7 +1474,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Flags:     -i -t --rm"), "flags line wrong: {s}");
     }
@@ -1460,7 +1489,7 @@ mod tests {
             &args,
             &Policy::default(),
             Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("Flags:     (none)"), "flags line wrong: {s}");
     }
@@ -1476,7 +1505,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("unmatched destinations: denied by the catch-all rule"),
@@ -1496,7 +1525,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("file: ./lns-local-mixin.yaml"));
         assert!(
@@ -1522,7 +1551,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("1 allow, 0 deny, 1 raw allow, 0 raw deny, anything else asks"),
@@ -1542,7 +1571,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("0 allow, 0 deny, 1 raw allow, 0 raw deny, anything else asks"),
@@ -1556,7 +1585,7 @@ mod tests {
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(
             s.contains("rules: none defined; anything else asks"),
@@ -1573,31 +1602,31 @@ mod tests {
             &run_args(Some("ubuntu")),
             &policy,
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
         assert!(s.contains("1 allow, 1 deny, anything else asks"));
     }
 
     #[test]
-    fn source_line_for_found_in_cwd_reads_found_in_this_directory() {
+    fn source_line_for_a_found_file_names_the_project_directory() {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         );
-        assert!(s.contains("source: found in this directory"));
+        assert!(s.contains("source: found in the project directory"));
     }
 
     #[test]
-    fn source_line_for_auto_created_calls_out_no_policy_in_directory() {
+    fn source_line_for_auto_created_calls_out_no_policy_in_the_project_directory() {
         let s = summary_of(
             &run_args(Some("ubuntu")),
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
             &PolicySource::AutoCreated,
         );
-        assert!(s.contains("source: auto-created (no policy in this directory)"));
+        assert!(s.contains("source: auto-created (no policy in the project directory)"));
     }
 
     #[test]
@@ -1615,17 +1644,24 @@ mod tests {
     fn resolve_policy_explicit_passthrough_does_not_touch_disk() {
         let dir = tempfile::TempDir::new().unwrap();
         let explicit = dir.path().join("absent-but-named.yaml");
-        let (resolved, source) = resolve_policy(Some(&explicit), dir.path()).unwrap();
+        let (resolved, source) =
+            resolve_policy(Some(&explicit), DecisionsSite::one_directory(dir.path())).unwrap();
         assert_eq!(resolved, explicit);
         assert_eq!(source, PolicySource::Explicit(explicit));
         assert!(!dir.path().join(DEFAULT_POLICY_FILENAME).exists());
     }
 
     #[test]
-    fn resolve_policy_makes_relative_explicit_paths_absolute_against_cwd() {
+    fn resolve_policy_roots_a_relative_explicit_path_where_the_developer_typed_it() {
+        // A path the developer typed is theirs, as a --mixin is (§3.3.1), so it roots where they stood and not at the project a definition somewhere else names.
         let dir = tempfile::TempDir::new().unwrap();
+        let project = tempfile::TempDir::new().unwrap();
         let relative = Path::new("team-policy.yaml");
-        let (resolved, source) = resolve_policy(Some(relative), dir.path()).unwrap();
+        let site = DecisionsSite {
+            typed_in: dir.path(),
+            project: project.path(),
+        };
+        let (resolved, source) = resolve_policy(Some(relative), site).unwrap();
         assert_eq!(
             resolved,
             dir.path().join("team-policy.yaml"),
@@ -1639,19 +1675,27 @@ mod tests {
     }
 
     #[test]
-    fn resolve_policy_finds_existing_default_file_in_cwd() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let preexisting = dir.path().join(DEFAULT_POLICY_FILENAME);
+    fn resolve_policy_finds_the_default_file_of_the_project_rather_than_of_the_cwd() {
+        // One directory is one project (§8.1), so the run reads the decisions beside the definition it runs, wherever the developer started it.
+        let cwd = tempfile::TempDir::new().unwrap();
+        let project = tempfile::TempDir::new().unwrap();
+        let preexisting = project.path().join(DEFAULT_POLICY_FILENAME);
         Policy::default().save_atomic(&preexisting).unwrap();
-        let (resolved, source) = resolve_policy(None, dir.path()).unwrap();
+        let site = DecisionsSite {
+            typed_in: cwd.path(),
+            project: project.path(),
+        };
+        let (resolved, source) = resolve_policy(None, site).unwrap();
         assert_eq!(resolved, preexisting);
-        assert_eq!(source, PolicySource::FoundInCwd);
+        assert_eq!(source, PolicySource::Found);
+        assert!(!cwd.path().join(DEFAULT_POLICY_FILENAME).exists());
     }
 
     #[test]
     fn resolve_policy_auto_creates_default_file_when_missing() {
         let dir = tempfile::TempDir::new().unwrap();
-        let (resolved, source) = resolve_policy(None, dir.path()).unwrap();
+        let (resolved, source) =
+            resolve_policy(None, DecisionsSite::one_directory(dir.path())).unwrap();
         assert_eq!(resolved, dir.path().join(DEFAULT_POLICY_FILENAME));
         assert_eq!(source, PolicySource::AutoCreated);
         let body = std::fs::read_to_string(&resolved).unwrap();
@@ -1672,7 +1716,8 @@ mod tests {
     fn resolve_policy_errors_when_default_path_is_a_directory() {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::create_dir(dir.path().join(DEFAULT_POLICY_FILENAME)).unwrap();
-        let err = resolve_policy(None, dir.path()).expect_err("must reject non-file");
+        let err = resolve_policy(None, DecisionsSite::one_directory(dir.path()))
+            .expect_err("must reject non-file");
         assert!(format!("{err:#}").contains("not a regular file"));
     }
 
@@ -1684,7 +1729,7 @@ mod tests {
         let path = print_run_summary(
             &args,
             resolved_size(Default::default(), &args),
-            dir.path(),
+            DecisionsSite::one_directory(dir.path()),
             &mut buf,
         )
         .unwrap();

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -284,8 +284,10 @@ pub async fn run_image(
 ) -> Result<i32> {
     let client = real_client()?;
     args.mixins = crate::run::target::root_named_directories(&args.mixins, &cwd)?;
+    let project_dir = target.project_dir().unwrap_or(&cwd).to_path_buf();
+    let site = crate::run::summary::DecisionsSite::for_run(&cwd, Some(&project_dir));
     // §8.1 has every run in a directory resolve its decisions, so a directory that decided something needs the preflight even when nothing declared a mixin.
-    let decisions = crate::run::summary::policy_path(args.policy.as_deref(), &cwd);
+    let decisions = crate::run::summary::policy_path(args.policy.as_deref(), site);
     let mut authored_egress = None;
     // A mixin the preflight pulled brings its filesets packed in its own artifact, and the merged document alone cannot say which.
     let mut packed_filesets = Vec::new();
@@ -388,10 +390,10 @@ pub async fn run_image(
     let size = crate::run::summary::resolved_size(defaults.size, &args);
     let quiet = args.quiet;
     let resolved_policy = if quiet {
-        let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), &cwd)?;
+        let (path, _source) = crate::run::summary::resolve_policy(args.policy.as_deref(), site)?;
         path
     } else {
-        print_run_summary(&args, size, &cwd, &mut std::io::stderr())?
+        print_run_summary(&args, size, site, &mut std::io::stderr())?
     };
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -2,8 +2,9 @@ Feature: selecting the sandbox definition file
   `./lns.yaml` is the sandbox — one directory is one sandbox. A path-shaped
   reference naming a `.yaml` file, or the explicit `-f/--file` selector, is
   the override that operates on a different definition file: the file's
-  directory roots its relative binds and filesets, compose-style, while the
-  policy still comes from where you run.
+  directory is the project, so it roots the relative binds and filesets,
+  compose-style, and holds the decisions the run resolves. A `--policy` path is
+  the developer's own, so that one roots where they typed it.
 
   Scenario: a path-shaped reference naming a yaml file runs that file's definition
     Given a sandbox definition file "lns.dev.yaml" in the current directory
@@ -56,3 +57,15 @@ Feature: selecting the sandbox definition file
     Then the command fails with an exit code other than 0
     And the output contains "no sandbox definition at"
     And the output contains "lns.dev.yaml"
+
+  Scenario: a definition in another directory is governed by that directory's decisions
+    Given a sandbox definition file "/other/lns.dev.yaml" declaring a relative bind and fileset
+    When the user runs "lns run /other/lns.dev.yaml"
+    Then the exit code is 0
+    And the run reads its decisions from "/other/lns-local-mixin.yaml"
+
+  Scenario: a --policy path still roots where the user typed it
+    Given a sandbox definition file "/other/lns.dev.yaml" declaring a relative bind and fileset
+    When the user runs "lns run --policy team.yaml /other/lns.dev.yaml"
+    Then the exit code is 0
+    And the run reads its decisions from "/work/team.yaml"

--- a/crates/lns-cli/tests/behaviours/run_visibility.feature
+++ b/crates/lns-cli/tests/behaviours/run_visibility.feature
@@ -24,12 +24,12 @@ Feature: users see what `lns run` is doing from the moment they hit Enter
     Then the Policy block shows the file path
     And what happens to a destination no rule names
     And a one-line rule summary: "3 allow, 1 deny, anything else asks"
-    And the provenance line: "source: found in this directory"
+    And the provenance line: "source: found in the project directory"
 
   Scenario: Auto-created policy is called out in the source line
     Given no `lns-local-mixin.yaml` exists in the working directory
     When the run starts
-    Then the Policy block source line reads "auto-created (no policy in this directory)"
+    Then the Policy block source line reads "auto-created (no policy in the project directory)"
     And a destination no rule names is "ask"ed
 
   Scenario: Explicit --policy is called out in the source line

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -83,7 +83,7 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut buf,
     )
     .expect("print_run_summary");
@@ -170,7 +170,7 @@ fn pulled_run_prepared(world: &mut BehaviourWorld) {
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut buf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -91,7 +91,7 @@ fn summarize(world: &mut BehaviourWorld, defaults: &Defaults, flags: &str, local
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut buf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -147,7 +147,7 @@ fn compose_summary(world: &mut BehaviourWorld, defaults: Defaults, flags: &str) 
             size,
             &lns_policy::Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &lns_cli::run::summary::PolicySource::FoundInCwd,
+            &lns_cli::run::summary::PolicySource::Found,
         ),
         ..Default::default()
     });

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -151,7 +151,7 @@ fn run_summary_discloses_tools(w: &mut BehaviourWorld) -> Result<(), String> {
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut buf,
     )
     .map_err(|e| format!("{e:#}"))?;

--- a/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
+++ b/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
@@ -70,6 +70,22 @@ fn request_carries_variant_definition(w: &mut BehaviourWorld, _name: String) -> 
     Ok(())
 }
 
+#[then(regex = r#"^the run reads its decisions from "([^"]+)"$"#)]
+fn run_reads_decisions_from(w: &mut BehaviourWorld, path: String) -> Result<(), String> {
+    let found = w
+        .sandbox_run
+        .decisions
+        .as_ref()
+        .ok_or("the run resolved no decisions file")?;
+    if found != &PathBuf::from(&path) {
+        return Err(format!(
+            "one directory is one project, so a definition somewhere else is governed by the decisions beside it; expected {path}, got {}",
+            found.display()
+        ));
+    }
+    Ok(())
+}
+
 #[then(regex = r#"^the service request roots the bind and fileset at "([^"]+)"$"#)]
 fn request_roots_sources_at(w: &mut BehaviourWorld, dir: String) -> Result<(), String> {
     let value = wire_definition(w)?;

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -140,7 +140,7 @@ fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
                 lns_cli::run::summary::resolved_size(Default::default(), &args),
                 &Policy::default(),
                 Path::new("./lns-local-mixin.yaml"),
-                &PolicySource::FoundInCwd,
+                &PolicySource::Found,
             );
             text.push_str(&format_bind_dispositions(resolved));
             text

--- a/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
+++ b/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
@@ -78,7 +78,7 @@ fn compose_the_summary(w: &mut BehaviourWorld) {
         resolved_size(Default::default(), &args),
         &Policy::default(),
         Path::new("./lns-local-mixin.yaml"),
-        &PolicySource::FoundInCwd,
+        &PolicySource::Found,
     );
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -204,7 +204,7 @@ async fn the_run_starts(world: &mut BehaviourWorld) {
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut buf,
     )
     .expect("print_run_summary");
@@ -500,7 +500,7 @@ async fn resolution_fails(world: &mut BehaviourWorld) {
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
+        lns_cli::run::summary::DecisionsSite::one_directory(&cwd),
         &mut sbuf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -28,7 +28,7 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
             lns_cli::run::summary::resolved_size(Default::default(), &resolved),
             &Policy::default(),
             Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::FoundInCwd,
+            &PolicySource::Found,
         ),
         ..Default::default()
     });

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -203,6 +203,10 @@ fn run_resolved(w: &mut BehaviourWorld, args: RunArgs, target: &RunTarget, cwd: 
     w.sandbox_run.verify_sandbox = Some(target.verify_sandbox());
     w.sandbox_run.definition = target.definition_json();
     w.sandbox_run.project_dir = target.project_dir().map(Path::to_path_buf);
+    w.sandbox_run.decisions = Some(lns_cli::run::summary::policy_path(
+        args.policy.as_deref(),
+        lns_cli::run::summary::DecisionsSite::for_run(cwd, target.project_dir()),
+    ));
     if let Some(policy) = args.policy.as_deref() {
         w.summary_output = format_summary(
             &args,

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -126,6 +126,7 @@ pub struct SandboxRunRig {
     pub verify_sandbox: Option<bool>,
     pub definition: Option<String>,
     pub project_dir: Option<std::path::PathBuf>,
+    pub decisions: Option<std::path::PathBuf>,
     pub refusal: Option<String>,
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -86,8 +86,9 @@ local definition** — `.`, `lns.yaml`, `./lns.yaml`, a relative/absolute path t
 a directory holding one, or a path-shaped `.yaml`/`.yml` file naming the
 definition itself (`./lns.dev.yaml`); omit it to run the `./lns.yaml` in the
 current directory, or select another file with `-f`/`--file` (exclusive with
-`REF`). A path-named definition's relative binds and filesets root at its own
-directory, compose-style; the policy still comes from where you run. A
+`REF`). A path-named definition's directory is the project: it roots the relative binds
+and filesets, compose-style, and holds the `lns-local-mixin.yaml` the run
+resolves. A
 `COMMAND` after the reference overrides the sandbox base image's default command
 (`lns run ghcr.io/acme/agent:1 echo hi`) while keeping its `ENTRYPOINT`; an explicit `--`
 separator is still accepted. A command with no `REF` (`lns run -- echo hi`) runs
@@ -97,10 +98,10 @@ the `./lns.yaml` definition with its command overridden.
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
 | `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
 | `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`, `-m 38Gi` — the same sizes `spec.resources.memory` accepts, all binary, rounded up to a whole MiB); falls back to the `run.mem` config default. |
-| `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory roots the definition's relative binds and filesets. Cannot be combined with `REF`. |
+| `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory is the project, so it roots the definition's relative binds and filesets and holds the decisions file. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |
-| `--policy <PATH>`            | `lns-local-mixin.yaml`| Policy file; auto-created with no rules if absent.                      |
+| `--policy <PATH>`            | the project's `lns-local-mixin.yaml`| Policy file; auto-created with no rules if absent. A relative path roots where you typed it, not at the project. |
 | `--mixin <REF>`              |                  | Merge a mixin into this run, after the ones the document declares (repeatable, in flag order — a later one wins). Takes a reference or a directory. A tag is allowed and is pinned before the run reports it; the summary shows `tag → digest`, and a directory shows its absolute path. |
 | `-w`, `--workdir <DIR>`      | `spec.workdir`, then image `WORKDIR` | Working directory inside the sandbox (absolute path; created if missing). |
 | `-e`, `--env <KEY=VALUE>`    |                  | Set a non-secret environment variable (repeatable). Secrets belong in the credential flow. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,11 +99,12 @@ lns run
     file: /Users/you/dev/my-app/lns-local-mixin.yaml
     unmatched destinations: ask
     rules: none defined; anything else asks
-    source: auto-created (no policy in this directory)
+    source: auto-created (no policy in the project directory)
 ```
 
 You run Lens Sandbox from a project directory — that's where it looks for
-`lns-local-mixin.yaml`, creating an empty one the first time. To
+`lns-local-mixin.yaml`, creating an empty one the first time. Run a definition in
+another directory and it reads that project's file instead. To
 give the workload your actual project files, bind-mount the directory with
 `-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for a
 portable definition use a declarative bind with `source: .`; for scratch

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -7,9 +7,10 @@ three things: **allow** it, **deny** it at the boundary, or — when no rule mat
 
 ## The policy file
 
-Policy lives in a human-readable YAML file. By default that's `lns-local-mixin.yaml` in
-the directory you run from; the first `lns run` in a directory without one creates
-it:
+Policy lives in a human-readable YAML file. By default that's
+`lns-local-mixin.yaml` beside the definition being run — the directory you run
+from, unless you name a definition in another one — and the first `lns run` in a
+directory without one creates it:
 
 ```yaml
 apiVersion: lns.run/v1
@@ -218,7 +219,8 @@ section before using it.
 
 You can hand-edit the YAML, but `lns policy` edits it for you and keeps it
 well-formed. All subcommands default to `lns-local-mixin.yaml` in the current directory;
-pass `--policy <path>` to target another file.
+pass `--policy <path>` to target another file, including the one governing a
+definition you run from elsewhere.
 
 ### Add an allow or deny rule
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -101,9 +101,9 @@ lns run [OPTIONS] [REF] [-- COMMAND...]
 or a **path to a local definition**. Omit it to run the `./lns.yaml` in the current
 directory; `.`, `lns.yaml`, and `./lns.yaml` mean the same thing, a relative or
 absolute path runs another directory's definition, and a path-shaped `.yaml`/`.yml`
-file names the definition itself. Either way the definition's relative binds and
-filesets root at its own directory, compose-style, while the policy still comes
-from where you run:
+file names the definition itself. Either way the definition's directory is the
+project: it roots the relative binds and filesets, compose-style, and holds the
+decisions the run resolves:
 
 ```bash
 lns run                                  # run ./lns.yaml in this directory
@@ -114,11 +114,15 @@ lns run ./lns.dev.yaml                   # run a definition file by name
 lns run ghcr.io/acme/agent:latest        # run a published sandbox by reference
 ```
 
-You run `lns run` from a project directory; that's where Lens Sandbox looks for the
-`lns-local-mixin.yaml` that governs the run. To expose your actual host files to the
-workload, bind-mount a directory with `-v /host/path:/guest/path` (see
-[Host bind mounts](#host-bind-mounts)); for scratch space that persists across runs,
-attach a named volume instead.
+One directory is one project, and the definition you run names which: the
+`lns-local-mixin.yaml` that governs a run sits beside the `lns.yaml` being run, so
+`lns run ../other-project` reads and writes that project's decisions rather than
+yours. A published reference has no directory of its own, so a run of one is
+governed by the directory you start it in.
+
+To expose your actual host files to the workload, bind-mount a directory with
+`-v /host/path:/guest/path` (see [Host bind mounts](#host-bind-mounts)); for
+scratch space that persists across runs, attach a named volume instead.
 
 ### Running a definition vs. a reference
 
@@ -155,8 +159,8 @@ lns push -f lns.dev.yaml ghcr.io/acme/agent-dev:1.0.0
 lns inspect -f lns.dev.yaml              # render it, offline
 ```
 
-The selected file's directory roots its relative binds and filesets, exactly as
-a path-shaped `REF` does, and the policy still comes from where you run. On
+The selected file's directory is the project, exactly as a path-shaped `REF`
+makes it: it roots the relative binds and filesets and holds the decisions. On
 `lns run` the selector is exclusive with `REF`; `lns run ./lns.dev.yaml` is the
 equivalent path spelling.
 


### PR DESCRIPTION
Stacked on #254 (itself on #252) — review those first; the base retargets as they merge.

`docs/sandbox-spec.md` §8 puts a directory's decisions "in the directory the work is happening in", and §8.1 has every run there resolve them. The code anchored `lns-local-mixin.yaml` at the process working directory instead, while mounts and filesets already rooted at the definition's own directory. So:

```bash
lns run ../other-project      # binds that project's files, reads YOUR decisions
```

`docs/running-workloads.md` advertised exactly that shape (`lns run ./docs/examples/claude-code   # same, no cd needed`) a few lines above stating that the policy comes from where you run. One of the two had to go.

### What changed

The default decisions file anchors at the **project directory**: the definition's own directory when a path names one, the run's own directory for a published reference, which has none. That is the rule mounts and filesets already follow.

A relative `--policy` still roots where you typed it. §3.3.1 settles the principle for a reference the user types rather than a document names — "a `--mixin` roots where the user typed it, since no document names one" — and a path typed on a command line is the same species. Both rules are pinned by their own scenario.

`DecisionsSite { typed_in, project }` carries the two anchors apart. Two bare `&Path` parameters would be transposable at a call site and would silently put the bug back; the type makes the distinction impossible to lose. The decision also lives in `run/summary.rs`, which the coverage gate enforces at 100%, rather than in `service/orchestrator.rs`, which is in the IGNORES table — and the Layer 2 step calls that same production function, so the scenario cannot pass while the product stays broken.

`PolicySource::FoundInCwd` becomes `Found`, and the summary's two source lines now say "the project directory"; the old wording became false the moment the anchor moved.

### Breaking, deliberately, no shim

The workload grant sidecar keys a project by its decisions-file path (`crates/lns-policy/src/grants.rs:332`). For the shapes this fixes — a definition run from another directory — the key changes, so connector consent recorded under the old cwd-anchored key reads as not-connected and the connect card appears once more. Recognising the old key would mean carrying the old spelling, which the pre-1.0 rule forbids; §8.4's "a clone asks for its own consent" is the same failure direction by design.

### Out of scope, by your call

`lns policy` and `lns connector` stay anchored to the directory they stand in. They name no definition, so there is nothing to anchor them to, and giving them a `-f` selector would add a CLI flag the specification does not describe. `--policy <path>` reaches the file of a project you run from elsewhere.

### Verification

`cargo test -p lns-cli --test behaviours` → 415 scenarios green (two new). `cargo test -p lns-cli --lib` → 817 passed. `cargo fmt --check` and `cargo clippy -p lns-cli --all-targets -- -D warnings` clean.

The red step: the first scenario was watched failing before the change, expecting `/other/lns-local-mixin.yaml` and getting `/work/lns-local-mixin.yaml`.

23 `update::tests` failures in `lns-cli --lib` are pre-existing and environmental — httpmock's local server does not complete requests in this container, and `src/update.rs` is untouched here.