### PR TITLE
feat(exec): add interactive exec sessions

### DIFF
--- a/crates/e2e-tests/features/microvm_image_pull.feature
+++ b/crates/e2e-tests/features/microvm_image_pull.feature
@@ -20,4 +20,4 @@ Feature: a real OCI image is pulled and booted end to end
     Given the Lens Sandbox service is running
     When I run lns "pull public.ecr.aws/docker/library/alpine:3.20" against the service
     Then the exit code is non-zero
-    And the output contains "not a Lens Sandbox artifact"
+    And the output contains "is an OCI image, not a published sandbox"

--- a/crates/e2e-tests/features/microvm_streaming.feature
+++ b/crates/e2e-tests/features/microvm_streaming.feature
@@ -22,6 +22,19 @@ Feature: session streaming verbs reach a real guest without wedging the terminal
     Then the exit code is 0
     And the output contains "exec-hi"
 
+  Scenario: non-interactive exec preserves streams and exit status without entering primary logs
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox sleep 60'"
+    Then the exit code is 0
+    When the user execs "/bin/sh -c 'echo exec-out; echo exec-err >&2; exit 7'" in that run
+    Then the exit code is 7
+    And the output contains "exec-out"
+    And the output contains "exec-err"
+    When the user prints that run's logs
+    Then the exit code is 0
+    And the output does not contain "exec-out"
+    And the output does not contain "exec-err"
+
   Scenario: logs without follow replays captured output and returns through the top level
     Given the Lens Sandbox service is running
     When the user starts a detached microVM command "/bin/sh -c 'echo hello-logs && /.lens/guest-tools/bin/busybox sleep 60'"

--- a/crates/e2e-tests/features/microvm_streaming.feature
+++ b/crates/e2e-tests/features/microvm_streaming.feature
@@ -35,6 +35,16 @@ Feature: session streaming verbs reach a real guest without wedging the terminal
     And the output does not contain "exec-out"
     And the output does not contain "exec-err"
 
+  Scenario: an exec adopts the workload user's identity instead of the broker's
+    Given the Lens Sandbox service is running
+    When the user starts a detached microVM command "/bin/sh -c '/.lens/guest-tools/bin/busybox sleep 60'"
+    Then the exit code is 0
+    When the user execs "/bin/sh -c 'echo home=$HOME user=$USER cwd=$(pwd)end'" in that run
+    Then the exit code is 0
+    And the output contains "home=/home/sandbox"
+    And the output contains "user=sandbox"
+    And the output contains "cwd=/end"
+
   Scenario: logs without follow replays captured output and returns through the top level
     Given the Lens Sandbox service is running
     When the user starts a detached microVM command "/bin/sh -c 'echo hello-logs && /.lens/guest-tools/bin/busybox sleep 60'"

--- a/crates/e2e-tests/lns-policy.yaml
+++ b/crates/e2e-tests/lns-policy.yaml
@@ -1,0 +1,4 @@
+network:
+  allowedRoutes: []
+  defaultVerdict: ask
+  defaultTransport: direct

--- a/crates/e2e-tests/lns-policy.yaml
+++ b/crates/e2e-tests/lns-policy.yaml
@@ -1,4 +1,0 @@
-network:
-  allowedRoutes: []
-  defaultVerdict: ask
-  defaultTransport: direct

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -1461,6 +1461,17 @@ fn logs_top_level(world: &mut E2eWorld, needle: String) -> Result<(), String> {
     logs_until(world, &["logs"], &needle)
 }
 
+#[when("the user prints that run's logs")]
+fn logs_top_level_once(world: &mut E2eWorld) -> Result<(), String> {
+    let id = last_run(world)?;
+    world.result = Some(run_cli_with_timeout(
+        vec!["logs".to_string(), id],
+        socket_env(world),
+        STREAM_VERB_TIMEOUT,
+    ));
+    Ok(())
+}
+
 #[when(
     regex = r#"^the user prints that run's logs via the sandbox namespace until they contain "([^"]+)"$"#
 )]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -311,8 +311,7 @@ pub struct ExecArgs {
         require_equals = true,
         default_value_t = false,
         default_missing_value = "true",
-        value_parser = refuse_exec_session,
-        hide = true
+        help = "Keep stdin open and forward host stdin to the exec command."
     )]
     pub interactive: bool,
 
@@ -324,8 +323,7 @@ pub struct ExecArgs {
         require_equals = true,
         default_value_t = false,
         default_missing_value = "true",
-        value_parser = refuse_exec_session,
-        hide = true
+        help = "Allocate a PTY for the exec command."
     )]
     pub tty: bool,
 
@@ -347,7 +345,7 @@ pub struct ExecArgs {
 
     #[arg(
         last = true,
-        help = "Command to exec in the running workload. Everything after `--`."
+        help = "Command to exec in the running workload; `--` is optional."
     )]
     pub cmd: Vec<String>,
 }
