### PR TITLE
chore(deps): Bump lens-sandbox-core and the toolchain

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+# mise's rust backend exports RUSTUP_TOOLCHAIN, which outranks rust-toolchain.toml; this makes mise read the repo pin instead of overriding it.
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Adding a new crate that needs the per-crate `complexity` gate step: add it to `G
 
 ## Toolchain
 
-Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.95.0`). One-time setup:
+Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.96.1`). One-time setup:
 
 ```
 cargo install cargo-llvm-cov   # for `make coverage` / `make coverage-lcov`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Adding a new crate that needs the per-crate `complexity` gate step: add it to `G
 
 ## Toolchain
 
-Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.96.1`). One-time setup:
+Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.97.1`). One-time setup:
 
 ```
 cargo install cargo-llvm-cov   # for `make coverage` / `make coverage-lcov`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,8 @@ Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.96.1`). One-tim
 cargo install cargo-llvm-cov   # for `make coverage` / `make coverage-lcov`
 ```
 
+If you use mise, run `mise trust && mise install` too — `.mise.toml` points mise at `rust-toolchain.toml`, and until it is trusted every mise command errors, then warns `missing: rust@<pin>` until the pinned version is installed.
+
 `cargo-llvm-cov` measures **Layer 2 + Layer 3 only** (see [Test layers](#test-layers)). It wraps `cargo` with LLVM source-based instrumentation. Layer 1 (E2E) tests are deliberately excluded from coverage scoring — their value is wiring confidence, not line attribution. Vendored upstream code (`composefs/vendor/`), the build script, and the thin production-wiring adapters (`kernel/real.rs`, `kernel/traits.rs`, `service/real.rs`) all flow through the same IGNORES table in `scripts/coverage-floor.sh` — one mechanism, one place to look.
 
 The Layer 1 cucumber crate (`crates/e2e-tests`) is excluded from `cargo test --workspace --exclude e2e-tests` in `coverage-data`, so its subprocess spawns do not contribute to any crate's coverage data — `make e2e` runs it separately for wiring confirmation only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apollo-parser"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f6e2be4b3474e5890d34d3e483d49ec9b5cbf9e358bc62c9cc5423376df54b"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +248,28 @@ checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
 dependencies = [
  "async-lock",
  "event-listener",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -979,6 +1012,12 @@ dependencies = [
  "core-foundation 0.9.4",
  "libc",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "coverage-strip-ast"
@@ -2397,6 +2436,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2446,6 +2491,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,12 +2525,39 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
+ "prefix-trie",
  "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2876,10 +2972,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -3104,8 +3216,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens-sandbox-core"
 version = "0.1.0"
-source = "git+https://github.com/lensapp/lens-sandbox-core?rev=ceb3815662e41bd0b987a65f5152b96afbfdb0ca#ceb3815662e41bd0b987a65f5152b96afbfdb0ca"
+source = "git+https://github.com/lensapp/lens-sandbox-core?rev=64d25772331fb6da5569b1c54e61f84ee0730fca#64d25772331fb6da5569b1c54e61f84ee0730fca"
 dependencies = [
+ "apollo-parser",
  "async-trait",
  "aws-credential-types",
  "aws-sigv4",
@@ -3113,8 +3226,10 @@ dependencies = [
  "futures-util",
  "hex",
  "hickory-proto",
+ "hickory-resolver",
  "ipnet",
  "libc",
+ "nfq",
  "nix 0.30.1",
  "rand 0.9.4",
  "rcgen",
@@ -3123,6 +3238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "switchyard-translation",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
@@ -3568,6 +3684,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3652,6 +3785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nfq"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c8f4c88952507d9df9400a6a2e48640fb460e21dcb2b4716eb3ff156d6db9e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4583,6 +4725,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,6 +5282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5140,6 +5299,18 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
 ]
 
 [[package]]
@@ -5841,6 +6012,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "switchyard-protocol"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8be18d2d2c600ba679651f9e31ec9eb9dff96060a078c39e50e42ccd4e2318"
+dependencies = [
+ "async-trait",
+ "futures",
+ "http 1.4.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "switchyard-translation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40cc4f9517e2fa6ecf11c5ffaace82d04689d088ed3095631609e46d2a3f940"
+dependencies = [
+ "async-stream",
+ "futures",
+ "serde",
+ "serde_json",
+ "switchyard-protocol",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5915,6 +6114,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,6 +6155,12 @@ checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -5984,6 +6210,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"
@@ -7250,6 +7482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7271,7 +7509,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7361,6 +7599,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/lensapp/lens-sandbox/actions/workflows/ci.yml/badge.svg)](https://github.com/lensapp/lens-sandbox/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Rust 1.95+](https://img.shields.io/badge/rust-1.95%2B-orange.svg)](rust-toolchain.toml)
+[![Rust 1.96+](https://img.shields.io/badge/rust-1.96%2B-orange.svg)](rust-toolchain.toml)
 
 > **The sandbox you'll actually leave running.**
 >

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/lensapp/lens-sandbox/actions/workflows/ci.yml/badge.svg)](https://github.com/lensapp/lens-sandbox/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Rust 1.96+](https://img.shields.io/badge/rust-1.96%2B-orange.svg)](rust-toolchain.toml)
+[![Rust 1.97+](https://img.shields.io/badge/rust-1.97%2B-orange.svg)](rust-toolchain.toml)
 
 > **The sandbox you'll actually leave running.**
 >

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -533,32 +533,32 @@ pub fn lds_visuals() -> egui::Visuals {
     v.override_text_color = Some(TEXT_PRIMARY);
     v.hyperlink_color = ACCENT_GREEN;
     v.selection.bg_fill = Color32::from_gray(64);
-    v.selection.stroke = Stroke::new(1.0, TEXT_ACCENT);
+    v.selection.stroke = Stroke::new(1.0_f32, TEXT_ACCENT);
 
     let radius = egui::CornerRadius::same(8);
 
     v.widgets.noninteractive.bg_fill = BG_SECONDARY;
     v.widgets.noninteractive.weak_bg_fill = BG_SECONDARY;
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, BORDER);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, BORDER);
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, TEXT_PRIMARY);
     v.widgets.noninteractive.corner_radius = radius;
 
     v.widgets.inactive.bg_fill = ACCENT_GREEN;
     v.widgets.inactive.weak_bg_fill = ACCENT_GREEN;
     v.widgets.inactive.bg_stroke = Stroke::NONE;
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, BG_PRIMARY);
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, BG_PRIMARY);
     v.widgets.inactive.corner_radius = radius;
 
     v.widgets.hovered.bg_fill = ACCENT_GREEN_HOVER;
     v.widgets.hovered.weak_bg_fill = ACCENT_GREEN_HOVER;
-    v.widgets.hovered.bg_stroke = Stroke::new(1.0, ACCENT_GREEN_HOVER);
-    v.widgets.hovered.fg_stroke = Stroke::new(1.0, BG_PRIMARY);
+    v.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, ACCENT_GREEN_HOVER);
+    v.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, BG_PRIMARY);
     v.widgets.hovered.corner_radius = radius;
 
     v.widgets.active.bg_fill = ACCENT_GREEN_PRESSED;
     v.widgets.active.weak_bg_fill = ACCENT_GREEN_PRESSED;
-    v.widgets.active.bg_stroke = Stroke::new(1.0, ACCENT_GREEN_PRESSED);
-    v.widgets.active.fg_stroke = Stroke::new(1.0, BG_PRIMARY);
+    v.widgets.active.bg_stroke = Stroke::new(1.0_f32, ACCENT_GREEN_PRESSED);
+    v.widgets.active.fg_stroke = Stroke::new(1.0_f32, BG_PRIMARY);
     v.widgets.active.corner_radius = radius;
     v
 }

--- a/crates/lns-service/src/dashboard/mod.rs
+++ b/crates/lns-service/src/dashboard/mod.rs
@@ -118,12 +118,12 @@ fn dashboard_visuals() -> egui::Visuals {
     v.override_text_color = Some(TEXT_PRIMARY);
     v.panel_fill = CONTENT_FILL;
     v.window_fill = CHROME_FILL;
-    v.window_stroke = Stroke::new(1.0, BORDER);
+    v.window_stroke = Stroke::new(1.0_f32, BORDER);
     v.window_corner_radius = CornerRadius::same(10);
     v.extreme_bg_color = INPUT_FILL;
     v.faint_bg_color = CHROME_FILL;
     v.selection.bg_fill = CATEGORY;
-    v.selection.stroke = Stroke::new(0.0, Color32::WHITE);
+    v.selection.stroke = Stroke::new(0.0_f32, Color32::WHITE);
     let radius = CornerRadius::same(4);
     for w in [
         &mut v.widgets.inactive,
@@ -133,16 +133,16 @@ fn dashboard_visuals() -> egui::Visuals {
     ] {
         w.corner_radius = radius;
         w.bg_stroke = Stroke::NONE;
-        w.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+        w.fg_stroke = Stroke::new(1.0_f32, TEXT_PRIMARY);
         w.weak_bg_fill = INPUT_FILL;
         w.bg_fill = INPUT_FILL;
     }
     v.widgets.hovered.weak_bg_fill = HOVER_FILL;
     v.widgets.hovered.bg_fill = HOVER_FILL;
-    v.widgets.hovered.fg_stroke = Stroke::new(1.0, HOVER_LINE);
-    v.widgets.active.fg_stroke = Stroke::new(1.0, DRAG_LINE);
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, WEAK_BORDER);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    v.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, HOVER_LINE);
+    v.widgets.active.fg_stroke = Stroke::new(1.0_f32, DRAG_LINE);
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, WEAK_BORDER);
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, TEXT_PRIMARY);
     v
 }
 
@@ -474,7 +474,7 @@ fn control_button(ui: &mut egui::Ui, label: &str, open: bool) -> egui::Response 
     let border = if open { CATEGORY } else { BORDER };
     Frame::new()
         .fill(INPUT_FILL)
-        .stroke(Stroke::new(1.0, border))
+        .stroke(Stroke::new(1.0_f32, border))
         .corner_radius(CornerRadius::same(6))
         .inner_margin(Margin::symmetric(10, 7))
         .show(ui, |ui| {
@@ -494,7 +494,7 @@ fn control_button(ui: &mut egui::Ui, label: &str, open: bool) -> egui::Response 
 fn kind_popup_body(ui: &mut egui::Ui, state: &mut DashboardState) {
     Frame::new()
         .fill(MODAL_FILL)
-        .stroke(Stroke::new(1.0, BORDER))
+        .stroke(Stroke::new(1.0_f32, BORDER))
         .corner_radius(CornerRadius::same(8))
         .inner_margin(Margin::same(6))
         .show(ui, |ui| {
@@ -858,7 +858,7 @@ fn search_modal(ui: &mut egui::Ui, state: &mut DashboardState, reveal: f32) {
         .frame(
             Frame::new()
                 .fill(MODAL_FILL)
-                .stroke(Stroke::new(1.0, BORDER))
+                .stroke(Stroke::new(1.0_f32, BORDER))
                 .corner_radius(CornerRadius::same(12))
                 .shadow(shadow)
                 .inner_margin(Margin::same(14)),

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -906,7 +906,7 @@ fn paint_pile_ledges(ui: &egui::Ui, geom: &PileGeom, layout: &PileLayout, top_h:
             rect,
             radius,
             fill,
-            Stroke::new(1.0, window::BORDER.gamma_multiply(a)),
+            Stroke::new(1.0_f32, window::BORDER.gamma_multiply(a)),
             StrokeKind::Inside,
         );
     }
@@ -1039,7 +1039,7 @@ fn pile_pill(
         r,
         radius,
         Color32::from_rgba_unmultiplied(96, 97, 104, fill_a),
-        Stroke::new(1.0, Color32::from_white_alpha(stroke_a)),
+        Stroke::new(1.0_f32, Color32::from_white_alpha(stroke_a)),
         StrokeKind::Inside,
     );
     if resp.hovered() {
@@ -1107,7 +1107,7 @@ fn pile_header(
     );
     let arm = content.width() * 0.18;
     let c = content.center();
-    let x = Stroke::new(1.6, fg);
+    let x = Stroke::new(1.6_f32, fg);
     ui.painter()
         .line_segment([c - vec2(arm, arm), c + vec2(arm, arm)], x);
     ui.painter()
@@ -1352,7 +1352,7 @@ fn close_button(ui: &mut egui::Ui, id: egui::Id, rect: egui::Rect) -> egui::Resp
     painter.circle_filled(center, radius, fill);
 
     let arm = radius * 0.34;
-    let x = Stroke::new(1.6, Color32::from_gray(235));
+    let x = Stroke::new(1.6_f32, Color32::from_gray(235));
     painter.line_segment([center - vec2(arm, arm), center + vec2(arm, arm)], x);
     painter.line_segment([center + vec2(arm, -arm), center - vec2(arm, -arm)], x);
     resp
@@ -1445,7 +1445,7 @@ fn remember_toggle(ui: &mut egui::Ui, remember: &mut bool) {
                 rect,
                 CornerRadius::same(4),
                 fill,
-                Stroke::new(1.5, border),
+                Stroke::new(1.5_f32, border),
                 StrokeKind::Inside,
             );
             if *remember {
@@ -1457,7 +1457,7 @@ fn remember_toggle(ui: &mut egui::Ui, remember: &mut bool) {
                         c + vec2(-0.1 * r, 0.34 * r),
                         c + vec2(0.42 * r, -0.34 * r),
                     ],
-                    Stroke::new(1.7, window::BG_PRIMARY),
+                    Stroke::new(1.7_f32, window::BG_PRIMARY),
                 ));
             }
             ui.label(
@@ -1885,9 +1885,10 @@ fn help_link(ui: &mut egui::Ui, text: &str) -> egui::Response {
 
 fn secret_input(ui: &mut egui::Ui, value: &mut String, hint: &str) -> egui::Response {
     ui.scope(|ui| {
-        ui.style_mut().visuals.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, window::BORDER);
+        ui.style_mut().visuals.widgets.inactive.bg_stroke =
+            egui::Stroke::new(1.0_f32, window::BORDER);
         ui.style_mut().visuals.widgets.hovered.bg_stroke =
-            egui::Stroke::new(1.0, egui::Color32::from_gray(96));
+            egui::Stroke::new(1.0_f32, egui::Color32::from_gray(96));
         ui.add(
             egui::TextEdit::singleline(value)
                 .password(true)

--- a/crates/lns-service/src/ui/badge.rs
+++ b/crates/lns-service/src/ui/badge.rs
@@ -10,7 +10,7 @@ fn badge_fill() -> Color32 {
 fn badge(ui: &mut egui::Ui, label: &str) {
     egui::Frame::new()
         .fill(badge_fill())
-        .stroke(Stroke::new(1.0, window::BORDER))
+        .stroke(Stroke::new(1.0_f32, window::BORDER))
         .corner_radius(CornerRadius::same(theme::BADGE_CORNER_RADIUS))
         .inner_margin(Margin::symmetric(theme::BADGE_PAD_X, theme::BADGE_PAD_Y))
         .show(ui, |ui| {

--- a/crates/lns-service/src/ui/button.rs
+++ b/crates/lns-service/src/ui/button.rs
@@ -128,8 +128,8 @@ fn style_button(style: &mut egui::Style, kind: ButtonKind) {
 fn set_state(w: &mut egui::style::WidgetVisuals, c: &StateColors, radius: CornerRadius) {
     w.bg_fill = c.fill;
     w.weak_bg_fill = c.fill;
-    w.bg_stroke = Stroke::new(1.0, c.stroke);
-    w.fg_stroke = Stroke::new(1.0, c.fg);
+    w.bg_stroke = Stroke::new(1.0_f32, c.stroke);
+    w.fg_stroke = Stroke::new(1.0_f32, c.fg);
     w.corner_radius = radius;
 }
 

--- a/crates/lns-service/src/ui/card.rs
+++ b/crates/lns-service/src/ui/card.rs
@@ -39,7 +39,7 @@ pub fn eyebrow(ui: &mut egui::Ui, icon: MaterialIcon, label: &str) {
 fn card_frame() -> egui::Frame {
     egui::Frame::new()
         .fill(card_fill())
-        .stroke(Stroke::new(1.0, window::BORDER))
+        .stroke(Stroke::new(1.0_f32, window::BORDER))
         .corner_radius(CornerRadius::same(theme::CARD_CORNER_RADIUS))
 }
 

--- a/crates/lns-supervisor/Cargo.toml
+++ b/crates/lns-supervisor/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 lns-session = { path = "../lns-session" }
 # Reads the guest's own passwd/group, which lens-sandbox-core's resolver cannot (it needs a same-named group).
 nix = { version = "0.29", features = ["user"] }
-lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "ceb3815662e41bd0b987a65f5152b96afbfdb0ca" }
+lens-sandbox-core = { git = "https://github.com/lensapp/lens-sandbox-core", rev = "64d25772331fb6da5569b1c54e61f84ee0730fca" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 tracing = "0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]
 targets = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.1"
 components = ["clippy", "rustfmt"]
 targets = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

The `lens-sandbox-core` pin was 29 commits behind upstream. This moves it to `64d2577` and takes the toolchain move that comes with it.

### 1. The dependency, and why the toolchain rides along

Upstream raised its `rust-version` to 1.96.1, and so do the two new `switchyard` crates it pulls in, so cargo refuses the new rev under the old 1.95.0 pin. The toolchain had to move in the same commit — splitting them would leave a commit that does not build.

The pin then went to **1.97.1** rather than stopping at 1.96.1, because 1.96.1 is not a chosen version, only the floor the dependency imposes. 1.97.1 leaves one release train below stable.

1.97 promotes a future-incompatibility lint to a hard error under the gate's `-D warnings`:

```
error: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
   --> crates/lns-service/src/ui/button.rs:132:31
    |
