### PR TITLE
fix(lns-cli): keep the pre-boot prompts off the session's stdin lock

### DIFF
--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -123,6 +123,47 @@ fn resolve_host_binds(
     )
 }
 
+/// Every question a run asks before it boots, and the stores that remember the answers.
+struct PreBootQuestions<'a> {
+    pulled: Option<crate::run::pull_confirm::PulledEffects<'a>>,
+    origin: crate::run::host_path_consent::DocumentOrigin,
+    filesets: &'a [crate::run::summary::FilesetSummary],
+    host_paths: &'a lns_policy::host_path_decisions::HostPathDecisionStore,
+    bind_specs: &'a [lns_ipc::BindSpec],
+    bind_decisions: &'a lns_policy::host_bind_decisions::HostBindDecisionStore,
+    assume_yes: bool,
+    interactive: bool,
+}
+
+/// Asks all of them under one stdin guard and drops it before returning: an attached session reads the tty through tokio's stdin, whose blocking thread takes this same lock, so a guard that outlives the questions leaves the session with no keyboard.
+fn ask_before_boot(
+    q: &PreBootQuestions,
+) -> Result<(Vec<String>, Vec<crate::run::host_bind::ResolvedBind>)> {
+    let stdin = std::io::stdin();
+    let mut input = stdin.lock();
+    if let Some(effects) = q.pulled.as_ref() {
+        crate::run::pull_confirm::confirm_pulled_effects(
+            effects,
+            q.assume_yes,
+            q.interactive,
+            &mut input,
+            &mut std::io::stderr(),
+        )?;
+    }
+    let denied = crate::run::host_path_consent::decide_host_paths(
+        &q.origin,
+        q.filesets,
+        q.host_paths,
+        q.assume_yes,
+        q.interactive,
+        &mut input,
+        &mut std::io::stderr(),
+    )?
+    .denied;
+    let binds = resolve_host_binds(q.bind_specs, q.interactive, &mut input, q.bind_decisions)?;
+    Ok((denied, binds))
+}
+
 #[derive(Debug)]
 struct PublishedTarget {
     image: String,
@@ -402,28 +443,9 @@ pub async fn run_image(
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
     let interactive = host_binds_interactive(args.detach, crate::raw_mode::stdin_is_tty());
     let reference = target.image();
-    let stdin = std::io::stdin();
-    let mut input = stdin.lock();
-    if published.is_some() {
-        let (declared_volumes, declared_binds) = crate::run::pull_confirm::artifact_declared_mounts(
-            &args.mounts,
-            &consumer_mount_targets,
-        );
-        let effects = crate::run::pull_confirm::PulledEffects {
-            reference: &reference,
-            binds: &declared_binds,
-            volumes: &declared_volumes,
-            filesets: &args.filesets,
-            tools: &args.tools,
-        };
-        crate::run::pull_confirm::confirm_pulled_effects(
-            &effects,
-            args.assume_yes,
-            interactive,
-            &mut input,
-            &mut std::io::stderr(),
-        )?;
-    }
+    let declared_mounts = published.is_some().then(|| {
+        crate::run::pull_confirm::artifact_declared_mounts(&args.mounts, &consumer_mount_targets)
+    });
     // A mixin is an artifact from a registry whichever document layered it in, so a local run reaches this too.
     let origin = if published.is_some() {
         crate::run::host_path_consent::DocumentOrigin::Pulled {
@@ -432,22 +454,28 @@ pub async fn run_image(
     } else {
         crate::run::host_path_consent::DocumentOrigin::OwnDirectory
     };
-    let denied_host_paths = crate::run::host_path_consent::decide_host_paths(
-        &origin,
-        &args.filesets,
-        &lns_policy::host_path_decisions::JsonFileHostPathDecisionStore::new(
+    let (denied_host_paths, resolved_binds) = ask_before_boot(&PreBootQuestions {
+        pulled: declared_mounts.as_ref().map(|(volumes, binds)| {
+            crate::run::pull_confirm::PulledEffects {
+                reference: &reference,
+                binds,
+                volumes,
+                filesets: &args.filesets,
+                tools: &args.tools,
+            }
+        }),
+        origin,
+        filesets: &args.filesets,
+        host_paths: &lns_policy::host_path_decisions::JsonFileHostPathDecisionStore::new(
             lns_policy::host_path_decisions::default_host_path_decisions_path(),
         ),
-        args.assume_yes,
+        bind_specs: &bind_specs,
+        bind_decisions: &lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
+            lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
+        ),
+        assume_yes: args.assume_yes,
         interactive,
-        &mut input,
-        &mut std::io::stderr(),
-    )?
-    .denied;
-    let bind_decisions = lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
-        lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
-    );
-    let resolved_binds = resolve_host_binds(&bind_specs, interactive, &mut input, &bind_decisions)?;
+    })?;
     if !quiet {
         let dispositions = crate::run::summary::format_bind_dispositions(&resolved_binds);
         if !dispositions.is_empty() {
@@ -1988,6 +2016,60 @@ mod tests {
         ) -> std::io::Result<()> {
             panic!("a run with nothing to ask must record no decision")
         }
+    }
+
+    struct NoHostPathDecisions;
+    impl
+        lns_policy::decision_store::DecisionStore<lns_policy::host_path_decisions::HostPathDecision>
+        for NoHostPathDecisions
+    {
+        fn load(&self) -> std::io::Result<lns_policy::host_path_decisions::HostPathDecisionFile> {
+            Ok(Default::default())
+        }
+        fn save(
+            &self,
+            _state: &lns_policy::host_path_decisions::HostPathDecisionFile,
+        ) -> std::io::Result<()> {
+            panic!("a run with no hostPath fileset must record no decision")
+        }
+    }
+
+    /// The stdin guard the questions need must not reach the attached session: tokio's stdin takes the same lock from a blocking thread, so a leaked guard leaves the run with a dead keyboard.
+    #[test]
+    fn the_questions_before_boot_leave_stdin_lockable_for_the_session() {
+        let dir = tempfile::tempdir().expect("a temp dir for the bind source");
+        std::fs::write(dir.path().join("Cargo.toml"), b"").expect("a file with no secret shape");
+        let bind_specs = vec![lns_ipc::BindSpec {
+            host_source: dir.path().to_string_lossy().into_owned(),
+            target: "/work".into(),
+            read_only: false,
+            exclude: Vec::new(),
+            optional: false,
+        }];
+
+        let (denied, binds) = ask_before_boot(&PreBootQuestions {
+            pulled: None,
+            origin: crate::run::host_path_consent::DocumentOrigin::OwnDirectory,
+            filesets: &[],
+            host_paths: &NoHostPathDecisions,
+            bind_specs: &bind_specs,
+            bind_decisions: &EmptyDecisions,
+            assume_yes: false,
+            interactive: false,
+        })
+        .expect("a local run with one clean bind asks nothing");
+        assert!(denied.is_empty(), "no hostPath fileset can be denied");
+        assert_eq!(binds.len(), 1, "the bind survives the questions");
+
+        // What the stdin pump's blocking thread does once the run is attached.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let stdin = std::io::stdin();
+            let _held = stdin.lock();
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the questions must drop the stdin guard before the session reads the tty");
     }
 
     /// A resolve that locks stdin itself deadlocks every run that declares a bind, because the caller's guard is already held and stdin is not reentrant.

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -102,25 +102,23 @@ fn host_binds_interactive(detached: bool, stdin_is_tty: bool) -> bool {
     !detached && stdin_is_tty
 }
 
+/// Takes the caller's input because the caller holds the process-wide stdin lock, which is not reentrant.
 fn resolve_host_binds(
     specs: &[lns_ipc::BindSpec],
     interactive: bool,
+    input: &mut dyn std::io::BufRead,
+    store: &lns_policy::host_bind_decisions::HostBindDecisionStore,
 ) -> Result<Vec<crate::run::host_bind::ResolvedBind>> {
     if specs.is_empty() {
         return Ok(Vec::new());
     }
     let scan = crate::run::host_bind::RealDirScan;
-    let store = lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
-        lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
-    );
-    let stdin = std::io::stdin();
-    let mut input = stdin.lock();
     crate::run::host_bind::resolve_binds(
         specs,
         &scan,
-        &store,
+        store,
         interactive,
-        &mut input,
+        input,
         &mut std::io::stderr(),
     )
 }
@@ -446,7 +444,10 @@ pub async fn run_image(
         &mut std::io::stderr(),
     )?
     .denied;
-    let resolved_binds = resolve_host_binds(&bind_specs, interactive)?;
+    let bind_decisions = lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
+        lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
+    );
+    let resolved_binds = resolve_host_binds(&bind_specs, interactive, &mut input, &bind_decisions)?;
     if !quiet {
         let dispositions = crate::run::summary::format_bind_dispositions(&resolved_binds);
         if !dispositions.is_empty() {
@@ -1970,6 +1971,57 @@ mod tests {
     fn lf_to_crlf_expands_every_newline_and_leaves_other_bytes() {
         assert_eq!(lf_to_crlf(b"a\nb\n"), b"a\r\nb\r\n");
         assert_eq!(lf_to_crlf(b"no newline"), b"no newline");
+    }
+
+    struct EmptyDecisions;
+    impl
+        lns_policy::decision_store::DecisionStore<
+            lns_policy::host_bind_decisions::SecretDisposition,
+        > for EmptyDecisions
+    {
+        fn load(&self) -> std::io::Result<lns_policy::host_bind_decisions::HostBindDecisionFile> {
+            Ok(Default::default())
+        }
+        fn save(
+            &self,
+            _state: &lns_policy::host_bind_decisions::HostBindDecisionFile,
+        ) -> std::io::Result<()> {
+            panic!("a run with nothing to ask must record no decision")
+        }
+    }
+
+    /// A resolve that locks stdin itself deadlocks every run that declares a bind, because the caller's guard is already held and stdin is not reentrant.
+    #[test]
+    fn resolving_host_binds_while_the_caller_holds_stdin_does_not_deadlock() {
+        let dir = tempfile::tempdir().expect("a temp dir for the bind source");
+        std::fs::write(dir.path().join("Cargo.toml"), b"").expect("a file with no secret shape");
+        let specs = vec![lns_ipc::BindSpec {
+            host_source: dir.path().to_string_lossy().into_owned(),
+            target: "/work".into(),
+            read_only: false,
+            exclude: Vec::new(),
+            optional: false,
+        }];
+
+        // Off the test thread, so a deadlock times out here instead of hanging the suite.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let stdin = std::io::stdin();
+            let mut held = stdin.lock();
+            let _ = tx.send(
+                resolve_host_binds(&specs, false, &mut held, &EmptyDecisions)
+                    .expect("a clean bind resolves"),
+            );
+        });
+
+        let resolved = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("resolve_host_binds must return while the caller holds stdin, not block on it");
+        assert_eq!(resolved.len(), 1, "the bind survives the resolve");
+        assert!(
+            resolved[0].dropped.is_empty(),
+            "nothing here is secret-shaped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two bugs, one cause: the pre-boot consent prompts take the process-wide std stdin lock
inside a command that owns the terminal.

## 1. `lns run` hangs on any host bind

`lns run` hung forever on any definition declaring a host bind. No prompt, no output, no
timeout — the client sat there after printing the run summary.

`run_image` held the stdin guard across the host-bind resolve, and `resolve_host_binds`
locked `std::io::stdin()` a second time. `std::io::Stdin` is a plain mutex, unlike
`Stdout`/`Stderr`, so the second lock blocked on the guard already held.

A sample of the stuck client:

```
lns_cli::service::orchestrator::run_image::{{closure}}
  lns_cli::service::orchestrator::resolve_host_binds
    std::io::stdio::Stdin::lock
      _pthread_mutex_firstfit_lock_wait
        __psynch_mutexwait
```

`resolve_host_binds` returns early only when there are no bind specs, so it hung even when
the bind held nothing secret-shaped and there was never a question to ask. That is how it
was found: a dev sandbox binding `~/.claude`, which matches none of the secret shapes,
stopped starting at 0.19.0.

Fix: the resolve takes the caller's `&mut dyn BufRead`. Its decision store is injected the
same way, which also keeps the test off `$HOME`.

## 2. The attached session has no keyboard

With the double lock gone the run booted — and took no keyboard input at all. herdr came up
frozen.

`run_from_matches` already documents the rule (`crates/lns-cli/src/lib.rs:38`): a
terminal-owning command gets `std::io::empty()`, because "run/exec drive the tty over tokio
stdin/stdout, whose blocking threads take the std stdin/stdout locks; holding those locks
here would deadlock the interactive session." `run_image` broke that rule for its own
prompts: it held the guard through `drive_attached_session`, whose `run_stdin_pump` reads
via `tokio::io::stdin()` — the same std lock, from a blocking thread. Every keystroke queued
behind a guard released only when the run ended.

Fix: the three questions (pulled-effects confirm, host-path consent, host-bind resolve) move
into `ask_before_boot`, which takes the guard, asks them, and drops it before returning.
`run_image` receives the answers and holds no guard.

## Tests

Both regressions are pinned by a test that fails by timeout, not by hanging the suite:

- `resolving_host_binds_while_the_caller_holds_stdin_does_not_deadlock` — holds the guard the
  way `run_image` does and requires the resolve to return. Pre-fix: `Timeout` at 5.01s.
- `the_questions_before_boot_leave_stdin_lockable_for_the_session` — locks stdin from another
  thread afterwards, which is what the pump's blocking thread does. With
  `std::mem::forget(input)` restoring the leak: `Timeout` at 5.01s.

`cargo test -p lns-cli --lib`: 876 passed, 0 failed. `cargo clippy -p lns-cli --all-targets`:
clean. Both fixes were also run by hand: the box boots and takes input.

Introduced in f49b77b4 ("scan host binds for secrets and resolve KEEP/DROP before run").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