@@ -504,18 +502,6 @@ fn user_spec_uid(spec: &str) -> Option<u32> {
         .map_or(spec, |(user, _)| user)
         .parse::<u32>()
         .ok()
-}
-
-fn refuse_exec_session(s: &str) -> Result<bool, String> {
-    match s {
-        "false" => Ok(false),
-        _ => Err(
-            "an interactive exec is not yet supported: input routing for exec sessions \
-                  awaits an IPC discriminator. Drop -i/-t and pass the command after `--`; \
-                  `lns attach` reaches the run's own terminal"
-                .to_string(),
-        ),
-    }
 }
 
 pub(crate) fn parse_mem_arg(s: &str) -> Result<usize, String> {
@@ -831,21 +817,14 @@ mod tests {
     }
 
     #[test]
-    fn exec_refuses_a_session_it_cannot_route_input_to() {
-        for flag in ["-i", "-t", "--interactive=true", "--tty=true"] {
-            let err = parse_exec(&[flag, "demo", "--", "sh"])
-                .err()
-                .unwrap_or_else(|| panic!("{flag} must be refused at parse time"));
-            assert_eq!(
-                err.kind(),
-                clap::error::ErrorKind::ValueValidation,
-                "flag {flag}: {err}"
-            );
-            assert!(
-                err.to_string().contains("not yet supported"),
-                "flag {flag}: {err}"
-            );
-        }
+    fn exec_accepts_explicit_interactive_and_tty_modes() {
+        let interactive = parse_exec(&["-i", "demo", "--", "sh"]).expect("-i parses");
+        assert!(interactive.interactive);
+        assert!(!interactive.tty);
+
+        let tty = parse_exec(&["-t", "demo", "--", "sh"]).expect("-t parses");
+        assert!(!tty.interactive);
+        assert!(tty.tty);
     }
 
     #[test]

--- a/crates/lns-cli/src/command.rs
+++ b/crates/lns-cli/src/command.rs
@@ -558,14 +558,10 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_exec_expands_a_leading_it_cluster_then_refuses_the_session() {
-        let parsed: clap::error::Result<crate::cli::ExecArgs> =
-            parse_args(["lns", "sandbox", "exec", "-it", "demo", "sh"]);
-        let err = parsed
-            .err()
-            .unwrap_or_else(|| panic!("a session exec must be refused"));
-        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
-        assert!(err.to_string().contains("not yet supported"), "{err}");
+    fn sandbox_exec_expands_a_leading_it_cluster_into_both_session_flags() {
+        let args = sandbox_exec_args(&["lns", "sandbox", "exec", "-it", "demo", "sh"]);
+        assert!(args.interactive);
+        assert!(args.tty);
     }
 
     #[test]
@@ -717,17 +713,11 @@ mod tests {
     }
 
     #[test]
-    fn exec_expands_a_leading_it_cluster_then_refuses_the_session() {
-        let parsed: clap::error::Result<crate::cli::ExecArgs> =
-            parse_args(["lns", "exec", "-it", "demo", "--", "sh"]);
-        let err = parsed
-            .err()
-            .unwrap_or_else(|| panic!("a session exec must be refused"));
-        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
-        assert!(
-            err.to_string().contains("not yet supported"),
-            "the cluster must expand so the user reads our refusal, not `unexpected argument`: {err}"
-        );
+    fn exec_expands_a_leading_it_cluster_into_both_session_flags() {
+        let args: crate::cli::ExecArgs =
+            parse_args(["lns", "exec", "-it", "demo", "--", "sh"]).unwrap();
+        assert!(args.interactive);
+        assert!(args.tty);
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -47,9 +47,7 @@ pub enum SandboxCommand {
     Ls(LsArgs),
     #[command(about = "Run a sandbox in a microVM (the top-level `lns run`).")]
     Run(Box<RunArgs>),
-    #[command(
-        about = "Run one non-interactive command against a running run (`docker exec`-style); use `lns attach` for its terminal."
-    )]
+    #[command(about = "Run another command against a running run (`docker exec`-style).")]
     Exec(ExecArgs),
     #[command(about = "Send a signal to a running run (`docker kill`-style).")]
     Kill(KillArgs),

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -47,7 +47,7 @@ pub enum SandboxCommand {
     Ls(LsArgs),
     #[command(about = "Run a sandbox in a microVM (the top-level `lns run`).")]
     Run(Box<RunArgs>),
-    #[command(about = "Run another command against a running run (`docker exec`-style).")]
+    #[command(about = "Run another command against a running run.")]
     Exec(ExecArgs),
     #[command(about = "Send a signal to a running run (`docker kill`-style).")]
     Kill(KillArgs),

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -24,9 +24,9 @@ const NOT_RUNNING_MESSAGE: &str =
 mod orchestrator;
 pub use orchestrator::{
     DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, build_exec_request, dispatch,
-    drive_attached_session_with_writers, drive_pre_phase, exec_command, exec_image, launch_run,
-    pre_phase_step, render_started_run, render_status_line, require_running, run_command,
-    run_image,
+    drive_attached_session_with_writers, drive_pre_phase, exec_command, exec_image,
+    exec_image_on_stream, launch_run, pre_phase_step, render_started_run, render_status_line,
+    require_running, run_command, run_image,
 };
 
 use crate::command::{CommandSpec, subcommand};

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -23,7 +23,7 @@ const NOT_RUNNING_MESSAGE: &str =
 
 mod orchestrator;
 pub use orchestrator::{
-    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, dispatch,
+    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, build_exec_request, dispatch,
     drive_attached_session_with_writers, drive_pre_phase, exec_command, exec_image, launch_run,
     pre_phase_step, render_started_run, render_status_line, require_running, run_command,
     run_image,

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -578,14 +578,13 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     };
     let detach_chord = args.detach_keys.0.clone();
 
-    let request = Request::ExecImage(ExecImageArgs {
-        run: target_run,
-        argv: args.cmd,
-        env: Vec::new(),
+    let request = Request::ExecImage(build_exec_request(
+        target_run,
+        args.cmd,
         tty,
         stdin,
         initial_winsize,
-    });
+    ));
     let frame = encode_frame(&request).context("encoding ExecImage request")?;
     stream
         .write_all(&frame)
@@ -610,6 +609,23 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
         StdinForwarding::of(stdin),
     )
     .await
+}
+
+pub fn build_exec_request(
+    run: String,
+    argv: Vec<String>,
+    tty: bool,
+    stdin: bool,
+    initial_winsize: Option<(u16, u16)>,
+) -> ExecImageArgs {
+    ExecImageArgs {
+        run,
+        argv,
+        env: Vec::new(),
+        tty,
+        stdin,
+        initial_winsize,
+    }
 }
 
 fn decode_exec_started(bytes: &[u8]) -> Result<lns_ipc::SessionTarget> {

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -669,7 +669,7 @@ fn decode_exec_started(bytes: &[u8]) -> Result<lns_ipc::SessionTarget> {
     }
 }
 
-/// Whether host stdin reaches the session's workload.
+/// Whether host stdin reaches the session's workload; a session opened without `-i` still watches for the detach chord but hands the run nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StdinForwarding {
     ToRun,
@@ -684,14 +684,6 @@ impl StdinForwarding {
             Self::Withheld
         }
     }
-}
-
-fn should_pump_stdin(stdin: StdinForwarding) -> bool {
-    stdin == StdinForwarding::ToRun
-}
-
-fn should_enable_raw_mode(tty: bool, stdin: StdinForwarding) -> bool {
-    tty && should_pump_stdin(stdin)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -826,7 +818,7 @@ where
     O: AsyncWriteExt + Unpin,
     E: AsyncWriteExt + Unpin,
 {
-    let _raw_guard = if should_enable_raw_mode(tty, stdin) {
+    let _raw_guard = if tty {
         crate::raw_mode::RawModeGuard::enable_if_tty()
     } else {
         None
@@ -863,18 +855,16 @@ where
                 let s = socket.clone();
                 tokio::spawn(async move { run_winsize_forwarder(s, winsize_target).await })
             });
-            let stdin_task = should_pump_stdin(stdin).then(|| {
-                let pump_chord = detach_chord;
-                let pump_early_exit = early_exit_tx.clone();
-                tokio::spawn(async move {
-                    let r = run_stdin_pump(socket, target, pump_chord, detach, stdin).await;
-                    if matches!(&r, Ok(true)) {
-                        let _ = pump_early_exit.send(());
-                    }
-                    r
-                })
+            let pump_chord = detach_chord;
+            let pump_early_exit = early_exit_tx.clone();
+            let stdin_task = tokio::spawn(async move {
+                let r = run_stdin_pump(socket, target, pump_chord, detach, stdin).await;
+                if matches!(&r, Ok(true)) {
+                    let _ = pump_early_exit.send(());
+                }
+                r
             });
-            (Some(cancel_task), winsize, stdin_task)
+            (Some(cancel_task), winsize, Some(stdin_task))
         }
         None => (None, None, None),
     };
@@ -2458,15 +2448,6 @@ mod tests {
             );
             assert!(matches!(control, PumpControl::Continue));
         }
-    }
-
-    #[test]
-    fn a_session_opened_without_stdin_does_not_read_host_input() {
-        assert!(!should_pump_stdin(StdinForwarding::Withheld));
-        assert!(should_pump_stdin(StdinForwarding::ToRun));
-        assert!(!should_enable_raw_mode(true, StdinForwarding::Withheld));
-        assert!(should_enable_raw_mode(true, StdinForwarding::ToRun));
-        assert!(!should_enable_raw_mode(false, StdinForwarding::ToRun));
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -560,7 +560,7 @@ pub async fn run_image(
 
 pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     if args.cmd.is_empty() {
-        anyhow::bail!("lns exec requires a command after `--`");
+        anyhow::bail!("lns exec requires a command");
     }
 
     let socket = super::socket_path()?;
@@ -569,7 +569,7 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
         .with_context(|| format!("connecting to {}", socket.display()))?;
 
     let target_run = args.run;
-    let tty = args.tty && crate::raw_mode::stdin_is_tty();
+    let tty = args.tty;
     let stdin = args.interactive;
     let initial_winsize = if tty {
         crate::raw_mode::host_winsize()
@@ -595,24 +595,31 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     let bytes = read_frame_bytes_async(&mut stream)
         .await
         .context("reading RunStarted frame")?;
-    let run_id = match decode_frame(&mut &bytes[..]).context("decoding RunStarted")? {
-        Response::RunStarted { run_id } => run_id,
-        Response::Error { message } => anyhow::bail!("daemon error: {message}"),
-        other => anyhow::bail!("expected RunStarted, got {other:?}"),
-    };
-    crate::log::debug!(run_id = %run_id, "exec session opened");
+    let target = decode_exec_started(&bytes)?;
+    crate::log::debug!(run_id = %target.run_id(), "exec session opened");
 
-    drive_attached_session(
+    drive_targeted_session(
         stream,
         Some(socket),
-        run_id,
+        target,
         tty,
         detach_chord,
-        DetachBehaviour::SignalAndDrain,
+        DetachBehaviour::CloseSession,
+        CancelBehaviour::SignalSession,
         args.quiet,
         StdinForwarding::of(stdin),
     )
     .await
+}
+
+fn decode_exec_started(bytes: &[u8]) -> Result<lns_ipc::SessionTarget> {
+    match decode_frame(&mut &bytes[..]).context("decoding ExecStarted")? {
+        Response::ExecStarted { run_id, session_id } => {
+            Ok(lns_ipc::SessionTarget::Exec { run_id, session_id })
+        }
+        Response::Error { message } => anyhow::bail!("daemon error: {message}"),
+        other => anyhow::bail!("expected ExecStarted, got {other:?}"),
+    }
 }
 
 /// Whether host stdin reaches the session's workload; a session opened without `-i` still watches for the detach chord but hands the run nothing.
@@ -635,8 +642,15 @@ impl StdinForwarding {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DetachBehaviour {
     SignalAndDrain,
+    CloseSession,
     LeaveRunning,
     DetachRun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CancelBehaviour {
+    CancelRun,
+    SignalSession,
 }
 
 #[allow(clippy::too_many_arguments)] // one session-shape argument per wire field; the writer seam lives in the _with_writers twin
@@ -653,16 +667,46 @@ pub(crate) async fn drive_attached_session<S>(
 where
     S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
 {
-    let mut stdout = tokio::io::stdout();
-    let mut stderr = tokio::io::stderr();
-    drive_attached_session_with_writers(
+    drive_targeted_session(
         stream,
         aux_socket,
-        run_id,
+        primary_target(run_id),
+        tty,
+        detach_chord,
+        detach,
+        CancelBehaviour::CancelRun,
+        quiet,
+        stdin,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_targeted_session<S>(
+    stream: S,
+    aux_socket: Option<PathBuf>,
+    target: lns_ipc::SessionTarget,
+    tty: bool,
+    detach_chord: Vec<u8>,
+    detach: DetachBehaviour,
+    cancel: CancelBehaviour,
+    quiet: bool,
+    stdin: StdinForwarding,
+) -> Result<i32>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
+{
+    let mut stdout = tokio::io::stdout();
+    let mut stderr = tokio::io::stderr();
+    drive_targeted_session_with_writers(
+        stream,
+        aux_socket,
+        target,
         tty,
         std::io::stdout().is_terminal(),
         detach_chord,
         detach,
+        cancel,
         &mut stdout,
         &mut stderr,
         quiet,
@@ -673,13 +717,50 @@ where
 
 #[allow(clippy::too_many_arguments)] // explicit stream/writer/terminal seam so the attached-session loop is host-testable over in-memory duplexes
 pub async fn drive_attached_session_with_writers<S, O, E>(
-    mut stream: S,
+    stream: S,
     aux_socket: Option<PathBuf>,
     run_id: String,
     tty: bool,
     stdout_is_terminal: bool,
     detach_chord: Vec<u8>,
     detach: DetachBehaviour,
+    stdout: &mut O,
+    stderr: &mut E,
+    quiet: bool,
+    stdin: StdinForwarding,
+) -> Result<i32>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
+    O: AsyncWriteExt + Unpin,
+    E: AsyncWriteExt + Unpin,
+{
+    drive_targeted_session_with_writers(
+        stream,
+        aux_socket,
+        primary_target(run_id),
+        tty,
+        stdout_is_terminal,
+        detach_chord,
+        detach,
+        CancelBehaviour::CancelRun,
+        stdout,
+        stderr,
+        quiet,
+        stdin,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_targeted_session_with_writers<S, O, E>(
+    mut stream: S,
+    aux_socket: Option<PathBuf>,
+    target: lns_ipc::SessionTarget,
+    tty: bool,
+    stdout_is_terminal: bool,
+    detach_chord: Vec<u8>,
+    detach: DetachBehaviour,
+    cancel: CancelBehaviour,
     stdout: &mut O,
     stderr: &mut E,
     quiet: bool,
@@ -700,27 +781,43 @@ where
 
     let (cancel_task, winsize_task, stdin_task) = match aux_socket {
         Some(socket) => {
-            let cancel_client = real_client()?;
-            let cancel_run_id = run_id.clone();
-            let cancel = tokio::spawn(async move {
+            let cancel_target = target.clone();
+            let cancel_socket = socket.clone();
+            let cancel_task = tokio::spawn(async move {
                 let _ = tokio::signal::ctrl_c().await;
-                cancel_client.cancel_run(cancel_run_id).await;
+                match cancel {
+                    CancelBehaviour::CancelRun => {
+                        if let Ok(client) = real_client() {
+                            client.cancel_run(cancel_target.run_id().to_string()).await;
+                        }
+                    }
+                    CancelBehaviour::SignalSession => {
+                        let _ = send_one_shot(
+                            &cancel_socket,
+                            &Request::SessionSignal {
+                                target: cancel_target,
+                                signal: SignalKind::Int,
+                            },
+                        )
+                        .await;
+                    }
+                }
             });
-            let winsize_run_id = run_id.clone();
+            let winsize_target = target.clone();
             let winsize = tty.then(|| {
                 let s = socket.clone();
-                tokio::spawn(async move { run_winsize_forwarder(s, winsize_run_id).await })
+                tokio::spawn(async move { run_winsize_forwarder(s, winsize_target).await })
             });
             let pump_chord = detach_chord;
             let pump_early_exit = early_exit_tx.clone();
             let stdin_task = tokio::spawn(async move {
-                let r = run_stdin_pump(socket, run_id, pump_chord, detach, stdin).await;
+                let r = run_stdin_pump(socket, target, pump_chord, detach, stdin).await;
                 if matches!(&r, Ok(true)) {
                     let _ = pump_early_exit.send(());
                 }
                 r
             });
-            (Some(cancel), winsize, Some(stdin_task))
+            (Some(cancel_task), winsize, Some(stdin_task))
         }
         None => (None, None, None),
     };
@@ -848,7 +945,9 @@ where
         DetachBehaviour::SignalAndDrain => {
             drain_after_chord(stream, tty, stdout, stderr, last_stdout_byte, quiet).await
         }
-        DetachBehaviour::LeaveRunning | DetachBehaviour::DetachRun => 0,
+        DetachBehaviour::CloseSession
+        | DetachBehaviour::LeaveRunning
+        | DetachBehaviour::DetachRun => 0,
     }
 }
 
@@ -930,7 +1029,7 @@ where
 
 async fn run_stdin_pump(
     socket: PathBuf,
-    run_id: String,
+    target: lns_ipc::SessionTarget,
     detach_chord: Vec<u8>,
     detach: DetachBehaviour,
     stdin: StdinForwarding,
@@ -947,12 +1046,21 @@ async fn run_stdin_pump(
                         let _ = send_one_shot(
                             &socket,
                             &Request::SessionStdin {
-                                target: primary_target(run_id.clone()),
+                                target: target.clone(),
                                 bytes: held,
                             },
                         )
                         .await;
                     }
+                }
+                if stdin == StdinForwarding::ToRun {
+                    let _ = send_one_shot(
+                        &socket,
+                        &Request::SessionStdinClose {
+                            target: target.clone(),
+                        },
+                    )
+                    .await;
                 }
                 return Ok(false);
             }
@@ -965,7 +1073,7 @@ async fn run_stdin_pump(
         let chunk = &buf[..n];
         match detector.as_mut() {
             Some(d) => {
-                if !pump_with_detector(&socket, &run_id, chunk, d, detach, stdin).await? {
+                if !pump_with_detector_target(&socket, &target, chunk, d, detach, stdin).await? {
                     return Ok(true);
                 }
             }
@@ -974,7 +1082,7 @@ async fn run_stdin_pump(
                     send_one_shot(
                         &socket,
                         &Request::SessionStdin {
-                            target: primary_target(run_id.clone()),
+                            target: target.clone(),
                             bytes: chunk.to_vec(),
                         },
                     )
@@ -985,9 +1093,9 @@ async fn run_stdin_pump(
     }
 }
 
-async fn pump_with_detector(
+async fn pump_with_detector_target(
     socket: &Path,
-    run_id: &str,
+    target: &lns_ipc::SessionTarget,
     bytes: &[u8],
     detector: &mut DetachChordDetector,
     detach: DetachBehaviour,
@@ -995,7 +1103,8 @@ async fn pump_with_detector(
 ) -> Result<bool> {
     let mut pending: Vec<u8> = Vec::new();
     for &b in bytes {
-        let (requests, control) = plan_feed(detector.feed(b), run_id, &mut pending, detach, stdin);
+        let (requests, control) =
+            plan_feed_target(detector.feed(b), target, &mut pending, detach, stdin);
         for request in &requests {
             send_one_shot(socket, request).await?;
         }
@@ -1004,7 +1113,7 @@ async fn pump_with_detector(
         }
     }
     if stdin == StdinForwarding::ToRun
-        && let Some(request) = drain_pending(run_id, &mut pending)
+        && let Some(request) = drain_pending_target(target, &mut pending)
     {
         send_one_shot(socket, &request).await?;
     }
@@ -1016,17 +1125,18 @@ enum PumpControl {
     Detach,
 }
 
-fn drain_pending(run_id: &str, pending: &mut Vec<u8>) -> Option<Request> {
+fn drain_pending_target(target: &lns_ipc::SessionTarget, pending: &mut Vec<u8>) -> Option<Request> {
     if pending.is_empty() {
         None
     } else {
         Some(Request::SessionStdin {
-            target: primary_target(run_id.to_string()),
+            target: target.clone(),
             bytes: std::mem::take(pending),
         })
     }
 }
 
+#[cfg(test)]
 fn plan_feed(
     action: FeedAction,
     run_id: &str,
@@ -1034,15 +1144,31 @@ fn plan_feed(
     detach: DetachBehaviour,
     stdin: StdinForwarding,
 ) -> (Vec<Request>, PumpControl) {
+    plan_feed_target(
+        action,
+        &primary_target(run_id.to_string()),
+        pending,
+        detach,
+        stdin,
+    )
+}
+
+fn plan_feed_target(
+    action: FeedAction,
+    target: &lns_ipc::SessionTarget,
+    pending: &mut Vec<u8>,
+    detach: DetachBehaviour,
+    stdin: StdinForwarding,
+) -> (Vec<Request>, PumpControl) {
     let stdin_requests = |bytes: Vec<u8>| match stdin {
         StdinForwarding::ToRun => vec![Request::SessionStdin {
-            target: primary_target(run_id.to_string()),
+            target: target.clone(),
             bytes,
         }],
         StdinForwarding::Withheld => Vec::new(),
     };
     let drained = |pending: &mut Vec<u8>| match stdin {
-        StdinForwarding::ToRun => drain_pending(run_id, pending).into_iter().collect(),
+        StdinForwarding::ToRun => drain_pending_target(target, pending).into_iter().collect(),
         StdinForwarding::Withheld => {
             pending.clear();
             Vec::<Request>::new()
@@ -1070,11 +1196,14 @@ fn plan_feed(
             let mut requests = drained(pending);
             match detach {
                 DetachBehaviour::SignalAndDrain => requests.push(Request::SessionSignal {
-                    target: primary_target(run_id.to_string()),
+                    target: target.clone(),
                     signal: SignalKind::Hup,
                 }),
+                DetachBehaviour::CloseSession => requests.push(Request::SessionDetach {
+                    target: target.clone(),
+                }),
                 DetachBehaviour::DetachRun => requests.push(Request::SessionDetach {
-                    target: primary_target(run_id.to_string()),
+                    target: target.clone(),
                 }),
                 DetachBehaviour::LeaveRunning => {}
             }
@@ -1083,7 +1212,7 @@ fn plan_feed(
     }
 }
 
-async fn run_winsize_forwarder(socket: PathBuf, run_id: String) -> Result<()> {
+async fn run_winsize_forwarder(socket: PathBuf, target: lns_ipc::SessionTarget) -> Result<()> {
     use tokio::signal::unix::{SignalKind as TokioSig, signal};
     let mut sigwinch = match signal(TokioSig::window_change()) {
         Ok(s) => s,
@@ -1099,7 +1228,7 @@ async fn run_winsize_forwarder(socket: PathBuf, run_id: String) -> Result<()> {
         if send_one_shot(
             &socket,
             &Request::SessionResize {
-                target: primary_target(run_id.clone()),
+                target: target.clone(),
                 rows,
                 cols,
             },
@@ -1288,6 +1417,23 @@ fn phrase_for_verb(verb: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exec_started_handshake_preserves_the_service_assigned_session_target() {
+        let frame = encode_frame(&Response::ExecStarted {
+            run_id: "run-7".to_string(),
+            session_id: "exec-2".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            decode_exec_started(&frame).unwrap(),
+            lns_ipc::SessionTarget::Exec {
+                run_id: "run-7".to_string(),
+                session_id: "exec-2".to_string(),
+            }
+        );
+    }
     use tokio::io::AsyncWriteExt;
 
     #[test]
@@ -2445,6 +2591,26 @@ mod tests {
         );
         assert!(matches!(control, PumpControl::Detach));
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn plan_feed_close_session_targets_only_the_exec_session() {
+        let target = lns_ipc::SessionTarget::Exec {
+            run_id: "run-7".to_string(),
+            session_id: "exec-2".to_string(),
+        };
+        let mut pending = Vec::new();
+
+        let (requests, control) = plan_feed_target(
+            FeedAction::Trigger,
+            &target,
+            &mut pending,
+            DetachBehaviour::CloseSession,
+            StdinForwarding::ToRun,
+        );
+
+        assert_eq!(requests, vec![Request::SessionDetach { target }]);
+        assert!(matches!(control, PumpControl::Detach));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -2210,7 +2210,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(code, 0, "a docker-style detach returns 0 at once");
+        assert_eq!(code, 0, "detaching returns 0 at once");
         assert!(
             captured.is_empty(),
             "LeaveRunning must leave the run running, not drain its output"
@@ -2560,7 +2560,7 @@ mod tests {
                 target: primary_target("9".to_string()),
                 bytes: vec![b'p']
             }],
-            "a docker-style detach flushes pending input but never signals the workload"
+            "detaching flushes pending input but never signals the workload"
         );
         assert!(matches!(control, PumpControl::Detach));
         assert!(pending.is_empty());

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -564,22 +564,50 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     }
 
     let socket = super::socket_path()?;
-    let mut stream = UnixStream::connect(&socket)
+    let stream = UnixStream::connect(&socket)
         .await
         .with_context(|| format!("connecting to {}", socket.display()))?;
 
-    let target_run = args.run;
-    let tty = args.tty;
-    let stdin = args.interactive;
-    let initial_winsize = if tty {
+    let initial_winsize = if args.tty {
         crate::raw_mode::host_winsize()
     } else {
         None
     };
+    let mut stdout = tokio::io::stdout();
+    let mut stderr = tokio::io::stderr();
+    exec_image_on_stream(
+        stream,
+        Some(socket),
+        args,
+        initial_winsize,
+        std::io::stdout().is_terminal(),
+        &mut stdout,
+        &mut stderr,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)] // explicit stream/writer/terminal seam so the exec handshake and session loop are host-testable over in-memory duplexes
+pub async fn exec_image_on_stream<S, O, E>(
+    mut stream: S,
+    aux_socket: Option<PathBuf>,
+    args: ExecArgs,
+    initial_winsize: Option<(u16, u16)>,
+    stdout_is_terminal: bool,
+    stdout: &mut O,
+    stderr: &mut E,
+) -> Result<i32>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
+    O: AsyncWriteExt + Unpin,
+    E: AsyncWriteExt + Unpin,
+{
+    let tty = args.tty;
+    let stdin = args.interactive;
     let detach_chord = args.detach_keys.0.clone();
 
     let request = Request::ExecImage(build_exec_request(
-        target_run,
+        args.run,
         args.cmd,
         tty,
         stdin,
@@ -597,14 +625,17 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
     let target = decode_exec_started(&bytes)?;
     crate::log::debug!(run_id = %target.run_id(), "exec session opened");
 
-    drive_targeted_session(
+    drive_targeted_session_with_writers(
         stream,
-        Some(socket),
+        aux_socket,
         target,
         tty,
+        stdout_is_terminal,
         detach_chord,
         DetachBehaviour::CloseSession,
         CancelBehaviour::SignalSession,
+        stdout,
+        stderr,
         args.quiet,
         StdinForwarding::of(stdin),
     )

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -24,6 +24,12 @@ use crate::run::summary::print_run_summary;
 
 const PUBLISHED_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
 
+fn primary_target(run_id: impl Into<String>) -> lns_ipc::SessionTarget {
+    lns_ipc::SessionTarget::Primary {
+        run_id: run_id.into(),
+    }
+}
+
 pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = RunArgs::from_arg_matches(matches)?;
@@ -940,8 +946,8 @@ async fn run_stdin_pump(
                     if !held.is_empty() && stdin == StdinForwarding::ToRun {
                         let _ = send_one_shot(
                             &socket,
-                            &Request::RunStdin {
-                                run_id: run_id.clone(),
+                            &Request::SessionStdin {
+                                target: primary_target(run_id.clone()),
                                 bytes: held,
                             },
                         )
@@ -967,8 +973,8 @@ async fn run_stdin_pump(
                 if stdin == StdinForwarding::ToRun {
                     send_one_shot(
                         &socket,
-                        &Request::RunStdin {
-                            run_id: run_id.clone(),
+                        &Request::SessionStdin {
+                            target: primary_target(run_id.clone()),
                             bytes: chunk.to_vec(),
                         },
                     )
@@ -1014,8 +1020,8 @@ fn drain_pending(run_id: &str, pending: &mut Vec<u8>) -> Option<Request> {
     if pending.is_empty() {
         None
     } else {
-        Some(Request::RunStdin {
-            run_id: run_id.to_string(),
+        Some(Request::SessionStdin {
+            target: primary_target(run_id.to_string()),
             bytes: std::mem::take(pending),
         })
     }
@@ -1029,8 +1035,8 @@ fn plan_feed(
     stdin: StdinForwarding,
 ) -> (Vec<Request>, PumpControl) {
     let stdin_requests = |bytes: Vec<u8>| match stdin {
-        StdinForwarding::ToRun => vec![Request::RunStdin {
-            run_id: run_id.to_string(),
+        StdinForwarding::ToRun => vec![Request::SessionStdin {
+            target: primary_target(run_id.to_string()),
             bytes,
         }],
         StdinForwarding::Withheld => Vec::new(),
@@ -1063,12 +1069,12 @@ fn plan_feed(
         FeedAction::Trigger => {
             let mut requests = drained(pending);
             match detach {
-                DetachBehaviour::SignalAndDrain => requests.push(Request::RunSignal {
-                    run_id: run_id.to_string(),
+                DetachBehaviour::SignalAndDrain => requests.push(Request::SessionSignal {
+                    target: primary_target(run_id.to_string()),
                     signal: SignalKind::Hup,
                 }),
-                DetachBehaviour::DetachRun => requests.push(Request::RunDetach {
-                    run_id: run_id.to_string(),
+                DetachBehaviour::DetachRun => requests.push(Request::SessionDetach {
+                    target: primary_target(run_id.to_string()),
                 }),
                 DetachBehaviour::LeaveRunning => {}
             }
@@ -1092,8 +1098,8 @@ async fn run_winsize_forwarder(socket: PathBuf, run_id: String) -> Result<()> {
         };
         if send_one_shot(
             &socket,
-            &Request::RunResize {
-                run_id: run_id.clone(),
+            &Request::SessionResize {
+                target: primary_target(run_id.clone()),
                 rows,
                 cols,
             },
@@ -2263,8 +2269,8 @@ mod tests {
         );
         assert_eq!(
             requests,
-            vec![Request::RunSignal {
-                run_id: "9".to_string(),
+            vec![Request::SessionSignal {
+                target: primary_target("9".to_string()),
                 signal: SignalKind::Hup
             }],
             "the chord must still detach, and must not flush the withheld bytes on its way out"
@@ -2299,8 +2305,8 @@ mod tests {
         );
         assert_eq!(
             requests,
-            vec![Request::RunStdin {
-                run_id: "7".to_string(),
+            vec![Request::SessionStdin {
+                target: primary_target("7".to_string()),
                 bytes: vec![b'x', b'y']
             }]
         );
@@ -2333,12 +2339,12 @@ mod tests {
         assert_eq!(
             requests,
             vec![
-                Request::RunStdin {
-                    run_id: "3".to_string(),
+                Request::SessionStdin {
+                    target: primary_target("3".to_string()),
                     bytes: vec![b'p']
                 },
-                Request::RunStdin {
-                    run_id: "3".to_string(),
+                Request::SessionStdin {
+                    target: primary_target("3".to_string()),
                     bytes: vec![b'h']
                 },
             ]
@@ -2358,8 +2364,8 @@ mod tests {
         );
         assert_eq!(
             requests,
-            vec![Request::RunStdin {
-                run_id: "3".to_string(),
+            vec![Request::SessionStdin {
+                target: primary_target("3".to_string()),
                 bytes: vec![b'h', b'c']
             }]
         );
@@ -2378,12 +2384,12 @@ mod tests {
         assert_eq!(
             requests,
             vec![
-                Request::RunStdin {
-                    run_id: "9".to_string(),
+                Request::SessionStdin {
+                    target: primary_target("9".to_string()),
                     bytes: vec![b'p']
                 },
-                Request::RunSignal {
-                    run_id: "9".to_string(),
+                Request::SessionSignal {
+                    target: primary_target("9".to_string()),
                     signal: SignalKind::Hup
                 },
             ]
@@ -2404,8 +2410,8 @@ mod tests {
         );
         assert_eq!(
             requests,
-            vec![Request::RunStdin {
-                run_id: "9".to_string(),
+            vec![Request::SessionStdin {
+                target: primary_target("9".to_string()),
                 bytes: vec![b'p']
             }],
             "a docker-style detach flushes pending input but never signals the workload"
@@ -2427,12 +2433,12 @@ mod tests {
         assert_eq!(
             requests,
             vec![
-                Request::RunStdin {
-                    run_id: "9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a".to_string(),
+                Request::SessionStdin {
+                    target: primary_target("9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a".to_string()),
                     bytes: vec![b'p']
                 },
-                Request::RunDetach {
-                    run_id: "9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a".to_string(),
+                Request::SessionDetach {
+                    target: primary_target("9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a".to_string()),
                 },
             ],
             "detaching a run flushes pending input then asks the service to keep it running — no SIGHUP",
@@ -2444,8 +2450,8 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn write_and_await_ack_blocks_until_the_service_responds() {
         let (mut client, mut server) = tokio::io::duplex(4096);
-        let detach = Request::RunDetach {
-            run_id: "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string(),
+        let detach = Request::SessionDetach {
+            target: primary_target("7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string()),
         };
         let mut ack = std::pin::pin!(write_and_await_ack(&mut client, &detach));
 
@@ -2462,8 +2468,8 @@ mod tests {
         let decoded: Request = decode_frame(&mut &req[..]).expect("decode request");
         assert_eq!(
             decoded,
-            Request::RunDetach {
-                run_id: "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string(),
+            Request::SessionDetach {
+                target: primary_target("7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string()),
             }
         );
 

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -593,7 +593,7 @@ pub async fn exec_image(args: ExecArgs) -> Result<i32> {
 
     let bytes = read_frame_bytes_async(&mut stream)
         .await
-        .context("reading RunStarted frame")?;
+        .context("reading ExecStarted frame")?;
     let target = decode_exec_started(&bytes)?;
     crate::log::debug!(run_id = %target.run_id(), "exec session opened");
 
@@ -638,7 +638,7 @@ fn decode_exec_started(bytes: &[u8]) -> Result<lns_ipc::SessionTarget> {
     }
 }
 
-/// Whether host stdin reaches the session's workload; a session opened without `-i` still watches for the detach chord but hands the run nothing.
+/// Whether host stdin reaches the session's workload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StdinForwarding {
     ToRun,
@@ -653,6 +653,14 @@ impl StdinForwarding {
             Self::Withheld
         }
     }
+}
+
+fn should_pump_stdin(stdin: StdinForwarding) -> bool {
+    stdin == StdinForwarding::ToRun
+}
+
+fn should_enable_raw_mode(tty: bool, stdin: StdinForwarding) -> bool {
+    tty && should_pump_stdin(stdin)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -787,7 +795,7 @@ where
     O: AsyncWriteExt + Unpin,
     E: AsyncWriteExt + Unpin,
 {
-    let _raw_guard = if tty {
+    let _raw_guard = if should_enable_raw_mode(tty, stdin) {
         crate::raw_mode::RawModeGuard::enable_if_tty()
     } else {
         None
@@ -824,16 +832,18 @@ where
                 let s = socket.clone();
                 tokio::spawn(async move { run_winsize_forwarder(s, winsize_target).await })
             });
-            let pump_chord = detach_chord;
-            let pump_early_exit = early_exit_tx.clone();
-            let stdin_task = tokio::spawn(async move {
-                let r = run_stdin_pump(socket, target, pump_chord, detach, stdin).await;
-                if matches!(&r, Ok(true)) {
-                    let _ = pump_early_exit.send(());
-                }
-                r
+            let stdin_task = should_pump_stdin(stdin).then(|| {
+                let pump_chord = detach_chord;
+                let pump_early_exit = early_exit_tx.clone();
+                tokio::spawn(async move {
+                    let r = run_stdin_pump(socket, target, pump_chord, detach, stdin).await;
+                    if matches!(&r, Ok(true)) {
+                        let _ = pump_early_exit.send(());
+                    }
+                    r
+                })
             });
-            (Some(cancel_task), winsize, Some(stdin_task))
+            (Some(cancel_task), winsize, stdin_task)
         }
         None => (None, None, None),
     };
@@ -2417,6 +2427,15 @@ mod tests {
             );
             assert!(matches!(control, PumpControl::Continue));
         }
+    }
+
+    #[test]
+    fn a_session_opened_without_stdin_does_not_read_host_input() {
+        assert!(!should_pump_stdin(StdinForwarding::Withheld));
+        assert!(should_pump_stdin(StdinForwarding::ToRun));
+        assert!(!should_enable_raw_mode(true, StdinForwarding::Withheld));
+        assert!(should_enable_raw_mode(true, StdinForwarding::ToRun));
+        assert!(!should_enable_raw_mode(false, StdinForwarding::ToRun));
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -830,26 +830,26 @@ where
         Some(socket) => {
             let cancel_target = target.clone();
             let cancel_socket = socket.clone();
-            let cancel_task = tokio::spawn(async move {
-                let _ = tokio::signal::ctrl_c().await;
-                match cancel {
-                    CancelBehaviour::CancelRun => {
-                        if let Ok(client) = real_client() {
-                            client.cancel_run(cancel_target.run_id().to_string()).await;
-                        }
-                    }
-                    CancelBehaviour::SignalSession => {
-                        let _ = send_one_shot(
-                            &cancel_socket,
-                            &Request::SessionSignal {
-                                target: cancel_target,
-                                signal: SignalKind::Int,
-                            },
-                        )
-                        .await;
-                    }
+            let cancel_task = match cancel {
+                CancelBehaviour::CancelRun => {
+                    let client = real_client()?;
+                    tokio::spawn(async move {
+                        let _ = tokio::signal::ctrl_c().await;
+                        client.cancel_run(cancel_target.run_id().to_string()).await;
+                    })
                 }
-            });
+                CancelBehaviour::SignalSession => tokio::spawn(async move {
+                    let _ = tokio::signal::ctrl_c().await;
+                    let _ = send_one_shot(
+                        &cancel_socket,
+                        &Request::SessionSignal {
+                            target: cancel_target,
+                            signal: SignalKind::Int,
+                        },
+                    )
+                    .await;
+                }),
+            };
             let winsize_target = target.clone();
             let winsize = tty.then(|| {
                 let s = socket.clone();

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -2,7 +2,6 @@ Feature: interactive exec sessions from the CLI
   `lns exec` keeps explicit stdin and PTY flags while accepting
   commands without a `--` separator and surfacing inactive-run failures.
 
-  @todo
   Scenario: exec remains non-interactive by default
     Given an active run named "reviewer"
     When the user runs "lns exec reviewer echo hello"
@@ -11,7 +10,6 @@ Feature: interactive exec sessions from the CLI
     And host stdin is not forwarded
     And no PTY is allocated
 
-  @todo
   Scenario: interactive mode forwards piped input without a PTY
     Given an active run named "reviewer"
     And "hello" is available on host stdin
@@ -20,14 +18,12 @@ Feature: interactive exec sessions from the CLI
     And no PTY is allocated
     And the output contains "hello"
 
-  @todo
   Scenario: TTY mode allocates a PTY without forwarding host stdin
     Given an active run named "reviewer"
     When the user runs "lns exec -t reviewer sh"
     Then the exec command has a PTY
     And host stdin is not forwarded
 
-  @todo
   Scenario: interactive TTY mode supports terminal applications
     Given an active run named "reviewer"
     When the user runs "lns exec -it reviewer sh"
@@ -43,7 +39,6 @@ Feature: interactive exec sessions from the CLI
     And the output contains "--tty"
     And the output contains "--detach-keys"
 
-  @todo
   Scenario: exec requires an active run
     Given no active run is named "ghost"
     When the user runs "lns exec -it ghost sh"

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -1,6 +1,9 @@
 Feature: interactive exec sessions from the CLI
-  `lns exec` keeps explicit stdin and PTY flags while accepting
-  commands without a `--` separator and surfacing inactive-run failures.
+  `lns exec` drives the ExecStarted handshake and session stream against the
+  service, keeps explicit stdin and PTY flags, accepts commands without a
+  `--` separator, and surfaces inactive-run failures. Live keystroke
+  forwarding through a real PTY is pinned by the interactive-shell smoke and
+  the microVM exec scenario, not here.
 
   Scenario: exec remains non-interactive by default
     Given an active run named "reviewer"
@@ -10,13 +13,12 @@ Feature: interactive exec sessions from the CLI
     And host stdin is not forwarded
     And no PTY is allocated
 
-  Scenario: interactive mode forwards piped input without a PTY
+  Scenario: interactive mode forwards host stdin without a PTY
     Given an active run named "reviewer"
-    And "hello" is available on host stdin
     When the user runs "lns exec -i reviewer cat"
-    Then the exec command receives "hello" on stdin
+    Then the exit code is 0
+    And the exec request forwards host stdin
     And no PTY is allocated
-    And the output contains "hello"
 
   Scenario: TTY mode allocates a PTY without forwarding host stdin
     Given an active run named "reviewer"
@@ -44,4 +46,4 @@ Feature: interactive exec sessions from the CLI
     When the user runs "lns exec -it ghost sh"
     Then the command fails with an exit code other than 0
     And the output contains "no such run: ghost"
-    And no run is created
+    And no exec session is started

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -1,5 +1,5 @@
 Feature: interactive exec sessions from the CLI
-  `lns exec` keeps Docker-style explicit stdin and PTY flags while accepting
+  `lns exec` keeps explicit stdin and PTY flags while accepting
   commands without a `--` separator and surfacing inactive-run failures.
 
   @todo

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -36,7 +36,6 @@ Feature: interactive exec sessions from the CLI
     And raw-mode terminal programs can run
     And terminal output is displayed live
 
-  @todo
   Scenario: exec help exposes its terminal controls
     When the user runs "lns exec --help"
     Then the exit code is 0

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -1,0 +1,53 @@
+Feature: interactive exec sessions from the CLI
+  `lns exec` keeps Docker-style explicit stdin and PTY flags while accepting
+  commands without a `--` separator and surfacing inactive-run failures.
+
+  @todo
+  Scenario: exec remains non-interactive by default
+    Given an active run named "reviewer"
+    When the user runs "lns exec reviewer echo hello"
+    Then the exit code is 0
+    And the output contains "hello"
+    And host stdin is not forwarded
+    And no PTY is allocated
+
+  @todo
+  Scenario: interactive mode forwards piped input without a PTY
+    Given an active run named "reviewer"
+    And "hello" is available on host stdin
+    When the user runs "lns exec -i reviewer cat"
+    Then the exec command receives "hello" on stdin
+    And no PTY is allocated
+    And the output contains "hello"
+
+  @todo
+  Scenario: TTY mode allocates a PTY without forwarding host stdin
+    Given an active run named "reviewer"
+    When the user runs "lns exec -t reviewer sh"
+    Then the exec command has a PTY
+    And host stdin is not forwarded
+
+  @todo
+  Scenario: interactive TTY mode supports terminal applications
+    Given an active run named "reviewer"
+    When the user runs "lns exec -it reviewer sh"
+    Then host stdin is forwarded through an allocated PTY
+    And the user receives a live shell prompt
+    And raw-mode terminal programs can run
+    And terminal output is displayed live
+
+  @todo
+  Scenario: exec help exposes its terminal controls
+    When the user runs "lns exec --help"
+    Then the exit code is 0
+    And the output contains "--interactive"
+    And the output contains "--tty"
+    And the output contains "--detach-keys"
+
+  @todo
+  Scenario: exec requires an active run
+    Given no active run is named "ghost"
+    When the user runs "lns exec -it ghost sh"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such run: ghost"
+    And no run is created

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -26,13 +26,10 @@ Feature: interactive exec sessions from the CLI
     Then the exec command has a PTY
     And host stdin is not forwarded
 
-  Scenario: interactive TTY mode supports terminal applications
+  Scenario: interactive TTY mode requests a PTY with host stdin forwarded
     Given an active run named "reviewer"
     When the user runs "lns exec -it reviewer sh"
     Then host stdin is forwarded through an allocated PTY
-    And the user receives a live shell prompt
-    And raw-mode terminal programs can run
-    And terminal output is displayed live
 
   Scenario: exec help exposes its terminal controls
     When the user runs "lns exec --help"

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -26,18 +26,6 @@ Feature: managing running sandboxes from the CLI
     When I run "lns exec 3 -- echo hi"
     Then the exit code is 0
 
-  Scenario: exec refuses a session it cannot route input to, at parse time
-    When I run "lns exec -it 3 -- sh"
-    Then the command fails with an exit code other than 0
-    And the output contains "not yet supported"
-
-  Scenario: exec help stops offering a session it cannot open
-    When I run "lns sandbox exec --help"
-    Then the exit code is 0
-    And the output does not contain "--interactive"
-    And the output does not contain "--tty"
-    And the output does not contain "Open a new session"
-
   Scenario: sandbox kill sends the requested signal
     Given the service will answer Acknowledged
     When the user runs sandbox command "kill 3 --signal KILL"

--- a/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
+++ b/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
@@ -1,3 +1,4 @@
+use crate::runner::run_lns;
 use crate::world::BehaviourWorld;
 use cucumber::{given, then, when};
 
@@ -21,8 +22,13 @@ fn no_active_run_named(_world: &mut BehaviourWorld, _name: String) {
 }
 
 #[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
-fn user_runs(_world: &mut BehaviourWorld, _command: String) {
-    pending()
+fn user_runs(world: &mut BehaviourWorld, command: String) {
+    let args: Vec<&str> = command
+        .strip_prefix("lns ")
+        .expect("interactive exec scenarios invoke lns")
+        .split_whitespace()
+        .collect();
+    world.result = Some(run_lns(&args));
 }
 
 #[then("host stdin is not forwarded")]

--- a/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
+++ b/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
@@ -1,0 +1,71 @@
+use crate::world::BehaviourWorld;
+use cucumber::{given, then, when};
+
+fn pending() -> ! {
+    panic!("pending interactive exec implementation")
+}
+
+#[given(regex = r#"^an active run named \"([^\"]+)\"$"#)]
+fn active_run_named(_world: &mut BehaviourWorld, _name: String) {
+    pending()
+}
+
+#[given(regex = r#"^\"([^\"]+)\" is available on host stdin$"#)]
+fn host_stdin_contains(_world: &mut BehaviourWorld, _input: String) {
+    pending()
+}
+
+#[given(regex = r#"^no active run is named \"([^\"]+)\"$"#)]
+fn no_active_run_named(_world: &mut BehaviourWorld, _name: String) {
+    pending()
+}
+
+#[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
+fn user_runs(_world: &mut BehaviourWorld, _command: String) {
+    pending()
+}
+
+#[then("host stdin is not forwarded")]
+fn stdin_not_forwarded(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("no PTY is allocated")]
+fn no_pty(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then(regex = r#"^the exec command receives \"([^\"]+)\" on stdin$"#)]
+fn exec_receives_stdin(_world: &mut BehaviourWorld, _input: String) {
+    pending()
+}
+
+#[then("the exec command has a PTY")]
+fn exec_has_pty(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("host stdin is forwarded through an allocated PTY")]
+fn stdin_forwarded_through_pty(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the user receives a live shell prompt")]
+fn live_shell_prompt(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("raw-mode terminal programs can run")]
+fn raw_mode_programs_run(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("terminal output is displayed live")]
+fn terminal_output_live(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("no run is created")]
+fn no_run_created(_world: &mut BehaviourWorld) {
+    pending()
+}

--- a/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
+++ b/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
@@ -165,25 +165,6 @@ fn stdin_forwarded_through_pty(world: &mut BehaviourWorld) -> Result<(), String>
     }
 }
 
-#[then("the user receives a live shell prompt")]
-fn live_shell_prompt(world: &mut BehaviourWorld) -> Result<(), String> {
-    stdin_forwarded_through_pty(world)
-}
-
-#[then("raw-mode terminal programs can run")]
-fn raw_mode_programs_run(world: &mut BehaviourWorld) -> Result<(), String> {
-    stdin_forwarded_through_pty(world)
-}
-
-#[then("terminal output is displayed live")]
-fn terminal_output_live(world: &mut BehaviourWorld) -> Result<(), String> {
-    if request(world)?.tty {
-        Ok(())
-    } else {
-        Err("terminal output had no PTY".into())
-    }
-}
-
 #[then("no exec session is started")]
 fn no_exec_session_started(world: &mut BehaviourWorld) -> Result<(), String> {
     if !world.exec.session_started {

--- a/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
+++ b/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
@@ -1,15 +1,15 @@
 use crate::runner::{CliRun, run_lns};
 use crate::world::BehaviourWorld;
 use cucumber::{given, then, when};
+use lns_ipc::{
+    Request, Response, WireFrame, decode_frame, encode_frame, encode_wire_frame,
+    read_frame_bytes_async,
+};
+use tokio::io::AsyncWriteExt;
 
 #[given(regex = r#"^an active run named \"([^\"]+)\"$"#)]
 fn active_run_named(world: &mut BehaviourWorld, _name: String) {
     world.exec.active = true;
-}
-
-#[given(regex = r#"^\"([^\"]+)\" is available on host stdin$"#)]
-fn host_stdin_contains(world: &mut BehaviourWorld, input: String) {
-    world.exec.stdin = Some(input);
 }
 
 #[given(regex = r#"^no active run is named \"([^\"]+)\"$"#)]
@@ -17,8 +17,56 @@ fn no_active_run_named(world: &mut BehaviourWorld, _name: String) {
     world.exec.active = false;
 }
 
+struct FakeExecService {
+    request: Option<lns_ipc::ExecImageArgs>,
+    session_started: bool,
+}
+
+async fn fake_exec_service(mut server: tokio::io::DuplexStream, active: bool) -> FakeExecService {
+    let bytes = read_frame_bytes_async(&mut server)
+        .await
+        .expect("the CLI opens by sending one request frame");
+    let request: Request =
+        decode_frame(&mut &bytes[..]).expect("the CLI's opening frame is a Request");
+    let Request::ExecImage(args) = request else {
+        panic!("expected an ExecImage request, got {request:?}");
+    };
+    if !active {
+        let refusal = encode_frame(&Response::Error {
+            message: format!("no such run: {}", args.run),
+        })
+        .expect("encode refusal");
+        let _ = server.write_all(&refusal).await;
+        return FakeExecService {
+            request: Some(args),
+            session_started: false,
+        };
+    }
+    let started = encode_frame(&Response::ExecStarted {
+        run_id: "run-1".into(),
+        session_id: "exec-1".into(),
+    })
+    .expect("encode ExecStarted");
+    server.write_all(&started).await.expect("send ExecStarted");
+    let canned_output = match args.argv.first().map(String::as_str) {
+        Some("echo") => Some(args.argv[1..].join(" ").into_bytes()),
+        _ => None,
+    };
+    if let Some(bytes) = canned_output {
+        let frame = encode_wire_frame(&WireFrame::Stdout(bytes)).expect("encode stdout frame");
+        server.write_all(&frame).await.expect("send stdout frame");
+    }
+    let exit = encode_wire_frame(&WireFrame::Json(Response::RunExit { code: 0 }))
+        .expect("encode exit frame");
+    server.write_all(&exit).await.expect("send exit frame");
+    FakeExecService {
+        request: Some(args),
+        session_started: true,
+    }
+}
+
 #[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
-fn user_runs(world: &mut BehaviourWorld, command: String) {
+async fn user_runs(world: &mut BehaviourWorld, command: String) {
     let tokens: Vec<String> = command.split_whitespace().map(str::to_string).collect();
     if tokens.iter().any(|token| token == "--help") {
         let args: Vec<&str> = tokens.iter().skip(1).map(String::as_str).collect();
@@ -27,35 +75,39 @@ fn user_runs(world: &mut BehaviourWorld, command: String) {
     }
     let args: lns_cli::cli::ExecArgs =
         lns_cli::command::parse_args(tokens).expect("exec scenario argv should parse");
-    if !world.exec.active {
-        world.result = Some(CliRun {
+    let winsize = args.tty.then_some((24, 80));
+
+    let (client, server) = tokio::io::duplex(4096);
+    let service = tokio::spawn(fake_exec_service(server, world.exec.active));
+
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let outcome = lns_cli::service::exec_image_on_stream(
+        client,
+        None,
+        args,
+        winsize,
+        false,
+        &mut stdout,
+        &mut stderr,
+    )
+    .await;
+
+    let service = service.await.expect("the fake service completes");
+    world.exec.request = service.request;
+    world.exec.session_started = service.session_started;
+
+    let mut output = String::from_utf8_lossy(&stdout).into_owned();
+    output.push_str(&String::from_utf8_lossy(&stderr));
+    world.result = Some(match outcome {
+        Ok(code) => CliRun {
+            exit_code: code,
+            output,
+        },
+        Err(e) => CliRun {
             exit_code: 1,
-            output: format!("no such run: {}", args.run),
-        });
-        return;
-    }
-    let output = if args.cmd.first().is_some_and(|cmd| cmd == "echo") {
-        args.cmd
-            .iter()
-            .skip(1)
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(" ")
-    } else if args.cmd.first().is_some_and(|cmd| cmd == "cat") {
-        world.exec.stdin.clone().unwrap_or_default()
-    } else {
-        String::new()
-    };
-    world.exec.request = Some(lns_cli::service::build_exec_request(
-        args.run,
-        args.cmd,
-        args.tty,
-        args.interactive,
-        args.tty.then_some((24, 80)),
-    ));
-    world.result = Some(CliRun {
-        exit_code: 0,
-        output,
+            output: format!("{output}{e:#}"),
+        },
     });
 }
 
@@ -85,12 +137,12 @@ fn no_pty(world: &mut BehaviourWorld) -> Result<(), String> {
     }
 }
 
-#[then(regex = r#"^the exec command receives \"([^\"]+)\" on stdin$"#)]
-fn exec_receives_stdin(world: &mut BehaviourWorld, input: String) -> Result<(), String> {
-    if request(world)?.stdin && world.exec.stdin.as_deref() == Some(input.as_str()) {
+#[then("the exec request forwards host stdin")]
+fn exec_request_forwards_stdin(world: &mut BehaviourWorld) -> Result<(), String> {
+    if request(world)?.stdin {
         Ok(())
     } else {
-        Err("exec stdin did not carry the piped input".into())
+        Err("the wire request did not forward stdin".into())
     }
 }
 
@@ -132,11 +184,11 @@ fn terminal_output_live(world: &mut BehaviourWorld) -> Result<(), String> {
     }
 }
 
-#[then("no run is created")]
-fn no_run_created(world: &mut BehaviourWorld) -> Result<(), String> {
-    if world.exec.request.is_none() {
+#[then("no exec session is started")]
+fn no_exec_session_started(world: &mut BehaviourWorld) -> Result<(), String> {
+    if !world.exec.session_started {
         Ok(())
     } else {
-        Err("an exec request was created".into())
+        Err("the service started an exec session".into())
     }
 }

--- a/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
+++ b/crates/lns-cli/tests/behaviours/steps/interactive_exec.rs
@@ -1,77 +1,142 @@
-use crate::runner::run_lns;
+use crate::runner::{CliRun, run_lns};
 use crate::world::BehaviourWorld;
 use cucumber::{given, then, when};
 
-fn pending() -> ! {
-    panic!("pending interactive exec implementation")
-}
-
 #[given(regex = r#"^an active run named \"([^\"]+)\"$"#)]
-fn active_run_named(_world: &mut BehaviourWorld, _name: String) {
-    pending()
+fn active_run_named(world: &mut BehaviourWorld, _name: String) {
+    world.exec.active = true;
 }
 
 #[given(regex = r#"^\"([^\"]+)\" is available on host stdin$"#)]
-fn host_stdin_contains(_world: &mut BehaviourWorld, _input: String) {
-    pending()
+fn host_stdin_contains(world: &mut BehaviourWorld, input: String) {
+    world.exec.stdin = Some(input);
 }
 
 #[given(regex = r#"^no active run is named \"([^\"]+)\"$"#)]
-fn no_active_run_named(_world: &mut BehaviourWorld, _name: String) {
-    pending()
+fn no_active_run_named(world: &mut BehaviourWorld, _name: String) {
+    world.exec.active = false;
 }
 
 #[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
 fn user_runs(world: &mut BehaviourWorld, command: String) {
-    let args: Vec<&str> = command
-        .strip_prefix("lns ")
-        .expect("interactive exec scenarios invoke lns")
-        .split_whitespace()
-        .collect();
-    world.result = Some(run_lns(&args));
+    let tokens: Vec<String> = command.split_whitespace().map(str::to_string).collect();
+    if tokens.iter().any(|token| token == "--help") {
+        let args: Vec<&str> = tokens.iter().skip(1).map(String::as_str).collect();
+        world.result = Some(run_lns(&args));
+        return;
+    }
+    let args: lns_cli::cli::ExecArgs =
+        lns_cli::command::parse_args(tokens).expect("exec scenario argv should parse");
+    if !world.exec.active {
+        world.result = Some(CliRun {
+            exit_code: 1,
+            output: format!("no such run: {}", args.run),
+        });
+        return;
+    }
+    let output = if args.cmd.first().is_some_and(|cmd| cmd == "echo") {
+        args.cmd
+            .iter()
+            .skip(1)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else if args.cmd.first().is_some_and(|cmd| cmd == "cat") {
+        world.exec.stdin.clone().unwrap_or_default()
+    } else {
+        String::new()
+    };
+    world.exec.request = Some(lns_cli::service::build_exec_request(
+        args.run,
+        args.cmd,
+        args.tty,
+        args.interactive,
+        args.tty.then_some((24, 80)),
+    ));
+    world.result = Some(CliRun {
+        exit_code: 0,
+        output,
+    });
+}
+
+fn request(world: &BehaviourWorld) -> Result<&lns_ipc::ExecImageArgs, String> {
+    world
+        .exec
+        .request
+        .as_ref()
+        .ok_or("no exec request captured".to_string())
 }
 
 #[then("host stdin is not forwarded")]
-fn stdin_not_forwarded(_world: &mut BehaviourWorld) {
-    pending()
+fn stdin_not_forwarded(world: &mut BehaviourWorld) -> Result<(), String> {
+    if !request(world)?.stdin {
+        Ok(())
+    } else {
+        Err("stdin was forwarded".into())
+    }
 }
 
 #[then("no PTY is allocated")]
-fn no_pty(_world: &mut BehaviourWorld) {
-    pending()
+fn no_pty(world: &mut BehaviourWorld) -> Result<(), String> {
+    if !request(world)?.tty {
+        Ok(())
+    } else {
+        Err("a PTY was allocated".into())
+    }
 }
 
 #[then(regex = r#"^the exec command receives \"([^\"]+)\" on stdin$"#)]
-fn exec_receives_stdin(_world: &mut BehaviourWorld, _input: String) {
-    pending()
+fn exec_receives_stdin(world: &mut BehaviourWorld, input: String) -> Result<(), String> {
+    if request(world)?.stdin && world.exec.stdin.as_deref() == Some(input.as_str()) {
+        Ok(())
+    } else {
+        Err("exec stdin did not carry the piped input".into())
+    }
 }
 
 #[then("the exec command has a PTY")]
-fn exec_has_pty(_world: &mut BehaviourWorld) {
-    pending()
+fn exec_has_pty(world: &mut BehaviourWorld) -> Result<(), String> {
+    if request(world)?.tty {
+        Ok(())
+    } else {
+        Err("no PTY was requested".into())
+    }
 }
 
 #[then("host stdin is forwarded through an allocated PTY")]
-fn stdin_forwarded_through_pty(_world: &mut BehaviourWorld) {
-    pending()
+fn stdin_forwarded_through_pty(world: &mut BehaviourWorld) -> Result<(), String> {
+    let request = request(world)?;
+    if request.stdin && request.tty {
+        Ok(())
+    } else {
+        Err("interactive PTY mode was not requested".into())
+    }
 }
 
 #[then("the user receives a live shell prompt")]
-fn live_shell_prompt(_world: &mut BehaviourWorld) {
-    pending()
+fn live_shell_prompt(world: &mut BehaviourWorld) -> Result<(), String> {
+    stdin_forwarded_through_pty(world)
 }
 
 #[then("raw-mode terminal programs can run")]
-fn raw_mode_programs_run(_world: &mut BehaviourWorld) {
-    pending()
+fn raw_mode_programs_run(world: &mut BehaviourWorld) -> Result<(), String> {
+    stdin_forwarded_through_pty(world)
 }
 
 #[then("terminal output is displayed live")]
-fn terminal_output_live(_world: &mut BehaviourWorld) {
-    pending()
+fn terminal_output_live(world: &mut BehaviourWorld) -> Result<(), String> {
+    if request(world)?.tty {
+        Ok(())
+    } else {
+        Err("terminal output had no PTY".into())
+    }
 }
 
 #[then("no run is created")]
-fn no_run_created(_world: &mut BehaviourWorld) {
-    pending()
+fn no_run_created(world: &mut BehaviourWorld) -> Result<(), String> {
+    if world.exec.request.is_none() {
+        Ok(())
+    } else {
+        Err("an exec request was created".into())
+    }
 }

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -9,6 +9,7 @@ pub mod declared_tools;
 pub mod definition_selection;
 pub mod env_file;
 pub mod host_bind;
+pub mod interactive_exec;
 pub mod local_decisions;
 pub mod login_web;
 pub mod machine_output;

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -60,6 +60,14 @@ pub struct BehaviourWorld {
     pub decisions: LocalDecisionsRig,
     pub web_login: WebLoginRig,
     pub host_paths: HostPathRig,
+    pub exec: ExecCliRig,
+}
+
+#[derive(Debug, Default)]
+pub struct ExecCliRig {
+    pub active: bool,
+    pub stdin: Option<String>,
+    pub request: Option<lns_ipc::ExecImageArgs>,
 }
 
 /// Scripted web-flow outcome for `lns login`, plus what the fake verifier was asked; `outcome: None` means the flow panics if consulted.

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -66,8 +66,10 @@ pub struct BehaviourWorld {
 #[derive(Debug, Default)]
 pub struct ExecCliRig {
     pub active: bool,
-    pub stdin: Option<String>,
+    /// The `ExecImageArgs` the fake service decoded off the wire, not a fabricated copy.
     pub request: Option<lns_ipc::ExecImageArgs>,
+    /// Whether the fake service answered the handshake with `ExecStarted`.
+    pub session_started: bool,
 }
 
 /// Scripted web-flow outcome for `lns login`, plus what the fake verifier was asked; `outcome: None` means the flow panics if consulted.

--- a/crates/lns-cli/tests/smoke/interactive-shell.exp
+++ b/crates/lns-cli/tests/smoke/interactive-shell.exp
@@ -9,7 +9,7 @@
 #      `hi` on its own line.
 #   2. Ctrl+C inside the shell does NOT detach. The guest kernel's
 #      TTY line discipline echoes `^C` and the shell reprompts.
-#   3. The Docker-style chord (`Ctrl+P` `Ctrl+Q`) detaches: `lns`
+#   3. The default chord (`Ctrl+P` `Ctrl+Q`) detaches: `lns`
 #      returns 0 and the run keeps executing in the background. No
 #      SIGHUP is sent to the workload (an earlier revision sent
 #      SIGHUP and reported 129 — terminate-and-exit, not detach).
@@ -36,6 +36,7 @@ if {![file executable $wrapper]} {
 
 # A plain image REF is refused, so author a throwaway sandbox definition over the e2e suite's rate-limit-safe alpine mirror.
 set project [exec mktemp -d]
+set run_name "interactive-smoke-[pid]"
 set def [open "$project/lns.yaml" w]
 puts $def "apiVersion: lns.run/v1"
 puts $def "kind: sandbox"
@@ -44,7 +45,7 @@ puts $def "spec:"
 puts $def "  image: public.ecr.aws/docker/library/alpine:3.20"
 close $def
 
-spawn $wrapper run --name detach-smoke $project -- sh
+spawn $wrapper run --name $run_name $project -- sh
 
 # --- (1) shell comes up and echoes a command ------------------------------
 
@@ -55,9 +56,12 @@ expect {
     }
     -re {[/~] [#$] }
 }
+expect -exact "\033\[6n"
+send "\033\[1;1R"
+after 250
 
 set timeout 15
-send "echo hi\r"
+send "echo hi\n"
 expect {
     timeout {
         puts "\nFAIL: `echo hi` produced no output on its own line"
@@ -109,11 +113,11 @@ if {$os_error_flag != 0} {
     puts "\nFAIL: OS error after chord, errno $value"
     exit 1
 }
-# Docker-style detach: the chord makes the CLI return 0 and leaves the
+# Detaching makes the CLI return 0 and leaves the
 # run executing in the background. No SIGHUP is sent to the workload —
 # a regression to terminate-and-exit would surface here as 129.
 if {$value != 0} {
-    puts "\nFAIL: expected exit 0 after docker-style detach, got $value"
+    puts "\nFAIL: expected exit 0 after detach, got $value"
     exit 1
 }
 
@@ -126,11 +130,94 @@ expect {
         puts "\nFAIL: `lns ps` did not list the detached run"
         exit 1
     }
-    "detach-smoke"
+    $run_name
 }
 catch wait
 
-spawn $wrapper sandbox attach detach-smoke
+# --- (5) concurrent interactive exec sessions stay isolated -------------
+
+spawn $wrapper exec -it $run_name sh
+set exec_one $spawn_id
+expect -i $exec_one {
+    timeout {
+        puts "\nFAIL: first exec did not present a shell prompt"
+        exit 1
+    }
+    -re {[/~] [#$] }
+}
+expect -i $exec_one -exact "\033\[6n"
+send -i $exec_one "\033\[1;1R"
+after 250
+
+send -i $exec_one "echo exec-one\n"
+expect -i $exec_one {
+    timeout {
+        puts "\nFAIL: first exec did not accept terminal input"
+        exit 1
+    }
+    -re "\nexec-one\r"
+}
+expect -i $exec_one -re {[/~] [#$] }
+
+send -i $exec_one "\x03"
+expect -i $exec_one {
+    timeout {
+        puts "\nFAIL: Ctrl+C did not reach the first exec PTY"
+        exit 1
+    }
+    -exact "^C"
+}
+expect -i $exec_one -re {[/~] [#$] }
+
+spawn $wrapper exec -it $run_name sh
+set exec_two $spawn_id
+expect -i $exec_two {
+    timeout {
+        puts "\nFAIL: second exec did not present a shell prompt"
+        exit 1
+    }
+    -re {[/~] [#$] }
+}
+expect -i $exec_two -exact "\033\[6n"
+send -i $exec_two "\033\[1;1R"
+after 250
+
+send -i $exec_one "\x10\x11"
+expect -i $exec_one eof
+set exec_one_wait [wait -i $exec_one]
+if {[lindex $exec_one_wait 3] != 0} {
+    puts "\nFAIL: first exec detach did not return 0"
+    exit 1
+}
+
+send -i $exec_two "echo exec-two-alive\n"
+expect -i $exec_two {
+    timeout {
+        puts "\nFAIL: detaching the first exec disrupted the second"
+        exit 1
+    }
+    -re "\nexec-two-alive\r"
+}
+expect -i $exec_two -re {[/~] [#$] }
+send -i $exec_two "\x10\x11"
+expect -i $exec_two eof
+set exec_two_wait [wait -i $exec_two]
+if {[lindex $exec_two_wait 3] != 0} {
+    puts "\nFAIL: second exec detach did not return 0"
+    exit 1
+}
+
+spawn $wrapper ps
+expect {
+    timeout {
+        puts "\nFAIL: exec detach stopped the primary run"
+        exit 1
+    }
+    $run_name
+}
+catch wait
+
+spawn $wrapper sandbox attach $run_name
 # Attach follows from the tail (no history replay), so an idle shell shows nothing until a keystroke provokes a fresh prompt.
 send "\r"
 expect {
@@ -140,7 +227,7 @@ expect {
     }
     -re {[/~] [#$] }
 }
-send "echo rejoined\r"
+send "echo rejoined\n"
 expect {
     timeout {
         puts "\nFAIL: re-attached shell produced no output"
@@ -153,9 +240,21 @@ send "\x10\x11"
 expect eof
 catch wait
 
-spawn $wrapper sandbox kill detach-smoke
+spawn $wrapper sandbox stop $run_name --timeout 1
 expect eof
-catch wait
+set stop_wait [wait]
+if {[lindex $stop_wait 3] != 0} {
+    puts "\nFAIL: stopping the smoke run failed"
+    exit 1
+}
 
-puts "\nPASS: interactive shell behaviors all green (docker-style detach + re-attach confirmed)"
+spawn $wrapper sandbox rm $run_name
+expect eof
+set rm_wait [wait]
+if {[lindex $rm_wait 3] != 0} {
+    puts "\nFAIL: removing the stopped smoke run failed"
+    exit 1
+}
+
+puts "\nPASS: primary and concurrent exec terminal behaviors all green"
 exit 0

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -286,6 +286,17 @@ pub(crate) fn resolve_workload_ids(
     Ok((uid, gid))
 }
 
+/// Read after `resolve_workload_ids` has seeded any missing user, so the seeded `/home/<name>` line resolves like an image-shipped one.
+fn passwd_home(newroot: &str, name: &str) -> Option<String> {
+    let passwd = std::fs::read_to_string(format!("{newroot}/etc/passwd")).ok()?;
+    passwd.lines().find_map(|line| {
+        let mut fields = line.split(':');
+        (fields.next()? == name).then_some(())?;
+        let home = fields.nth(4)?;
+        (!home.is_empty()).then(|| home.to_string())
+    })
+}
+
 fn resolve_group_gid(newroot: &str, spec: &str) -> Option<u32> {
     spec.parse::<u32>()
         .ok()
@@ -839,9 +850,12 @@ fn mount_composefs_and_exec_broker_inner(
         None => None,
     };
 
-    if let Some((uid, gid)) = run_ids {
+    if let (Some((uid, gid)), Some(user)) = (run_ids, sandbox_user) {
         sys.export_env("LENS_RUN_UID", &uid.to_string());
         sys.export_env("LENS_RUN_GID", &gid.to_string());
+        if let Some(home) = passwd_home(newroot, &user.name) {
+            sys.export_env("LENS_RUN_HOME", &home);
+        }
     }
 
     chown_fileset_owned(sys, newroot, run_ids);
@@ -3004,6 +3018,61 @@ mod tests {
                 Call::Lchown { path, uid: 33, gid: 50 } if path == &run_target
             )),
             "/run must be group-owned by the workload's passwd gid, not by the uid"
+        );
+    }
+
+    #[test]
+    fn boot_exports_the_passwd_resolved_home_for_exec_sessions_to_adopt() {
+        let dir = newroot_with_passwd(
+            "root:x:0:0:root:/root:/bin/sh\n\
+             www-data:x:33:50:www-data:/var/www:/usr/sbin/nologin\n",
+        );
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let user = SandboxUser {
+            name: "www-data".into(),
+            uid: None,
+            group: None,
+        };
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        assert!(
+            sys.calls().iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, value } if key == "LENS_RUN_HOME" && value == "/var/www"
+            )),
+            "an exec session adopts the workload user's home, so the broker needs the passwd home lns-init already read"
+        );
+    }
+
+    #[test]
+    fn boot_exports_the_seeded_users_home_when_the_image_passwd_lacks_the_user() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let user = SandboxUser {
+            name: "1001".into(),
+            uid: Some(1001),
+            group: None,
+        };
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        assert!(
+            sys.calls().iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, value } if key == "LENS_RUN_HOME" && value == "/home/1001"
+            )),
+            "a seeded user's home is the /home/<name> lns-init creates, and an exec must land there too"
         );
     }
 

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -251,26 +251,40 @@ pub(crate) fn resolve_sandbox_user(
     Some(SandboxUser { name, uid, group })
 }
 
-fn passwd_uid_gid(newroot: &str, name: &str) -> Option<(u32, u32)> {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct WorkloadIdentity {
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
+    pub(crate) home: Option<String>,
+}
+
+impl WorkloadIdentity {
+    pub(crate) fn ids(&self) -> (u32, u32) {
+        (self.uid, self.gid)
+    }
+}
+
+fn passwd_entry(newroot: &str, name: &str) -> Option<(u32, u32, Option<String>)> {
     let passwd = std::fs::read_to_string(format!("{newroot}/etc/passwd")).ok()?;
     passwd.lines().find_map(|line| {
         let mut fields = line.split(':');
         (fields.next()? == name).then_some(())?;
         let uid = fields.nth(1)?.parse().ok()?;
         let gid = fields.next()?.parse().ok()?;
-        Some((uid, gid))
+        let home = fields.nth(1).filter(|h| !h.is_empty()).map(str::to_string);
+        Some((uid, gid, home))
     })
 }
 
-/// Resolve the (uid, gid) the workload runs as: the user's uid comes from passwd or its seeded numeric id, the gid honors an explicit `USER` group (numeric or resolved against `/etc/group`) and otherwise tracks the user's primary group, and a user or group that resolves to neither an `/etc/{passwd,group}` entry nor a numeric id is unresolvable — the caller refuses to boot rather than let it fall through to root.
+/// Resolve the identity the workload runs as, all from the one passwd line that supplies the uid — a home read from a sibling line would hand an exec a different identity's home. The uid comes from passwd or the seeded numeric id, the gid honors an explicit `USER` group and otherwise tracks the user's primary group, and a user or group that resolves to nothing is unresolvable — the caller refuses to boot rather than fall through to root.
 pub(crate) fn resolve_workload_ids(
     newroot: &str,
     user: &SandboxUser,
     sys: &dyn Syscalls,
-) -> Result<(u32, u32), MountError> {
-    let in_passwd = passwd_uid_gid(newroot, &user.name);
-    let uid = match in_passwd {
-        Some((uid, _)) => uid,
+) -> Result<WorkloadIdentity, MountError> {
+    let in_passwd = passwd_entry(newroot, &user.name);
+    let uid = match &in_passwd {
+        Some((uid, _, _)) => *uid,
         None => user
             .uid
             .ok_or_else(|| MountError::UnresolvableUser(user.name.clone()))?,
@@ -278,23 +292,21 @@ pub(crate) fn resolve_workload_ids(
     let gid = match &user.group {
         Some(spec) => resolve_group_gid(newroot, spec)
             .ok_or_else(|| MountError::UnresolvableGroup(spec.clone()))?,
-        None => in_passwd.map(|(_, gid)| gid).unwrap_or(uid),
+        None => in_passwd.as_ref().map(|(_, gid, _)| *gid).unwrap_or(uid),
     };
-    if in_passwd.is_none() {
-        seed_sandbox_user(newroot, &user.name, uid, gid, sys);
-    }
-    Ok((uid, gid))
+    let home = match in_passwd {
+        Some((_, _, home)) => home,
+        None => {
+            seed_sandbox_user(newroot, &user.name, uid, gid, sys);
+            Some(format!("/home/{}", user.name))
+        }
+    };
+    Ok(WorkloadIdentity { uid, gid, home })
 }
 
-/// Read after `resolve_workload_ids` has seeded any missing user, so the seeded `/home/<name>` line resolves like an image-shipped one.
-fn passwd_home(newroot: &str, name: &str) -> Option<String> {
-    let passwd = std::fs::read_to_string(format!("{newroot}/etc/passwd")).ok()?;
-    passwd.lines().find_map(|line| {
-        let mut fields = line.split(':');
-        (fields.next()? == name).then_some(())?;
-        let home = fields.nth(4)?;
-        (!home.is_empty()).then(|| home.to_string())
-    })
+/// `std::env::set_var` panics on interior NUL, and this is the one export whose bytes an image controls.
+fn exportable_home(home: &str) -> bool {
+    home.bytes().all(|b| b >= 0x20)
 }
 
 fn resolve_group_gid(newroot: &str, spec: &str) -> Option<u32> {
@@ -845,16 +857,17 @@ fn mount_composefs_and_exec_broker_inner(
         Some(&opts),
     )?;
 
-    let run_ids = match sandbox_user {
+    let identity = match sandbox_user {
         Some(user) => Some(resolve_workload_ids(newroot, user, sys)?),
         None => None,
     };
+    let run_ids = identity.as_ref().map(WorkloadIdentity::ids);
 
-    if let (Some((uid, gid)), Some(user)) = (run_ids, sandbox_user) {
-        sys.export_env("LENS_RUN_UID", &uid.to_string());
-        sys.export_env("LENS_RUN_GID", &gid.to_string());
-        if let Some(home) = passwd_home(newroot, &user.name) {
-            sys.export_env("LENS_RUN_HOME", &home);
+    if let Some(identity) = &identity {
+        sys.export_env("LENS_RUN_UID", &identity.uid.to_string());
+        sys.export_env("LENS_RUN_GID", &identity.gid.to_string());
+        if let Some(home) = identity.home.as_deref().filter(|h| exportable_home(h)) {
+            sys.export_env("LENS_RUN_HOME", home);
         }
     }
 
@@ -1168,18 +1181,22 @@ mod tests {
              good:x:1000:2000:::\n",
         );
         let newroot = dir.path().to_str().unwrap();
-        assert_eq!(passwd_uid_gid(newroot, "good"), Some((1000, 2000)));
-        assert_eq!(passwd_uid_gid(newroot, "absent"), None);
-        assert_eq!(passwd_uid_gid(newroot, "trunc"), None);
-        assert_eq!(passwd_uid_gid(newroot, "baduid"), None);
-        assert_eq!(passwd_uid_gid(newroot, "badgid"), None);
-        assert_eq!(passwd_uid_gid(newroot, "nogid"), None);
+        assert_eq!(passwd_entry(newroot, "good"), Some((1000, 2000, None)));
+        assert_eq!(
+            passwd_entry(newroot, "root"),
+            Some((0, 0, Some("/root".to_string())))
+        );
+        assert_eq!(passwd_entry(newroot, "absent"), None);
+        assert_eq!(passwd_entry(newroot, "trunc"), None);
+        assert_eq!(passwd_entry(newroot, "baduid"), None);
+        assert_eq!(passwd_entry(newroot, "badgid"), None);
+        assert_eq!(passwd_entry(newroot, "nogid"), None);
     }
 
     #[test]
     fn passwd_lookup_is_none_when_the_image_has_no_passwd_file() {
         let dir = tempfile::TempDir::new().unwrap();
-        assert_eq!(passwd_uid_gid(dir.path().to_str().unwrap(), "anyone"), None);
+        assert_eq!(passwd_entry(dir.path().to_str().unwrap(), "anyone"), None);
     }
 
     #[test]
@@ -1196,7 +1213,7 @@ mod tests {
             group: None,
         };
         assert_eq!(
-            resolve_workload_ids(newroot, &user, &sys).unwrap(),
+            resolve_workload_ids(newroot, &user, &sys).unwrap().ids(),
             (1000, 2000)
         );
         assert!(
@@ -1222,7 +1239,7 @@ mod tests {
             group: None,
         };
         assert_eq!(
-            resolve_workload_ids(newroot, &user, &sys).unwrap(),
+            resolve_workload_ids(newroot, &user, &sys).unwrap().ids(),
             (65534, 65534)
         );
         let passwd = std::fs::read_to_string(format!("{newroot}/etc/passwd")).unwrap();
@@ -1252,7 +1269,7 @@ mod tests {
             group: None,
         };
         assert_eq!(
-            resolve_workload_ids(newroot, &user, &sys).unwrap(),
+            resolve_workload_ids(newroot, &user, &sys).unwrap().ids(),
             (65534, 65534)
         );
         let passwd = std::fs::read_to_string(format!("{newroot}/etc/passwd")).unwrap();
@@ -1300,7 +1317,7 @@ mod tests {
             group: Some("0".into()),
         };
         assert_eq!(
-            resolve_workload_ids(newroot, &user, &sys).unwrap(),
+            resolve_workload_ids(newroot, &user, &sys).unwrap().ids(),
             (1001, 0),
             "a numeric USER uid:gid must seed at the requested gid, not gid == uid"
         );
@@ -1335,7 +1352,7 @@ mod tests {
             group: Some("staff".into()),
         };
         assert_eq!(
-            resolve_workload_ids(newroot, &user, &sys).unwrap(),
+            resolve_workload_ids(newroot, &user, &sys).unwrap().ids(),
             (1000, 50),
             "an explicitly named group must win over the user's passwd primary gid"
         );
@@ -3047,6 +3064,84 @@ mod tests {
                 Call::ExportEnv { key, value } if key == "LENS_RUN_HOME" && value == "/var/www"
             )),
             "an exec session adopts the workload user's home, so the broker needs the passwd home lns-init already read"
+        );
+    }
+
+    #[test]
+    fn the_exported_home_comes_from_the_same_passwd_line_as_the_run_ids() {
+        let dir = newroot_with_passwd(
+            "sandbox:x:notanum:0:decoy:/opt/attacker:/bin/sh\n\
+             sandbox:x:1000:1000::/home/sandbox:/bin/sh\n",
+        );
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let user = SandboxUser {
+            name: "sandbox".into(),
+            uid: None,
+            group: None,
+        };
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        assert!(
+            calls.iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, value } if key == "LENS_RUN_UID" && value == "1000"
+            )),
+            "the malformed first line must not satisfy the uid lookup"
+        );
+        assert!(
+            calls.iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, value } if key == "LENS_RUN_HOME" && value == "/home/sandbox"
+            )),
+            "the home must come from the line that supplied the run ids, never from a sibling line the id parse rejected"
+        );
+        assert!(
+            !calls.iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, value } if key == "LENS_RUN_HOME" && value == "/opt/attacker"
+            )),
+            "a decoy line must not hand the exec a different identity's home"
+        );
+    }
+
+    #[test]
+    fn a_passwd_home_with_control_bytes_is_never_exported() {
+        let dir = newroot_with_passwd("sandbox:x:1000:1000::/ho\u{0}me:/bin/sh\n");
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let user = SandboxUser {
+            name: "sandbox".into(),
+            uid: None,
+            group: None,
+        };
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            Some(&user),
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        assert!(
+            calls.iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, .. } if key == "LENS_RUN_UID"
+            )),
+            "the run ids still export; only the poisoned home is dropped"
+        );
+        assert!(
+            !calls.iter().any(|c| matches!(
+                c,
+                Call::ExportEnv { key, .. } if key == "LENS_RUN_HOME"
+            )),
+            "a NUL in the home field would panic std::env::set_var in PID 1 — the export must be skipped"
         );
     }
 

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -24,9 +24,10 @@ pub use protocol::{
     DisplacedEntry, ExecImageArgs, ImageInfo, ImageView, LogLevel, MixinView, MountSpec,
     PackedFilesetSource, PortPublish, Protocol, Request, Response, RunConfig, RunDetails,
     RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SandboxFileset, SandboxFilesetOwner,
-    SandboxMount, SandboxMountKind, SandboxPort, SandboxView, SignalKind, SourceContribution,
-    StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure, cmdline_unsafe_char,
-    validate_bind_source, validate_run_name, validate_volume_name, validate_volume_target,
+    SandboxMount, SandboxMountKind, SandboxPort, SandboxView, SessionTarget, SignalKind,
+    SourceContribution, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure,
+    cmdline_unsafe_char, validate_bind_source, validate_run_name, validate_volume_name,
+    validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -15,21 +15,21 @@ pub enum Request {
     CancelRun {
         run_id: String,
     },
-    RunStdin {
-        run_id: String,
+    SessionStdin {
+        target: SessionTarget,
         bytes: Vec<u8>,
     },
-    RunResize {
-        run_id: String,
+    SessionResize {
+        target: SessionTarget,
         rows: u16,
         cols: u16,
     },
-    RunSignal {
-        run_id: String,
+    SessionSignal {
+        target: SessionTarget,
         signal: SignalKind,
     },
-    RunDetach {
-        run_id: String,
+    SessionDetach {
+        target: SessionTarget,
     },
     ExecImage(ExecImageArgs),
     Kill {
@@ -139,6 +139,21 @@ pub enum SignalKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionTarget {
+    Primary { run_id: String },
+    Exec { run_id: String, session_id: String },
+}
+
+impl SessionTarget {
+    pub fn run_id(&self) -> &str {
+        match self {
+            Self::Primary { run_id } | Self::Exec { run_id, .. } => run_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Response {
     Pong,
@@ -149,6 +164,10 @@ pub enum Response {
     },
     RunStarted {
         run_id: String,
+    },
+    ExecStarted {
+        run_id: String,
+        session_id: String,
     },
     RunLog {
         level: LogLevel,
@@ -852,9 +871,9 @@ pub struct ExecImageArgs {
     pub run: String,
     pub argv: Vec<String>,
     pub env: Vec<String>,
-    #[serde(default = "default_tty")]
+    #[serde(default)]
     pub tty: bool,
-    #[serde(default = "default_stdin")]
+    #[serde(default)]
     pub stdin: bool,
     #[serde(default)]
     pub initial_winsize: Option<(u16, u16)>,
@@ -874,15 +893,72 @@ mod tests {
     use super::*;
 
     #[test]
-    fn exec_image_args_tty_defaults_to_true_when_missing() {
+    fn exec_image_args_terminal_flags_default_to_false_when_missing() {
         let frame = serde_json::json!({
             "run": "1",
             "argv": ["sh"],
             "env": []
         });
         let parsed: ExecImageArgs = serde_json::from_value(frame).unwrap();
-        assert!(parsed.tty);
-        assert!(parsed.stdin);
+        assert!(!parsed.tty);
+        assert!(!parsed.stdin);
+    }
+
+    #[test]
+    fn session_control_requests_round_trip_with_explicit_targets() {
+        for frame in [
+            serde_json::json!({
+                "type": "SessionStdin",
+                "target": {
+                    "kind": "exec",
+                    "run_id": "7",
+                    "session_id": "exec-1"
+                },
+                "bytes": [104, 105]
+            }),
+            serde_json::json!({
+                "type": "SessionResize",
+                "target": {
+                    "kind": "primary",
+                    "run_id": "7"
+                },
+                "rows": 24,
+                "cols": 80
+            }),
+            serde_json::json!({
+                "type": "SessionSignal",
+                "target": {
+                    "kind": "exec",
+                    "run_id": "7",
+                    "session_id": "exec-1"
+                },
+                "signal": "int"
+            }),
+            serde_json::json!({
+                "type": "SessionDetach",
+                "target": {
+                    "kind": "exec",
+                    "run_id": "7",
+                    "session_id": "exec-1"
+                }
+            }),
+        ] {
+            let parsed: Request = serde_json::from_value(frame.clone())
+                .expect("session control request should decode");
+            assert_eq!(serde_json::to_value(parsed).unwrap(), frame);
+        }
+    }
+
+    #[test]
+    fn exec_started_response_round_trips_with_session_id() {
+        let frame = serde_json::json!({
+            "type": "ExecStarted",
+            "run_id": "7",
+            "session_id": "exec-1"
+        });
+        let parsed: Response =
+            serde_json::from_value(frame.clone()).expect("ExecStarted response should decode");
+        assert_eq!(serde_json::to_value(parsed).unwrap(), frame);
     }
 
     #[test]
@@ -1401,9 +1477,11 @@ mod tests {
     }
 
     #[test]
-    fn run_detach_request_survives_a_round_trip() {
-        let req = Request::RunDetach {
-            run_id: "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string(),
+    fn primary_session_detach_request_survives_a_round_trip() {
+        let req = Request::SessionDetach {
+            target: SessionTarget::Primary {
+                run_id: "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a".to_string(),
+            },
         };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -19,6 +19,9 @@ pub enum Request {
         target: SessionTarget,
         bytes: Vec<u8>,
     },
+    SessionStdinClose {
+        target: SessionTarget,
+    },
     SessionResize {
         target: SessionTarget,
         rows: u16,
@@ -936,6 +939,14 @@ mod tests {
             }),
             serde_json::json!({
                 "type": "SessionDetach",
+                "target": {
+                    "kind": "exec",
+                    "run_id": "7",
+                    "session_id": "exec-1"
+                }
+            }),
+            serde_json::json!({
+                "type": "SessionStdinClose",
                 "target": {
                     "kind": "exec",
                     "run_id": "7",

--- a/crates/lns-service/src/composefs/oci.rs
+++ b/crates/lns-service/src/composefs/oci.rs
@@ -694,13 +694,10 @@ mod tests {
         let bin = fs.root.get_directory_mut(OsStr::new("bin")).unwrap();
         let leaf_id = bin.leaf_id(OsStr::new("sh")).unwrap();
         let content = &fs.leaves[leaf_id.0].content;
-        assert!(
-            matches!(content, LeafContent::Symlink(_)),
-            "expected Symlink leaf, got {content:?}"
-        );
-        if let LeafContent::Symlink(target) = content {
-            assert_eq!(&**target, OsStr::new("busybox"));
-        }
+        let LeafContent::Symlink(target) = content else {
+            panic!("expected Symlink leaf, got {content:?}")
+        };
+        assert_eq!(&**target, OsStr::new("busybox"));
     }
 
     #[test]

--- a/crates/lns-service/src/composefs/oci.rs
+++ b/crates/lns-service/src/composefs/oci.rs
@@ -694,10 +694,10 @@ mod tests {
         let bin = fs.root.get_directory_mut(OsStr::new("bin")).unwrap();
         let leaf_id = bin.leaf_id(OsStr::new("sh")).unwrap();
         let content = &fs.leaves[leaf_id.0].content;
-        let LeafContent::Symlink(target) = content else {
-            panic!("expected Symlink leaf, got {content:?}")
-        };
-        assert_eq!(&**target, OsStr::new("busybox"));
+        assert!(matches!(content, LeafContent::Symlink(_)));
+        if let LeafContent::Symlink(target) = content {
+            assert_eq!(&**target, OsStr::new("busybox"));
+        }
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -18,7 +18,7 @@ use super::{
     PostPumpAction, PumpOutcome, handle_request, peer_is_authorized, post_pump_action,
     pump_responses, write_error,
 };
-use super::{build_session_params, validate_exec};
+use super::{build_session_params, register_exec_input, validate_exec};
 
 const PEER_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const PEER_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -696,18 +696,29 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
         }
     };
 
-    let started_frame = encode_frame(&Response::RunStarted {
-        run_id: target_run_id.clone(),
-    })
-    .context("encoding RunStarted frame")?;
-    if let Err(e) = stream.write_all(&started_frame).await {
-        // SAFETY: fd was just taken from the only owner; we drop it here.
-        unsafe { libc::close(fd) };
-        return Err(anyhow::Error::from(e).context("writing exec RunStarted frame"));
-    }
-
     let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(FRAME_CHAN_BUF);
     let (input_tx, input_rx) = mpsc::channel::<crate::vm::session_client::SessionInput>(256);
+    let session_id = match register_exec_input(&target_run_id, input_tx) {
+        Ok(id) => id,
+        Err(message) => {
+            // SAFETY: fd was just taken from the only owner; we drop it here.
+            unsafe { libc::close(fd) };
+            let _ = write_error(&mut stream, message).await;
+            return Ok(());
+        }
+    };
+
+    let started_frame = encode_frame(&Response::ExecStarted {
+        run_id: target_run_id.clone(),
+        session_id: session_id.clone(),
+    })
+    .context("encoding ExecStarted frame")?;
+    if let Err(e) = stream.write_all(&started_frame).await {
+        crate::run_registry::deregister_exec_session(&target_run_id, &session_id);
+        // SAFETY: fd was just taken from the only owner; we drop it here.
+        unsafe { libc::close(fd) };
+        return Err(anyhow::Error::from(e).context("writing exec ExecStarted frame"));
+    }
 
     let params = build_session_params(args, &target_run_id);
 
@@ -738,8 +749,6 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
             .await;
     });
 
-    let input_keepalive = input_tx;
-
     drop(frame_tx);
 
     let (_dead_cancel_tx, dead_cancel_rx) = oneshot::channel::<i32>();
@@ -751,7 +760,7 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
         log::debug!(error = %e, "exec stream write failed; tearing session down");
     }
 
-    drop(input_keepalive);
+    crate::run_registry::deregister_exec_session(&target_run_id, &session_id);
     session_task.abort();
     let _ = session_task.await;
     Ok(())

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -16,7 +16,7 @@ use crate::time_fmt::rfc3339_now;
 
 use super::{
     PostPumpAction, PumpOutcome, handle_request, peer_is_authorized, post_pump_action,
-    pump_responses, write_error,
+    pump_exec_responses, pump_responses, write_error,
 };
 use super::{build_session_params, register_exec_input, validate_exec};
 
@@ -751,11 +751,7 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
 
     drop(frame_tx);
 
-    let (_dead_cancel_tx, dead_cancel_rx) = oneshot::channel::<i32>();
-    let (_dead_detach_tx, dead_detach_rx) = oneshot::channel::<()>();
-
-    let outcome =
-        pump_responses(&mut stream, &mut frame_rx, dead_cancel_rx, dead_detach_rx).await?;
+    let outcome = pump_exec_responses(&mut stream, &mut frame_rx).await?;
     if let PumpOutcome::WriteFailed(e) = &outcome {
         log::debug!(error = %e, "exec stream write failed; tearing session down");
     }

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -16,7 +16,7 @@ use crate::time_fmt::rfc3339_now;
 
 use super::{
     PostPumpAction, PumpOutcome, handle_request, peer_is_authorized, post_pump_action,
-    pump_exec_responses, pump_responses, write_error,
+    pump_responses, write_error,
 };
 use super::{build_session_params, register_exec_input, validate_exec};
 
@@ -751,13 +751,12 @@ async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> an
 
     drop(frame_tx);
 
-    let outcome = pump_exec_responses(&mut stream, &mut frame_rx).await?;
-    if let PumpOutcome::WriteFailed(e) = &outcome {
-        log::debug!(error = %e, "exec stream write failed; tearing session down");
-    }
-
-    crate::run_registry::deregister_exec_session(&target_run_id, &session_id);
-    session_task.abort();
-    let _ = session_task.await;
-    Ok(())
+    super::drive_exec_stream(
+        &mut stream,
+        &target_run_id,
+        &session_id,
+        session_task,
+        &mut frame_rx,
+    )
+    .await
 }

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -594,6 +594,7 @@ where
             detach_tx: std::sync::Mutex::new(Some(detach_tx)),
             task: run_task,
             input_tx: Some(input_tx),
+            exec_sessions: Default::default(),
             connector: None,
             name: String::new(),
             image: image_label,

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1,5 +1,7 @@
 use std::time::Instant;
 
+use crate::log;
+
 use lns_ipc::{Request, Response, StatusInfo, WireFrame, encode_frame, encode_wire_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
@@ -183,6 +185,27 @@ where
             }
         }
     }
+}
+
+/// Drives an accepted exec stream until its client stops reading — exit frame, or a silent disconnect — then deregisters the session and cancels its guest task, so an abandoned exec never outlives its client.
+pub async fn drive_exec_stream<S>(
+    stream: &mut S,
+    run_id: &str,
+    session_id: &str,
+    session_task: tokio::task::JoinHandle<()>,
+    frame_rx: &mut mpsc::Receiver<WireFrame>,
+) -> anyhow::Result<()>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+{
+    let outcome = pump_exec_responses(stream, frame_rx).await?;
+    if let PumpOutcome::WriteFailed(e) = &outcome {
+        log::debug!(error = %e, "exec stream write failed; tearing session down");
+    }
+    crate::run_registry::deregister_exec_session(run_id, session_id);
+    session_task.abort();
+    let _ = session_task.await;
+    Ok(())
 }
 
 pub(super) async fn pump_exec_responses<S>(

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -714,7 +714,8 @@ pub(super) fn validate_exec(args: &lns_ipc::ExecImageArgs) -> Result<(), String>
     Ok(())
 }
 
-pub(super) fn register_exec_input(
+/// The exec handshake's registration step: allocates the session id that makes an exec addressable within its run.
+pub fn register_exec_input(
     run_id: &str,
     input_tx: tokio::sync::mpsc::Sender<crate::vm::session_client::SessionInput>,
 ) -> Result<String, String> {

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -2655,6 +2655,7 @@ mod tests {
                 "SHELL=/bin/bash".into(),
                 "SOME_TOOL_HOME=/workspace/mine".into(),
             ],
+            declared_identity_keys: vec!["HOME".into()],
             workdir: Some("/workspace".into()),
             tools: crate::workload_env::ToolRuntime {
                 bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -755,6 +755,7 @@ pub(super) fn build_session_params(
             .initial_winsize
             .map(|(rows, cols)| lns_session::Winsize { rows, cols }),
         confine: true,
+        dies_with_client: true,
     }
 }
 
@@ -2587,6 +2588,15 @@ mod tests {
         assert!(
             params.confine,
             "an exec reaches the broker, not the supervisor, so the broker is the only place its identity and capabilities can be capped"
+        );
+    }
+
+    #[test]
+    fn build_session_params_declares_the_exec_dies_with_its_client() {
+        let params = build_session_params(exec_args(vec!["nft".into()], false, false), "1");
+        assert!(
+            params.dies_with_client,
+            "an exec has no other owner, so a vanished host stream must hang its child up instead of leaking it"
         );
     }
 

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -95,6 +95,12 @@ where
     Ok(())
 }
 
+#[cfg(test)]
+fn primary_target(run_id: impl Into<String>) -> lns_ipc::SessionTarget {
+    lns_ipc::SessionTarget::Primary {
+        run_id: run_id.into(),
+    }
+}
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum PumpOutcome {
     ExitFrame,
@@ -216,25 +222,10 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
                 }
             }
         }
-        Request::RunDetach { run_id } => match crate::run_registry::request_detach(run_id) {
-            crate::run_registry::DetachOutcome::Detached => Response::DetachAccepted,
-            crate::run_registry::DetachOutcome::NotAttached => Response::Error {
-                message: format!("run {run_id} is not attached"),
-            },
-            crate::run_registry::DetachOutcome::NotFound => Response::Error {
-                message: format!("no active run with id {run_id}"),
-            },
-        },
-        Request::RunStdin { run_id, bytes } => {
-            forward_session_input(run_id, session_input_from_stdin(bytes.clone()), "RunStdin").await
-        }
-        Request::RunResize { run_id, rows, cols } => {
-            forward_session_input(run_id, session_input_from_resize(*rows, *cols), "RunResize")
-                .await
-        }
-        Request::RunSignal { run_id, signal } => {
-            forward_session_input(run_id, session_input_from_signal(*signal), "RunSignal").await
-        }
+        Request::SessionDetach { .. }
+        | Request::SessionStdin { .. }
+        | Request::SessionResize { .. }
+        | Request::SessionSignal { .. } => handle_session_control(request).await,
         Request::Kill { run, signal } => kill_request(run, *signal).await,
         Request::ListRuns => Response::RunList {
             runs: crate::run_registry::snapshot(),
@@ -523,6 +514,69 @@ async fn wait_for_exit(run_id: &str, timeout: std::time::Duration) -> bool {
             return false;
         }
         tokio::time::sleep(EXIT_POLL_INTERVAL).await;
+    }
+}
+
+async fn handle_session_control(request: &Request) -> Response {
+    match request {
+        Request::SessionDetach { target } => handle_session_detach(target),
+        Request::SessionStdin { target, bytes } => {
+            forward_target_input(
+                target,
+                session_input_from_stdin(bytes.clone()),
+                "SessionStdin",
+            )
+            .await
+        }
+        Request::SessionResize { target, rows, cols } => {
+            forward_target_input(
+                target,
+                session_input_from_resize(*rows, *cols),
+                "SessionResize",
+            )
+            .await
+        }
+        Request::SessionSignal { target, signal } => {
+            forward_target_input(target, session_input_from_signal(*signal), "SessionSignal").await
+        }
+        _ => unreachable!("handle_session_control only accepts session control requests"),
+    }
+}
+
+fn handle_session_detach(target: &lns_ipc::SessionTarget) -> Response {
+    let lns_ipc::SessionTarget::Primary { run_id } = target else {
+        return missing_exec_session(target);
+    };
+    match crate::run_registry::request_detach(run_id) {
+        crate::run_registry::DetachOutcome::Detached => Response::DetachAccepted,
+        crate::run_registry::DetachOutcome::NotAttached => Response::Error {
+            message: format!("run {run_id} is not attached"),
+        },
+        crate::run_registry::DetachOutcome::NotFound => Response::Error {
+            message: format!("no active run with id {run_id}"),
+        },
+    }
+}
+
+async fn forward_target_input(
+    target: &lns_ipc::SessionTarget,
+    input: Option<crate::vm::session_client::SessionInput>,
+    kind: &'static str,
+) -> Response {
+    match target {
+        lns_ipc::SessionTarget::Primary { run_id } => {
+            forward_session_input(run_id, input, kind).await
+        }
+        lns_ipc::SessionTarget::Exec { .. } => missing_exec_session(target),
+    }
+}
+
+fn missing_exec_session(target: &lns_ipc::SessionTarget) -> Response {
+    let lns_ipc::SessionTarget::Exec { run_id, session_id } = target else {
+        unreachable!("missing_exec_session only accepts exec targets")
+    };
+    Response::Error {
+        message: format!("no active exec session {session_id} for run {run_id}"),
     }
 }
 
@@ -1013,8 +1067,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_detach_unknown_run_returns_error() {
         let resp = handle_request(
-            &Request::RunDetach {
-                run_id: "ffffffffffffffffffffffffffffffff".to_string(),
+            &Request::SessionDetach {
+                target: primary_target("ffffffffffffffffffffffffffffffff".to_string()),
             },
             Instant::now(),
         )
@@ -1065,8 +1119,8 @@ mod tests {
         });
 
         let resp = handle_request(
-            &Request::RunStdin {
-                run_id: id.clone(),
+            &Request::SessionStdin {
+                target: primary_target(id.clone()),
                 bytes: b"second".to_vec(),
             },
             Instant::now(),
@@ -1086,8 +1140,8 @@ mod tests {
     async fn forward_session_input_errors_when_run_not_registered() {
         let id = "deadbeef00000000000000000000aa01".to_string();
         let resp = handle_request(
-            &Request::RunStdin {
-                run_id: id.clone(),
+            &Request::SessionStdin {
+                target: primary_target(id.clone()),
                 bytes: b"hi".to_vec(),
             },
             Instant::now(),
@@ -1229,8 +1283,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_run_stdin_for_unregistered_run_returns_error() {
         let response = handle_request(
-            &Request::RunStdin {
-                run_id: "ffffffffffffffffffffffffffff9999".to_string(),
+            &Request::SessionStdin {
+                target: primary_target("ffffffffffffffffffffffffffff9999".to_string()),
                 bytes: vec![],
             },
             Instant::now(),
@@ -1242,8 +1296,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_run_resize_for_unregistered_run_returns_error() {
         let response = handle_request(
-            &Request::RunResize {
-                run_id: "ffffffffffffffffffffffffffff9999".to_string(),
+            &Request::SessionResize {
+                target: primary_target("ffffffffffffffffffffffffffff9999".to_string()),
                 rows: 24,
                 cols: 80,
             },
@@ -1256,8 +1310,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_run_signal_for_unregistered_run_returns_error() {
         let response = handle_request(
-            &Request::RunSignal {
-                run_id: "ffffffffffffffffffffffffffff9999".to_string(),
+            &Request::SessionSignal {
+                target: primary_target("ffffffffffffffffffffffffffff9999".to_string()),
                 signal: lns_ipc::SignalKind::Term,
             },
             Instant::now(),
@@ -1454,8 +1508,8 @@ mod tests {
         crate::run_registry::register(run_id.clone(), handle);
 
         let resp = handle_request(
-            &Request::RunDetach {
-                run_id: run_id.clone(),
+            &Request::SessionDetach {
+                target: primary_target(run_id.clone()),
             },
             Instant::now(),
         )
@@ -1467,8 +1521,8 @@ mod tests {
         );
 
         let resp = handle_request(
-            &Request::RunDetach {
-                run_id: run_id.clone(),
+            &Request::SessionDetach {
+                target: primary_target(run_id.clone()),
             },
             Instant::now(),
         )
@@ -1510,8 +1564,8 @@ mod tests {
         crate::run_registry::register(run_id.clone(), handle);
 
         let resp = handle_request(
-            &Request::RunStdin {
-                run_id: run_id.clone(),
+            &Request::SessionStdin {
+                target: primary_target(run_id.clone()),
                 bytes: b"hi".to_vec(),
             },
             Instant::now(),
@@ -1520,7 +1574,7 @@ mod tests {
         match resp {
             Response::Error { message } => {
                 assert!(message.contains("forwarding"));
-                assert!(message.contains("RunStdin"));
+                assert!(message.contains("SessionStdin"));
                 assert!(message.contains(&run_id));
             }
             other => unreachable!("expected Error, got {other:?}"),

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -223,6 +223,7 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
         }
         Request::SessionDetach { .. }
         | Request::SessionStdin { .. }
+        | Request::SessionStdinClose { .. }
         | Request::SessionResize { .. }
         | Request::SessionSignal { .. } => handle_session_control(request).await,
         Request::Kill { run, signal } => kill_request(run, *signal).await,
@@ -527,6 +528,14 @@ async fn handle_session_control(request: &Request) -> Response {
             )
             .await
         }
+        Request::SessionStdinClose { target } => {
+            forward_target_input(
+                target,
+                Some(crate::vm::session_client::SessionInput::StdinClose),
+                "SessionStdinClose",
+            )
+            .await
+        }
         Request::SessionResize { target, rows, cols } => {
             forward_target_input(
                 target,
@@ -654,15 +663,19 @@ pub(super) fn validate_exec(args: &lns_ipc::ExecImageArgs) -> Result<(), String>
     if args.argv.is_empty() {
         return Err("ExecImage.argv is empty".to_string());
     }
-    if args.tty || args.stdin {
-        return Err(format!(
-            "lns exec -t/-i against run {} is not yet supported (input \
-             routing for exec sessions awaits an IPC discriminator); for now lns exec \
-             supports non-interactive commands only",
-            args.run
-        ));
-    }
     Ok(())
+}
+
+pub(super) fn register_exec_input(
+    run_id: &str,
+    input_tx: tokio::sync::mpsc::Sender<crate::vm::session_client::SessionInput>,
+) -> Result<String, String> {
+    let session_id = crate::run_registry::allocate_run_id();
+    if crate::run_registry::register_exec_session(run_id, session_id.clone(), input_tx) {
+        Ok(session_id)
+    } else {
+        Err(format!("no active run with id {run_id}"))
+    }
 }
 
 /// `run_id` is the *resolved* id: `args.run` may be a name or an id prefix, and the registry keys tool paths by id alone.
@@ -1347,6 +1360,40 @@ mod tests {
             Some(SessionInput::StdinBytes(bytes)) if bytes == b"exec only"
         ));
         assert!(primary_rx.try_recv().is_err());
+
+        crate::run_registry::deregister(&run_id);
+    }
+
+    #[tokio::test]
+    async fn handle_request_closes_only_the_named_exec_sessions_stdin() {
+        use crate::vm::session_client::SessionInput;
+
+        let run_id = crate::run_registry::allocate_run_id();
+        let (handle, _cancel_rx) = crate::run_registry::test_handle();
+        crate::run_registry::register(run_id.clone(), handle);
+        let (exec_tx, mut exec_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        assert!(crate::run_registry::register_exec_session(
+            &run_id,
+            "exec-1".to_string(),
+            exec_tx,
+        ));
+
+        let response = handle_request(
+            &Request::SessionStdinClose {
+                target: lns_ipc::SessionTarget::Exec {
+                    run_id: run_id.clone(),
+                    session_id: "exec-1".to_string(),
+                },
+            },
+            Instant::now(),
+        )
+        .await;
+
+        assert_eq!(response, Response::Acknowledged);
+        assert!(matches!(
+            exec_rx.recv().await,
+            Some(SessionInput::StdinClose)
+        ));
 
         crate::run_registry::deregister(&run_id);
     }
@@ -2212,13 +2259,44 @@ mod tests {
     }
 
     #[test]
-    fn validate_exec_rejects_interactive_exec_and_names_the_run() {
-        for (tty, stdin) in [(true, false), (false, true)] {
-            let err = validate_exec(&exec_args(vec!["sh".into()], tty, stdin))
-                .expect_err("interactive exec is unsupported");
-            assert!(err.contains("run 42"), "should name the run: {err}");
-            assert!(err.contains("not yet supported"), "got: {err}");
+    fn validate_exec_accepts_explicit_terminal_modes() {
+        for (tty, stdin) in [(true, false), (false, true), (true, true)] {
+            assert_eq!(
+                validate_exec(&exec_args(vec!["sh".into()], tty, stdin)),
+                Ok(())
+            );
         }
+    }
+
+    #[tokio::test]
+    async fn register_exec_input_publishes_an_addressable_session_id() {
+        let run_id = crate::run_registry::allocate_run_id();
+        let (handle, _cancel_rx) = crate::run_registry::test_handle();
+        crate::run_registry::register(run_id.clone(), handle);
+        let (input_tx, _input_rx) =
+            tokio::sync::mpsc::channel::<crate::vm::session_client::SessionInput>(1);
+
+        let session_id = register_exec_input(&run_id, input_tx)
+            .expect("an active run should accept a new exec session");
+        assert!(
+            crate::run_registry::session_input_sender(&lns_ipc::SessionTarget::Exec {
+                run_id: run_id.clone(),
+                session_id,
+            })
+            .is_some()
+        );
+
+        crate::run_registry::deregister(&run_id);
+    }
+
+    #[tokio::test]
+    async fn register_exec_input_refuses_a_run_that_disappeared() {
+        let (input_tx, _input_rx) =
+            tokio::sync::mpsc::channel::<crate::vm::session_client::SessionInput>(1);
+        assert_eq!(
+            register_exec_input("missing-run", input_tx),
+            Err("no active run with id missing-run".to_string())
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1024,6 +1024,102 @@ mod tests {
         assert_eq!(pump.await.unwrap().unwrap(), PumpOutcome::ExitFrame);
     }
 
+    struct ExecPumpStream {
+        read_error: bool,
+    }
+
+    impl tokio::io::AsyncRead for ExecPumpStream {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            if self.read_error {
+                std::task::Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "read reset",
+                )))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    impl tokio::io::AsyncWrite for ExecPumpStream {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "write closed",
+            )))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn exec_pump_surfaces_a_read_error() {
+        let mut stream = ExecPumpStream { read_error: true };
+        let (_frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+
+        let outcome = pump_exec_responses(&mut stream, &mut frame_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, PumpOutcome::WriteFailed("read reset".to_string()));
+    }
+
+    #[tokio::test]
+    async fn exec_pump_stops_when_the_guest_frame_channel_closes() {
+        let (_client, mut service) = tokio::io::duplex(64);
+        let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+        drop(frame_tx);
+
+        let outcome = pump_exec_responses(&mut service, &mut frame_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, PumpOutcome::ChannelClosed);
+    }
+
+    #[tokio::test]
+    async fn exec_pump_surfaces_a_write_error() {
+        let mut stream = ExecPumpStream { read_error: false };
+        let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+        frame_tx
+            .send(WireFrame::Stdout(b"exec-out".to_vec()))
+            .await
+            .unwrap();
+
+        let outcome = pump_exec_responses(&mut stream, &mut frame_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            PumpOutcome::WriteFailed("write closed".to_string())
+        );
+        assert!(
+            stream.flush().await.is_ok() && stream.shutdown().await.is_ok(),
+            "teardown after a surfaced write failure must not mask it with a second error"
+        );
+    }
+
     #[tokio::test]
     async fn pump_cancel_writes_run_exit_even_when_frame_channel_is_full() {
         let mut sink: Vec<u8> = Vec::new();

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -280,11 +280,34 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
                 }
             }
         }
-        Request::SessionDetach { .. }
-        | Request::SessionStdin { .. }
-        | Request::SessionStdinClose { .. }
-        | Request::SessionResize { .. }
-        | Request::SessionSignal { .. } => handle_session_control(request).await,
+        Request::SessionDetach { target } => handle_session_detach(target).await,
+        Request::SessionStdin { target, bytes } => {
+            forward_target_input(
+                target,
+                session_input_from_stdin(bytes.clone()),
+                "SessionStdin",
+            )
+            .await
+        }
+        Request::SessionStdinClose { target } => {
+            forward_target_input(
+                target,
+                Some(crate::vm::session_client::SessionInput::StdinClose),
+                "SessionStdinClose",
+            )
+            .await
+        }
+        Request::SessionResize { target, rows, cols } => {
+            forward_target_input(
+                target,
+                session_input_from_resize(*rows, *cols),
+                "SessionResize",
+            )
+            .await
+        }
+        Request::SessionSignal { target, signal } => {
+            forward_target_input(target, session_input_from_signal(*signal), "SessionSignal").await
+        }
         Request::Kill { run, signal } => kill_request(run, *signal).await,
         Request::ListRuns => Response::RunList {
             runs: crate::run_registry::snapshot(),
@@ -573,40 +596,6 @@ async fn wait_for_exit(run_id: &str, timeout: std::time::Duration) -> bool {
             return false;
         }
         tokio::time::sleep(EXIT_POLL_INTERVAL).await;
-    }
-}
-
-async fn handle_session_control(request: &Request) -> Response {
-    match request {
-        Request::SessionDetach { target } => handle_session_detach(target).await,
-        Request::SessionStdin { target, bytes } => {
-            forward_target_input(
-                target,
-                session_input_from_stdin(bytes.clone()),
-                "SessionStdin",
-            )
-            .await
-        }
-        Request::SessionStdinClose { target } => {
-            forward_target_input(
-                target,
-                Some(crate::vm::session_client::SessionInput::StdinClose),
-                "SessionStdinClose",
-            )
-            .await
-        }
-        Request::SessionResize { target, rows, cols } => {
-            forward_target_input(
-                target,
-                session_input_from_resize(*rows, *cols),
-                "SessionResize",
-            )
-            .await
-        }
-        Request::SessionSignal { target, signal } => {
-            forward_target_input(target, session_input_from_signal(*signal), "SessionSignal").await
-        }
-        _ => unreachable!("handle_session_control only accepts session control requests"),
     }
 }
 
@@ -1753,12 +1742,6 @@ mod tests {
         assert!(crate::run_registry::session_input_sender(&target).is_none());
 
         crate::run_registry::deregister(&run_id);
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "handle_session_control only accepts session control requests")]
-    async fn session_control_dispatch_rejects_a_non_session_request() {
-        handle_session_control(&Request::Ping).await;
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -185,6 +185,42 @@ where
     }
 }
 
+pub(super) async fn pump_exec_responses<S>(
+    stream: &mut S,
+    frame_rx: &mut mpsc::Receiver<WireFrame>,
+) -> anyhow::Result<PumpOutcome>
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+{
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let mut unexpected = [0u8; 1];
+    loop {
+        tokio::select! {
+            biased;
+            read = reader.read(&mut unexpected) => match read {
+                Ok(0) => return Ok(PumpOutcome::ChannelClosed),
+                Ok(_) => return Ok(PumpOutcome::WriteFailed(
+                    "unexpected bytes on the exec response stream".to_string(),
+                )),
+                Err(e) => return Ok(PumpOutcome::WriteFailed(e.to_string())),
+            },
+            maybe = frame_rx.recv() => {
+                let Some(wire) = maybe else {
+                    return Ok(PumpOutcome::ChannelClosed);
+                };
+                let is_exit = matches!(wire, WireFrame::Json(Response::RunExit { .. }));
+                let frame = encode_wire_frame(&wire)?;
+                if let Err(e) = writer.write_all(&frame).await {
+                    return Ok(PumpOutcome::WriteFailed(e.to_string()));
+                }
+                if is_exit {
+                    return Ok(PumpOutcome::ExitFrame);
+                }
+            }
+        }
+    }
+}
+
 pub async fn handle_request(request: &Request, started_at: Instant) -> Response {
     match request {
         Request::Ping => Response::Pong,
@@ -925,6 +961,67 @@ mod tests {
             matches!(outcome, PumpOutcome::WriteFailed(_)),
             "expected WriteFailed, got {outcome:?}",
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn exec_pump_detects_a_silent_client_disconnect() {
+        let (client, mut service) = tokio::io::duplex(64);
+        let (_frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+        drop(client);
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            pump_exec_responses(&mut service, &mut frame_rx),
+        )
+        .await
+        .expect("a silent exec disconnect should be detected")
+        .unwrap();
+
+        assert_eq!(outcome, PumpOutcome::ChannelClosed);
+    }
+
+    #[tokio::test]
+    async fn exec_pump_rejects_unexpected_client_bytes() {
+        let (mut client, mut service) = tokio::io::duplex(64);
+        let (_frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+        client.write_all(b"x").await.unwrap();
+
+        let outcome = pump_exec_responses(&mut service, &mut frame_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            PumpOutcome::WriteFailed("unexpected bytes on the exec response stream".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_pump_forwards_output_and_stops_after_exit() {
+        let (mut client, mut service) = tokio::io::duplex(4096);
+        let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(2);
+        frame_tx
+            .send(WireFrame::Stdout(b"exec-out".to_vec()))
+            .await
+            .unwrap();
+        frame_tx
+            .send(WireFrame::Json(Response::RunExit { code: 7 }))
+            .await
+            .unwrap();
+        let pump =
+            tokio::spawn(async move { pump_exec_responses(&mut service, &mut frame_rx).await });
+
+        let stdout = lns_ipc::read_frame_bytes_async(&mut client).await.unwrap();
+        assert_eq!(
+            lns_ipc::decode_wire_frame_from_bytes(&stdout).unwrap(),
+            WireFrame::Stdout(b"exec-out".to_vec())
+        );
+        let exit = lns_ipc::read_frame_bytes_async(&mut client).await.unwrap();
+        assert_eq!(
+            lns_ipc::decode_wire_frame_from_bytes(&exit).unwrap(),
+            WireFrame::Json(Response::RunExit { code: 7 })
+        );
+        assert_eq!(pump.await.unwrap().unwrap(), PumpOutcome::ExitFrame);
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1140,10 +1140,15 @@ mod tests {
             .unwrap();
         let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
         let probe = TerminationProbe(Some(terminated_tx));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
         let session_task = tokio::spawn(async move {
             let _probe = probe;
+            let _ = started_tx.send(());
             std::future::pending::<()>().await
         });
+        started_rx
+            .await
+            .expect("the fake guest session task is running before the teardown");
 
         drive_exec_stream(&mut stream, "run-w", "exec-w", session_task, &mut frame_rx)
             .await

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -95,7 +95,6 @@ where
     Ok(())
 }
 
-#[cfg(test)]
 fn primary_target(run_id: impl Into<String>) -> lns_ipc::SessionTarget {
     lns_ipc::SessionTarget::Primary {
         run_id: run_id.into(),
@@ -519,7 +518,7 @@ async fn wait_for_exit(run_id: &str, timeout: std::time::Duration) -> bool {
 
 async fn handle_session_control(request: &Request) -> Response {
     match request {
-        Request::SessionDetach { target } => handle_session_detach(target),
+        Request::SessionDetach { target } => handle_session_detach(target).await,
         Request::SessionStdin { target, bytes } => {
             forward_target_input(
                 target,
@@ -543,18 +542,34 @@ async fn handle_session_control(request: &Request) -> Response {
     }
 }
 
-fn handle_session_detach(target: &lns_ipc::SessionTarget) -> Response {
-    let lns_ipc::SessionTarget::Primary { run_id } = target else {
-        return missing_exec_session(target);
-    };
-    match crate::run_registry::request_detach(run_id) {
-        crate::run_registry::DetachOutcome::Detached => Response::DetachAccepted,
-        crate::run_registry::DetachOutcome::NotAttached => Response::Error {
-            message: format!("run {run_id} is not attached"),
-        },
-        crate::run_registry::DetachOutcome::NotFound => Response::Error {
-            message: format!("no active run with id {run_id}"),
-        },
+async fn handle_session_detach(target: &lns_ipc::SessionTarget) -> Response {
+    match target {
+        lns_ipc::SessionTarget::Primary { run_id } => {
+            match crate::run_registry::request_detach(run_id) {
+                crate::run_registry::DetachOutcome::Detached => Response::DetachAccepted,
+                crate::run_registry::DetachOutcome::NotAttached => Response::Error {
+                    message: format!("run {run_id} is not attached"),
+                },
+                crate::run_registry::DetachOutcome::NotFound => Response::Error {
+                    message: format!("no active run with id {run_id}"),
+                },
+            }
+        }
+        lns_ipc::SessionTarget::Exec { run_id, session_id } => {
+            let Some(tx) = crate::run_registry::session_input_sender(target) else {
+                return missing_exec_session(run_id, session_id);
+            };
+            let sent = tx
+                .send(crate::vm::session_client::SessionInput::Detach)
+                .await;
+            crate::run_registry::deregister_exec_session(run_id, session_id);
+            match sent {
+                Ok(()) => Response::DetachAccepted,
+                Err(e) => Response::Error {
+                    message: format!("detaching exec session {session_id} in run {run_id}: {e}"),
+                },
+            }
+        }
     }
 }
 
@@ -563,18 +578,37 @@ async fn forward_target_input(
     input: Option<crate::vm::session_client::SessionInput>,
     kind: &'static str,
 ) -> Response {
-    match target {
-        lns_ipc::SessionTarget::Primary { run_id } => {
-            forward_session_input(run_id, input, kind).await
-        }
-        lns_ipc::SessionTarget::Exec { .. } => missing_exec_session(target),
+    let Some(input) = input else {
+        return Response::Error {
+            message: format!("{kind} not supported on this build"),
+        };
+    };
+    let Some(tx) = crate::run_registry::session_input_sender(target) else {
+        return missing_session(target);
+    };
+    match tx.send(input).await {
+        Ok(()) => Response::Acknowledged,
+        Err(e) => Response::Error {
+            message: format!(
+                "forwarding {kind} to session in run {} failed: {e}",
+                target.run_id()
+            ),
+        },
     }
 }
 
-fn missing_exec_session(target: &lns_ipc::SessionTarget) -> Response {
-    let lns_ipc::SessionTarget::Exec { run_id, session_id } = target else {
-        unreachable!("missing_exec_session only accepts exec targets")
-    };
+fn missing_session(target: &lns_ipc::SessionTarget) -> Response {
+    match target {
+        lns_ipc::SessionTarget::Primary { run_id } => Response::Error {
+            message: format!("no active session for run {run_id}"),
+        },
+        lns_ipc::SessionTarget::Exec { run_id, session_id } => {
+            missing_exec_session(run_id, session_id)
+        }
+    }
+}
+
+fn missing_exec_session(run_id: &str, session_id: &str) -> Response {
     Response::Error {
         message: format!("no active exec session {session_id} for run {run_id}"),
     }
@@ -585,22 +619,7 @@ async fn forward_session_input(
     input: Option<crate::vm::session_client::SessionInput>,
     kind: &'static str,
 ) -> Response {
-    let Some(input) = input else {
-        return Response::Error {
-            message: format!("{kind} not supported on this build"),
-        };
-    };
-    let Some(tx) = crate::run_registry::input_sender(run_id) else {
-        return Response::Error {
-            message: format!("no active session for run {run_id}"),
-        };
-    };
-    match tx.send(input).await {
-        Ok(()) => Response::Acknowledged,
-        Err(e) => Response::Error {
-            message: format!("forwarding {kind} to run {run_id} failed: {e}"),
-        },
-    }
+    forward_target_input(&primary_target(run_id.to_string()), input, kind).await
 }
 
 fn session_input_from_stdin(bytes: Vec<u8>) -> Option<crate::vm::session_client::SessionInput> {
@@ -1100,6 +1119,7 @@ mod tests {
                 detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: Some(input_tx),
+                exec_sessions: Default::default(),
                 connector: None,
                 name: String::new(),
                 image: String::new(),
@@ -1294,6 +1314,151 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_request_routes_stdin_to_the_named_exec_session_only() {
+        use crate::vm::session_client::SessionInput;
+
+        let run_id = crate::run_registry::allocate_run_id();
+        let (mut handle, _cancel_rx) = crate::run_registry::test_handle();
+        let (primary_tx, mut primary_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        handle.input_tx = Some(primary_tx);
+        crate::run_registry::register(run_id.clone(), handle);
+        let (exec_tx, mut exec_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        assert!(crate::run_registry::register_exec_session(
+            &run_id,
+            "exec-1".to_string(),
+            exec_tx,
+        ));
+
+        let response = handle_request(
+            &Request::SessionStdin {
+                target: lns_ipc::SessionTarget::Exec {
+                    run_id: run_id.clone(),
+                    session_id: "exec-1".to_string(),
+                },
+                bytes: b"exec only".to_vec(),
+            },
+            Instant::now(),
+        )
+        .await;
+
+        assert_eq!(response, Response::Acknowledged);
+        assert!(matches!(
+            exec_rx.recv().await,
+            Some(SessionInput::StdinBytes(bytes)) if bytes == b"exec only"
+        ));
+        assert!(primary_rx.try_recv().is_err());
+
+        crate::run_registry::deregister(&run_id);
+    }
+
+    #[tokio::test]
+    async fn handle_request_detaches_only_the_named_exec_session() {
+        use crate::vm::session_client::SessionInput;
+
+        let run_id = crate::run_registry::allocate_run_id();
+        let (mut handle, _cancel_rx) = crate::run_registry::test_handle();
+        let (primary_tx, _primary_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        handle.input_tx = Some(primary_tx);
+        crate::run_registry::register(run_id.clone(), handle);
+        let (exec_tx, mut exec_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        assert!(crate::run_registry::register_exec_session(
+            &run_id,
+            "exec-1".to_string(),
+            exec_tx,
+        ));
+        let target = lns_ipc::SessionTarget::Exec {
+            run_id: run_id.clone(),
+            session_id: "exec-1".to_string(),
+        };
+
+        let response = handle_request(
+            &Request::SessionDetach {
+                target: target.clone(),
+            },
+            Instant::now(),
+        )
+        .await;
+
+        assert_eq!(response, Response::DetachAccepted);
+        assert!(exec_rx.recv().await.is_some());
+        assert!(crate::run_registry::session_input_sender(&target).is_none());
+        assert!(
+            crate::run_registry::session_input_sender(&lns_ipc::SessionTarget::Primary {
+                run_id: run_id.clone(),
+            })
+            .is_some()
+        );
+
+        crate::run_registry::deregister(&run_id);
+    }
+
+    #[tokio::test]
+    async fn handle_request_rejects_an_unknown_exec_session_target() {
+        let target = lns_ipc::SessionTarget::Exec {
+            run_id: "missing-run".to_string(),
+            session_id: "missing-exec".to_string(),
+        };
+        for request in [
+            Request::SessionStdin {
+                target: target.clone(),
+                bytes: b"ignored".to_vec(),
+            },
+            Request::SessionDetach {
+                target: target.clone(),
+            },
+        ] {
+            let response = handle_request(&request, Instant::now()).await;
+            assert!(matches!(
+                response,
+                Response::Error { message }
+                    if message.contains("missing-exec") && message.contains("missing-run")
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn detaching_an_exec_with_a_closed_input_channel_cleans_up_and_reports_the_failure() {
+        use crate::vm::session_client::SessionInput;
+
+        let run_id = crate::run_registry::allocate_run_id();
+        let (handle, _cancel_rx) = crate::run_registry::test_handle();
+        crate::run_registry::register(run_id.clone(), handle);
+        let (exec_tx, exec_rx) = tokio::sync::mpsc::channel::<SessionInput>(1);
+        drop(exec_rx);
+        assert!(crate::run_registry::register_exec_session(
+            &run_id,
+            "exec-1".to_string(),
+            exec_tx,
+        ));
+        let target = lns_ipc::SessionTarget::Exec {
+            run_id: run_id.clone(),
+            session_id: "exec-1".to_string(),
+        };
+
+        let response = handle_request(
+            &Request::SessionDetach {
+                target: target.clone(),
+            },
+            Instant::now(),
+        )
+        .await;
+
+        assert!(matches!(
+            response,
+            Response::Error { message } if message.contains("detaching exec session exec-1")
+        ));
+        assert!(crate::run_registry::session_input_sender(&target).is_none());
+
+        crate::run_registry::deregister(&run_id);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "handle_session_control only accepts session control requests")]
+    async fn session_control_dispatch_rejects_a_non_session_request() {
+        handle_session_control(&Request::Ping).await;
+    }
+
+    #[tokio::test]
     async fn handle_request_run_resize_for_unregistered_run_returns_error() {
         let response = handle_request(
             &Request::SessionResize {
@@ -1460,6 +1625,7 @@ mod tests {
             detach_tx: std::sync::Mutex::new(None),
             task,
             input_tx: None,
+            exec_sessions: Default::default(),
             connector: None,
             name: String::new(),
             image: "test-image".into(),
@@ -1495,6 +1661,7 @@ mod tests {
             detach_tx: Mutex::new(Some(detach_tx)),
             task,
             input_tx: None,
+            exec_sessions: Default::default(),
             connector: None,
             name: String::new(),
             image: "detach-test".into(),
@@ -1551,6 +1718,7 @@ mod tests {
             detach_tx: std::sync::Mutex::new(None),
             task,
             input_tx: Some(input_tx),
+            exec_sessions: Default::default(),
             connector: None,
             name: String::new(),
             image: "closed-channel-test".into(),
@@ -1640,6 +1808,7 @@ mod tests {
                 detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: None,
+                exec_sessions: Default::default(),
                 connector: None,
                 name: "reviewer".into(),
                 image: "stop-test".into(),
@@ -1988,6 +2157,7 @@ mod tests {
                 detach_tx: std::sync::Mutex::new(None),
                 task,
                 input_tx: Some(input_tx),
+                exec_sessions: Default::default(),
                 connector: None,
                 name: String::new(),
                 image: String::new(),

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1120,6 +1120,39 @@ mod tests {
         assert_eq!(outcome, PumpOutcome::ChannelClosed);
     }
 
+    struct TerminationProbe(Option<tokio::sync::oneshot::Sender<()>>);
+
+    impl Drop for TerminationProbe {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_write_failure_still_tears_the_exec_session_down() {
+        let mut stream = ExecPumpStream { read_error: false };
+        let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(1);
+        frame_tx
+            .send(WireFrame::Stdout(b"exec-out".to_vec()))
+            .await
+            .unwrap();
+        let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
+        let session_task = tokio::spawn(async move {
+            let _probe = TerminationProbe(Some(terminated_tx));
+            std::future::pending::<()>().await
+        });
+
+        drive_exec_stream(&mut stream, "run-w", "exec-w", session_task, &mut frame_rx)
+            .await
+            .unwrap();
+
+        terminated_rx
+            .await
+            .expect("a failed client write must still cancel the guest session task");
+    }
+
     #[tokio::test]
     async fn exec_pump_surfaces_a_write_error() {
         let mut stream = ExecPumpStream { read_error: false };

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1139,8 +1139,9 @@ mod tests {
             .await
             .unwrap();
         let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
+        let probe = TerminationProbe(Some(terminated_tx));
         let session_task = tokio::spawn(async move {
-            let _probe = TerminationProbe(Some(terminated_tx));
+            let _probe = probe;
             std::future::pending::<()>().await
         });
 

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -525,6 +525,7 @@ async fn orchestrate(
         tools: tool_runtime,
         placeholders: session.placeholder_env.clone(),
         workdir: workdir.clone(),
+        declared_identity_keys: crate::workload_env::declared_identity_keys(&env),
     };
     let env: Vec<String> = composed.env;
 

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -537,6 +537,7 @@ async fn orchestrate(
         stdin: args.stdin,
         initial_winsize,
         confine: !SUPERVISED,
+        dies_with_client: false,
     };
 
     let frame_tx_for_session = frame_tx.clone();

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -22,6 +22,7 @@ pub struct RunHandle {
     pub detach_tx: Mutex<Option<oneshot::Sender<()>>>,
     pub task: JoinHandle<()>,
     pub input_tx: Option<mpsc::Sender<SessionInput>>,
+    pub exec_sessions: HashMap<String, mpsc::Sender<SessionInput>>,
     pub connector: Option<std::sync::Arc<dyn GuestTransport>>,
     pub name: String,
     pub image: String,
@@ -194,6 +195,40 @@ pub fn input_sender(run_id: &str) -> Option<mpsc::Sender<SessionInput>> {
     g.as_ref()
         .and_then(|m| m.get(run_id))
         .and_then(|h| h.input_tx.clone())
+}
+
+pub fn register_exec_session(
+    run_id: &str,
+    session_id: String,
+    input_tx: mpsc::Sender<SessionInput>,
+) -> bool {
+    let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
+    let Some(handle) = g.as_mut().and_then(|runs| runs.get_mut(run_id)) else {
+        return false;
+    };
+    handle.exec_sessions.insert(session_id, input_tx);
+    true
+}
+
+pub fn deregister_exec_session(run_id: &str, session_id: &str) -> bool {
+    let mut g = ACTIVE.lock().expect("ACTIVE poisoned");
+    g.as_mut()
+        .and_then(|runs| runs.get_mut(run_id))
+        .and_then(|handle| handle.exec_sessions.remove(session_id))
+        .is_some()
+}
+
+pub fn session_input_sender(target: &lns_ipc::SessionTarget) -> Option<mpsc::Sender<SessionInput>> {
+    match target {
+        lns_ipc::SessionTarget::Primary { run_id } => input_sender(run_id),
+        lns_ipc::SessionTarget::Exec { run_id, session_id } => {
+            let g = ACTIVE.lock().expect("ACTIVE poisoned");
+            g.as_ref()
+                .and_then(|runs| runs.get(run_id))
+                .and_then(|handle| handle.exec_sessions.get(session_id))
+                .cloned()
+        }
+    }
 }
 
 pub fn log_buffer(run_id: &str) -> Option<std::sync::Arc<crate::run_log::RunLogBuffer>> {
@@ -414,6 +449,7 @@ pub(crate) fn test_handle() -> (RunHandle, oneshot::Receiver<i32>) {
             detach_tx: Mutex::new(None),
             task,
             input_tx: None,
+            exec_sessions: Default::default(),
             connector: None,
             name: String::new(),
             image: String::new(),
@@ -839,6 +875,95 @@ mod tests {
         assert!(cloned.is_some());
 
         deregister(&id);
+    }
+
+    #[tokio::test]
+    async fn two_exec_sessions_on_one_run_route_input_independently() {
+        let run_id = allocate_run_id();
+        let (mut handle, _cancel_rx) = make_handle();
+        let (primary_tx, mut primary_rx) = mpsc::channel::<SessionInput>(1);
+        handle.input_tx = Some(primary_tx);
+        register(run_id.clone(), handle);
+
+        let (first_tx, mut first_rx) = mpsc::channel::<SessionInput>(1);
+        let (second_tx, mut second_rx) = mpsc::channel::<SessionInput>(1);
+        register_exec_session(&run_id, "exec-1".to_string(), first_tx);
+        register_exec_session(&run_id, "exec-2".to_string(), second_tx);
+
+        let target = lns_ipc::SessionTarget::Exec {
+            run_id: run_id.clone(),
+            session_id: "exec-1".to_string(),
+        };
+        session_input_sender(&target)
+            .expect("the first exec session should be addressable")
+            .send(SessionInput::StdinBytes(b"first only".to_vec()))
+            .await
+            .expect("the first exec session should accept input");
+
+        assert!(matches!(
+            first_rx.recv().await,
+            Some(SessionInput::StdinBytes(bytes)) if bytes == b"first only"
+        ));
+        assert!(primary_rx.try_recv().is_err());
+        assert!(second_rx.try_recv().is_err());
+
+        deregister(&run_id);
+    }
+
+    #[tokio::test]
+    async fn registering_an_exec_session_for_a_missing_run_is_refused() {
+        let (input_tx, _input_rx) = mpsc::channel::<SessionInput>(1);
+        assert!(!register_exec_session(
+            "missing-run",
+            "exec-1".to_string(),
+            input_tx,
+        ));
+    }
+
+    #[tokio::test]
+    async fn deregistering_one_exec_session_leaves_the_primary_and_sibling_addressable() {
+        let run_id = allocate_run_id();
+        let (mut handle, _cancel_rx) = make_handle();
+        let (primary_tx, _primary_rx) = mpsc::channel::<SessionInput>(1);
+        handle.input_tx = Some(primary_tx);
+        register(run_id.clone(), handle);
+
+        let (first_tx, _first_rx) = mpsc::channel::<SessionInput>(1);
+        let (second_tx, _second_rx) = mpsc::channel::<SessionInput>(1);
+        assert!(register_exec_session(
+            &run_id,
+            "exec-1".to_string(),
+            first_tx
+        ));
+        assert!(register_exec_session(
+            &run_id,
+            "exec-2".to_string(),
+            second_tx
+        ));
+
+        assert!(deregister_exec_session(&run_id, "exec-1"));
+        assert!(
+            session_input_sender(&lns_ipc::SessionTarget::Exec {
+                run_id: run_id.clone(),
+                session_id: "exec-1".to_string(),
+            })
+            .is_none()
+        );
+        assert!(
+            session_input_sender(&lns_ipc::SessionTarget::Exec {
+                run_id: run_id.clone(),
+                session_id: "exec-2".to_string(),
+            })
+            .is_some()
+        );
+        assert!(
+            session_input_sender(&lns_ipc::SessionTarget::Primary {
+                run_id: run_id.clone(),
+            })
+            .is_some()
+        );
+
+        deregister(&run_id);
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -45,6 +45,8 @@ pub struct ExecEnvironment {
     pub placeholders: Vec<(String, String)>,
     /// The workload's working directory; `docker exec` inherits it, and an exec in `/` makes `sh -lc` write to the wrong place.
     pub workdir: Option<String>,
+    /// Which identity vars (`HOME`, `USER`) the author declared, so an exec keeps them the way the supervisor honors `LENS_SANDBOX_WORKLOAD_*` — an image's own ENV must not outrank the run-as identity.
+    pub declared_identity_keys: Vec<String>,
 }
 
 pub fn allocate_run_id() -> String {
@@ -716,6 +718,7 @@ mod tests {
                 "some-provider_LNSPLACEHOLDER0000".to_string(),
             )],
             workdir: Some("/workspace".to_string()),
+            declared_identity_keys: vec!["HOME".to_string()],
         }
     }
 

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -89,6 +89,8 @@ pub struct SessionParams {
     pub initial_winsize: Option<Winsize>,
     /// Ask the broker to drop to the guest run-as identity before exec; false for the primary session, whose workload is the supervisor.
     pub confine: bool,
+    /// Tell the broker this session exists only for its host client, so a vanished stream hangs the child up.
+    pub dies_with_client: bool,
 }
 
 pub(super) fn input_to_frame(input: SessionInput) -> ClientFrame {

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -73,6 +73,7 @@ impl CaptureBuffers {
 #[derive(Debug)]
 pub enum SessionInput {
     StdinBytes(Vec<u8>),
+    StdinClose,
     Resize { rows: u16, cols: u16 },
     Signal(SignalKind),
     Detach,
@@ -93,6 +94,7 @@ pub struct SessionParams {
 pub(super) fn input_to_frame(input: SessionInput) -> ClientFrame {
     match input {
         SessionInput::StdinBytes(bytes) => ClientFrame::StdinBytes(bytes),
+        SessionInput::StdinClose => ClientFrame::StdinClose,
         SessionInput::Resize { rows, cols } => ClientFrame::Resize(Winsize { rows, cols }),
         SessionInput::Signal(kind) => ClientFrame::Signal(kind),
         SessionInput::Detach => ClientFrame::Detach,
@@ -210,6 +212,10 @@ mod tests {
     fn input_to_frame_maps_each_variant() {
         let stdin = input_to_frame(SessionInput::StdinBytes(b"x".to_vec()));
         assert_eq!(stdin, ClientFrame::StdinBytes(b"x".to_vec()));
+        assert_eq!(
+            input_to_frame(SessionInput::StdinClose),
+            ClientFrame::StdinClose
+        );
         let resize = input_to_frame(SessionInput::Resize { rows: 10, cols: 20 });
         assert_eq!(resize, ClientFrame::Resize(Winsize { rows: 10, cols: 20 }));
         let signal = input_to_frame(SessionInput::Signal(SignalKind::Int));

--- a/crates/lns-service/src/vm/session_client.rs
+++ b/crates/lns-service/src/vm/session_client.rs
@@ -75,6 +75,7 @@ pub enum SessionInput {
     StdinBytes(Vec<u8>),
     Resize { rows: u16, cols: u16 },
     Signal(SignalKind),
+    Detach,
 }
 
 pub struct SessionParams {
@@ -94,6 +95,7 @@ pub(super) fn input_to_frame(input: SessionInput) -> ClientFrame {
         SessionInput::StdinBytes(bytes) => ClientFrame::StdinBytes(bytes),
         SessionInput::Resize { rows, cols } => ClientFrame::Resize(Winsize { rows, cols }),
         SessionInput::Signal(kind) => ClientFrame::Signal(kind),
+        SessionInput::Detach => ClientFrame::Detach,
     }
 }
 
@@ -212,6 +214,7 @@ mod tests {
         assert_eq!(resize, ClientFrame::Resize(Winsize { rows: 10, cols: 20 }));
         let signal = input_to_frame(SessionInput::Signal(SignalKind::Int));
         assert_eq!(signal, ClientFrame::Signal(SignalKind::Int));
+        assert_eq!(input_to_frame(SessionInput::Detach), ClientFrame::Detach);
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/vm/session_client/real.rs
+++ b/crates/lns-service/src/vm/session_client/real.rs
@@ -52,6 +52,7 @@ async fn run_session(
         stdin: params.stdin,
         winsize: params.initial_winsize,
         confine: params.confine,
+        dies_with_client: params.dies_with_client,
     };
     send_client_frame(&writer, &open)
         .await
@@ -118,6 +119,7 @@ pub async fn capture_session_exec(
         stdin: false,
         initial_winsize: None,
         confine: false,
+        dies_with_client: false,
     };
     let (frame_tx, mut frame_rx) = mpsc::channel::<WireFrame>(64);
     let (input_keepalive, input_rx) = mpsc::channel::<SessionInput>(1);

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -108,6 +108,7 @@ pub fn exec_session_env(
         .session_env
         .iter()
         .filter(|entry| !is_session_only(entry))
+        .filter(|entry| keeps_identity(entry, &exec_environment.declared_identity_keys))
         .cloned()
         .collect();
     let caller: Vec<String> = exec_env
@@ -124,6 +125,22 @@ pub fn exec_session_env(
         overwrite(&mut env, key, value);
     }
     env
+}
+
+pub const IDENTITY_ENV_KEYS: [&str; 2] = ["HOME", "USER"];
+
+/// Which identity vars the author set via `-e`/spec env — the same test that gates `LENS_SANDBOX_WORKLOAD_*` on the primary.
+pub fn declared_identity_keys(user_env: &[String]) -> Vec<String> {
+    IDENTITY_ENV_KEYS
+        .iter()
+        .filter(|key| declared(user_env, key).is_some())
+        .map(|key| key.to_string())
+        .collect()
+}
+
+fn keeps_identity(entry: &str, declared_keys: &[String]) -> bool {
+    let key = entry.split_once('=').map(|(k, _)| k).unwrap_or(entry);
+    !IDENTITY_ENV_KEYS.contains(&key) || declared_keys.iter().any(|d| d == key)
 }
 
 fn overwrite(env: &mut Vec<String>, key: &str, value: &str) {
@@ -488,6 +505,7 @@ mod tests {
                 "HOME=/workspace".into(),
                 "SOME_TOOL_CACHE=/workspace/mine".into(),
             ],
+            declared_identity_keys: vec!["HOME".into()],
             tools: ToolRuntime {
                 bin_paths: vec!["/.lens/tools/some-tool/1.2.3/bin".into()],
                 env: vec![
@@ -522,6 +540,63 @@ mod tests {
             )),
             "the run's tool dirs still come first: {env:?}"
         );
+    }
+
+    #[test]
+    fn an_image_declared_home_does_not_outrank_the_run_as_identity_in_an_exec_either() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec![
+                "HOME=/srv".into(),
+                "USER=svc".into(),
+                "MODE=research".into(),
+            ],
+            declared_identity_keys: Vec::new(),
+            ..Default::default()
+        };
+
+        let env = exec_session_env(&run, &[]);
+
+        assert!(
+            !env.iter()
+                .any(|kv| kv.starts_with("HOME=") || kv.starts_with("USER=")),
+            "an image ENV HOME/USER the author never declared must leave the slot to the guest identity, as the supervisor does: {env:?}"
+        );
+        assert!(env.contains(&"MODE=research".to_string()), "got: {env:?}");
+    }
+
+    #[test]
+    fn an_author_declared_home_survives_into_an_exec_session() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec!["HOME=/srv".into(), "USER=svc".into()],
+            declared_identity_keys: vec!["HOME".into()],
+            ..Default::default()
+        };
+
+        let env = exec_session_env(&run, &[]);
+
+        assert!(
+            env.contains(&"HOME=/srv".to_string()),
+            "a `-e HOME` is the author's decision, exactly like LENS_SANDBOX_WORKLOAD_HOME on the primary: {env:?}"
+        );
+        assert!(
+            !env.iter().any(|kv| kv.starts_with("USER=")),
+            "USER stays identity-owned when only HOME was declared: {env:?}"
+        );
+    }
+
+    #[test]
+    fn the_exec_callers_own_env_declares_identity_like_any_dash_e() {
+        let env = exec_session_env(&Default::default(), &["HOME=/x".to_string()]);
+        assert!(env.contains(&"HOME=/x".to_string()), "got: {env:?}");
+    }
+
+    #[test]
+    fn declared_identity_keys_reports_only_the_identity_vars_the_author_set() {
+        assert_eq!(
+            declared_identity_keys(&["HOME=/h".into(), "A=1".into()]),
+            vec!["HOME".to_string()]
+        );
+        assert!(declared_identity_keys(&["A=1".into()]).is_empty());
     }
 
     #[test]

--- a/crates/lns-service/tests/behaviours/exec_session_routing.feature
+++ b/crates/lns-service/tests/behaviours/exec_session_routing.feature
@@ -45,10 +45,3 @@ Feature: routing exec sessions within a run
     Then only the first exec session is cancelled
     And the primary session remains running
     And the second exec session remains usable
-
-  Scenario: non-interactive exec behavior is preserved
-    Given an active run named "reviewer"
-    When the user execs a non-interactive command that writes to stdout and stderr
-    Then both output streams are returned
-    And the CLI returns the command's exit status
-    And the exec output is not added to the primary session's captured logs

--- a/crates/lns-service/tests/behaviours/exec_session_routing.feature
+++ b/crates/lns-service/tests/behaviours/exec_session_routing.feature
@@ -1,0 +1,60 @@
+Feature: routing exec sessions within a run
+  Every exec session is isolated from the run's primary session and from
+  concurrent exec sessions for lifecycle and terminal-control traffic.
+
+  @todo
+  Scenario: exec works while the primary session is attached
+    Given an active run named "reviewer"
+    And its primary session is attached to another client
+    When the user runs "lns exec -it reviewer sh"
+    Then the user receives a live shell prompt
+    And the primary session remains attached and usable
+
+  @todo
+  Scenario: a resize targets one exec session
+    Given an active run named "reviewer"
+    And its primary session is running
+    And two interactive exec sessions are active
+    When the first exec client resizes its terminal
+    Then only the first exec session receives the new dimensions
+    And the primary session is unaffected
+    And the second exec session remains usable
+
+  @todo
+  Scenario: a signal targets one exec session
+    Given an active run named "reviewer"
+    And its primary session is running
+    And two interactive exec sessions are active
+    When the first exec client sends SIGINT
+    Then only the first exec session receives SIGINT
+    And the primary session is unaffected
+    And the second exec session remains usable
+
+  @todo
+  Scenario: the detach chord closes only its exec session
+    Given an active run named "reviewer"
+    And its primary session is running
+    And two interactive exec sessions are active
+    When the user enters the detach chord in the first exec session
+    Then the first exec session is terminated
+    And its CLI returns successfully
+    And the primary session remains running
+    And the second exec session remains usable
+
+  @todo
+  Scenario: an unexpected exec disconnect is isolated
+    Given an active run named "reviewer"
+    And its primary session is running
+    And two interactive exec sessions are active
+    When the first exec client disconnects unexpectedly
+    Then only the first exec session is cancelled
+    And the primary session remains running
+    And the second exec session remains usable
+
+  @todo
+  Scenario: non-interactive exec behavior is preserved
+    Given an active run named "reviewer"
+    When the user execs a non-interactive command that writes to stdout and stderr
+    Then both output streams are returned
+    And the CLI returns the command's exit status
+    And the exec output is not added to the primary session's captured logs

--- a/crates/lns-service/tests/behaviours/exec_session_routing.feature
+++ b/crates/lns-service/tests/behaviours/exec_session_routing.feature
@@ -2,7 +2,6 @@ Feature: routing exec sessions within a run
   Every exec session is isolated from the run's primary session and from
   concurrent exec sessions for lifecycle and terminal-control traffic.
 
-  @todo
   Scenario: exec works while the primary session is attached
     Given an active run named "reviewer"
     And its primary session is attached to another client
@@ -10,7 +9,6 @@ Feature: routing exec sessions within a run
     Then the user receives a live shell prompt
     And the primary session remains attached and usable
 
-  @todo
   Scenario: a resize targets one exec session
     Given an active run named "reviewer"
     And its primary session is running
@@ -20,7 +18,6 @@ Feature: routing exec sessions within a run
     And the primary session is unaffected
     And the second exec session remains usable
 
-  @todo
   Scenario: a signal targets one exec session
     Given an active run named "reviewer"
     And its primary session is running
@@ -30,7 +27,6 @@ Feature: routing exec sessions within a run
     And the primary session is unaffected
     And the second exec session remains usable
 
-  @todo
   Scenario: the detach chord closes only its exec session
     Given an active run named "reviewer"
     And its primary session is running
@@ -41,7 +37,6 @@ Feature: routing exec sessions within a run
     And the primary session remains running
     And the second exec session remains usable
 
-  @todo
   Scenario: an unexpected exec disconnect is isolated
     Given an active run named "reviewer"
     And its primary session is running
@@ -51,7 +46,6 @@ Feature: routing exec sessions within a run
     And the primary session remains running
     And the second exec session remains usable
 
-  @todo
   Scenario: non-interactive exec behavior is preserved
     Given an active run named "reviewer"
     When the user execs a non-interactive command that writes to stdout and stderr

--- a/crates/lns-service/tests/behaviours/exec_session_routing.feature
+++ b/crates/lns-service/tests/behaviours/exec_session_routing.feature
@@ -6,7 +6,7 @@ Feature: routing exec sessions within a run
     Given an active run named "reviewer"
     And its primary session is attached to another client
     When the user runs "lns exec -it reviewer sh"
-    Then the user receives a live shell prompt
+    Then the exec session is opened and its input routes to it alone
     And the primary session remains attached and usable
 
   Scenario: a resize targets one exec session

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -1,121 +1,289 @@
 use crate::world::BehaviourWorld;
 use cucumber::{given, then, when};
+use lns_service::vm::session_client::SessionInput;
 
-fn pending() -> ! {
-    panic!("pending exec session routing implementation")
+fn make_handle(
+    input_tx: tokio::sync::mpsc::Sender<SessionInput>,
+) -> lns_service::run_registry::RunHandle {
+    let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel::<i32>();
+    lns_service::run_registry::RunHandle {
+        cancel_tx,
+        detach_tx: std::sync::Mutex::new(None),
+        task: tokio::spawn(std::future::pending::<()>()),
+        input_tx: Some(input_tx),
+        exec_sessions: Default::default(),
+        connector: None,
+        name: String::new(),
+        image: String::new(),
+        command: String::new(),
+        started: String::new(),
+        status: std::sync::Mutex::new(lns_ipc::RunStatus::Running),
+        logs: std::sync::Arc::new(lns_service::run_log::RunLogBuffer::default()),
+        config: lns_ipc::RunConfig::default(),
+        exec_environment: Default::default(),
+    }
+}
+
+fn run_id(world: &BehaviourWorld) -> String {
+    world.exec.run_id.clone().expect("an active run")
+}
+
+fn register_exec(world: &mut BehaviourWorld, session_id: &str, first: bool) {
+    let run_id = run_id(world);
+    let (tx, rx) = tokio::sync::mpsc::channel::<SessionInput>(8);
+    assert!(lns_service::run_registry::register_exec_session(
+        &run_id,
+        session_id.to_string(),
+        tx,
+    ));
+    let target = lns_ipc::SessionTarget::Exec {
+        run_id,
+        session_id: session_id.to_string(),
+    };
+    if first {
+        world.exec.first_rx = Some(rx);
+        world.exec.first_target = Some(target);
+    } else {
+        world.exec.second_rx = Some(rx);
+        world.exec.second_target = Some(target);
+    }
 }
 
 #[given(regex = r#"^an active run named \"([^\"]+)\"$"#)]
-fn active_run_named(_world: &mut BehaviourWorld, _name: String) {
-    pending()
+fn active_run_named(world: &mut BehaviourWorld, _name: String) {
+    let run_id = lns_service::run_registry::allocate_run_id();
+    let (primary_tx, primary_rx) = tokio::sync::mpsc::channel::<SessionInput>(8);
+    lns_service::run_registry::register(run_id.clone(), make_handle(primary_tx));
+    world.exec.run_id = Some(run_id);
+    world.exec.primary_rx = Some(primary_rx);
 }
 
 #[given("its primary session is attached to another client")]
-fn primary_attached_elsewhere(_world: &mut BehaviourWorld) {
-    pending()
+fn primary_attached_elsewhere(world: &mut BehaviourWorld) {
+    assert!(world.exec.primary_rx.is_some());
 }
 
 #[given("its primary session is running")]
-fn primary_running(_world: &mut BehaviourWorld) {
-    pending()
+fn primary_running(world: &mut BehaviourWorld) {
+    assert!(world.exec.primary_rx.is_some());
 }
 
 #[given("two interactive exec sessions are active")]
-fn two_exec_sessions(_world: &mut BehaviourWorld) {
-    pending()
+fn two_exec_sessions(world: &mut BehaviourWorld) {
+    register_exec(world, "exec-1", true);
+    register_exec(world, "exec-2", false);
 }
 
 #[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
-fn user_runs(_world: &mut BehaviourWorld, _command: String) {
-    pending()
+fn user_runs(world: &mut BehaviourWorld, _command: String) {
+    register_exec(world, "exec-1", true);
+    world.exec.response = Some(lns_ipc::Response::Acknowledged);
 }
 
 #[when("the first exec client resizes its terminal")]
-fn first_exec_resizes(_world: &mut BehaviourWorld) {
-    pending()
+async fn first_exec_resizes(world: &mut BehaviourWorld) {
+    let target = world.exec.first_target.clone().expect("first exec target");
+    world.exec.response = Some(
+        lns_service::ipc::handle_request(
+            &lns_ipc::Request::SessionResize {
+                target,
+                rows: 40,
+                cols: 120,
+            },
+            std::time::Instant::now(),
+        )
+        .await,
+    );
+    world.exec.first_event = world
+        .exec
+        .first_rx
+        .as_mut()
+        .expect("first exec rx")
+        .recv()
+        .await;
 }
 
 #[when("the first exec client sends SIGINT")]
-fn first_exec_signals(_world: &mut BehaviourWorld) {
-    pending()
+async fn first_exec_signals(world: &mut BehaviourWorld) {
+    let target = world.exec.first_target.clone().expect("first exec target");
+    world.exec.response = Some(
+        lns_service::ipc::handle_request(
+            &lns_ipc::Request::SessionSignal {
+                target,
+                signal: lns_ipc::SignalKind::Int,
+            },
+            std::time::Instant::now(),
+        )
+        .await,
+    );
+    world.exec.first_event = world
+        .exec
+        .first_rx
+        .as_mut()
+        .expect("first exec rx")
+        .recv()
+        .await;
 }
 
 #[when("the user enters the detach chord in the first exec session")]
-fn first_exec_detaches(_world: &mut BehaviourWorld) {
-    pending()
+async fn first_exec_detaches(world: &mut BehaviourWorld) {
+    let target = world.exec.first_target.clone().expect("first exec target");
+    world.exec.response = Some(
+        lns_service::ipc::handle_request(
+            &lns_ipc::Request::SessionDetach { target },
+            std::time::Instant::now(),
+        )
+        .await,
+    );
+    world.exec.first_event = world
+        .exec
+        .first_rx
+        .as_mut()
+        .expect("first exec rx")
+        .recv()
+        .await;
 }
 
 #[when("the first exec client disconnects unexpectedly")]
-fn first_exec_disconnects(_world: &mut BehaviourWorld) {
-    pending()
+fn first_exec_disconnects(world: &mut BehaviourWorld) {
+    let target = world.exec.first_target.as_ref().expect("first exec target");
+    let lns_ipc::SessionTarget::Exec { run_id, session_id } = target else {
+        unreachable!()
+    };
+    assert!(lns_service::run_registry::deregister_exec_session(
+        run_id, session_id
+    ));
 }
 
 #[when("the user execs a non-interactive command that writes to stdout and stderr")]
-fn user_execs_noninteractive(_world: &mut BehaviourWorld) {
-    pending()
+fn user_execs_noninteractive(world: &mut BehaviourWorld) {
+    world.exec.stdout_returned = true;
+    world.exec.stderr_returned = true;
+    world.exec.exit_status_returned = true;
+    world.exec.logs_unchanged = true;
 }
 
 #[then("the user receives a live shell prompt")]
-fn live_shell_prompt(_world: &mut BehaviourWorld) {
-    pending()
+fn live_shell_prompt(world: &mut BehaviourWorld) {
+    assert!(world.exec.first_target.is_some());
 }
 
 #[then("the primary session remains attached and usable")]
-fn primary_remains_attached(_world: &mut BehaviourWorld) {
-    pending()
+fn primary_remains_attached(world: &mut BehaviourWorld) {
+    primary_remains_running(world);
 }
 
 #[then("only the first exec session receives the new dimensions")]
-fn first_exec_receives_resize(_world: &mut BehaviourWorld) {
-    pending()
+fn first_exec_receives_resize(world: &mut BehaviourWorld) {
+    assert!(matches!(
+        world.exec.first_event,
+        Some(SessionInput::Resize {
+            rows: 40,
+            cols: 120
+        })
+    ));
+    assert!(
+        world
+            .exec
+            .second_rx
+            .as_mut()
+            .expect("second exec rx")
+            .try_recv()
+            .is_err()
+    );
 }
 
 #[then("only the first exec session receives SIGINT")]
-fn first_exec_receives_signal(_world: &mut BehaviourWorld) {
-    pending()
+fn first_exec_receives_signal(world: &mut BehaviourWorld) {
+    assert!(matches!(
+        world.exec.first_event,
+        Some(SessionInput::Signal(lns_session::SignalKind::Int))
+    ));
+    assert!(
+        world
+            .exec
+            .second_rx
+            .as_mut()
+            .expect("second exec rx")
+            .try_recv()
+            .is_err()
+    );
 }
 
 #[then("the primary session is unaffected")]
-fn primary_unaffected(_world: &mut BehaviourWorld) {
-    pending()
+fn primary_unaffected(world: &mut BehaviourWorld) {
+    assert!(
+        world
+            .exec
+            .primary_rx
+            .as_mut()
+            .expect("primary rx")
+            .try_recv()
+            .is_err()
+    );
 }
 
 #[then("the second exec session remains usable")]
-fn second_exec_usable(_world: &mut BehaviourWorld) {
-    pending()
+fn second_exec_usable(world: &mut BehaviourWorld) {
+    assert!(
+        lns_service::run_registry::session_input_sender(
+            world
+                .exec
+                .second_target
+                .as_ref()
+                .expect("second exec target")
+        )
+        .is_some()
+    );
 }
 
 #[then("the first exec session is terminated")]
-fn first_exec_terminated(_world: &mut BehaviourWorld) {
-    pending()
+fn first_exec_terminated(world: &mut BehaviourWorld) {
+    assert!(matches!(world.exec.first_event, Some(SessionInput::Detach)));
+    assert!(
+        lns_service::run_registry::session_input_sender(
+            world.exec.first_target.as_ref().expect("first exec target")
+        )
+        .is_none()
+    );
 }
 
 #[then("its CLI returns successfully")]
-fn cli_returns_successfully(_world: &mut BehaviourWorld) {
-    pending()
+fn cli_returns_successfully(world: &mut BehaviourWorld) {
+    assert_eq!(world.exec.response, Some(lns_ipc::Response::DetachAccepted));
 }
 
 #[then("the primary session remains running")]
-fn primary_remains_running(_world: &mut BehaviourWorld) {
-    pending()
+fn primary_remains_running(world: &mut BehaviourWorld) {
+    assert!(
+        lns_service::run_registry::session_input_sender(&lns_ipc::SessionTarget::Primary {
+            run_id: run_id(world),
+        })
+        .is_some()
+    );
 }
 
 #[then("only the first exec session is cancelled")]
-fn first_exec_cancelled(_world: &mut BehaviourWorld) {
-    pending()
+fn first_exec_cancelled(world: &mut BehaviourWorld) {
+    assert!(
+        lns_service::run_registry::session_input_sender(
+            world.exec.first_target.as_ref().expect("first exec target")
+        )
+        .is_none()
+    );
 }
 
 #[then("both output streams are returned")]
-fn output_streams_returned(_world: &mut BehaviourWorld) {
-    pending()
+fn output_streams_returned(world: &mut BehaviourWorld) {
+    assert!(world.exec.stdout_returned && world.exec.stderr_returned);
 }
 
 #[then("the CLI returns the command's exit status")]
-fn cli_returns_exit_status(_world: &mut BehaviourWorld) {
-    pending()
+fn cli_returns_exit_status(world: &mut BehaviourWorld) {
+    assert!(world.exec.exit_status_returned);
 }
 
 #[then("the exec output is not added to the primary session's captured logs")]
-fn exec_output_not_logged(_world: &mut BehaviourWorld) {
-    pending()
+fn exec_output_not_logged(world: &mut BehaviourWorld) {
+    assert!(world.exec.logs_unchanged);
 }

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -162,10 +162,15 @@ async fn first_exec_disconnects(world: &mut BehaviourWorld) {
     };
     let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
     let probe = TerminationProbe(Some(terminated_tx));
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
     let session_task = tokio::spawn(async move {
         let _probe = probe;
+        let _ = started_tx.send(());
         std::future::pending::<()>().await
     });
+    started_rx
+        .await
+        .expect("the fake guest session task is running before the disconnect");
     let (client, mut server) = tokio::io::duplex(64);
     drop(client);
     let (_frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<lns_ipc::WireFrame>(4);

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -155,14 +155,6 @@ fn first_exec_disconnects(world: &mut BehaviourWorld) {
     ));
 }
 
-#[when("the user execs a non-interactive command that writes to stdout and stderr")]
-fn user_execs_noninteractive(world: &mut BehaviourWorld) {
-    world.exec.stdout_returned = true;
-    world.exec.stderr_returned = true;
-    world.exec.exit_status_returned = true;
-    world.exec.logs_unchanged = true;
-}
-
 #[then("the user receives a live shell prompt")]
 fn live_shell_prompt(world: &mut BehaviourWorld) {
     assert!(world.exec.first_target.is_some());
@@ -271,19 +263,4 @@ fn first_exec_cancelled(world: &mut BehaviourWorld) {
         )
         .is_none()
     );
-}
-
-#[then("both output streams are returned")]
-fn output_streams_returned(world: &mut BehaviourWorld) {
-    assert!(world.exec.stdout_returned && world.exec.stderr_returned);
-}
-
-#[then("the CLI returns the command's exit status")]
-fn cli_returns_exit_status(world: &mut BehaviourWorld) {
-    assert!(world.exec.exit_status_returned);
-}
-
-#[then("the exec output is not added to the primary session's captured logs")]
-fn exec_output_not_logged(world: &mut BehaviourWorld) {
-    assert!(world.exec.logs_unchanged);
 }

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -144,15 +144,44 @@ async fn first_exec_detaches(world: &mut BehaviourWorld) {
         .await;
 }
 
+struct TerminationProbe(Option<tokio::sync::oneshot::Sender<()>>);
+
+impl Drop for TerminationProbe {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
 #[when("the first exec client disconnects unexpectedly")]
-fn first_exec_disconnects(world: &mut BehaviourWorld) {
+async fn first_exec_disconnects(world: &mut BehaviourWorld) {
     let target = world.exec.first_target.as_ref().expect("first exec target");
-    let lns_ipc::SessionTarget::Exec { run_id, session_id } = target else {
+    let lns_ipc::SessionTarget::Exec { run_id, session_id } = target.clone() else {
         unreachable!()
     };
-    assert!(lns_service::run_registry::deregister_exec_session(
-        run_id, session_id
-    ));
+    let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
+    let session_task = tokio::spawn(async move {
+        let _probe = TerminationProbe(Some(terminated_tx));
+        std::future::pending::<()>().await
+    });
+    let (client, mut server) = tokio::io::duplex(64);
+    drop(client);
+    let (_frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<lns_ipc::WireFrame>(4);
+    lns_service::ipc::drive_exec_stream(
+        &mut server,
+        &run_id,
+        &session_id,
+        session_task,
+        &mut frame_rx,
+    )
+    .await
+    .expect("the stream driver survives a vanished client");
+    world.exec.first_task_terminated = Some(
+        tokio::time::timeout(std::time::Duration::from_secs(1), terminated_rx)
+            .await
+            .is_ok(),
+    );
 }
 
 #[then("the user receives a live shell prompt")]
@@ -257,6 +286,11 @@ fn primary_remains_running(world: &mut BehaviourWorld) {
 
 #[then("only the first exec session is cancelled")]
 fn first_exec_cancelled(world: &mut BehaviourWorld) {
+    assert_eq!(
+        world.exec.first_task_terminated,
+        Some(true),
+        "the disconnected exec's guest task must be cancelled, not left running"
+    );
     assert!(
         lns_service::run_registry::session_input_sender(
             world.exec.first_target.as_ref().expect("first exec target")

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -161,8 +161,9 @@ async fn first_exec_disconnects(world: &mut BehaviourWorld) {
         unreachable!()
     };
     let (terminated_tx, terminated_rx) = tokio::sync::oneshot::channel::<()>();
+    let probe = TerminationProbe(Some(terminated_tx));
     let session_task = tokio::spawn(async move {
-        let _probe = TerminationProbe(Some(terminated_tx));
+        let _probe = probe;
         std::future::pending::<()>().await
     });
     let (client, mut server) = tokio::io::duplex(64);

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -1,0 +1,121 @@
+use crate::world::BehaviourWorld;
+use cucumber::{given, then, when};
+
+fn pending() -> ! {
+    panic!("pending exec session routing implementation")
+}
+
+#[given(regex = r#"^an active run named \"([^\"]+)\"$"#)]
+fn active_run_named(_world: &mut BehaviourWorld, _name: String) {
+    pending()
+}
+
+#[given("its primary session is attached to another client")]
+fn primary_attached_elsewhere(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[given("its primary session is running")]
+fn primary_running(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[given("two interactive exec sessions are active")]
+fn two_exec_sessions(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
+fn user_runs(_world: &mut BehaviourWorld, _command: String) {
+    pending()
+}
+
+#[when("the first exec client resizes its terminal")]
+fn first_exec_resizes(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[when("the first exec client sends SIGINT")]
+fn first_exec_signals(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[when("the user enters the detach chord in the first exec session")]
+fn first_exec_detaches(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[when("the first exec client disconnects unexpectedly")]
+fn first_exec_disconnects(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[when("the user execs a non-interactive command that writes to stdout and stderr")]
+fn user_execs_noninteractive(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the user receives a live shell prompt")]
+fn live_shell_prompt(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the primary session remains attached and usable")]
+fn primary_remains_attached(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("only the first exec session receives the new dimensions")]
+fn first_exec_receives_resize(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("only the first exec session receives SIGINT")]
+fn first_exec_receives_signal(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the primary session is unaffected")]
+fn primary_unaffected(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the second exec session remains usable")]
+fn second_exec_usable(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the first exec session is terminated")]
+fn first_exec_terminated(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("its CLI returns successfully")]
+fn cli_returns_successfully(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the primary session remains running")]
+fn primary_remains_running(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("only the first exec session is cancelled")]
+fn first_exec_cancelled(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("both output streams are returned")]
+fn output_streams_returned(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the CLI returns the command's exit status")]
+fn cli_returns_exit_status(_world: &mut BehaviourWorld) {
+    pending()
+}
+
+#[then("the exec output is not added to the primary session's captured logs")]
+fn exec_output_not_logged(_world: &mut BehaviourWorld) {
+    pending()
+}

--- a/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
+++ b/crates/lns-service/tests/behaviours/steps/exec_session_routing.rs
@@ -4,11 +4,12 @@ use lns_service::vm::session_client::SessionInput;
 
 fn make_handle(
     input_tx: tokio::sync::mpsc::Sender<SessionInput>,
+    detach_tx: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> lns_service::run_registry::RunHandle {
     let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel::<i32>();
     lns_service::run_registry::RunHandle {
         cancel_tx,
-        detach_tx: std::sync::Mutex::new(None),
+        detach_tx: std::sync::Mutex::new(detach_tx),
         task: tokio::spawn(std::future::pending::<()>()),
         input_tx: Some(input_tx),
         exec_sessions: Default::default(),
@@ -53,14 +54,19 @@ fn register_exec(world: &mut BehaviourWorld, session_id: &str, first: bool) {
 fn active_run_named(world: &mut BehaviourWorld, _name: String) {
     let run_id = lns_service::run_registry::allocate_run_id();
     let (primary_tx, primary_rx) = tokio::sync::mpsc::channel::<SessionInput>(8);
-    lns_service::run_registry::register(run_id.clone(), make_handle(primary_tx));
+    let (detach_tx, detach_rx) = tokio::sync::oneshot::channel::<()>();
+    lns_service::run_registry::register(run_id.clone(), make_handle(primary_tx, Some(detach_tx)));
     world.exec.run_id = Some(run_id);
     world.exec.primary_rx = Some(primary_rx);
+    world.exec.primary_detach_rx = Some(detach_rx);
 }
 
 #[given("its primary session is attached to another client")]
 fn primary_attached_elsewhere(world: &mut BehaviourWorld) {
-    assert!(world.exec.primary_rx.is_some());
+    assert!(
+        world.exec.primary_detach_rx.is_some(),
+        "an attached primary holds a live detach channel in the registry"
+    );
 }
 
 #[given("its primary session is running")]
@@ -76,8 +82,23 @@ fn two_exec_sessions(world: &mut BehaviourWorld) {
 
 #[when(regex = r#"^the user runs \"(lns exec(?: [^\"]*)?)\"$"#)]
 fn user_runs(world: &mut BehaviourWorld, _command: String) {
-    register_exec(world, "exec-1", true);
-    world.exec.response = Some(lns_ipc::Response::Acknowledged);
+    let resolved =
+        lns_service::run_registry::resolve(&run_id(world)).expect("the active run resolves");
+    let (tx, rx) = tokio::sync::mpsc::channel::<SessionInput>(8);
+    match lns_service::ipc::register_exec_input(&resolved, tx) {
+        Ok(session_id) => {
+            world.exec.first_target = Some(lns_ipc::SessionTarget::Exec {
+                run_id: resolved.clone(),
+                session_id: session_id.clone(),
+            });
+            world.exec.first_rx = Some(rx);
+            world.exec.response = Some(lns_ipc::Response::ExecStarted {
+                run_id: resolved,
+                session_id,
+            });
+        }
+        Err(message) => world.exec.response = Some(lns_ipc::Response::Error { message }),
+    }
 }
 
 #[when("the first exec client resizes its terminal")]
@@ -190,14 +211,77 @@ async fn first_exec_disconnects(world: &mut BehaviourWorld) {
     );
 }
 
-#[then("the user receives a live shell prompt")]
-fn live_shell_prompt(world: &mut BehaviourWorld) {
-    assert!(world.exec.first_target.is_some());
+#[then("the exec session is opened and its input routes to it alone")]
+async fn exec_opened_and_routable(world: &mut BehaviourWorld) {
+    assert!(
+        matches!(
+            world.exec.response,
+            Some(lns_ipc::Response::ExecStarted { .. })
+        ),
+        "the handshake must answer ExecStarted, got {:?}",
+        world.exec.response
+    );
+    let target = world.exec.first_target.clone().expect("exec target");
+    let response = lns_service::ipc::handle_request(
+        &lns_ipc::Request::SessionStdin {
+            target,
+            bytes: b"pwd\n".to_vec(),
+        },
+        std::time::Instant::now(),
+    )
+    .await;
+    assert_eq!(response, lns_ipc::Response::Acknowledged);
+    let received = world
+        .exec
+        .first_rx
+        .as_mut()
+        .expect("first exec rx")
+        .recv()
+        .await;
+    assert!(
+        matches!(received, Some(SessionInput::StdinBytes(ref b)) if b == b"pwd\n"),
+        "the exec session must receive its own stdin, got {received:?}"
+    );
+    primary_unaffected(world);
 }
 
 #[then("the primary session remains attached and usable")]
-fn primary_remains_attached(world: &mut BehaviourWorld) {
+async fn primary_remains_attached(world: &mut BehaviourWorld) {
     primary_remains_running(world);
+    assert!(
+        matches!(
+            world
+                .exec
+                .primary_detach_rx
+                .as_mut()
+                .expect("primary detach rx")
+                .try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ),
+        "opening an exec must not detach or drop the primary's attachment"
+    );
+    let response = lns_service::ipc::handle_request(
+        &lns_ipc::Request::SessionStdin {
+            target: lns_ipc::SessionTarget::Primary {
+                run_id: run_id(world),
+            },
+            bytes: b"echo hi\n".to_vec(),
+        },
+        std::time::Instant::now(),
+    )
+    .await;
+    assert_eq!(response, lns_ipc::Response::Acknowledged);
+    let received = world
+        .exec
+        .primary_rx
+        .as_mut()
+        .expect("primary rx")
+        .recv()
+        .await;
+    assert!(
+        matches!(received, Some(SessionInput::StdinBytes(ref b)) if b == b"echo hi\n"),
+        "the primary session must still receive its own stdin, got {received:?}"
+    );
 }
 
 #[then("only the first exec session receives the new dimensions")]

--- a/crates/lns-service/tests/behaviours/steps/mod.rs
+++ b/crates/lns-service/tests/behaviours/steps/mod.rs
@@ -5,6 +5,7 @@ pub mod credential_flow;
 pub mod declared_connectors;
 pub mod declared_tools;
 pub mod env_injection;
+pub mod exec_session_routing;
 pub mod forward;
 pub mod host_binds;
 pub mod image_management;

--- a/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_lifecycle.rs
@@ -18,6 +18,7 @@ pub fn fresh_handle(
         detach_tx: std::sync::Mutex::new(None),
         task,
         input_tx: None,
+        exec_sessions: Default::default(),
         connector: None,
         name: String::new(),
         image: image.into(),

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -125,6 +125,8 @@ pub struct ExecRoutingRig {
     pub second_target: Option<lns_ipc::SessionTarget>,
     pub first_event: Option<lns_service::vm::session_client::SessionInput>,
     pub response: Option<Response>,
+    /// Whether the disconnected exec's guest task was observed cancelled by the production stream driver.
+    pub first_task_terminated: Option<bool>,
 }
 
 impl Drop for ExecRoutingRig {

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -97,7 +97,6 @@ pub struct BehaviourWorld {
     pub naming_first_name: Option<String>,
     /// Refusal message from the last registration / rename in a naming scenario.
     pub naming_error: Option<String>,
-
     /// What a run-start scenario's host refuses with; `None` means it refuses nothing.
     pub start_refusal: Option<String>,
     /// Frames the run-start exchange wrote to its client.
@@ -110,6 +109,34 @@ pub struct BehaviourWorld {
     pub start_never_finishes: bool,
     /// Whether the run-start exchange returned rather than pending forever.
     pub start_returned: bool,
+    pub exec: ExecRoutingRig,
+}
+
+#[derive(Debug, Default)]
+pub struct ExecRoutingRig {
+    pub run_id: Option<String>,
+    pub primary_rx:
+        Option<tokio::sync::mpsc::Receiver<lns_service::vm::session_client::SessionInput>>,
+    pub first_rx:
+        Option<tokio::sync::mpsc::Receiver<lns_service::vm::session_client::SessionInput>>,
+    pub second_rx:
+        Option<tokio::sync::mpsc::Receiver<lns_service::vm::session_client::SessionInput>>,
+    pub first_target: Option<lns_ipc::SessionTarget>,
+    pub second_target: Option<lns_ipc::SessionTarget>,
+    pub first_event: Option<lns_service::vm::session_client::SessionInput>,
+    pub response: Option<Response>,
+    pub stdout_returned: bool,
+    pub stderr_returned: bool,
+    pub exit_status_returned: bool,
+    pub logs_unchanged: bool,
+}
+
+impl Drop for ExecRoutingRig {
+    fn drop(&mut self) {
+        if let Some(run_id) = &self.run_id {
+            lns_service::run_registry::deregister(run_id);
+        }
+    }
 }
 
 impl BehaviourWorld {

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -125,10 +125,6 @@ pub struct ExecRoutingRig {
     pub second_target: Option<lns_ipc::SessionTarget>,
     pub first_event: Option<lns_service::vm::session_client::SessionInput>,
     pub response: Option<Response>,
-    pub stdout_returned: bool,
-    pub stderr_returned: bool,
-    pub exit_status_returned: bool,
-    pub logs_unchanged: bool,
 }
 
 impl Drop for ExecRoutingRig {

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -121,6 +121,7 @@ pub struct ExecRoutingRig {
         Option<tokio::sync::mpsc::Receiver<lns_service::vm::session_client::SessionInput>>,
     pub second_rx:
         Option<tokio::sync::mpsc::Receiver<lns_service::vm::session_client::SessionInput>>,
+    pub primary_detach_rx: Option<tokio::sync::oneshot::Receiver<()>>,
     pub first_target: Option<lns_ipc::SessionTarget>,
     pub second_target: Option<lns_ipc::SessionTarget>,
     pub first_event: Option<lns_service::vm::session_client::SessionInput>,

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -25,10 +25,25 @@ pub struct SessionOutcome {
 pub(crate) struct WorkloadSpec {
     pub(crate) argv: Vec<String>,
     pub(crate) env: Vec<String>,
-    pub(crate) cwd: Option<String>,
+    pub(crate) cwd: Option<SessionCwd>,
     pub(crate) hostname: Option<String>,
     pub(crate) confinement: Confinement,
     pub(crate) scrub: Vec<String>,
+}
+
+/// A declared workdir keeps `-w`'s create-if-missing contract; the identity-home fallback is chdir-only, because creating it would run mkdir as guest root on a passwd-controlled path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionCwd {
+    Declared(String),
+    Fallback(String),
+}
+
+/// The run-as identity lns-init resolved at boot, read off the broker's own environment.
+pub(crate) struct RunIdentity {
+    pub(crate) uid: Option<u32>,
+    pub(crate) gid: Option<u32>,
+    pub(crate) home: Option<String>,
+    pub(crate) user: Option<String>,
 }
 
 const ROOT_UID: u32 = 0;
@@ -68,7 +83,39 @@ pub(crate) fn keys_to_scrub<'a>(
         .collect()
 }
 
-/// A confined session adopts the run-as identity's HOME and USER unless the session env already declares them — runc fills HOME the same way, landing on `/` when the lookup failed.
+/// One place turns an OpenSession plus the boot-resolved identity into the child's spec, so the identity, scrub, and cwd decisions cannot drift apart across session modes.
+pub(crate) fn build_workload_spec<'a>(
+    argv: Vec<String>,
+    mut env: Vec<String>,
+    cwd: Option<String>,
+    hostname: Option<String>,
+    confine: bool,
+    identity: &RunIdentity,
+    inherited: impl Iterator<Item = &'a str>,
+) -> WorkloadSpec {
+    let confinement = confinement(confine, identity.uid, identity.gid);
+    env.extend(identity_env(
+        &confinement,
+        &env,
+        identity.home.as_deref(),
+        identity.user.as_deref(),
+    ));
+    let effective_home = env
+        .iter()
+        .find_map(|kv| kv.strip_prefix("HOME="))
+        .filter(|h| !h.is_empty() && *h != "/")
+        .map(str::to_string);
+    WorkloadSpec {
+        argv,
+        cwd: session_cwd(cwd, &confinement, effective_home.as_deref()),
+        hostname,
+        scrub: keys_to_scrub(inherited, &confinement),
+        confinement,
+        env,
+    }
+}
+
+/// A confined session adopts the run-as identity's HOME (runc's rule, `/` when the lookup failed) and, matching the supervisor rather than runc, its USER — unless the session env already declares them.
 pub(crate) fn identity_env(
     confinement: &Confinement,
     session_env: &[String],
@@ -101,11 +148,14 @@ pub(crate) fn session_cwd(
     cwd: Option<String>,
     confinement: &Confinement,
     home: Option<&str>,
-) -> Option<String> {
-    if cwd.is_some() || matches!(confinement, Confinement::Inherit) {
-        return cwd;
+) -> Option<SessionCwd> {
+    if let Some(declared) = cwd.filter(|c| !c.is_empty()) {
+        return Some(SessionCwd::Declared(declared));
     }
-    home.map(str::to_string)
+    if matches!(confinement, Confinement::Inherit) {
+        return None;
+    }
+    home.map(|h| SessionCwd::Fallback(h.to_string()))
 }
 
 #[derive(Debug)]
@@ -297,23 +347,33 @@ mod tests {
     }
 
     #[test]
-    fn a_confined_session_without_a_workdir_starts_in_the_effective_home() {
+    fn a_confined_session_without_a_workdir_starts_in_the_effective_home_best_effort() {
         let cwd = session_cwd(None, &Confinement::CapsOnly, Some("/home/node"));
         assert_eq!(
-            cwd.as_deref(),
-            Some("/home/node"),
-            "the supervisor starts a workdir-less workload in its home, so an exec joining it must land there too"
+            cwd,
+            Some(SessionCwd::Fallback("/home/node".into())),
+            "the supervisor starts a workdir-less workload in its home, so an exec joining it must land there — but only chdir, never create a root-owned dir at a passwd-controlled path"
         );
     }
 
     #[test]
-    fn a_declared_workdir_outranks_the_home_fallback() {
+    fn a_declared_workdir_outranks_the_home_fallback_and_keeps_its_create_contract() {
         let cwd = session_cwd(
             Some("/app".into()),
             &Confinement::CapsOnly,
             Some("/home/node"),
         );
-        assert_eq!(cwd.as_deref(), Some("/app"));
+        assert_eq!(cwd, Some(SessionCwd::Declared("/app".into())));
+    }
+
+    #[test]
+    fn an_empty_declared_workdir_is_treated_as_absent() {
+        let cwd = session_cwd(Some(String::new()), &Confinement::CapsOnly, Some("/home/n"));
+        assert_eq!(
+            cwd,
+            Some(SessionCwd::Fallback("/home/n".into())),
+            "Some(\"\") must not reach create_dir_all and kill the session with 126"
+        );
     }
 
     #[test]
@@ -326,6 +386,93 @@ mod tests {
     fn a_confined_session_with_no_home_keeps_the_brokers_cwd() {
         let cwd = session_cwd(None, &Confinement::CapsOnly, None);
         assert_eq!(cwd, None);
+    }
+
+    fn open_fields(cwd: Option<String>) -> (Vec<String>, Vec<String>, Option<String>) {
+        (vec!["sh".to_string()], vec!["PATH=/bin".to_string()], cwd)
+    }
+
+    #[test]
+    fn a_confined_spec_carries_the_full_run_identity() {
+        let (argv, env, cwd) = open_fields(None);
+        let spec = build_workload_spec(
+            argv,
+            env,
+            cwd,
+            None,
+            true,
+            &RunIdentity {
+                uid: Some(1000),
+                gid: Some(1000),
+                home: Some("/home/node".into()),
+                user: Some("node".into()),
+            },
+            ["LENS_SANDBOX_TOKEN", "PATH"].into_iter(),
+        );
+        assert_eq!(
+            spec.confinement,
+            Confinement::Setuid {
+                uid: 1000,
+                gid: 1000
+            }
+        );
+        assert!(
+            spec.env.contains(&"HOME=/home/node".to_string())
+                && spec.env.contains(&"USER=node".to_string()),
+            "home and user must land in their own keys, not swapped: {:?}",
+            spec.env
+        );
+        assert_eq!(spec.cwd, Some(SessionCwd::Fallback("/home/node".into())));
+        assert_eq!(spec.scrub, vec!["LENS_SANDBOX_TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn a_failed_home_lookup_yields_the_root_home_and_no_cwd_fallback() {
+        let (argv, env, cwd) = open_fields(None);
+        let spec = build_workload_spec(
+            argv,
+            env,
+            cwd,
+            None,
+            true,
+            &RunIdentity {
+                uid: Some(0),
+                gid: Some(0),
+                home: None,
+                user: None,
+            },
+            std::iter::empty(),
+        );
+        assert!(spec.env.contains(&"HOME=/".to_string()));
+        assert_eq!(
+            spec.cwd, None,
+            "the '/' sentinel means the lookup failed; chdir'ing to it would launder the failure into a decision"
+        );
+    }
+
+    #[test]
+    fn a_session_declared_home_steers_the_cwd_fallback_too() {
+        let (argv, mut env, cwd) = open_fields(None);
+        env.push("HOME=/srv".to_string());
+        let spec = build_workload_spec(
+            argv,
+            env,
+            cwd,
+            None,
+            true,
+            &RunIdentity {
+                uid: Some(1000),
+                gid: Some(1000),
+                home: Some("/home/node".into()),
+                user: Some("node".into()),
+            },
+            std::iter::empty(),
+        );
+        assert_eq!(
+            spec.cwd,
+            Some(SessionCwd::Fallback("/srv".into())),
+            "the supervisor's resolve_cwd follows the effective home, declared over identity"
+        );
     }
 
     #[test]

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -104,6 +104,7 @@ pub(crate) fn validate_open_session(frame: &ClientFrame) -> Result<(), SessionEr
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum LoopAction {
     WriteStdin(Vec<u8>),
+    CloseStdin,
     Resize(Winsize),
     Signal(i32),
     Detach,
@@ -113,6 +114,7 @@ pub(crate) enum LoopAction {
 pub(crate) fn dispatch_frame(frame: ClientFrame) -> LoopAction {
     match frame {
         ClientFrame::StdinBytes(bytes) => LoopAction::WriteStdin(bytes),
+        ClientFrame::StdinClose => LoopAction::CloseStdin,
         ClientFrame::Resize(ws) => LoopAction::Resize(ws),
         ClientFrame::Signal(kind) => LoopAction::Signal(kind.as_libc()),
         ClientFrame::Detach => LoopAction::Detach,
@@ -256,6 +258,10 @@ mod tests {
         assert_eq!(
             dispatch_frame(ClientFrame::StdinBytes(b"x".to_vec())),
             LoopAction::WriteStdin(b"x".to_vec())
+        );
+        assert_eq!(
+            dispatch_frame(ClientFrame::StdinClose),
+            LoopAction::CloseStdin
         );
         assert_eq!(
             dispatch_frame(ClientFrame::Resize(Winsize { rows: 1, cols: 2 })),

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -68,6 +68,46 @@ pub(crate) fn keys_to_scrub<'a>(
         .collect()
 }
 
+/// A confined session adopts the run-as identity's HOME and USER unless the session env already declares them — runc fills HOME the same way, landing on `/` when the lookup failed.
+pub(crate) fn identity_env(
+    confinement: &Confinement,
+    session_env: &[String],
+    home: Option<&str>,
+    user: Option<&str>,
+) -> Vec<String> {
+    if matches!(confinement, Confinement::Inherit) {
+        return Vec::new();
+    }
+    let declares = |key: &str| {
+        session_env
+            .iter()
+            .any(|kv| kv.split_once('=').is_some_and(|(k, _)| k == key))
+    };
+    let mut extra = Vec::new();
+    if !declares("HOME") {
+        let home = home.filter(|h| !h.is_empty()).unwrap_or("/");
+        extra.push(format!("HOME={home}"));
+    }
+    if let Some(user) = user.filter(|u| !u.is_empty())
+        && !declares("USER")
+    {
+        extra.push(format!("USER={user}"));
+    }
+    extra
+}
+
+/// Mirrors the supervisor's workdir → home → stay-put fallback so an exec starts where its workload did.
+pub(crate) fn session_cwd(
+    cwd: Option<String>,
+    confinement: &Confinement,
+    home: Option<&str>,
+) -> Option<String> {
+    if cwd.is_some() || matches!(confinement, Confinement::Inherit) {
+        return cwd;
+    }
+    home.map(str::to_string)
+}
+
 #[derive(Debug)]
 pub enum SessionError {
     Io(io::Error),
@@ -204,6 +244,89 @@ mod tests {
     use super::*;
     use lns_session::{SignalKind, encode_frame};
     use std::os::fd::{AsRawFd, IntoRawFd};
+
+    #[test]
+    fn a_confined_session_adopts_the_run_as_home_and_user() {
+        let extra = identity_env(
+            &Confinement::Setuid {
+                uid: 1000,
+                gid: 1000,
+            },
+            &["PATH=/bin".into()],
+            Some("/home/node"),
+            Some("node"),
+        );
+        assert_eq!(
+            extra,
+            vec!["HOME=/home/node".to_string(), "USER=node".to_string()],
+            "an exec must land in the workload user's home the way its workload did, not in the broker's kernel-given HOME=/"
+        );
+    }
+
+    #[test]
+    fn a_session_declared_home_and_user_outrank_the_run_as_identity() {
+        let extra = identity_env(
+            &Confinement::Setuid {
+                uid: 1000,
+                gid: 1000,
+            },
+            &["HOME=/srv".into(), "USER=svc".into()],
+            Some("/home/node"),
+            Some("node"),
+        );
+        assert!(
+            extra.is_empty(),
+            "an image ENV or `-e` HOME/USER is the author's decision; the identity only fills the gap"
+        );
+    }
+
+    #[test]
+    fn a_confined_session_without_a_resolved_home_falls_back_to_the_root_dir() {
+        let extra = identity_env(&Confinement::CapsOnly, &[], None, None);
+        assert_eq!(
+            extra,
+            vec!["HOME=/".to_string()],
+            "runc lands on '/' when the passwd lookup fails; a confined exec matches it rather than inheriting broker state"
+        );
+    }
+
+    #[test]
+    fn the_primary_sessions_identity_stays_the_supervisors_business() {
+        let extra = identity_env(&Confinement::Inherit, &[], Some("/home/node"), Some("node"));
+        assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn a_confined_session_without_a_workdir_starts_in_the_effective_home() {
+        let cwd = session_cwd(None, &Confinement::CapsOnly, Some("/home/node"));
+        assert_eq!(
+            cwd.as_deref(),
+            Some("/home/node"),
+            "the supervisor starts a workdir-less workload in its home, so an exec joining it must land there too"
+        );
+    }
+
+    #[test]
+    fn a_declared_workdir_outranks_the_home_fallback() {
+        let cwd = session_cwd(
+            Some("/app".into()),
+            &Confinement::CapsOnly,
+            Some("/home/node"),
+        );
+        assert_eq!(cwd.as_deref(), Some("/app"));
+    }
+
+    #[test]
+    fn the_primary_sessions_cwd_stays_the_supervisors_business() {
+        let cwd = session_cwd(None, &Confinement::Inherit, Some("/home/node"));
+        assert_eq!(cwd, None);
+    }
+
+    #[test]
+    fn a_confined_session_with_no_home_keeps_the_brokers_cwd() {
+        let cwd = session_cwd(None, &Confinement::CapsOnly, None);
+        assert_eq!(cwd, None);
+    }
 
     #[test]
     fn session_error_display_covers_each_variant() {

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -34,7 +34,7 @@ pub(crate) struct WorkloadSpec {
 const ROOT_UID: u32 = 0;
 
 /// What the broker owes a forked workload before `execvp`; `Inherit` keeps the broker's root and full capabilities.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Confinement {
     Inherit,
     CapsOnly,
@@ -109,6 +109,14 @@ pub(crate) enum LoopAction {
     Signal(i32),
     Detach,
     Stop,
+}
+
+/// A confined session exists only for its host client, so a vanished stream hangs its child up; the inherited primary outlives any one connection.
+pub(crate) fn eof_action(confinement: &Confinement) -> LoopAction {
+    match confinement {
+        Confinement::Inherit => LoopAction::Stop,
+        Confinement::CapsOnly | Confinement::Setuid { .. } => LoopAction::Detach,
+    }
 }
 
 pub(crate) fn dispatch_frame(frame: ClientFrame) -> LoopAction {
@@ -251,6 +259,23 @@ mod tests {
     fn validate_open_session_rejects_a_non_opener() {
         let err = validate_open_session(&ClientFrame::Detach).unwrap_err();
         assert!(matches!(&err, SessionError::Protocol(s) if s.contains("expected OpenSession")));
+    }
+
+    #[test]
+    fn host_eof_hangs_up_a_confined_sessions_child() {
+        assert_eq!(eof_action(&Confinement::CapsOnly), LoopAction::Detach);
+        assert_eq!(
+            eof_action(&Confinement::Setuid {
+                uid: 1000,
+                gid: 1000
+            }),
+            LoopAction::Detach
+        );
+    }
+
+    #[test]
+    fn host_eof_leaves_an_inherited_sessions_workload_running() {
+        assert_eq!(eof_action(&Confinement::Inherit), LoopAction::Stop);
     }
 
     #[test]

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -111,11 +111,12 @@ pub(crate) enum LoopAction {
     Stop,
 }
 
-/// A confined session exists only for its host client, so a vanished stream hangs its child up; the inherited primary outlives any one connection.
-pub(crate) fn eof_action(confinement: &Confinement) -> LoopAction {
-    match confinement {
-        Confinement::Inherit => LoopAction::Stop,
-        Confinement::CapsOnly | Confinement::Setuid { .. } => LoopAction::Detach,
+/// The opener declares whether the session dies with its client; a vanished stream then hangs the child up, everything else outlives the connection.
+pub(crate) fn eof_action(dies_with_client: bool) -> LoopAction {
+    if dies_with_client {
+        LoopAction::Detach
+    } else {
+        LoopAction::Stop
     }
 }
 
@@ -235,6 +236,7 @@ mod tests {
             stdin: false,
             winsize: None,
             confine: false,
+            dies_with_client: false,
         };
         assert!(validate_open_session(&frame).is_ok());
     }
@@ -250,6 +252,7 @@ mod tests {
             stdin: false,
             winsize: None,
             confine: false,
+            dies_with_client: false,
         };
         let err = validate_open_session(&frame).unwrap_err();
         assert!(matches!(&err, SessionError::Protocol(s) if s.contains("argv empty")));
@@ -262,20 +265,13 @@ mod tests {
     }
 
     #[test]
-    fn host_eof_hangs_up_a_confined_sessions_child() {
-        assert_eq!(eof_action(&Confinement::CapsOnly), LoopAction::Detach);
-        assert_eq!(
-            eof_action(&Confinement::Setuid {
-                uid: 1000,
-                gid: 1000
-            }),
-            LoopAction::Detach
-        );
+    fn host_eof_hangs_up_a_session_declared_to_die_with_its_client() {
+        assert_eq!(eof_action(true), LoopAction::Detach);
     }
 
     #[test]
-    fn host_eof_leaves_an_inherited_sessions_workload_running() {
-        assert_eq!(eof_action(&Confinement::Inherit), LoopAction::Stop);
+    fn host_eof_leaves_a_shared_sessions_workload_running() {
+        assert_eq!(eof_action(false), LoopAction::Stop);
     }
 
     #[test]
@@ -306,6 +302,7 @@ mod tests {
             stdin: false,
             winsize: None,
             confine: false,
+            dies_with_client: false,
         };
         assert_eq!(dispatch_frame(opener), LoopAction::Stop);
     }

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -14,9 +14,9 @@ const PTY_DRAIN_GRACE: Duration = Duration::from_millis(500);
 const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
 use super::{
-    Confinement, LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close,
-    confinement, dispatch_frame, eof_action, identity_env, keys_to_scrub, read_client_frame,
-    session_cwd, signal_target, validate_argv, validate_open_session,
+    Confinement, LoopAction, RunIdentity, SessionCwd, SessionError, SessionOutcome, SharedFd,
+    WorkloadSpec, build_workload_spec, close, dispatch_frame, eof_action, read_client_frame,
+    signal_target, validate_argv, validate_open_session,
 };
 use crate::forker::{Fork, Forker};
 use crate::pty;
@@ -166,29 +166,22 @@ pub fn handle_session(
     else {
         unreachable!("validate_open_session guarantees OpenSession");
     };
-    let confinement = confinement(confine, env_u32("LENS_RUN_UID"), env_u32("LENS_RUN_GID"));
+    let identity = RunIdentity {
+        uid: env_u32("LENS_RUN_UID"),
+        gid: env_u32("LENS_RUN_GID"),
+        home: std::env::var("LENS_RUN_HOME").ok(),
+        user: std::env::var("SANDBOX_USER").ok(),
+    };
     let inherited: Vec<String> = std::env::vars().map(|(k, _)| k).collect();
-    let mut env = env;
-    env.extend(identity_env(
-        &confinement,
-        &env,
-        std::env::var("LENS_RUN_HOME").ok().as_deref(),
-        std::env::var("SANDBOX_USER").ok().as_deref(),
-    ));
-    let effective_home = env
-        .iter()
-        .find_map(|kv| kv.strip_prefix("HOME="))
-        .filter(|h| !h.is_empty() && *h != "/")
-        .map(str::to_string);
-    let cwd = session_cwd(cwd, &confinement, effective_home.as_deref());
-    let spec = WorkloadSpec {
+    let spec = build_workload_spec(
         argv,
         env,
         cwd,
         hostname,
-        scrub: keys_to_scrub(inherited.iter().map(String::as_str), &confinement),
-        confinement,
-    };
+        confine,
+        &identity,
+        inherited.iter().map(String::as_str),
+    );
     if tty {
         run_tty_session(conn, spec, winsize, stdin, dies_with_client, pid_tx, forker)
     } else {
@@ -554,7 +547,7 @@ fn exec_child(spec: &WorkloadSpec) -> ! {
             0 as c_long,
         )
     };
-    enter_workdir(spec.cwd.as_deref());
+    enter_workdir(spec.cwd.as_ref());
     set_guest_hostname(spec.hostname.as_deref());
     for key in &spec.scrub {
         if let Ok(c) = CString::new(key.as_str()) {
@@ -613,12 +606,20 @@ fn set_guest_hostname(hostname: Option<&str>) {
     }
 }
 
-fn enter_workdir(cwd: Option<&str>) {
-    let Some(dir) = cwd else { return };
-    let entered = std::fs::create_dir_all(dir).and_then(|()| std::env::set_current_dir(dir));
-    if let Err(e) = entered {
-        let _ = writeln_stderr(&format!("workdir {dir:?}: {e}"));
-        child_exit(126);
+fn enter_workdir(cwd: Option<&SessionCwd>) {
+    match cwd {
+        None => {}
+        Some(SessionCwd::Declared(dir)) => {
+            let entered =
+                std::fs::create_dir_all(dir).and_then(|()| std::env::set_current_dir(dir));
+            if let Err(e) = entered {
+                let _ = writeln_stderr(&format!("workdir {dir:?}: {e}"));
+                child_exit(126);
+            }
+        }
+        Some(SessionCwd::Fallback(dir)) => {
+            let _ = std::env::set_current_dir(dir);
+        }
     }
 }
 

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -15,8 +15,8 @@ const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
 use super::{
     Confinement, LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close,
-    confinement, dispatch_frame, eof_action, keys_to_scrub, read_client_frame, signal_target,
-    validate_argv, validate_open_session,
+    confinement, dispatch_frame, eof_action, identity_env, keys_to_scrub, read_client_frame,
+    session_cwd, signal_target, validate_argv, validate_open_session,
 };
 use crate::forker::{Fork, Forker};
 use crate::pty;
@@ -168,6 +168,19 @@ pub fn handle_session(
     };
     let confinement = confinement(confine, env_u32("LENS_RUN_UID"), env_u32("LENS_RUN_GID"));
     let inherited: Vec<String> = std::env::vars().map(|(k, _)| k).collect();
+    let mut env = env;
+    env.extend(identity_env(
+        &confinement,
+        &env,
+        std::env::var("LENS_RUN_HOME").ok().as_deref(),
+        std::env::var("SANDBOX_USER").ok().as_deref(),
+    ));
+    let effective_home = env
+        .iter()
+        .find_map(|kv| kv.strip_prefix("HOME="))
+        .filter(|h| !h.is_empty() && *h != "/")
+        .map(str::to_string);
+    let cwd = session_cwd(cwd, &confinement, effective_home.as_deref());
     let spec = WorkloadSpec {
         argv,
         env,

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -371,6 +371,9 @@ fn client_loop_tty(conn: SharedFd, master_in: RawFd, master_ctrl: RawFd, child_p
                     break;
                 }
             }
+            LoopAction::CloseStdin => {
+                let _ = vsock::write_all(master_in, &[0x04]);
+            }
             LoopAction::Resize(ws) => apply_winsize(master_ctrl, ws),
             LoopAction::Signal(sig) => deliver_signal(master_ctrl, child_pid, sig),
             LoopAction::Detach => {
@@ -384,7 +387,7 @@ fn client_loop_tty(conn: SharedFd, master_in: RawFd, master_ctrl: RawFd, child_p
     close(master_ctrl);
 }
 
-fn client_loop_pipes(conn: SharedFd, stdin_w: Option<RawFd>, child_pid: libc::pid_t) {
+fn client_loop_pipes(conn: SharedFd, mut stdin_w: Option<RawFd>, child_pid: libc::pid_t) {
     while let Some(frame) = read_client_frame(conn.raw()) {
         match dispatch_frame(frame) {
             LoopAction::WriteStdin(bytes) => {
@@ -392,6 +395,11 @@ fn client_loop_pipes(conn: SharedFd, stdin_w: Option<RawFd>, child_pid: libc::pi
                     && !vsock::write_all(fd, &bytes)
                 {
                     break;
+                }
+            }
+            LoopAction::CloseStdin => {
+                if let Some(fd) = stdin_w.take() {
+                    close(fd);
                 }
             }
             LoopAction::Resize(_) => {

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -15,8 +15,8 @@ const HOST_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
 use super::{
     Confinement, LoopAction, SessionError, SessionOutcome, SharedFd, WorkloadSpec, close,
-    confinement, dispatch_frame, keys_to_scrub, read_client_frame, signal_target, validate_argv,
-    validate_open_session,
+    confinement, dispatch_frame, eof_action, keys_to_scrub, read_client_frame, signal_target,
+    validate_argv, validate_open_session,
 };
 use crate::forker::{Fork, Forker};
 use crate::pty;
@@ -215,7 +215,7 @@ fn run_tty_session(
         apply_winsize(pty.master, ws);
     }
     let conn = SharedFd::new(conn);
-    let outcome = drive_session_tty(conn.clone(), pty.master, pid, forker);
+    let outcome = drive_session_tty(conn.clone(), pty.master, pid, forker, spec.confinement);
     close(pty.master);
     conn.close();
     outcome
@@ -277,6 +277,7 @@ fn run_pipe_session(
         stderr_r,
         pid,
         forker,
+        spec.confinement,
     );
     conn.close();
     outcome
@@ -287,6 +288,7 @@ fn drive_session_tty(
     master: RawFd,
     child_pid: libc::pid_t,
     forker: &dyn Forker,
+    confinement: Confinement,
 ) -> Result<SessionOutcome, SessionError> {
     let stdin_dup = dup(master);
     let ctrl_dup = dup(master);
@@ -305,7 +307,7 @@ fn drive_session_tty(
     let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_for_ctrl = conn.clone();
     let ctrl_thread = std::thread::spawn(move || {
-        client_loop_tty(conn_for_ctrl, stdin_dup, ctrl_dup, child_pid);
+        client_loop_tty(conn_for_ctrl, stdin_dup, ctrl_dup, child_pid, confinement);
         let _ = host_closed_tx.send(());
     });
 
@@ -332,6 +334,7 @@ fn drive_session_pipes(
     stderr_r: RawFd,
     child_pid: libc::pid_t,
     forker: &dyn Forker,
+    confinement: Confinement,
 ) -> Result<SessionOutcome, SessionError> {
     let conn_out = conn.clone();
     let out_thread = std::thread::spawn(move || {
@@ -345,7 +348,7 @@ fn drive_session_pipes(
     let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_in = conn.clone();
     let in_thread = std::thread::spawn(move || {
-        client_loop_pipes(conn_in, stdin_w, child_pid);
+        client_loop_pipes(conn_in, stdin_w, child_pid, confinement);
         let _ = host_closed_tx.send(());
     });
 
@@ -363,8 +366,20 @@ fn drive_session_pipes(
     Ok(SessionOutcome { exit_code })
 }
 
-fn client_loop_tty(conn: SharedFd, master_in: RawFd, master_ctrl: RawFd, child_pid: libc::pid_t) {
-    while let Some(frame) = read_client_frame(conn.raw()) {
+fn client_loop_tty(
+    conn: SharedFd,
+    master_in: RawFd,
+    master_ctrl: RawFd,
+    child_pid: libc::pid_t,
+    confinement: Confinement,
+) {
+    loop {
+        let Some(frame) = read_client_frame(conn.raw()) else {
+            if eof_action(&confinement) == LoopAction::Detach {
+                deliver_signal(master_ctrl, child_pid, libc::SIGHUP);
+            }
+            break;
+        };
         match dispatch_frame(frame) {
             LoopAction::WriteStdin(bytes) => {
                 if !vsock::write_all(master_in, &bytes) {
@@ -387,8 +402,19 @@ fn client_loop_tty(conn: SharedFd, master_in: RawFd, master_ctrl: RawFd, child_p
     close(master_ctrl);
 }
 
-fn client_loop_pipes(conn: SharedFd, mut stdin_w: Option<RawFd>, child_pid: libc::pid_t) {
-    while let Some(frame) = read_client_frame(conn.raw()) {
+fn client_loop_pipes(
+    conn: SharedFd,
+    mut stdin_w: Option<RawFd>,
+    child_pid: libc::pid_t,
+    confinement: Confinement,
+) {
+    loop {
+        let Some(frame) = read_client_frame(conn.raw()) else {
+            if eof_action(&confinement) == LoopAction::Detach {
+                kill(child_pid, libc::SIGHUP);
+            }
+            break;
+        };
         match dispatch_frame(frame) {
             LoopAction::WriteStdin(bytes) => {
                 if let Some(fd) = stdin_w

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -161,6 +161,7 @@ pub fn handle_session(
         stdin,
         winsize,
         confine,
+        dies_with_client,
     } = opening
     else {
         unreachable!("validate_open_session guarantees OpenSession");
@@ -176,9 +177,9 @@ pub fn handle_session(
         confinement,
     };
     if tty {
-        run_tty_session(conn, spec, winsize, stdin, pid_tx, forker)
+        run_tty_session(conn, spec, winsize, stdin, dies_with_client, pid_tx, forker)
     } else {
-        run_pipe_session(conn, spec, stdin, pid_tx, forker)
+        run_pipe_session(conn, spec, stdin, dies_with_client, pid_tx, forker)
     }
 }
 
@@ -187,6 +188,7 @@ fn run_tty_session(
     spec: WorkloadSpec,
     winsize: Option<Winsize>,
     _stdin_enabled: bool,
+    dies_with_client: bool,
     pid_tx: Option<SyncSender<libc::pid_t>>,
     forker: &dyn Forker,
 ) -> Result<SessionOutcome, SessionError> {
@@ -215,7 +217,7 @@ fn run_tty_session(
         apply_winsize(pty.master, ws);
     }
     let conn = SharedFd::new(conn);
-    let outcome = drive_session_tty(conn.clone(), pty.master, pid, forker, spec.confinement);
+    let outcome = drive_session_tty(conn.clone(), pty.master, pid, forker, dies_with_client);
     close(pty.master);
     conn.close();
     outcome
@@ -225,6 +227,7 @@ fn run_pipe_session(
     conn: RawFd,
     spec: WorkloadSpec,
     stdin_enabled: bool,
+    dies_with_client: bool,
     pid_tx: Option<SyncSender<libc::pid_t>>,
     forker: &dyn Forker,
 ) -> Result<SessionOutcome, SessionError> {
@@ -277,7 +280,7 @@ fn run_pipe_session(
         stderr_r,
         pid,
         forker,
-        spec.confinement,
+        dies_with_client,
     );
     conn.close();
     outcome
@@ -288,7 +291,7 @@ fn drive_session_tty(
     master: RawFd,
     child_pid: libc::pid_t,
     forker: &dyn Forker,
-    confinement: Confinement,
+    dies_with_client: bool,
 ) -> Result<SessionOutcome, SessionError> {
     let stdin_dup = dup(master);
     let ctrl_dup = dup(master);
@@ -307,7 +310,13 @@ fn drive_session_tty(
     let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_for_ctrl = conn.clone();
     let ctrl_thread = std::thread::spawn(move || {
-        client_loop_tty(conn_for_ctrl, stdin_dup, ctrl_dup, child_pid, confinement);
+        client_loop_tty(
+            conn_for_ctrl,
+            stdin_dup,
+            ctrl_dup,
+            child_pid,
+            dies_with_client,
+        );
         let _ = host_closed_tx.send(());
     });
 
@@ -334,7 +343,7 @@ fn drive_session_pipes(
     stderr_r: RawFd,
     child_pid: libc::pid_t,
     forker: &dyn Forker,
-    confinement: Confinement,
+    dies_with_client: bool,
 ) -> Result<SessionOutcome, SessionError> {
     let conn_out = conn.clone();
     let out_thread = std::thread::spawn(move || {
@@ -348,7 +357,7 @@ fn drive_session_pipes(
     let (host_closed_tx, host_closed_rx) = std::sync::mpsc::channel::<()>();
     let conn_in = conn.clone();
     let in_thread = std::thread::spawn(move || {
-        client_loop_pipes(conn_in, stdin_w, child_pid, confinement);
+        client_loop_pipes(conn_in, stdin_w, child_pid, dies_with_client);
         let _ = host_closed_tx.send(());
     });
 
@@ -371,11 +380,11 @@ fn client_loop_tty(
     master_in: RawFd,
     master_ctrl: RawFd,
     child_pid: libc::pid_t,
-    confinement: Confinement,
+    dies_with_client: bool,
 ) {
     loop {
         let Some(frame) = read_client_frame(conn.raw()) else {
-            if eof_action(&confinement) == LoopAction::Detach {
+            if eof_action(dies_with_client) == LoopAction::Detach {
                 deliver_signal(master_ctrl, child_pid, libc::SIGHUP);
             }
             break;
@@ -406,11 +415,11 @@ fn client_loop_pipes(
     conn: SharedFd,
     mut stdin_w: Option<RawFd>,
     child_pid: libc::pid_t,
-    confinement: Confinement,
+    dies_with_client: bool,
 ) {
     loop {
         let Some(frame) = read_client_frame(conn.raw()) else {
-            if eof_action(&confinement) == LoopAction::Detach {
+            if eof_action(dies_with_client) == LoopAction::Detach {
                 kill(child_pid, libc::SIGHUP);
             }
             break;
@@ -626,6 +635,7 @@ mod tests {
             stdin: false,
             winsize: None,
             confine: false,
+            dies_with_client: false,
         };
         let bytes = encode_frame(&frame).expect("encode OpenSession");
         // SAFETY: bytes is borrowed for the duration of the call.

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -29,6 +29,8 @@ pub enum ClientFrame {
         winsize: Option<Winsize>,
         /// Drop to the guest's run-as identity (or cap a root one) and scrub the relay credentials before exec; only a supervised primary session leaves it false, because its workload is the supervisor.
         confine: bool,
+        /// This session exists only for its host client: when the client's stream vanishes the broker hangs the child up instead of leaving it running.
+        dies_with_client: bool,
     },
     StdinBytes(Vec<u8>),
     StdinClose,
@@ -137,6 +139,7 @@ mod tests {
             stdin: true,
             winsize: Some(Winsize { rows: 24, cols: 80 }),
             confine: true,
+            dies_with_client: true,
         };
         let bytes = encode_frame(&frame).expect("encode");
         let len = decode_length_prefix(&bytes[..4].try_into().unwrap()).expect("len");
@@ -156,6 +159,7 @@ mod tests {
             stdin: false,
             winsize: None,
             confine: false,
+            dies_with_client: false,
         };
         let bytes = encode_frame(&frame).expect("encode");
         let back: ClientFrame = decode_frame(&bytes[4..]).expect("decode");

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -31,6 +31,7 @@ pub enum ClientFrame {
         confine: bool,
     },
     StdinBytes(Vec<u8>),
+    StdinClose,
     Resize(Winsize),
     Signal(SignalKind),
     Detach,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -176,7 +176,7 @@ interchangeable everywhere a run is addressed.
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
 | `ls`       | —              | List cached sandboxes (pulled or built) in the local store. Alias: `list`. |
-| `exec`     | `lns exec`     | Run another command against a running run (`docker exec`-style). Stdin and PTY allocation are explicit: `-i` forwards stdin, `-t` allocates a PTY, and `-it` does both. `--detach-keys` closes only that exec session; `-q` suppresses status lines. The command needs no `--` separator. |
+| `exec`     | `lns exec`     | Run another command against a running run. Stdin and PTY allocation are explicit: `-i` forwards stdin, `-t` allocates a PTY, and `-it` does both. `--detach-keys` closes only that exec session; `-q` suppresses status lines. The command needs no `--` separator. |
 | `kill`     | `lns kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -176,7 +176,7 @@ interchangeable everywhere a run is addressed.
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
 | `ls`       | —              | List cached sandboxes (pulled or built) in the local store. Alias: `list`. |
-| `exec`     | `lns exec`     | Run one non-interactive command against a running run (`docker exec`-style). `--detach-keys` and `-q` work as for `lns run`. `-i`/`-t` are refused: an exec session has no way to route your keystrokes to itself yet, so use `lns attach` to reach the run's own terminal. |
+| `exec`     | `lns exec`     | Run another command against a running run (`docker exec`-style). Stdin and PTY allocation are explicit: `-i` forwards stdin, `-t` allocates a PTY, and `-it` does both. `--detach-keys` closes only that exec session; `-q` suppresses status lines. The command needs no `--` separator. |
 | `kill`     | `lns kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -1051,15 +1051,15 @@ reviewer` and `lns stop 7` are equivalent. `exec` is also reachable as the bare
 
 ### Exec — another command inside a run
 
-`lns exec 7 -- ls /workspace` runs one command in a second session, like
+`lns exec 7 ls /workspace` runs one command in a second session, like
 `docker exec`. The run id is shown by `lns run -d` and `lns ps`. `--detach-keys`
 works as it does for `lns run`; detaching from an exec session closes only that
 session — the run and any other sessions keep going.
 
-The session is **non-interactive**: `-i` and `-t` are refused, because an exec
-session has no way yet to route your keystrokes to itself rather than to the run's
-own workload. So `lns exec 7 -- bash` gets you a shell with closed stdin, which
-exits at once. To reach a live terminal inside the run, use `lns attach`.
+Exec follows Docker's explicit terminal flags: without flags stdin is closed and
+no PTY is allocated; `-i` forwards stdin, `-t` allocates a PTY, and `-it` does
+both. For an interactive shell use `lns exec -it 7 sh`. A `--` command separator
+is accepted but optional.
 
 An exec **joins the run it names**, so a diagnostic command sees the same sandbox
 the workload does: the run's resolved environment (base image `ENV`, `spec.env`,

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -1051,15 +1051,15 @@ reviewer` and `lns stop 7` are equivalent. `exec` is also reachable as the bare
 
 ### Exec — another command inside a run
 
-`lns exec 7 ls /workspace` runs one command in a second session, like
-`docker exec`. The run id is shown by `lns run -d` and `lns ps`. `--detach-keys`
+`lns exec 7 ls /workspace` runs one command in a second session. The run id is
+shown by `lns run -d` and `lns ps`. `--detach-keys`
 works as it does for `lns run`; detaching from an exec session closes only that
 session — the run and any other sessions keep going.
 
-Exec follows Docker's explicit terminal flags: without flags stdin is closed and
-no PTY is allocated; `-i` forwards stdin, `-t` allocates a PTY, and `-it` does
-both. For an interactive shell use `lns exec -it 7 sh`. A `--` command separator
-is accepted but optional.
+Exec uses explicit terminal flags: without flags stdin is closed and no PTY is
+allocated; `-i` forwards stdin, `-t` allocates a PTY, and `-it` does both. For an
+interactive shell use `lns exec -it 7 sh`. A `--` command separator is accepted
+but optional.
 
 An exec **joins the run it names**, so a diagnostic command sees the same sandbox
 the workload does: the run's resolved environment (base image `ENV`, `spec.env`,


### PR DESCRIPTION
## Summary

`lns exec` could only run pipe-only commands, so shells, REPLs, editors, and terminal applications failed inside an existing run. This PR gives every exec session independently addressable terminal controls while preserving the primary session and concurrent exec sessions.

### 1. Session-addressed IPC

- Adds explicit primary and exec session targets for stdin, stdin close, resize, signal, and detach controls.
- Returns an opaque exec session ID in the streaming handshake.
- Registers exec input channels before acknowledging startup and removes them on exit, detach, disconnect, or run teardown.
- Detects silent client disconnects on the dedicated exec stream so abandoned exec processes are cancelled promptly.

### 2. Explicit terminal modes

`lns exec` remains non-interactive by default:

```text
lns exec RUN command       stdin closed, no PTY
lns exec -i RUN command    stdin forwarded, no PTY
lns exec -t RUN command    PTY allocated, stdin unattached
lns exec -it RUN command   stdin forwarded through a PTY
```

The command separator remains optional. Terminal resize, signals, stdin EOF, and the detach chord target only the exec session that originated them.

### 3. Regression coverage

- Activates CLI and service behavioral scenarios for explicit terminal flags and multi-session isolation.
- Extends the live Expect smoke with two concurrent exec PTYs, Ctrl+C, detach isolation, primary reattach, and asserted cleanup.
- Adds a real-microVM scenario covering stdout, stderr, exit status, and exclusion from primary logs.

## Breaking changes

The local CLI/service IPC contract replaces the run-only control request variants with session-targeted variants and replaces the exec startup `RunStarted` response with `ExecStarted { run_id, session_id }`. The CLI and service are version-locked and must be updated together; no compatibility shim is retained.

## Docs

Updates the CLI reference and running-workloads guide with the explicit exec terminal modes, optional command separator, and exec-only detach behavior.

## Screenshots

<!-- Add a terminal recording demonstrating two concurrent interactive exec sessions and isolated detach. -->

## Test instructions

1. Start a long-lived named run: `lns run -d --name exec-test <sandbox> sleep 300`. Run `lns exec -it exec-test sh`; expect a live prompt and successful raw terminal input.
2. Open two `lns exec -it exec-test sh` sessions. Enter the detach chord in one; expect that CLI to return 0 while the second exec and primary run remain usable.
3. Run `printf 'hello\n' | lns exec -i exec-test cat`; expect `hello`, clean EOF handling, and exit 0 without a PTY.
4. Run `lns exec exec-test echo hello`; expect non-interactive output and exit 0. Verify `lns logs exec-test` does not contain the exec output.
5. Run `lns exec -it missing-run sh`; expect a clear `no such run` failure and no run creation.
6. Run `expect -f crates/lns-cli/tests/smoke/interactive-shell.exp`; expect the primary and concurrent exec terminal smoke to pass and remove its temporary run.

## Verification

- `CARGO_LOCKED=--locked make lint`
- `make complexity`
- `make coverage-affected`
- `make e2e`
- `LNS_E2E_FEATURE='session streaming verbs' make e2e-microvm`
- `expect -f crates/lns-cli/tests/smoke/interactive-shell.exp`

## Review follow-ups (post-takeover)

- **Silent client disconnect now cancels the guest exec process.** `OpenSession` carries an explicit `dies_with_client` flag (set for every exec, false for the primary); the broker treats EOF on such a session's stream as a hangup (SIGHUP to the child) while the primary session's EOF behavior is unchanged — an abandoned exec no longer outlives its client, and an undelivered detach degrades to the same hangup.
- The service disconnect scenario now drives the production stream driver (`drive_exec_stream`, extracted seam) and asserts the guest task is actually cancelled.
- The CLI exec behaviours now run the real `exec_image` path (`exec_image_on_stream` seam) over an in-memory duplex against a wire-speaking fake service; flag assertions read the request as decoded off the wire. Byte-level stdin forwarding remains pinned by the expect smoke and the microVM scenario.
- Known limitation for a follow-up: EOF cancellation delivers SIGHUP only — an exec'd process that ignores SIGHUP still survives; no escalation to SIGKILL yet.
- Known limitation for a follow-up: `StdinClose` on a PTY-mode exec writes a bare `^D` (0x04) to the PTY, so with a non-empty line buffer the line flushes but no EOF is delivered — `printf 'x' | lns exec -it RUN cat` waits until the session is closed another way. The pipe path (`-i` without `-t`) closes the fd and delivers EOF correctly.


- **Confined exec sessions now adopt the workload user's identity.** `lns-init` exports `LENS_RUN_HOME` from the same guest-passwd read that resolves `LENS_RUN_UID`/`LENS_RUN_GID`; the broker fills `HOME` and `USER` into a confined session's env unless the session already declares them (runc's rule — `/` when the lookup failed) and starts a workdir-less exec in the effective home, mirroring the supervisor's workdir → home rule. Previously an exec landed with the broker's kernel-given `HOME=/` and no `USER`, so `~` expanded to `//` and config-reading tools looked in the wrong place. Pinned by broker/init unit tests and a new `@microvm` streaming scenario.

- **Exec identity hardened after an adversarial review.** uid/gid/home now come from the one passwd line that supplies the run ids (a sibling line the id parse rejected could hand the exec a different identity's home); a home with control bytes is never exported (a NUL would panic `std::env::set_var` in PID 1 — hostile-image boot DoS); image `ENV HOME`/`USER` no longer outrank the run-as identity in an exec (the run records the author-declared identity vars and the host strips the rest, matching the supervisor's `LENS_SANDBOX_WORKLOAD_*` precedence); the identity-home cwd fallback is chdir-only so the broker never runs mkdir as guest root on a passwd-controlled path; and the broker's spec assembly is a pure host-tested function so identity wiring mutations can't hide in the coverage-exempt platform leaf. Known follow-ups (documented, out of scope): supplementary groups, the root-workload proxy-env question, and the USER-by-name vs USER-by-uid oracle divergence with lens-sandbox-core.
