### PR TITLE
feat(lns-cli): close the artifact-verb gaps §3.1 names

### DIFF
--- a/crates/e2e-tests/features/sandbox_distribution.feature
+++ b/crates/e2e-tests/features/sandbox_distribution.feature
@@ -20,7 +20,8 @@ Feature: distributing a sandbox through a registry end to end
     Then the exit code is 0
     And the output contains the pushed reference
     And the output contains "/e2e-base@sha256:"
-    And the output contains "cached"
+    And the output contains "sandbox"
+    And the output contains "image"
 
   Scenario: tag re-references the cached sandbox under a new tag
     When I run lns "pull <pushed-ref>" against the service

--- a/crates/e2e-tests/features/sandbox_management.feature
+++ b/crates/e2e-tests/features/sandbox_management.feature
@@ -12,8 +12,11 @@ Feature: cached sandbox management end to end
   Scenario: listing an empty cache renders only the table header
     When I run "lns sandbox ls"
     Then the exit code is 0
-    And the output contains "SANDBOX"
-    And the output contains "STATE"
+    And the output contains "ARTIFACT"
+    And the output contains "KIND"
+    And the output contains "DIGEST"
+    And the output contains "SIZE"
+    And the output contains "HOLDER"
 
   Scenario: removing a sandbox that is not cached fails cleanly
     When I run "lns sandbox rm registry.example.test/absent:1"
@@ -25,7 +28,7 @@ Feature: cached sandbox management end to end
     Then the exit code is 0
     And the output contains "reclaimed 0 B"
 