132 |     w.fg_stroke = Stroke::new(1.0, c.fg);
    |                               ^^^ help: explicitly specify the type as `f32`: `1.0_f32`
```

30 sites, all in lns-service egui code, all the same class. Each was located by file/line/column from the compiler output rather than by pattern-matching float literals, so no unflagged number was touched. Values are unchanged. This lint becomes a hard error in a future release whatever we pin, so the cost was owed either way.

### 2. mise was silently overriding the pin

`rust-toolchain.toml` is meant to be the single source of truth, but mise's rust backend exports `RUSTUP_TOOLCHAIN`, which outranks it. A global `rust = "latest"` therefore decided the compiler for every cargo command.

This was not theoretical: the pre-commit hook inherited it and checked the first commit here with the exact compiler that commit replaces.

`.mise.toml` points mise at `rust-toolchain.toml` instead. Pinning a version in the mise config would have recreated the same bug with two pins.

### 3. No new policy surface is wired up

Upstream added four: `egress.udp`, GraphQL matchers, MCP matchers, and an `llm` backend/translation block. None is reachable, and none is enabled by this PR — `crates/lns-policy` models only `egress.http` and `egress.tcp`, and `docs/sandbox-spec.md` describes none of the four. Per Transitional mode each is a spec decision first, then behaviour work from a failing test.

A document using any of them fails to load rather than loading and doing nothing, which is the fail-closed outcome we want.

## Verification

`make lint`, `make complexity` and `make coverage` all pass on 1.97.1 — coverage at exit 0, every crate 0 failures, and per-crate file counts identical to the 1.96.1 run, so no file changed coverage class. The float-literal commit was also verified green on 1.96.1, so both commits in that pair stand alone.

Not yet run: `make e2e-microvm`. It matters here more than usual — this bumps the crate that owns in-guest nftables enforcement, and upstream added NFQUEUE packet queueing plus three DNS resolver fixes that the virt-free gate cannot observe. In particular the filter chain now queues all UDP unconditionally with no `bypass` flag, and this repo attaches no UDP relay.

Also noted, not addressed: under 1.97.1 cargo reports a future-incompat warning in `proc-macro-error2 v2.0.1`. Transitive, not gated.