### PR TITLE
fix: a pre-start script reads no stdin

### DIFF
--- a/crates/e2e-tests/features/microvm_guest_scripts.feature
+++ b/crates/e2e-tests/features/microvm_guest_scripts.feature
@@ -1,0 +1,17 @@
+@microvm
+Feature: a pre-start script prepares a real guest without holding the boot
+  A `pre-start` script runs in the booted guest before the workload
+  (`docs/sandbox-spec.md` §3.1.13). What a script may read is what this covers:
+  its stdin is `/dev/null`, so a tool that would ask a question reads an EOF and
+  the run reaches its workload. An inherited stdin has no one answering it before
+  the workload starts, and no timeout bounds a script, so a read there would hold
+  the boot open for good — with the script's own output the only clue, which a
+  quiet install does not give.
+
+  Scenario: a script that reads its stdin does not hold the boot
+    Given the Lens Sandbox service is running
+    And the project definition declares a pre-start script "cat > /dev/null"
+    And the project definition sets command "/bin/sh -c '/.lens/guest-tools/bin/busybox echo the workload ran'"
+    When the user runs the sandbox definition
+    Then the exit code is 0
+    And the output contains "the workload ran"

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -37,6 +37,8 @@ pub struct E2eWorld {
     pub project_filesets: Vec<(String, String, String, Option<String>)>,
     pub project_inline_filesets: Vec<(String, String, String, Option<String>)>,
     pub project_tools: Vec<String>,
+    /// `pre-start` script bodies the project definition declares, in run order.
+    pub project_scripts: Vec<String>,
     pub project_image: Option<String>,
     /// Raises the per-run budget for a tool whose upstream payload is far larger than the usual one.
     pub run_budget: Option<std::time::Duration>,

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -140,6 +140,17 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
             ));
         }
     }
+    if !world.project_scripts.is_empty() {
+        spec_tail.push_str("\n  scripts:");
+        for body in &world.project_scripts {
+            // A block scalar, like the inline filesets above: a body carrying `: ` or a
+            // leading `-` would change what the definition means as a plain one.
+            spec_tail.push_str("\n    - when: pre-start\n      run: |-");
+            for line in body.split('\n') {
+                spec_tail.push_str(&format!("\n        {line}"));
+            }
+        }
+    }
     if !world.project_ports.is_empty() {
         spec_tail.push_str("\n  ports:");
         for (host, container) in &world.project_ports {
@@ -302,6 +313,11 @@ fn project_declares_credential(world: &mut E2eWorld, env: String, domain: String
 #[given(regex = r#"^the project definition sets command "([^"]+)"$"#)]
 fn project_sets_command(world: &mut E2eWorld, command: String) {
     world.project_command = Some(command);
+}
+
+#[given(regex = r#"^the project definition declares a pre-start script "([^"]+)"$"#)]
+fn project_declares_a_script(world: &mut E2eWorld, body: String) {
+    world.project_scripts.push(body);
 }
 
 #[given(regex = r#"^the project definition sets env "([^"]+)=([^"]*)"$"#)]

--- a/crates/lns-supervisor/src/dispatcher/runtime.rs
+++ b/crates/lns-supervisor/src/dispatcher/runtime.rs
@@ -396,6 +396,8 @@ impl StepRunner for RealStepRunner {
             script.label
         ));
         let mut cmd = child_spawner::build_command(&script.spec);
+        // A script has no stdin (`docs/sandbox-spec.md` §3.1.13): nothing answers the run's own stdin before the workload starts, and no timeout ends a read left waiting on it.
+        cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
         let mut child = cmd.spawn().map_err(|e| e.to_string())?;

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -871,6 +871,13 @@ the half-prepared environment this block exists to prevent. An author who wants 
 command's failure tolerated says so where it is — `cmd || true`. Output streams to the run's own output as the
 script produces it.
 
+**A script has no stdin.** It reads `/dev/null`, so a tool that would ask a
+question reads an EOF instead of waiting. Nothing else would be answerable: the
+run's own console belongs to the workload that has not started, and a script is
+not attached to anyone. A script is not bounded by a timeout either, as this
+section states below, so an inherited stdin would hold a boot open forever with
+nothing to show for it.
+
 **A document that ships `apt-get install` ships the egress for its mirror too**,
 in the same document, because a script is not a way around the policy the
 consumer approved. A destination no rule decides is asked about the way any other


### PR DESCRIPTION
## What

A `pre-start` script ([#274](https://github.com/lensapp/lens-sandbox/pull/274)) inherited the supervisor's own stdin. Two commits: §3.1.13 states that a script reads `/dev/null`, and `RealStepRunner` makes it so.

| | |
|---|---|
| `832a7a10` | the rule in `docs/sandbox-spec.md` §3.1.13 — a normative change does not ride an implementation commit |
| `a6ffc12e` | `cmd.stdin(Stdio::null())`, and an `@microvm` scenario that pins it |

## Why

`RealStepRunner::run` piped a script's stdout and stderr and said nothing about its stdin, and `build_command` wires none — so fd 0 came from the supervisor. The supervisor is the broker's session child, so that descriptor is *the run's stdin*: a PTY slave on an attached run, or a pipe whose write end the broker holds open even when the client disabled stdin (`session/real.rs`). Nothing answers either before the workload starts, and §3.1.13 bounds a script with no timeout — so a script that read it held the boot open for good.

Found on a real box, not by inspection. A `pre-start` `apt-get install` never returned. The audit trail showed every download complete — three `InRelease` files, three indexes, both `.deb`s — and then nothing, no further events and no next-script line. The install was quiet (`-qq`, output to `/dev/null`), so whatever it was waiting to be asked was invisible as well. `/dev/null` makes that read an EOF.

Every other spawn in the guest already decides stdin deliberately: the workload gets a PTY with the client bridged, and an exec session with stdin disabled gets a pipe whose write end is closed, i.e. EOF. The script path was the only one that inherited.

## Testing

The repro is an `@microvm` scenario, `crates/e2e-tests/features/microvm_guest_scripts.feature`: a definition declares a `pre-start` script whose body is `cat > /dev/null`, and the run must still reach a workload that echoes. Pre-fix that script blocks until the run's kill; post-fix it reads an EOF and the workload runs.

It is Layer 1 because it has to be. `runtime.rs` is IGNORES-listed as "only runs inside the microVM", the `Stdio` a `Command` carries cannot be read back, and CLAUDE.md reserves subprocess spawns for Layer 1 — so no lower layer can tell the two behaviours apart. Declaring a script needed harness support, which is the rest of the diff: a `project_scripts` field on the world, a `scripts:` block in the definition writer (a `|-` block, so a body carrying `: ` or a leading `-` cannot change what the definition means), and a `declares a pre-start script` step. All reusable for the next script scenario.

- `make lint`, `make test`, `make complexity`: clean. `cargo check -p e2e-tests --tests`: clean.
- The new scenario is **unrun** — `@microvm` is off the PR gate, and it needs a virt host; the nightly `e2e-microvm` workflow is its execution path. The fix itself was verified by hand: the box that hung boots.
- Before settling on the scenario I did write it as an inline test that dup2'd an unanswerable pipe onto fd 0 — it failed on a 10s timeout without the one-liner and passed with it, which is how I know the mechanism. It is not in the diff: Layer 3 forbids subprocess spawns.

## Security impact

None. A script loses an inherited descriptor and gains `/dev/null`; nothing else about what a script may reach changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)