-  Scenario: prune refuses to run without --force
+  Scenario: with no terminal to ask at, prune refuses rather than assuming
     When I run "lns sandbox prune"
     Then the exit code is non-zero
     And the output contains "pass --force to confirm"

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -132,10 +132,7 @@ pub fn init<F: Fs, W: Write>(
     out: &mut W,
 ) -> Result<i32> {
     let path = selected_definition_path(file, cwd);
-    let name = path.file_name().map_or_else(
-        || LNS_YAML.to_string(),
-        |n| n.to_string_lossy().into_owned(),
-    );
+    let name = file.map_or_else(|| LNS_YAML.to_string(), |f| f.display().to_string());
     if fs.exists(&path) {
         bail!("{name} already exists in this directory; not overwriting it");
     }

--- a/crates/lns-cli/src/sandbox/author.rs
+++ b/crates/lns-cli/src/sandbox/author.rs
@@ -3,11 +3,23 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
-use super::SandboxCommand;
+use super::{DocumentKind, SandboxCommand};
 
 pub const LNS_YAML: &str = "lns.yaml";
 
-const SCAFFOLD: &str = "apiVersion: lns.run/v1
+const MIXIN_SCAFFOLD: &str = "apiVersion: lns.run/v1
+kind: mixin
+name: mixin
+spec:
+  egress:
+    http: []
+    tcp: []
+  credentials: []
+  filesets: []
+  tools: []
+";
+
+const SANDBOX_SCAFFOLD: &str = "apiVersion: lns.run/v1
 kind: sandbox
 name: sandbox
 spec:
@@ -85,7 +97,7 @@ pub fn map_dir_entries<'a>(
 /// The author verbs run offline, against the working directory rather than the service; inspect joins them when its target is a local definition (or omitted).
 pub fn is_offline(cmd: &SandboxCommand) -> bool {
     match cmd {
-        SandboxCommand::Init | SandboxCommand::Validate(_) => true,
+        SandboxCommand::Init(_) | SandboxCommand::Validate(_) => true,
         SandboxCommand::Inspect(args) => {
             args.file.is_some() || is_local_inspect(args.run.as_deref())
         }
@@ -112,16 +124,40 @@ pub fn selected_definition_path(file: Option<&Path>, cwd: &Path) -> PathBuf {
     }
 }
 
-pub fn init<F: Fs, W: Write>(fs: &F, cwd: &Path, out: &mut W) -> Result<i32> {
-    let path = yaml_path(cwd);
+pub fn init<F: Fs, W: Write>(
+    fs: &F,
+    cwd: &Path,
+    kind: DocumentKind,
+    file: Option<&Path>,
+    out: &mut W,
+) -> Result<i32> {
+    let path = selected_definition_path(file, cwd);
+    let name = path.file_name().map_or_else(
+        || LNS_YAML.to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
     if fs.exists(&path) {
-        bail!("{LNS_YAML} already exists in this directory; not overwriting it");
+        bail!("{name} already exists in this directory; not overwriting it");
     }
-    fs.write(&path, SCAFFOLD)
+    let (scaffold, next_steps) = match kind {
+        DocumentKind::Sandbox => (
+            SANDBOX_SCAFFOLD,
+            "  1. set spec.image (scaffolded to alpine:3.20)\n  2. boot it with `lns run`\n  3. share it with `lns push`, e.g. `lns push ghcr.io/acme/my-sandbox:1.0.0`",
+        ),
+        DocumentKind::Mixin => (
+            MIXIN_SCAFFOLD,
+            "  1. name the capability it layers on — tools, filesets, egress, credentials\n  2. try it with `lns run --mixin .`\n  3. share it with `lns push`, e.g. `lns push ghcr.io/acme/my-mixin:1.0.0`",
+        ),
+    };
+    fs.write(&path, scaffold)
         .with_context(|| format!("writing {}", path.display()))?;
+    let noun = match kind {
+        DocumentKind::Sandbox => "sandbox definition",
+        DocumentKind::Mixin => "mixin",
+    };
     writeln!(
         out,
-        "✓ created {LNS_YAML} — your sandbox definition, every field ready to edit\n\n  1. set spec.image (scaffolded to alpine:3.20)\n  2. boot it with `lns run`\n  3. share it with `lns push`, e.g. `lns push ghcr.io/acme/my-sandbox:1.0.0`"
+        "✓ created {name} — your {noun}, every field ready to edit\n\n{next_steps}"
     )?;
     Ok(0)
 }
@@ -143,6 +179,7 @@ pub fn load_definition_json_at<F: Fs + ?Sized>(fs: &F, path: &Path) -> Result<Ve
 pub fn validate<F: Fs, W: Write>(
     fs: &F,
     cwd: &Path,
+    kind: Option<DocumentKind>,
     file: Option<&Path>,
     out: &mut W,
 ) -> Result<i32> {
@@ -156,6 +193,7 @@ pub fn validate<F: Fs, W: Write>(
         Ok(()) => Vec::new(),
         Err(problems) => problems,
     };
+    problems.extend(wrong_kind_problem(&json, kind));
     if problems.is_empty()
         && let Ok(def) = lns_artifact::sandbox::parse_document(&json)
     {
@@ -177,6 +215,19 @@ pub fn validate<F: Fs, W: Write>(
     Ok(1)
 }
 
+/// `--kind` is the caller saying which document they think this is, so a file of another kind is a problem alongside whatever else validation found rather than instead of it.
+fn wrong_kind_problem(json: &[u8], wanted: Option<DocumentKind>) -> Option<String> {
+    let wanted = wanted?.as_artifact_kind();
+    let found = lns_artifact::spec::read_kind(json).ok()?;
+    (found != wanted).then(|| {
+        format!(
+            "kind: expected a {}, but this is a {}",
+            wanted.as_str(),
+            found.as_str()
+        )
+    })
+}
+
 pub fn inspect_local<F: Fs, W: Write>(
     fs: &F,
     cwd: &Path,
@@ -192,15 +243,27 @@ pub fn inspect_local<F: Fs, W: Write>(
         (None, file) => selected_definition_path(file, cwd),
     };
     let json = load_definition_json_at(fs, &path)?;
-    let def = lns_artifact::sandbox::parse(&json)
-        .map_err(|e| anyhow::anyhow!("{} is not a valid sandbox: {e:#}", path.display()))?;
-    render_effective(&def, out)?;
+    let kind = lns_artifact::spec::read_kind(&json)
+        .map_err(|e| anyhow::anyhow!("{}: {e:#}", path.display()))?;
+    let def = lns_artifact::sandbox::parse_document(&json).map_err(|e| {
+        anyhow::anyhow!("{} is not a valid {}: {e:#}", path.display(), kind.as_str())
+    })?;
+    render_effective(kind, &def, out)?;
     Ok(0)
 }
 
-fn render_effective<W: Write>(def: &lns_artifact::sandbox::Definition, out: &mut W) -> Result<()> {
-    writeln!(out, "Sandbox: {}", def.name)?;
-    writeln!(out, "  image:        {}", def.spec.image)?;
+fn render_effective<W: Write>(
+    kind: lns_artifact::spec::Kind,
+    def: &lns_artifact::sandbox::Definition,
+    out: &mut W,
+) -> Result<()> {
+    match kind {
+        lns_artifact::spec::Kind::Sandbox => {
+            writeln!(out, "Sandbox: {}", def.name)?;
+            writeln!(out, "  image:        {}", def.spec.image)?;
+        }
+        lns_artifact::spec::Kind::Mixin => writeln!(out, "Mixin: {}", def.name)?,
+    }
     for mixin in &def.spec.mixins {
         writeln!(out, "  mixin: {mixin}")?;
     }
@@ -298,9 +361,17 @@ mod tests {
 
     #[test]
     fn is_offline_matches_the_author_verbs_and_local_inspects_only() {
-        assert!(is_offline(&SandboxCommand::Init));
+        assert!(is_offline(&SandboxCommand::Init(
+            crate::sandbox::SandboxInitArgs {
+                kind: DocumentKind::Sandbox,
+                file: None,
+            }
+        )));
         assert!(is_offline(&SandboxCommand::Validate(
-            crate::sandbox::SandboxValidateArgs { file: None }
+            crate::sandbox::SandboxValidateArgs {
+                kind: None,
+                file: None,
+            }
         )));
         assert!(is_offline(&inspect_cmd(None)));
         assert!(is_offline(&inspect_cmd(Some("."))));
@@ -314,6 +385,7 @@ mod tests {
             },
         })));
         assert!(!is_offline(&SandboxCommand::Ls(crate::sandbox::LsArgs {
+            kind: None,
             output: crate::output::OutputArgs {
                 format: crate::output::Format::Table,
             },
@@ -324,7 +396,7 @@ mod tests {
     fn init_scaffolds_a_default_definition() {
         let fs = MapFs::default();
         let mut out = Vec::new();
-        let code = init(&fs, cwd(), &mut out).unwrap();
+        let code = init(&fs, cwd(), DocumentKind::Sandbox, None, &mut out).unwrap();
         assert_eq!(code, 0);
         let written = fs.read_to_string(&yaml_path(cwd())).unwrap();
         assert!(written.contains("kind: sandbox"));
@@ -338,7 +410,7 @@ mod tests {
     fn init_refuses_to_clobber_an_existing_definition() {
         let fs = fake("/work/lns.yaml", "keep me");
         let mut out = Vec::new();
-        let err = init(&fs, cwd(), &mut out).unwrap_err();
+        let err = init(&fs, cwd(), DocumentKind::Sandbox, None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("already exists"));
         assert_eq!(fs.read_to_string(&yaml_path(cwd())).unwrap(), "keep me");
     }
@@ -350,7 +422,7 @@ mod tests {
             ..Default::default()
         };
         let mut out = Vec::new();
-        let err = init(&fs, cwd(), &mut out).unwrap_err();
+        let err = init(&fs, cwd(), DocumentKind::Sandbox, None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("writing"));
     }
 
@@ -358,7 +430,7 @@ mod tests {
     fn validate_passes_a_well_formed_definition() {
         let fs = fake("/work/lns.yaml", valid_yaml());
         let mut out = Vec::new();
-        let code = validate(&fs, cwd(), None, &mut out).unwrap();
+        let code = validate(&fs, cwd(), None, None, &mut out).unwrap();
         assert_eq!(code, 0);
         assert!(String::from_utf8(out).unwrap().contains("is valid"));
     }
@@ -374,6 +446,7 @@ mod tests {
         let code = validate(
             &fs,
             cwd(),
+            None,
             Some(Path::new("../other/lns.dev.yaml")),
             &mut out,
         )
@@ -393,7 +466,7 @@ mod tests {
             "apiVersion: lns.run/v1\nkind: sandbox\nname: dev\nspec: {}\n",
         );
         let mut out = Vec::new();
-        let code = validate(&fs, cwd(), Some(Path::new("lns.dev.yaml")), &mut out).unwrap();
+        let code = validate(&fs, cwd(), None, Some(Path::new("lns.dev.yaml")), &mut out).unwrap();
         assert_eq!(code, 1);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("lns.dev.yaml is not valid:"), "got: {text}");
@@ -403,7 +476,7 @@ mod tests {
     fn validate_surfaces_a_missing_file() {
         let fs = MapFs::default();
         let mut out = Vec::new();
-        let err = validate(&fs, cwd(), None, &mut out).unwrap_err();
+        let err = validate(&fs, cwd(), None, None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("lns init"));
     }
 
@@ -411,7 +484,8 @@ mod tests {
     fn a_missing_variant_file_does_not_hint_lns_init() {
         let fs = MapFs::default();
         let mut out = Vec::new();
-        let err = validate(&fs, cwd(), Some(Path::new("lns.dev.yaml")), &mut out).unwrap_err();
+        let err =
+            validate(&fs, cwd(), None, Some(Path::new("lns.dev.yaml")), &mut out).unwrap_err();
         let text = format!("{err:#}");
         assert!(text.contains("lns.dev.yaml"), "got: {text}");
         assert!(
@@ -424,7 +498,7 @@ mod tests {
     fn validate_surfaces_malformed_yaml() {
         let fs = fake("/work/lns.yaml", "spec: [unterminated");
         let mut out = Vec::new();
-        let err = validate(&fs, cwd(), None, &mut out).unwrap_err();
+        let err = validate(&fs, cwd(), None, None, &mut out).unwrap_err();
         assert!(format!("{err:#}").contains("parsing"));
     }
 
@@ -526,7 +600,7 @@ mod tests {
             "apiVersion: lns.run/v1\nkind: sandbox\nname: hermes\nspec:\n  image: x:1\n  filesets:\n    - path: ./skills\n      guestPath: /root/.agent/skills\n",
         );
         let mut out = Vec::new();
-        let code = validate(&fs, cwd(), None, &mut out).unwrap();
+        let code = validate(&fs, cwd(), None, None, &mut out).unwrap();
         assert_eq!(code, 1);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("fileset ./skills"), "got: {text}");

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -532,7 +532,7 @@ where
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
-        SandboxCommand::Prune(args) => prune(svc, args, input, out).await,
+        SandboxCommand::Prune(args) => prune(svc, args, term, input, out).await,
     }
 }
 
@@ -954,11 +954,19 @@ async fn remove_cached<W: std::io::Write>(
 async fn prune<I: std::io::BufRead, W: std::io::Write>(
     svc: &impl SandboxService,
     args: &SandboxPruneArgs,
+    term: TermInfo,
     input: &mut I,
     out: &mut W,
 ) -> Result<i32> {
-    if !args.force && !confirm_prune(input, out)? {
-        return Ok(0);
+    if !args.force {
+        if !term.stdin_is_tty {
+            bail!(
+                "this removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache; there is no terminal to ask at, so pass --force to confirm"
+            );
+        }
+        if !confirm_prune(input, out)? {
+            return Ok(0);
+        }
     }
     match svc.one_shot(Request::PruneImages).await? {
         Response::ImagesPruned {
@@ -2601,6 +2609,10 @@ mod tests {
         let code = prune(
             &svc,
             &SandboxPruneArgs { force: false },
+            TermInfo {
+                stdin_is_tty: true,
+                stdout_is_terminal: false,
+            },
             &mut std::io::Cursor::new(b"n\n".to_vec()),
             &mut out,
         )
@@ -2621,6 +2633,7 @@ mod tests {
         let code = prune(
             &svc,
             &SandboxPruneArgs { force: true },
+            TermInfo::default(),
             &mut std::io::empty(),
             &mut out,
         )
@@ -2642,6 +2655,7 @@ mod tests {
                 message: "registry poisoned".into(),
             }),
             &SandboxPruneArgs { force: true },
+            TermInfo::default(),
             &mut std::io::empty(),
             &mut Vec::new(),
         )
@@ -2652,6 +2666,7 @@ mod tests {
         let err = prune(
             &CannedService::new(Response::Pong),
             &SandboxPruneArgs { force: true },
+            TermInfo::default(),
             &mut std::io::empty(),
             &mut Vec::new(),
         )

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -27,8 +27,8 @@ pub struct SandboxArgs {
 
 #[derive(clap::Subcommand)]
 pub enum SandboxCommand {
-    #[command(about = "Scaffold a default ./lns.yaml (kind: sandbox) in this directory.")]
-    Init,
+    #[command(about = "Scaffold a document in this directory; `--kind` chooses which.")]
+    Init(SandboxInitArgs),
     #[command(about = "Validate ./lns.yaml — schema, cross-field, and secret checks, offline.")]
     Validate(SandboxValidateArgs),
     #[command(
@@ -80,12 +80,81 @@ pub struct PsArgs {
 
 #[derive(clap::Args)]
 pub struct LsArgs {
+    #[arg(
+        long,
+        value_enum,
+        value_name = "KIND",
+        help = "List only the cached entries of this kind."
+    )]
+    pub kind: Option<CachedKindFilter>,
+
     #[command(flatten)]
     pub output: crate::output::OutputArgs,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum CachedKindFilter {
+    Image,
+    Sandbox,
+}
+
+impl CachedKindFilter {
+    fn matches(self, kind: lns_ipc::CachedKind) -> bool {
+        matches!(
+            (self, kind),
+            (CachedKindFilter::Image, lns_ipc::CachedKind::Image)
+                | (CachedKindFilter::Sandbox, lns_ipc::CachedKind::Sandbox)
+        )
+    }
+}
+
+#[derive(clap::Args)]
+pub struct SandboxInitArgs {
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = DocumentKind::Sandbox,
+        value_name = "KIND",
+        help = "Which document to scaffold."
+    )]
+    pub kind: DocumentKind,
+
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        help = "File to write instead of ./lns.yaml. Refuses to overwrite either way."
+    )]
+    pub file: Option<PathBuf>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum DocumentKind {
+    Sandbox,
+    Mixin,
+}
+
+impl DocumentKind {
+    pub fn as_artifact_kind(self) -> lns_artifact::spec::Kind {
+        match self {
+            DocumentKind::Sandbox => lns_artifact::spec::Kind::Sandbox,
+            DocumentKind::Mixin => lns_artifact::spec::Kind::Mixin,
+        }
+    }
+}
+
 #[derive(clap::Args)]
 pub struct SandboxValidateArgs {
+    #[arg(
+        long,
+        value_enum,
+        value_name = "KIND",
+        help = "Also require the document to be this kind."
+    )]
+    pub kind: Option<DocumentKind>,
+
     #[arg(
         short = 'f',
         long = "file",
@@ -238,7 +307,7 @@ pub struct SandboxPruneArgs {
         short = 'f',
         long,
         default_value_t = false,
-        help = "Required: confirm removing unused cached sandboxes and, when none is live, the provisioned tool cache."
+        help = "Remove unused cached sandboxes, and the provisioned tool cache when none is live, without asking."
     )]
     pub force: bool,
 }
@@ -279,8 +348,8 @@ pub const SPEC: CommandSpec = CommandSpec {
 
 pub fn augment_init(app: clap::Command) -> clap::Command {
     app.subcommand(
-        clap::Command::new("init")
-            .about("Scaffold a default ./lns.yaml (shortcut for `lns sandbox init`)."),
+        subcommand::<SandboxInitArgs>("init")
+            .about("Scaffold a document in this directory (shortcut for `lns sandbox init`)."),
     )
 }
 
@@ -440,7 +509,7 @@ where
     E: AsyncWriteExt + Unpin,
 {
     match cmd {
-        SandboxCommand::Init | SandboxCommand::Validate(_) => {
+        SandboxCommand::Init(_) | SandboxCommand::Validate(_) => {
             bail!("author commands run offline, not through the service dispatch")
         }
         SandboxCommand::Push(_) => {
@@ -463,7 +532,7 @@ where
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
-        SandboxCommand::Prune(args) => prune(svc, args, out).await,
+        SandboxCommand::Prune(args) => prune(svc, args, input, out).await,
     }
 }
 
@@ -681,7 +750,11 @@ async fn ls<W: std::io::Write>(
     match svc.one_shot(Request::ListImages).await? {
         Response::ImageList { mut images } => {
             images.sort_by(|a, b| a.reference.cmp(&b.reference));
-            let rows: Vec<SandboxRow> = images.iter().map(SandboxRow::new).collect();
+            let rows: Vec<SandboxRow> = images
+                .iter()
+                .filter(|image| args.kind.is_none_or(|kind| kind.matches(image.kind)))
+                .map(SandboxRow::new)
+                .collect();
             crate::output::emit(args.output.format, &rows, out)?;
             Ok(0)
         }
@@ -694,6 +767,7 @@ async fn ls<W: std::io::Write>(
 #[serde(rename_all = "camelCase")]
 struct SandboxRow {
     reference: String,
+    kind: String,
     digest: String,
     size_bytes: u64,
     layers: u32,
@@ -705,6 +779,7 @@ impl SandboxRow {
     fn new(image: &lns_ipc::ImageInfo) -> Self {
         Self {
             reference: image.reference.clone(),
+            kind: image.kind.as_str().to_string(),
             digest: image.digest.clone(),
             size_bytes: image.size_bytes,
             layers: image.layers,
@@ -714,11 +789,29 @@ impl SandboxRow {
     }
 }
 
+/// The digest column is the short form the tables elsewhere use, since the whole one crowds out every other column and the JSON carries it in full.
+fn short_digest(digest: &str) -> String {
+    let hex = digest.strip_prefix("sha256:").unwrap_or(digest);
+    hex.char_indices()
+        .nth(12)
+        .map_or(hex, |(i, _)| &hex[..i])
+        .to_string()
+}
+
 impl crate::output::TableRow for SandboxRow {
-    const HEADERS: &'static [&'static str] = &["SANDBOX", "STATE"];
+    const HEADERS: &'static [&'static str] = &["ARTIFACT", "KIND", "DIGEST", "SIZE", "HOLDER"];
 
     fn cells(&self) -> Vec<String> {
-        vec![self.reference.clone(), "cached".to_string()]
+        vec![
+            self.reference.clone(),
+            self.kind.clone(),
+            short_digest(&self.digest),
+            format_bytes(self.size_bytes),
+            match &self.in_use_by {
+                Some(run) => format!("run {}", lns_ipc::short_run_id(run)),
+                None => "-".to_string(),
+            },
+        ]
     }
 }
 
@@ -858,15 +951,14 @@ async fn remove_cached<W: std::io::Write>(
     }
 }
 
-async fn prune<W: std::io::Write>(
+async fn prune<I: std::io::BufRead, W: std::io::Write>(
     svc: &impl SandboxService,
     args: &SandboxPruneArgs,
+    input: &mut I,
     out: &mut W,
 ) -> Result<i32> {
-    if !args.force {
-        bail!(
-            "this removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache; pass --force to confirm"
-        );
+    if !args.force && !confirm_prune(input, out)? {
+        return Ok(0);
     }
     match svc.one_shot(Request::PruneImages).await? {
         Response::ImagesPruned {
@@ -883,6 +975,25 @@ async fn prune<W: std::io::Write>(
         Response::Error { message } => bail!("daemon error: {message}"),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
+}
+
+fn confirm_prune<I: std::io::BufRead, W: std::io::Write>(
+    input: &mut I,
+    out: &mut W,
+) -> Result<bool> {
+    write!(
+        out,
+        "This removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache. Continue? [y/N] "
+    )?;
+    out.flush()?;
+    let mut line = String::new();
+    input.read_line(&mut line)?;
+    let answer = line.trim();
+    let yes = answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes");
+    if !yes {
+        writeln!(out, "Aborted.")?;
+    }
+    Ok(yes)
 }
 
 /// `--mixin` composes a document before it boots, and neither a run that has already booted nor a file rendered offline can honour it.
@@ -1385,6 +1496,7 @@ mod tests {
     fn pulled_response() -> Response {
         Response::ImagePulled {
             image: lns_ipc::ImageInfo {
+                kind: lns_ipc::CachedKind::Sandbox,
                 reference: "ghcr.io/team/hermes:1.4.0".into(),
                 digest: format!("sha256:{}", "a".repeat(64)),
                 size_bytes: 1024,
@@ -1499,8 +1611,14 @@ mod tests {
     async fn run_with_writers_refuses_the_offline_author_verbs() {
         let svc = CannedService::new(Response::Pong);
         for cmd in [
-            SandboxCommand::Init,
-            SandboxCommand::Validate(SandboxValidateArgs { file: None }),
+            SandboxCommand::Init(SandboxInitArgs {
+                kind: DocumentKind::Sandbox,
+                file: None,
+            }),
+            SandboxCommand::Validate(SandboxValidateArgs {
+                kind: None,
+                file: None,
+            }),
             SandboxCommand::Inspect(SandboxInspectArgs {
                 run: None,
                 mixins: Vec::new(),
@@ -1557,6 +1675,7 @@ mod tests {
         let svc = CannedService::with_inspect_image(
             Response::ImagePulled {
                 image: lns_ipc::ImageInfo {
+                    kind: lns_ipc::CachedKind::Sandbox,
                     reference: "ghcr.io/team/hermes:1.4.0".into(),
                     digest: digest.clone(),
                     size_bytes: 1024,
@@ -1905,6 +2024,7 @@ mod tests {
 
     fn ls_args() -> LsArgs {
         LsArgs {
+            kind: None,
             output: crate::output::OutputArgs {
                 format: crate::output::Format::Table,
             },
@@ -2475,13 +2595,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prune_requires_force_before_touching_the_cache() {
+    async fn declining_the_prune_prompt_reaches_no_service() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
-        let err = prune(&svc, &SandboxPruneArgs { force: false }, &mut out)
-            .await
-            .unwrap_err();
-        assert!(format!("{err:#}").contains("--force"), "got: {err:#}");
+        let code = prune(
+            &svc,
+            &SandboxPruneArgs { force: false },
+            &mut std::io::Cursor::new(b"n\n".to_vec()),
+            &mut out,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert!(String::from_utf8(out).unwrap().contains("Aborted."));
+        assert!(svc.requests.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -2491,9 +2618,14 @@ mod tests {
             reclaimed_bytes: 64 * 1024 * 1024,
         });
         let mut out = Vec::new();
-        let code = prune(&svc, &SandboxPruneArgs { force: true }, &mut out)
-            .await
-            .unwrap();
+        let code = prune(
+            &svc,
+            &SandboxPruneArgs { force: true },
+            &mut std::io::empty(),
+            &mut out,
+        )
+        .await
+        .unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
         assert!(
@@ -2510,6 +2642,7 @@ mod tests {
                 message: "registry poisoned".into(),
             }),
             &SandboxPruneArgs { force: true },
+            &mut std::io::empty(),
             &mut Vec::new(),
         )
         .await
@@ -2519,6 +2652,7 @@ mod tests {
         let err = prune(
             &CannedService::new(Response::Pong),
             &SandboxPruneArgs { force: true },
+            &mut std::io::empty(),
             &mut Vec::new(),
         )
         .await

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -58,8 +58,11 @@ fn qualified_reference(reference: &str) -> Result<String> {
     ))
 }
 
-pub fn run_init<'a>(_matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
-    Box::pin(async move { run_author(&super::SandboxCommand::Init, ctx) })
+pub fn run_init<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
+    Box::pin(async move {
+        let args = super::SandboxInitArgs::from_arg_matches(matches)?;
+        run_author(&super::SandboxCommand::Init(args), ctx)
+    })
 }
 
 pub fn run_ps<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
@@ -302,9 +305,11 @@ fn run_author(command: &super::SandboxCommand, ctx: RunCtx<'_>) -> Result<i32> {
     let cwd = ctx.cwd()?;
     let mut out = std::io::stdout();
     match command {
-        super::SandboxCommand::Init => super::author::init(&RealFs, &cwd, &mut out),
+        super::SandboxCommand::Init(args) => {
+            super::author::init(&RealFs, &cwd, args.kind, args.file.as_deref(), &mut out)
+        }
         super::SandboxCommand::Validate(args) => {
-            super::author::validate(&RealFs, &cwd, args.file.as_deref(), &mut out)
+            super::author::validate(&RealFs, &cwd, args.kind, args.file.as_deref(), &mut out)
         }
         super::SandboxCommand::Inspect(args) => super::author::inspect_local(
             &RealFs,

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -1,7 +1,7 @@
-Feature: authoring a sandbox
-  A sandbox is authored on disk as `./lns.yaml` (kind: sandbox). The author
-  verbs scaffold it and validate it offline; `inspect` with no target (or a
-  path-shaped one) renders its effective definition, also offline.
+Feature: authoring a document
+  A document is authored on disk as `./lns.yaml`, or as whatever file `-f`
+  names. `init` scaffolds the kind you ask for, and `validate` and `inspect`
+  answer for whichever kind the file declares — offline, either way.
 
   Scenario: init scaffolds a default sandbox definition with every spec field
     Given the current directory has no lns.yaml
@@ -35,7 +35,40 @@ Feature: authoring a sandbox
     And the output contains "already exists"
     And the existing lns.yaml is left unchanged
 
-  Scenario: init takes no flags
+  Scenario: init scaffolds a mixin when asked for one
+    Given the current directory has no lns.yaml
+    When the user runs sandbox command "init --kind mixin"
+    Then the exit code is 0
+    And a file "lns.yaml" is created
+    And the file "lns.yaml" contains "kind: mixin"
+    And the file "lns.yaml" does not contain "image:"
+
+  Scenario: the scaffolded mixin is valid as written
+    Given the current directory has no lns.yaml
+    When the user runs sandbox command "init --kind mixin"
+    And the user runs sandbox command "validate"
+    Then the exit code is 0
+    And the output contains "valid"
+
+  Scenario: init writes the file -f names
+    Given the current directory has no lns.yaml
+    When the user runs sandbox command "init -f lns.dev.yaml"
+    Then the exit code is 0
+    And a file "lns.dev.yaml" is created
+    And the file "lns.dev.yaml" contains "kind: sandbox"
+
+  Scenario: init refuses to clobber the file -f names
+    Given the current directory already has an lns.dev.yaml
+    When the user runs sandbox command "init -f lns.dev.yaml"
+    Then the command fails with an exit code other than 0
+    And the output contains "already exists"
+
+  Scenario: init scaffolds no kind it cannot also validate
+    When I run "lns init --kind sorcery"
+    Then the exit code is 2
+    And the output contains "invalid value"
+
+  Scenario: init takes no flag that edits the document
     When I run "lns init --image alpine"
     Then the exit code is 2
     And the output contains "unexpected argument"
@@ -57,6 +90,20 @@ Feature: authoring a sandbox
   Scenario: validate answers for a mixin document too
     Given an lns.yaml holding a mixin document
     When the user runs sandbox command "validate"
+    Then the exit code is 0
+    And the output contains "valid"
+    And the service received no request
+
+  Scenario: validate --kind holds the document to the kind you named
+    Given an lns.yaml holding a mixin document
+    When the user runs sandbox command "validate --kind sandbox"
+    Then the command fails with an exit code other than 0
+    And the output contains "is a mixin"
+    And the service received no request
+
+  Scenario: validate --kind passes a document that is that kind
+    Given an lns.yaml holding a mixin document
+    When the user runs sandbox command "validate --kind mixin"
     Then the exit code is 0
     And the output contains "valid"
     And the service received no request
@@ -88,6 +135,14 @@ Feature: authoring a sandbox
     Then the exit code is 0
     And the output contains "image"
     And the output contains "egress"
+    And the service received no request
+
+  Scenario: inspect renders a mixin, not only a sandbox
+    Given an lns.yaml holding a mixin document
+    When the user runs sandbox command "inspect"
+    Then the exit code is 0
+    And the output contains "postgres-tools"
+    And the output contains "node@22"
     And the service received no request
 
   Scenario: inspect discloses the run-as user a definition asks for

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -82,6 +82,14 @@ Feature: managing cached sandboxes
     And the output contains "provisioned tool cache"
     And the service received a PruneImages request
 
+  Scenario: with no terminal to ask at, prune refuses rather than assuming
+    Given two cached sandboxes and one running sandbox
+    And sandbox input is non-interactive
+    When the user runs sandbox command "prune"
+    Then the command fails with an exit code other than 0
+    And the output contains "--force"
+    And the service received no request
+
   Scenario: declining the prune prompt touches nothing
     Given two cached sandboxes and one running sandbox
     And the user will answer "n" to the sandbox prompt

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -4,12 +4,35 @@ Feature: managing cached sandboxes
   reconstructible cache (artifacts + base-image layers + composefs/content)
   and never touches a named volume.
 
-  Scenario: ls lists cached sandboxes
+  Scenario: ls says what each cached artifact is, how big, and who holds it
     Given the service reports one cached sandbox "hermes:1.4.0"
     When the user runs sandbox command "ls"
     Then the exit code is 0
     And the output contains "hermes:1.4.0"
-    And the output contains "cached"
+    And the output contains "KIND"
+    And the output contains "DIGEST"
+    And the output contains "SIZE"
+    And the output contains "HOLDER"
+    And the output contains "sandbox"
+    And the output contains "14.0 MiB"
+
+  Scenario: ls names the run holding an artifact rather than leaving the column blank
+    Given the service reports one cached sandbox "hermes:1.4.0" held by run 3
+    When the user runs sandbox command "ls"
+    Then the exit code is 0
+    And the output contains "000000030000"
+
+  Scenario: ls --kind lists only the artifacts of that kind
+    Given the service reports a cached sandbox "hermes:1.4.0" and a cached image "alpine:3.20"
+    When the user runs sandbox command "ls --kind image"
+    Then the exit code is 0
+    And the output contains "alpine:3.20"
+    And the output does not contain "hermes:1.4.0"
+
+  Scenario: ls --kind rejects a kind the cache cannot hold
+    When I run "lns sandbox ls --kind sorcery"
+    Then the exit code is 2
+    And the output contains "invalid value"
 
   Scenario: there is no top-level ls shortcut for the cached list
     When I run "lns ls"
@@ -50,12 +73,21 @@ Feature: managing cached sandboxes
     And the running sandbox and its layers are kept
     And the service received a PruneImages request
 
-  Scenario: prune without force refuses before touching the cache
+  Scenario: prune asks before it sweeps, and proceeds on yes
     Given two cached sandboxes and one running sandbox
+    And the user will answer "y" to the sandbox prompt
     When the user runs sandbox command "prune"
-    Then the command fails with an exit code other than 0
-    And the output contains "--force"
+    Then the exit code is 0
+    And the output contains "Continue? [y/N]"
     And the output contains "provisioned tool cache"
+    And the service received a PruneImages request
+
+  Scenario: declining the prune prompt touches nothing
+    Given two cached sandboxes and one running sandbox
+    And the user will answer "n" to the sandbox prompt
+    When the user runs sandbox command "prune"
+    Then the exit code is 0
+    And the output contains "Aborted."
     And the service received no request
 
   Scenario: prune never removes a named volume

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
@@ -25,6 +25,14 @@ fn existing_lns_yaml(w: &mut BehaviourWorld) {
     seed(w, EXISTING_SENTINEL);
 }
 
+#[given("the current directory already has an lns.dev.yaml")]
+fn existing_named_definition(w: &mut BehaviourWorld) {
+    w.author_files.insert(
+        PathBuf::from("/work/lns.dev.yaml"),
+        EXISTING_SENTINEL.to_string(),
+    );
+}
+
 #[given("a valid lns.yaml in the current directory")]
 fn valid_lns_yaml(w: &mut BehaviourWorld) {
     seed(
@@ -229,28 +237,49 @@ fn project_directory_contains(w: &mut BehaviourWorld, dir: String, file: String)
     w.author_files.insert(path, "fixture contents".to_string());
 }
 
-#[then(regex = r#"^a file "lns\.yaml" is created$"#)]
-fn file_created(w: &mut BehaviourWorld) -> Result<(), String> {
-    if w.author_files.contains_key(&yaml_key()) {
+#[then(regex = r#"^a file "([^"]+)" is created$"#)]
+fn file_created(w: &mut BehaviourWorld, name: String) -> Result<(), String> {
+    if w.author_files
+        .contains_key(&PathBuf::from("/work").join(&name))
+    {
         Ok(())
     } else {
-        Err("lns.yaml was not created".to_string())
+        Err(format!("{name} was not created"))
     }
 }
 
-#[then(regex = r#"^the file "lns\.yaml" contains "([^"]+)"$"#)]
-fn file_contains(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
-    let contents = w
-        .author_files
-        .get(&yaml_key())
-        .ok_or("lns.yaml does not exist")?;
+#[then(regex = r#"^the file "([^"]+)" contains "([^"]+)"$"#)]
+fn file_contains(w: &mut BehaviourWorld, name: String, needle: String) -> Result<(), String> {
+    let contents = authored(w, &name)?;
     if contents.contains(&needle) {
         Ok(())
     } else {
         Err(format!(
-            "expected lns.yaml to contain {needle:?}, got:\n{contents}"
+            "expected {name} to contain {needle:?}, got:\n{contents}"
         ))
     }
+}
+
+#[then(regex = r#"^the file "([^"]+)" does not contain "([^"]+)"$"#)]
+fn file_does_not_contain(
+    w: &mut BehaviourWorld,
+    name: String,
+    needle: String,
+) -> Result<(), String> {
+    let contents = authored(w, &name)?;
+    if contents.contains(&needle) {
+        Err(format!(
+            "expected {name} not to contain {needle:?}, got:\n{contents}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn authored<'a>(w: &'a BehaviourWorld, name: &str) -> Result<&'a String, String> {
+    w.author_files
+        .get(&PathBuf::from("/work").join(name))
+        .ok_or_else(|| format!("{name} does not exist"))
 }
 
 #[then("the existing lns.yaml is left unchanged")]

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -320,9 +320,11 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &SandboxCommand) {
     };
     let mut out: Vec<u8> = Vec::new();
     let result = match cmd {
-        SandboxCommand::Init => author::init(&fs, cwd, &mut out),
+        SandboxCommand::Init(args) => {
+            author::init(&fs, cwd, args.kind, args.file.as_deref(), &mut out)
+        }
         SandboxCommand::Validate(args) => {
-            author::validate(&fs, cwd, args.file.as_deref(), &mut out)
+            author::validate(&fs, cwd, args.kind, args.file.as_deref(), &mut out)
         }
         SandboxCommand::Inspect(args) => author::inspect_local(
             &fs,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -1,7 +1,7 @@
 use cucumber::{given, then};
 use lns_ipc::{
-    ArtifactInspection, ImageInfo, Request, Response, RunConfig, RunDetails, RunStatus, RunSummary,
-    SandboxView,
+    ArtifactInspection, CachedKind, ImageInfo, Request, Response, RunConfig, RunDetails, RunStatus,
+    RunSummary, SandboxView,
 };
 
 use crate::world::BehaviourWorld;
@@ -147,16 +147,38 @@ fn reports_no_cached_sandboxes(w: &mut BehaviourWorld) {
     w.sandbox.response = Some(Response::ImageList { images: Vec::new() });
 }
 
+fn cached(reference: &str, kind: CachedKind, holder: Option<String>) -> ImageInfo {
+    ImageInfo {
+        reference: reference.to_string(),
+        kind,
+        digest: format!("sha256:{}", "a".repeat(64)),
+        size_bytes: 14 * 1024 * 1024,
+        layers: 3,
+        pulled: "2026-01-01T00:00:00Z".into(),
+        in_use_by: holder,
+    }
+}
+
 #[given(regex = r#"^the service reports one cached sandbox "([^"]+)"$"#)]
 fn reports_one_cached_sandbox(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.response = Some(Response::ImageList {
-        images: vec![ImageInfo {
-            reference,
-            digest: format!("sha256:{}", "a".repeat(64)),
-            size_bytes: 14 * 1024 * 1024,
-            layers: 3,
-            pulled: "2026-01-01T00:00:00Z".into(),
-            in_use_by: None,
-        }],
+        images: vec![cached(&reference, CachedKind::Sandbox, None)],
+    });
+}
+
+#[given(regex = r#"^the service reports one cached sandbox "([^"]+)" held by run (\d+)$"#)]
+fn reports_one_held_cached_sandbox(w: &mut BehaviourWorld, reference: String, run: u32) {
+    w.sandbox.response = Some(Response::ImageList {
+        images: vec![cached(&reference, CachedKind::Sandbox, Some(hexid(run)))],
+    });
+}
+
+#[given(regex = r#"^the service reports a cached sandbox "([^"]+)" and a cached image "([^"]+)"$"#)]
+fn reports_a_sandbox_and_an_image(w: &mut BehaviourWorld, sandbox: String, image: String) {
+    w.sandbox.response = Some(Response::ImageList {
+        images: vec![
+            cached(&sandbox, CachedKind::Sandbox, None),
+            cached(&image, CachedKind::Image, None),
+        ],
     });
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -57,6 +57,7 @@ fn registry_serves_sandbox(w: &mut BehaviourWorld, reference: String) {
     let digest = format!("sha256:{}", "a".repeat(64));
     w.sandbox.response = Some(lns_ipc::Response::ImagePulled {
         image: lns_ipc::ImageInfo {
+            kind: lns_ipc::CachedKind::Sandbox,
             reference: reference.clone(),
             digest: digest.clone(),
             size_bytes: 3 * 1024 * 1024,

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -20,7 +20,7 @@ pub use paths::{
     cache_root, connection_ledger, connection_ledger_anchor, data_root, short_run_id,
 };
 pub use protocol::{
-    ArtifactInspection, BindMount, BindSpec, ContributionBlock, CredentialBindDecision,
+    ArtifactInspection, BindMount, BindSpec, CachedKind, ContributionBlock, CredentialBindDecision,
     DisplacedEntry, ExecImageArgs, ImageInfo, ImageView, LogLevel, MixinView, MountSpec,
     PackedFilesetSource, PortPublish, Protocol, Request, Response, RunConfig, RunDetails,
     RunImageArgs, RunStatsInfo, RunStatus, RunSummary, SandboxFileset, SandboxFilesetOwner,

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -303,9 +303,27 @@ pub struct VolumePruneFailure {
     pub error: String,
 }
 
+/// What a cached entry is: an `lns.run/v1` sandbox artifact, or the plain OCI image one runs on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CachedKind {
+    Image,
+    Sandbox,
+}
+
+impl CachedKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CachedKind::Image => "image",
+            CachedKind::Sandbox => "sandbox",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImageInfo {
     pub reference: String,
+    pub kind: CachedKind,
     pub digest: String,
     pub size_bytes: u64,
     pub layers: u32,
@@ -1609,6 +1627,7 @@ mod tests {
     fn image_responses_survive_round_trips() {
         let info = ImageInfo {
             reference: "registry.example.test/some/image:1.0".into(),
+            kind: CachedKind::Sandbox,
             digest: format!("sha256:{}", "a".repeat(64)),
             size_bytes: 3 * 1024 * 1024,
             layers: 2,
@@ -1681,6 +1700,7 @@ mod tests {
     fn image_info_serializes_idle_holder_as_null() {
         let info = ImageInfo {
             reference: "registry.example.test/some/image:1.0".into(),
+            kind: CachedKind::Image,
             digest: format!("sha256:{}", "b".repeat(64)),
             size_bytes: 4096,
             layers: 1,

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -160,9 +160,19 @@ fn holder(active: &[lns_ipc::RunSummary], reference: &str) -> Option<String> {
         .map(|r| r.id.clone())
 }
 
+/// An artifact record names the base image it needs and carries no layers of its own; a plain image record is the other way round, so the dependency edge is what tells the two apart.
+fn kind_of(record: &ImageRecord) -> lns_ipc::CachedKind {
+    if record.dependencies.is_empty() {
+        lns_ipc::CachedKind::Image
+    } else {
+        lns_ipc::CachedKind::Sandbox
+    }
+}
+
 fn info_from(record: &ImageRecord, active: &[lns_ipc::RunSummary]) -> lns_ipc::ImageInfo {
     lns_ipc::ImageInfo {
         reference: record.reference.clone(),
+        kind: kind_of(record),
         digest: record.digest.clone(),
         size_bytes: record.layers.iter().map(|l| l.size_bytes).sum(),
         layers: record.layers.len() as u32,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,8 +41,8 @@ What the JSON gives you:
 - **The same exit code as the table.** `--format` changes the shape and nothing else:
   `lns config get` on an unset key still exits 1, emitting `[]`.
 - Some verbs report more in JSON than the table has room for. `lns sandbox ls` is the
-  clearest case: the table shows a reference and a state, the JSON adds digest, size,
-  layer count, pull time, and holder.
+  clearest case: the table abbreviates the digest and formats the size, and the JSON
+  adds the whole digest, the raw byte count, the layer count, and the pull time.
 - The empty-list sentences (`No rules in …`) become `[]`. Warnings go to stderr in both
   formats, so stdout stays parseable either way.
 
@@ -135,8 +135,8 @@ The complete sandbox surface: author, distribute, run, and manage it.
 
 ```bash
 # author (offline)
-lns sandbox init
-lns sandbox validate
+lns sandbox init [--kind <sandbox|mixin>] [-f <FILE>]
+lns sandbox validate [--kind <KIND>] [-f <FILE>]
 lns inspect              # target-less: render ./lns.yaml, offline
 
 # distribute
@@ -146,7 +146,7 @@ lns sandbox tag <SOURCE> <TARGET>
 
 # running lifecycle
 lns sandbox ps
-lns sandbox ls
+lns sandbox ls [--kind <image|sandbox>]
 lns sandbox exec [OPTIONS] <RUN> [-- COMMAND...]
 lns sandbox kill <RUN> [--signal <SIG>]
 lns sandbox stop <RUN> [-t <SECONDS>]
@@ -165,21 +165,21 @@ interchangeable everywhere a run is addressed.
 
 | Subcommand | Shortcut       | Meaning |
 | ---------- | -------------- | ------- |
-| `init`     | `lns init`     | Scaffold a default `./lns.yaml` (`kind: sandbox`) in this directory. |
-| `validate` | —              | Validate `./lns.yaml` — schema, cross-field, and secret checks, offline. Exits non-zero and lists each problem when the definition is broken. `-f`/`--file` validates another definition file instead. |
+| `init`     | `lns init`     | Scaffold a document in this directory. `--kind` chooses which — `sandbox` (the default) or `mixin`; the file is `./lns.yaml` unless `-f`/`--file` names another. Refuses to overwrite. |
+| `validate` | —              | Validate `./lns.yaml` — schema, cross-field, and secret checks, offline. It answers for whichever kind the file declares. Exits non-zero and lists each problem when the document is broken. `--kind <KIND>` also requires the document to be that kind. `-f`/`--file` validates another file instead. |
 | `push`     | `lns push`     | Build `./lns.yaml` and upload it to a registry as an artifact — a `kind: sandbox` document publishes as a sandbox, a `kind: mixin` one as a mixin — in one step. `<REF>` is the registry reference to publish at; a bare one (`you/agent`) resolves against the `run.registry` default, else the Lens hub (`hub.lns.run`). Each `spec.filesets` `path` directory is packed into a layer of that same artifact, in declaration order, so the files and the declaration that mounts them share one digest; each fuzzy `spec.tools` version resolves against the tool's public version index and publishes as an exact pin. A `spec.mixins` entry that names a local path is published too: the document it names goes up first as its own artifact, beside `<REF>` and under that mixin's own `name`, tagged with its own digest, and the entry you uploaded is pinned to that digest — your own file keeps the path. Push lists those mixins and asks before it uploads anything; `--yes` accepts without prompting. `--dry-run` validates, packs, and builds all of it offline, prints the digests every artifact would publish under, and uploads nothing (declared tools are not resolved — it notes when a published digest may differ). `-f`/`--file` publishes another definition file instead. |
 | `pull`     | `lns pull`     | Inspect and fetch a published sandbox and its base image into the local cache. A published **mixin** pulls too: it is config-only, so the pull caches its document and every mixin it names, which is what lets a digest-pinned graph resolve offline afterwards — it takes no index entry, so it never appears in `lns image ls`. A bare `<REF>` resolves the same way as for `push`. If a **sandbox** declares tools, disclose them and ask before running their installers in a disposable provisioning guest — a mixin pull installs nothing, so it asks nothing; `--yes` accepts them non-interactively. The pull is bound to the inspected digest. |
 | `tag`      | `lns tag`      | Re-reference a cached sandbox under a new tag (`docker tag`-style). |
 | `ps`       | `lns ps`       | List running sandboxes with their CPU and memory (`docker ps`-style). |
-| `ls`       | —              | List cached sandboxes (pulled or built) in the local store. Alias: `list`. |
+| `ls`       | —              | List what the local store holds — reference, kind, digest, size, and the run holding each. `--kind` filters to `sandbox` (a pulled or built artifact) or `image` (the base OCI image one runs on). Alias: `list`. |
 | `exec`     | `lns exec`     | Run another command against a running run. Stdin and PTY allocation are explicit: `-i` forwards stdin, `-t` allocates a PTY, and `-it` does both. `--detach-keys` closes only that exec session; `-q` suppresses status lines. The command needs no `--` separator. |
 | `kill`     | `lns kill`     | Send one signal (`--signal`, default `TERM`; bare or `SIG`-prefixed, case-insensitive: `TERM`, `INT`, `QUIT`, `HUP`, `WINCH`, `KILL`) and return. |
 | `stop`     | `lns stop`     | Stop a run gracefully: SIGTERM first, SIGKILL once the timeout passes (`-t`, default 10s). Reports whether it had to escalate. |
 | `logs`     | `lns logs`     | Print the run's captured stdout/stderr; `-f` keeps streaming until the run exits. The service keeps the most recent 2 MiB of output per run, while the run is listed. |
 | `attach`   | `lns attach`   | Re-join a run's live output, most useful after `lns run -d`. The detach chord (`ctrl-p,ctrl-q` by default) leaves the run running and returns you to your shell (docker-attach style; no signal is sent). Stdin reaches the workload only if the run was started with stdin open. |
-| `inspect`  | `lns inspect`  | With no target, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: render that local definition's effective form, offline. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <source> -> <guestPath>`), connectors, declared tools (`tool: node@22.11.0`), its `pre-start` scripts with the user each asks for and its body printed whole, the mixins it resolved into (`mixin: <ref>`), and any over-broad-policy flag; a `mixin`'s own blocks as its author wrote them, unresolved; or a plain `image`. `--mixin <REF>` resolves that mixin into the sandbox first, so a composition can be previewed without starting a run. |
+| `inspect`  | `lns inspect`  | With no target, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: render that local document's effective form, offline — a `mixin` renders as one, not as a broken sandbox. For a running run: print its live state and launch configuration as JSON, with the policy file's parsed contents embedded when readable. For a cached reference: print the artifact's kind and definition — a `sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <source> -> <guestPath>`), connectors, declared tools (`tool: node@22.11.0`), its `pre-start` scripts with the user each asks for and its body printed whole, the mixins it resolved into (`mixin: <ref>`), and any over-broad-policy flag; a `mixin`'s own blocks as its author wrote them, unresolved; or a plain `image`. `--mixin <REF>` resolves that mixin into the sandbox first, so a composition can be previewed without starting a run. |
 | `rm`       | `lns rm`       | Remove a cached sandbox and free its now-unreferenced layers; refuses a running one (a running id/name is rejected). |
-| `prune`    | —              | Remove every cached sandbox not held by a running one and, when none is live, reclaim the provisioned tool cache. Requires `-f`/`--force` — there is no interactive prompt. |
+| `prune`    | —              | Remove every cached sandbox not held by a running one and, when none is live, reclaim the provisioned tool cache. Asks first, unless `-f`/`--force`. |
 
 The `./lns.yaml` definition (`apiVersion: lns.run/v1`, `kind: sandbox`) carries a
 `spec` with `image` (**required** base OCI image), and the optional `command`,

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -217,7 +217,9 @@ section before using it.
 
 No command edits the rules. A decision is recorded one of two ways: you answer the
 card a run raises, or you open `lns-local-mixin.yaml` and write the rule yourself.
-Both write the same document.
+Both write the same document, and because it is a `kind: mixin` document,
+`lns sandbox validate -f lns-local-mixin.yaml` checks what you wrote and
+`lns sandbox inspect -f lns-local-mixin.yaml` renders it.
 
 ### Add an allow or deny rule
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -21,8 +21,12 @@ Scaffold a `./lns.yaml` in the current directory with `lns init` (a shortcut for
 `lns sandbox init`):
 
 ```bash
-lns init
+lns init                        # ./lns.yaml, kind: sandbox
+lns init --kind mixin           # a mixin instead
+lns init -f lns.dev.yaml        # under another name
 ```
+
+`init` refuses to overwrite a file that is already there.
 
 ```yaml
 apiVersion: lns.run/v1


### PR DESCRIPTION
Stage 3 of 9. This PR closes the five artifact-verb gaps that §3.1 names.

> **Stacked on #279.** The base of this PR is `cli-spec-s2-run-flags`. The diff shows stage 3 only. Merge #279 first.

The verbs stay under `lns sandbox` here. Stage 5 (#283) moves them to `lns artifact`.

## What ships

| Gap | What it does now |
|---|---|
| `init` made one kind, with one file name | `lns sandbox init [--kind sandbox\|mixin] [-f FILE]`. You write a mixin in an editor too, so it gets a scaffold. `init` still refuses to overwrite. |
| `validate` answered only "is this valid" | `--kind <KIND>` also holds the document to the kind that you name. The report shows this together with everything else that validation found. |
| `inspect` of a local file supposed a sandbox | It reads the kind. `parse_document` replaces `sandbox::parse`, so a mixin shows as a mixin. Before, a mixin failed as a broken sandbox. |
| `ls` showed a reference and the word `cached` | The table shows `ARTIFACT  KIND  DIGEST  SIZE  HOLDER`. `--kind` filters it. |
| `prune` refused without `--force` | It asks you, as `lns volume prune` already does. `-f` skips the question. |

## What you see

Make a mixin:

```console
$ lns sandbox init --kind mixin
✓ created lns.yaml — your mixin, every field ready to edit

  1. name the capability it layers on — tools, filesets, egress, credentials
  2. try it with `lns run --mixin .`
  3. share it with `lns push`, e.g. `lns push ghcr.io/acme/my-mixin:1.0.0`

$ cat lns.yaml
apiVersion: lns.run/v1
kind: mixin
name: mixin
spec:
  egress:
    http: []
    tcp: []
  credentials: []
  filesets: []
  tools: []
```

`init` protects a file that is already there:

```console
$ lns sandbox init
Error: lns.yaml already exists in this directory; not overwriting it
```

`validate --kind` holds the document to the kind that you name:

```console
$ lns sandbox validate --kind sandbox
lns.yaml is not valid:
  - kind: expected a sandbox, but this is a mixin

$ echo $?
1

$ lns sandbox validate
lns.yaml is valid.
```

`inspect` reads the kind, so a mixin shows as a mixin:

```console
$ lns sandbox inspect
Mixin: mixin
  egress:       0 route(s)
```

`ls` shows what each cached artifact is:

```console
$ lns sandbox ls
ARTIFACT  KIND  DIGEST  SIZE  HOLDER

$ lns sandbox ls --kind sorcery
error: invalid value 'sorcery' for '--kind <KIND>'
  [possible values: image, sandbox]

For more information, try '--help'.
```

`prune` asks first. With no terminal to ask at, it refuses:

```console
$ lns sandbox prune
Error: this removes every cached sandbox not held by a running one and, when none is
live, the provisioned tool cache; there is no terminal to ask at, so pass --force to confirm
```

## Where the kind comes from

`ImageInfo` gets a `kind` field: `image` or `sandbox`. The store reads the kind from the dependency edge of the record. An artifact record names the base image that it needs, and holds no layers of its own. A plain image record is the opposite. The stored format does not change, so no cache is lost, and no cache becomes unreadable.

The table does not list mixins. A pulled mixin takes no index entry, because it is configuration only, and nothing must reclaim it. When that changes, `CachedKind` gets one more value.

## `--kind connector` is not here

`lns_artifact::Kind` has only `Sandbox` and `Mixin`, so `kind: connector` is not a document that the code can read. `init --kind connector` would write a file that `validate`, `inspect`, `push` and `pull` all refuse:

```console
$ lns sandbox init --kind connector
error: invalid value 'connector' for '--kind <KIND>'
  [possible values: sandbox, mixin]
```

§3.3 waits for the same gap. The scaffold lands with that document format.

## Tests first

Twelve scenarios in `sandbox_author.feature` and `sandbox_manage.feature`. The code landed before the re-run, so each scenario got a mutation proof. Four mutations — a revert of `parse_document`, a drop of the `--kind` filter, a return to the old headers, and a short-circuit of the prompt — each failed the one scenario that claims the behaviour, and no other scenario.

## Docs

`cli-reference.md` — the `init`, `validate`, `ls`, `prune` and `inspect` rows and their synopses. It also says that the JSON now holds more than the table, and not different data. `running-workloads.md` — the three `init` forms. `policy.md` — the project's own mixin is a document that `validate` and `inspect` answer for, which is now true.
