### PR TITLE
feat!: one directory, ~/.lns, and LNS_HOME to move it

### DIFF
--- a/crates/e2e-tests/tests/specutil/mod.rs
+++ b/crates/e2e-tests/tests/specutil/mod.rs
@@ -232,12 +232,9 @@ pub fn audit_runs_dir(home: &Path) -> PathBuf {
     data_lns_dir(home).join("runs")
 }
 
+/// One directory holds everything lns keeps, and the harness points `LNS_HOME` at it.
 pub fn data_lns_dir(home: &Path) -> PathBuf {
-    if cfg!(target_os = "macos") {
-        home.join("Library/Application Support/lns")
-    } else {
-        home.join(".local/share/lns")
-    }
+    home.join(".lns")
 }
 
 pub fn assert_eq_int(expected: i32, actual: i32, label: &str) -> Result<(), String> {

--- a/crates/e2e-tests/tests/steps/cli.rs
+++ b/crates/e2e-tests/tests/steps/cli.rs
@@ -16,12 +16,7 @@ fn home_config_with_invalid_cpus(world: &mut E2eWorld) {
         .home
         .as_ref()
         .expect("Given a clean lns cache home first");
-    let config_dir = if cfg!(target_os = "macos") {
-        home.path().join("Library").join("Application Support")
-    } else {
-        home.path().join(".config")
-    };
-    let dir = config_dir.join("lns");
+    let dir = home.path().join(".lns");
     std::fs::create_dir_all(&dir).expect("create config dir");
     std::fs::write(dir.join("config.yaml"), "run:\n  cpus: 0\n").expect("write config");
 }
@@ -32,9 +27,7 @@ fn i_run(world: &mut E2eWorld, cmd_line: String) {
     let mut envs: Vec<(&str, std::ffi::OsString)> = Vec::new();
     if let Some(home) = &world.home {
         envs.push(("HOME", home.path().into()));
-        envs.push(("XDG_CACHE_HOME", home.path().join(".cache").into()));
-        envs.push(("XDG_CONFIG_HOME", home.path().join(".config").into()));
-        envs.push(("XDG_DATA_HOME", home.path().join(".local/share").into()));
+        envs.push(("LNS_HOME", home.path().join(".lns").into()));
     }
     if let Some(socket) = &world.service_socket {
         envs.push(("LNS_SOCKET_PATH", socket.clone().into()));
@@ -56,7 +49,7 @@ fn i_run_with_stdout_closed(world: &mut E2eWorld, cmd_line: String) {
         .expect("Given a clean lns cache home before piping");
     let envs = [
         ("HOME", home.path().to_path_buf()),
-        ("XDG_CACHE_HOME", home.path().join(".cache")),
+        ("LNS_HOME", home.path().join(".lns")),
     ];
     world.result = Some(run_cli_with_closed_stdout(args, envs));
 }

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -208,9 +208,7 @@ fn socket_env(world: &E2eWorld) -> Vec<(&'static str, std::ffi::OsString)> {
     let mut envs: Vec<(&'static str, std::ffi::OsString)> = Vec::new();
     if let Some(home) = &world.home {
         envs.push(("HOME", home.path().into()));
-        envs.push(("XDG_CACHE_HOME", home.path().join(".cache").into()));
-        envs.push(("XDG_CONFIG_HOME", home.path().join(".config").into()));
-        envs.push(("XDG_DATA_HOME", home.path().join(".local/share").into()));
+        envs.push(("LNS_HOME", home.path().join(".lns").into()));
     }
     if let Some(socket) = &world.service_socket {
         envs.push(("LNS_SOCKET_PATH", socket.clone().into()));
@@ -290,7 +288,8 @@ fn home_catalog_declares(world: &mut E2eWorld, id: String, env: String) {
     let catalog = format!(
         "connectors:\n  - id: {id}\n    authKind: credential\n    routes:\n      - match: api.{id}.example\n    credential:\n      envVar: {env}\n      placeholder: {id}-LNSPLACEHOLDER0000000000\n      injections:\n        - kind: bearer_header\n          domain: api.{id}.example\n"
     );
-    std::fs::write(home.path().join(".lns-connectors.yaml"), catalog)
+    std::fs::create_dir_all(home.path().join(".lns")).expect("create the lns home");
+    std::fs::write(home.path().join(".lns").join("connectors.yaml"), catalog)
         .expect("write the user connector catalog");
 }
 
@@ -330,7 +329,8 @@ fn home_catalog_declares_oauth(world: &mut E2eWorld, id: String, endpoint: Strin
     let catalog = format!(
         "connectors:\n  - id: {id}\n    authKind: oauth\n    routes:\n      - match: api.{id}.example\n    oauth:\n      clientId: some-client\n      deviceAuthorizationEndpoint: {endpoint}/device\n      tokenEndpoint: {endpoint}/token\n      envVar: SOME_OAUTH_TOKEN\n      placeholder: {id}-LNSPLACEHOLDER0000000000\n      injections:\n        - kind: bearer_header\n          domain: api.{id}.example\n"
     );
-    std::fs::write(home.path().join(".lns-connectors.yaml"), catalog)
+    std::fs::create_dir_all(home.path().join(".lns")).expect("create the lns home");
+    std::fs::write(home.path().join(".lns").join("connectors.yaml"), catalog)
         .expect("write the user connector catalog");
 }
 
@@ -1075,12 +1075,7 @@ fn tool_resolution_record_is_lost(world: &mut E2eWorld) {
         .as_ref()
         .expect("Given a clean lns cache home first")
         .path();
-    let cache_root = if cfg!(target_os = "macos") {
-        home.join("Library").join("Caches")
-    } else {
-        home.join(".cache")
-    };
-    let record = cache_root.join("lns").join("tools").join("resolved.json");
+    let record = home.join(".lns").join("tools").join("resolved.json");
     assert!(
         record.is_file(),
         "the pull must have written {} before this step deletes it",
@@ -1583,13 +1578,8 @@ fn volume_image_path(world: &E2eWorld, name: &str) -> Result<std::path::PathBuf,
         .as_ref()
         .ok_or("Given a clean lns cache home first")?
         .path();
-    let cache_root = if cfg!(target_os = "macos") {
-        home.join("Library").join("Caches")
-    } else {
-        home.join(".cache")
-    };
-    Ok(cache_root
-        .join("lns")
+    Ok(home
+        .join(".lns")
         .join("volumes")
         .join(format!("{name}.img")))
 }

--- a/crates/e2e-tests/tests/steps/producer.rs
+++ b/crates/e2e-tests/tests/steps/producer.rs
@@ -25,8 +25,8 @@ fn cache_env(world: &mut E2eWorld) -> Vec<(String, String)> {
             home.path().to_string_lossy().into_owned(),
         ),
         (
-            "XDG_CACHE_HOME".to_string(),
-            home.path().join(".cache").to_string_lossy().into_owned(),
+            "LNS_HOME".to_string(),
+            home.path().join(".lns").to_string_lossy().into_owned(),
         ),
     ]
 }

--- a/crates/e2e-tests/tests/steps/sandbox.rs
+++ b/crates/e2e-tests/tests/steps/sandbox.rs
@@ -64,7 +64,7 @@ fn run_in_project_dir(world: &mut E2eWorld, cmd_line: String) {
     let mut envs: Vec<(String, std::ffi::OsString)> = Vec::new();
     if let Some(home) = &world.home {
         envs.push(("HOME".into(), home.path().into()));
-        envs.push(("XDG_CACHE_HOME".into(), home.path().join(".cache").into()));
+        envs.push(("LNS_HOME".into(), home.path().join(".lns").into()));
     }
     if let Some(socket) = &world.service_socket {
         envs.push(("LNS_SOCKET_PATH".into(), socket.clone().into()));

--- a/crates/e2e-tests/tests/steps/service.rs
+++ b/crates/e2e-tests/tests/steps/service.rs
@@ -19,7 +19,7 @@ pub(crate) fn start_service_with(world: &mut E2eWorld, extra: &[(&str, &str)]) {
     ];
     if let Some(home) = &world.home {
         envs.push(("HOME", home.path().into()));
-        envs.push(("XDG_CACHE_HOME", home.path().join(".cache").into()));
+        envs.push(("LNS_HOME", home.path().join(".lns").into()));
     }
     envs.extend(extra.iter().map(|(k, v)| (*k, std::ffi::OsString::from(v))));
     let result = run_cli_with_env(["service", "start"], envs);

--- a/crates/lns-cli/src/audit/mod.rs
+++ b/crates/lns-cli/src/audit/mod.rs
@@ -114,23 +114,21 @@ mod tests {
         let mut env = serde_json::Map::new();
         env.insert("FOO".into(), "bar".into());
         let run_env = lns_ocsf::run_env(&octx(run_id, "2026-06-29T13:00:01Z"), &env).to_string();
-        for data in ["Library/Application Support", ".local/share"] {
-            let dir = home.join(data).join("lns").join("runs").join(run_id);
-            std::fs::create_dir_all(&dir).unwrap();
-            let mut chain = lns_ipc::AuditChain::new();
-            let mut payload = String::new();
-            for line in [&volume, &run_env] {
-                let aug = chain.augment(line).unwrap();
-                payload.push_str(std::str::from_utf8(&aug).unwrap());
-                payload.push('\n');
-            }
-            std::fs::write(dir.join("audit.jsonl"), payload).unwrap();
-            std::fs::write(
-                dir.join("audit.anchor"),
-                chain.anchor().expect("chain has events").to_line(),
-            )
-            .unwrap();
+        let dir = home.join(".lns").join("runs").join(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut payload = String::new();
+        for line in [&volume, &run_env] {
+            let aug = chain.augment(line).unwrap();
+            payload.push_str(std::str::from_utf8(&aug).unwrap());
+            payload.push('\n');
         }
+        std::fs::write(dir.join("audit.jsonl"), payload).unwrap();
+        std::fs::write(
+            dir.join("audit.anchor"),
+            chain.anchor().expect("chain has events").to_line(),
+        )
+        .unwrap();
     }
 
     fn write_sandbox_run_chain(home: &std::path::Path, run_id: &str) {
@@ -142,19 +140,17 @@ mod tests {
             "policyhash",
         )
         .to_string();
-        for data in ["Library/Application Support", ".local/share"] {
-            let dir = home.join(data).join("lns").join("runs").join(run_id);
-            std::fs::create_dir_all(&dir).unwrap();
-            let mut chain = lns_ipc::AuditChain::new();
-            let mut payload = chain.augment(&event).unwrap();
-            payload.push(b'\n');
-            std::fs::write(dir.join("audit.jsonl"), payload).unwrap();
-            std::fs::write(
-                dir.join("audit.anchor"),
-                chain.anchor().expect("chain has events").to_line(),
-            )
-            .unwrap();
-        }
+        let dir = home.join(".lns").join("runs").join(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut payload = chain.augment(&event).unwrap();
+        payload.push(b'\n');
+        std::fs::write(dir.join("audit.jsonl"), payload).unwrap();
+        std::fs::write(
+            dir.join("audit.anchor"),
+            chain.anchor().expect("chain has events").to_line(),
+        )
+        .unwrap();
     }
 
     fn tamper_run_log(home: &std::path::Path, run_id: &str) {
@@ -165,17 +161,12 @@ mod tests {
             .unwrap()
             .insert("prev_hash".into(), "deadbeef".into());
         let line = format!("{event}\n");
-        for data in ["Library/Application Support", ".local/share"] {
-            let log = home
-                .join(data)
-                .join("lns")
-                .join("runs")
-                .join(run_id)
-                .join("audit.jsonl");
-            if log.exists() {
-                std::fs::write(&log, &line).unwrap();
-            }
-        }
+        let log = home
+            .join(".lns")
+            .join("runs")
+            .join(run_id)
+            .join("audit.jsonl");
+        std::fs::write(&log, &line).unwrap();
     }
 
     fn write_ledger(home: &std::path::Path) {
@@ -188,27 +179,24 @@ mod tests {
             None,
         )
         .to_string();
-        for data in ["Library/Application Support", ".local/share"] {
-            let dir = home.join(data).join("lns");
-            std::fs::create_dir_all(&dir).unwrap();
-            let mut chain = lns_ipc::AuditChain::new();
-            let mut line = chain.augment(&event).unwrap();
-            line.push(b'\n');
-            std::fs::write(dir.join("ledger.jsonl"), line).unwrap();
-            std::fs::write(
-                dir.join("ledger.anchor"),
-                chain.anchor().expect("chain has events").to_line(),
-            )
-            .unwrap();
-        }
+        let dir = home.join(".lns");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut chain = lns_ipc::AuditChain::new();
+        let mut line = chain.augment(&event).unwrap();
+        line.push(b'\n');
+        std::fs::write(dir.join("ledger.jsonl"), line).unwrap();
+        std::fs::write(
+            dir.join("ledger.anchor"),
+            chain.anchor().expect("chain has events").to_line(),
+        )
+        .unwrap();
     }
 
     fn home_env(home: &std::path::Path) -> Vec<crate::test_env::EnvScope> {
-        vec![
-            crate::test_env::EnvScope::set("HOME", home),
-            crate::test_env::EnvScope::set("XDG_CACHE_HOME", home.join(".cache")),
-            crate::test_env::EnvScope::set("XDG_DATA_HOME", home.join(".local/share")),
-        ]
+        vec![crate::test_env::EnvScope::set(
+            "LNS_HOME",
+            home.join(".lns"),
+        )]
     }
 
     async fn dispatch_argv(argv: &[&str], out: &mut Vec<u8>) -> Result<i32> {

--- a/crates/lns-cli/src/build/push.rs
+++ b/crates/lns-cli/src/build/push.rs
@@ -1,16 +1,14 @@
 use anyhow::{Context, Result};
 use http::HeaderValue;
 use lns_artifact::build::BuiltArtifact;
-use lns_policy::registry_auth::{
-    JsonFileRegistryAuthStore, RegistryAuthStore, default_registry_auth_path,
-};
+use lns_policy::registry_auth::{JsonFileRegistryAuthStore, RegistryAuthStore};
 use oci_client::{Reference, RegistryOperation, client::ClientConfig, secrets::RegistryAuth};
 
 use crate::build::push_auth::{auth_error, push_error, select_auth};
 
 /// The stored login for `reference`'s registry, or anonymous when none is recorded.
 fn registry_auth_for(reference: &Reference) -> RegistryAuth {
-    let loaded = JsonFileRegistryAuthStore::new(default_registry_auth_path()).load();
+    let loaded = JsonFileRegistryAuthStore::new(lns_ipc::registry_auth_path()).load();
     select_auth(loaded, reference.registry())
 }
 

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -121,21 +121,7 @@ impl RunSection {
 }
 
 pub fn default_config_path() -> Result<PathBuf> {
-    config_path_with(
-        |k| std::env::var_os(k).map(PathBuf::from),
-        dirs::config_dir(),
-    )
-}
-
-pub fn config_path_with(
-    env: impl Fn(&str) -> Option<PathBuf>,
-    config_dir: Option<PathBuf>,
-) -> Result<PathBuf> {
-    if let Some(p) = env("LNS_CONFIG_PATH") {
-        return Ok(p);
-    }
-    let dir = config_dir.context("could not determine the user config directory")?;
-    Ok(dir.join("lns").join("config.yaml"))
+    Ok(lns_ipc::config_path()?)
 }
 
 pub fn load(path: &Path) -> Result<ConfigFile> {
@@ -461,7 +447,7 @@ mod tests {
     async fn run_command_resolves_the_default_path_and_writes_a_stored_default() {
         let dir = TempDir::new().unwrap();
         let cfg = dir.path().join("config.yaml");
-        let _scope = crate::test_env::EnvScope::set("LNS_CONFIG_PATH", &cfg);
+        let _scope = crate::test_env::EnvScope::set("LNS_HOME", dir.path());
 
         let set = crate::command::build_cli()
             .try_get_matches_from(["lns", "config", "set", "run.cpus", "4"])
@@ -644,47 +630,12 @@ mod tests {
     }
 
     #[test]
-    fn config_path_with_prefers_the_env_override() {
-        let path = config_path_with(
-            |k| (k == "LNS_CONFIG_PATH").then(|| PathBuf::from("/tmp/elsewhere.yaml")),
-            Some(PathBuf::from("/home/dev/.config")),
-        )
-        .unwrap();
-        assert_eq!(path, PathBuf::from("/tmp/elsewhere.yaml"));
-    }
-
-    #[test]
-    fn config_path_with_defaults_to_lns_config_yaml_under_the_config_dir() {
-        let path = config_path_with(|_| None, Some(PathBuf::from("/home/dev/.config"))).unwrap();
-        assert_eq!(path, PathBuf::from("/home/dev/.config/lns/config.yaml"));
-    }
-
-    #[test]
-    fn config_path_with_errors_when_no_config_dir_exists() {
-        let err = config_path_with(|_| None, None).unwrap_err();
-        assert!(
-            format!("{err:#}").contains("config directory"),
-            "got: {err:#}"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_config_path_honours_the_lns_config_path_override() {
-        let _guard = crate::test_env::EnvScope::set("LNS_CONFIG_PATH", "/tmp/override.yaml");
+    fn the_defaults_file_lives_in_the_one_directory_lns_keeps_everything_in() {
         assert_eq!(
             default_config_path().unwrap(),
-            PathBuf::from("/tmp/override.yaml")
+            lns_ipc::config_path().unwrap(),
+            "the config file is not a location of its own; LNS_HOME moves it with everything else"
         );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_config_path_lands_under_the_user_config_dir() {
-        let _guard = crate::test_env::EnvScope::unset("LNS_CONFIG_PATH");
-        let path = default_config_path().unwrap();
-        assert!(path.ends_with("lns/config.yaml"), "got: {path:?}");
-        assert!(path.is_absolute(), "got: {path:?}");
     }
 
     fn bare_run_args() -> RunArgs {

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -752,7 +752,7 @@ mod tests {
     }
 
     fn catalog_at(dir: &Path) -> std::path::PathBuf {
-        dir.join(".lns-connectors.yaml")
+        dir.join("connectors.yaml")
     }
 
     fn load(path: &Path) -> Catalog {

--- a/crates/lns-cli/src/connector/real.rs
+++ b/crates/lns-cli/src/connector/real.rs
@@ -14,8 +14,8 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
     Box::pin(async move {
         let args = super::ConnectorArgs::from_arg_matches(matches)?;
         let cwd = ctx.cwd()?;
-        let catalog_path = lns_policy::connectors::default_connectors_path();
-        let grants_path = lns_policy::grants::default_workload_grants_path();
+        let catalog_path = lns_ipc::connectors_path();
+        let grants_path = lns_ipc::workload_grants_path();
         let signin = RealConnectorSignIn::new(crate::service::socket_path()?);
         let mut out = ctx.out;
         crate::connector::run(

--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -381,7 +381,7 @@ mod tests {
     }
 
     fn store_at(dir: &TempDir) -> std::path::PathBuf {
-        dir.path().join(".lns-registry-auth.json")
+        dir.path().join("registry-auth.json")
     }
 
     fn loaded(path: &Path) -> lns_policy::registry_auth::RegistryAuthFile {

--- a/crates/lns-cli/src/login/real.rs
+++ b/crates/lns-cli/src/login/real.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use clap::FromArgMatches;
 use lns_ipc::{Request, Response, decode_frame, encode_frame, read_frame_bytes_async};
-use lns_policy::registry_auth::default_registry_auth_path;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 
@@ -15,7 +14,7 @@ pub fn run_login<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutur
     Box::pin(async move {
         let args = LoginArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let auth_path = default_registry_auth_path();
+        let auth_path = lns_ipc::registry_auth_path();
         let verifier = RealRegistryVerifier::new(crate::service::socket_path()?);
         let input = ctx.input;
         let mut out = ctx.out;
@@ -36,7 +35,7 @@ pub fn run_logout<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutu
     Box::pin(async move {
         let args = LogoutArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let auth_path = default_registry_auth_path();
+        let auth_path = lns_ipc::registry_auth_path();
         let mut out = ctx.out;
         super::logout(&args, &default_registry, &auth_path, &mut out)
     })

--- a/crates/lns-cli/src/run/host_path_consent.rs
+++ b/crates/lns-cli/src/run/host_path_consent.rs
@@ -101,7 +101,7 @@ fn apply(
     if !entry.optional {
         bail!(
             "declined: {host_path} is required by this sandbox, so there is nothing to run without it — allow it, or edit {}",
-            lns_policy::host_path_decisions::default_host_path_decisions_path().display()
+            lns_ipc::host_path_decisions_path().display()
         );
     }
     grant.denied.push(host_path.to_string());

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -492,11 +492,11 @@ pub async fn run_image(
         origin,
         filesets: &args.filesets,
         host_paths: &lns_policy::host_path_decisions::JsonFileHostPathDecisionStore::new(
-            lns_policy::host_path_decisions::default_host_path_decisions_path(),
+            lns_ipc::host_path_decisions_path(),
         ),
         bind_specs: &bind_specs,
         bind_decisions: &lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
-            lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
+            lns_ipc::host_bind_decisions_path(),
         ),
         assume_yes: args.assume_yes,
         interactive,

--- a/crates/lns-cli/src/uninstall/mod.rs
+++ b/crates/lns-cli/src/uninstall/mod.rs
@@ -19,7 +19,7 @@ pub struct UninstallArgs {
     #[arg(
         long,
         default_value_t = false,
-        help = "Also delete all local data: cached images and layers, named volumes, the audit trail, config, and stored credentials. Without this, only the program is removed and your data is kept."
+        help = "Also delete everything under ~/.lns: cached artifacts and layers, named volumes, the audit trail, config, connectors, and stored credentials. Without this, only the program is removed and the directory is kept."
     )]
     pub purge: bool,
 
@@ -65,7 +65,6 @@ pub struct UninstallPlan {
     pub binaries: Vec<PathBuf>,
     pub purge_dirs: Vec<PathBuf>,
     pub purge_files: Vec<PathBuf>,
-    pub kept_paths: Vec<PathBuf>,
 }
 
 pub struct Deps<'a, S, C, A, F> {
@@ -200,13 +199,6 @@ async fn purge(fs: &impl Fs, plan: &UninstallPlan, writer: &mut impl Write) -> R
     for file in &plan.purge_files {
         removed(fs.remove_file(file).await, file, writer)?;
     }
-    for kept in &plan.kept_paths {
-        writeln!(
-            writer,
-            "kept {} (your own edits; delete it manually to remove)",
-            kept.display()
-        )?;
-    }
     Ok(())
 }
 
@@ -245,56 +237,27 @@ async fn remove_binaries(
     Ok(())
 }
 
-/// The resolved locations `--purge` clears, plus whether the config and socket paths came from an env override.
+/// What `--purge` clears: the one directory lns keeps everything in, and the socket, which lives with the service rather than with your data.
 pub(crate) struct PurgeSources {
-    pub cache_root: PathBuf,
-    pub data_root: PathBuf,
-    pub config: PathBuf,
-    pub config_overridden: bool,
+    pub lns_home: PathBuf,
     pub socket: PathBuf,
     pub socket_overridden: bool,
-    pub secret_files: Vec<PathBuf>,
-    pub kept: Vec<PathBuf>,
 }
 
-pub(crate) fn purge_targets(src: PurgeSources) -> (Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>) {
-    let mut dirs = vec![src.cache_root, src.data_root];
-    let mut files = src.secret_files;
-    push_owned(
-        &mut dirs,
-        &mut files,
-        src.config,
-        src.config_overridden,
-        None,
-    );
-    let log = src.socket.parent().map(|p| p.join("service.log"));
-    push_owned(
-        &mut dirs,
-        &mut files,
-        src.socket,
-        src.socket_overridden,
-        log,
-    );
-    (dirs, files, src.kept)
-}
-
-/// A path at its default lns-owned location takes its whole parent directory; an env-overridden path may live anywhere, so only its own file (and any named sibling) is removed — never an arbitrary parent.
-fn push_owned(
-    dirs: &mut Vec<PathBuf>,
-    files: &mut Vec<PathBuf>,
-    path: PathBuf,
-    overridden: bool,
-    sibling: Option<PathBuf>,
-) {
-    match (overridden, path.parent()) {
+pub(crate) fn purge_targets(src: PurgeSources) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let mut dirs = vec![src.lns_home];
+    let mut files = Vec::new();
+    // A socket at its default lns-owned location takes its whole parent directory; an env-overridden one may live anywhere, so only the socket and the log beside it go.
+    match (src.socket_overridden, src.socket.parent()) {
         (false, Some(parent)) => dirs.push(parent.to_path_buf()),
         _ => {
-            files.push(path);
-            if let Some(sibling) = sibling {
-                files.push(sibling);
+            if let Some(log) = src.socket.parent().map(|p| p.join("service.log")) {
+                files.push(log);
             }
+            files.push(src.socket);
         }
     }
+    (dirs, files)
 }
 
 #[cfg(test)]
@@ -886,12 +849,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn purge_removes_data_prints_kept_paths_then_removes_binaries() {
+    async fn purge_removes_the_one_directory_and_the_socket_then_the_binaries() {
         let plan = UninstallPlan {
             binaries: vec![PathBuf::from("/bin/lns")],
-            purge_dirs: vec![PathBuf::from("/cache/lns"), PathBuf::from("/data/lns")],
-            purge_files: vec![PathBuf::from("/home/me/.lns-credentials.json")],
-            kept_paths: vec![PathBuf::from("/home/me/.lns-connectors.yaml")],
+            purge_dirs: vec![PathBuf::from("/home/me/.lns")],
+            purge_files: vec![PathBuf::from("/run/user/1000/lns/service.log")],
         };
         let rig = rig(
             FakeService::default(),
@@ -904,16 +866,12 @@ mod tests {
         assert_eq!(
             rig.fs.removed(),
             vec![
-                PathBuf::from("/cache/lns"),
-                PathBuf::from("/data/lns"),
-                PathBuf::from("/home/me/.lns-credentials.json"),
+                PathBuf::from("/home/me/.lns"),
+                PathBuf::from("/run/user/1000/lns/service.log"),
                 PathBuf::from("/bin/lns"),
             ]
         );
-        assert!(
-            out.contains("kept /home/me/.lns-connectors.yaml"),
-            "got: {out}"
-        );
+        assert!(out.contains("removed /home/me/.lns"), "got: {out}");
     }
 
     #[tokio::test]
@@ -985,9 +943,8 @@ mod tests {
     async fn purge_tolerates_already_removed_data() {
         let plan = UninstallPlan {
             binaries: vec![PathBuf::from("/bin/lns")],
-            purge_dirs: vec![PathBuf::from("/cache/lns")],
-            purge_files: vec![PathBuf::from("/home/me/.lns-credentials.json")],
-            ..UninstallPlan::default()
+            purge_dirs: vec![PathBuf::from("/home/me/.lns")],
+            purge_files: vec![PathBuf::from("/run/user/1000/lns/service.log")],
         };
         let rig = rig(
             FakeService::default(),
@@ -995,9 +952,9 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs {
                 errors: [
-                    (PathBuf::from("/cache/lns"), std::io::ErrorKind::NotFound),
+                    (PathBuf::from("/home/me/.lns"), std::io::ErrorKind::NotFound),
                     (
-                        PathBuf::from("/home/me/.lns-credentials.json"),
+                        PathBuf::from("/run/user/1000/lns/service.log"),
                         std::io::ErrorKind::NotFound,
                     ),
                 ]
@@ -1055,49 +1012,29 @@ mod tests {
 
     fn sources() -> PurgeSources {
         PurgeSources {
-            cache_root: PathBuf::from("/home/me/.cache/lns"),
-            data_root: PathBuf::from("/home/me/.local/share/lns"),
-            config: PathBuf::from("/home/me/.config/lns/config.yaml"),
-            config_overridden: false,
+            lns_home: PathBuf::from("/home/me/.lns"),
             socket: PathBuf::from("/run/user/1000/lns/service.sock"),
             socket_overridden: false,
-            secret_files: vec![PathBuf::from("/home/me/.lns-credentials.json")],
-            kept: vec![PathBuf::from("/home/me/.lns-connectors.yaml")],
         }
     }
 
     #[test]
-    fn purge_targets_at_default_locations_take_their_owned_parent_dirs() {
-        let (dirs, files, kept) = purge_targets(sources());
+    fn purge_takes_the_one_directory_lns_keeps_everything_in() {
+        let (dirs, files) = purge_targets(sources());
         assert_eq!(
             dirs,
             vec![
-                PathBuf::from("/home/me/.cache/lns"),
-                PathBuf::from("/home/me/.local/share/lns"),
-                PathBuf::from("/home/me/.config/lns"),
+                PathBuf::from("/home/me/.lns"),
                 PathBuf::from("/run/user/1000/lns"),
-            ]
+            ],
+            "one root means one thing to delete, plus the socket's own directory"
         );
-        assert_eq!(files, vec![PathBuf::from("/home/me/.lns-credentials.json")]);
-        assert_eq!(kept, vec![PathBuf::from("/home/me/.lns-connectors.yaml")]);
-    }
-
-    #[test]
-    fn an_overridden_config_is_removed_as_a_file_never_its_parent() {
-        let (dirs, files, _) = purge_targets(PurgeSources {
-            config_overridden: true,
-            ..sources()
-        });
-        assert!(
-            !dirs.contains(&PathBuf::from("/home/me/.config/lns")),
-            "an override's arbitrary parent must never be rm -rf'd"
-        );
-        assert!(files.contains(&PathBuf::from("/home/me/.config/lns/config.yaml")));
+        assert!(files.is_empty(), "got: {files:?}");
     }
 
     #[test]
     fn an_overridden_socket_removes_the_socket_and_log_files_never_its_parent() {
-        let (dirs, files, _) = purge_targets(PurgeSources {
+        let (dirs, files) = purge_targets(PurgeSources {
             socket_overridden: true,
             ..sources()
         });
@@ -1110,11 +1047,12 @@ mod tests {
     }
 
     #[test]
-    fn a_parentless_path_is_removed_as_a_file() {
-        let mut dirs = Vec::new();
-        let mut files = Vec::new();
-        push_owned(&mut dirs, &mut files, PathBuf::from("/"), false, None);
-        assert!(dirs.is_empty());
+    fn a_parentless_socket_is_removed_as_a_file() {
+        let (dirs, files) = purge_targets(PurgeSources {
+            socket: PathBuf::from("/"),
+            ..sources()
+        });
+        assert_eq!(dirs, vec![PathBuf::from("/home/me/.lns")]);
         assert_eq!(files, vec![PathBuf::from("/")]);
     }
 

--- a/crates/lns-cli/src/uninstall/real.rs
+++ b/crates/lns-cli/src/uninstall/real.rs
@@ -49,39 +49,23 @@ async fn build_plan(purge: bool) -> Result<UninstallPlan> {
         }
     }
     binaries.push(lns);
-    let (purge_dirs, purge_files, kept_paths) = if purge {
+    let (purge_dirs, purge_files) = if purge {
         purge_targets_from_env()?
     } else {
-        (Vec::new(), Vec::new(), Vec::new())
+        (Vec::new(), Vec::new())
     };
     Ok(UninstallPlan {
         binaries,
         purge_dirs,
         purge_files,
-        kept_paths,
     })
 }
 
-fn purge_targets_from_env() -> Result<(Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>)> {
-    let connectors = lns_policy::connectors::default_connectors_path();
-    let kept = if connectors.exists() {
-        vec![connectors]
-    } else {
-        Vec::new()
-    };
+fn purge_targets_from_env() -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
     Ok(super::purge_targets(PurgeSources {
-        cache_root: lns_ipc::cache_root().context("resolving the cache directory")?,
-        data_root: lns_ipc::data_root().context("resolving the data directory")?,
-        config: crate::config::default_config_path()?,
-        config_overridden: std::env::var_os("LNS_CONFIG_PATH").is_some(),
+        lns_home: lns_ipc::lns_home().context("resolving the lns home directory")?,
         socket: crate::service::socket_path()?,
         socket_overridden: std::env::var_os("LNS_SOCKET_PATH").is_some(),
-        secret_files: vec![
-            lns_policy::credentials::default_credentials_path(),
-            lns_policy::registry_auth::default_registry_auth_path(),
-            lns_policy::host_bind_decisions::default_host_bind_decisions_path(),
-        ],
-        kept,
     }))
 }
 

--- a/crates/lns-cli/src/update_check/real.rs
+++ b/crates/lns-cli/src/update_check/real.rs
@@ -7,7 +7,7 @@ pub struct RealStatusReader;
 
 impl RealStatusReader {
     fn root() -> Option<PathBuf> {
-        lns_ipc::data_root().ok()
+        lns_ipc::lns_home().ok()
     }
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -68,8 +68,8 @@ impl ConnectorSignIn for FakeSignIn {
 
 async fn run_connector(world: &mut BehaviourWorld, tail: &[&str]) {
     let dir = cwd(world);
-    let catalog = dir.join(".lns-connectors.yaml");
-    let grants = dir.join(".lns-workload-grants.json");
+    let catalog = dir.join("connectors.yaml");
+    let grants = dir.join("workload-grants.json");
     let signin = FakeSignIn {
         outcome: world
             .signin_outcome
@@ -142,7 +142,7 @@ fn given_user_oauth_connector(world: &mut BehaviourWorld, id: String) {
             token_fallback: None,
         }],
     }
-    .save_atomic(&dir.join(".lns-connectors.yaml"))
+    .save_atomic(&dir.join("connectors.yaml"))
     .unwrap();
 }
 
@@ -188,7 +188,7 @@ fn given_user_pkce_connector(world: &mut BehaviourWorld, id: String) {
             token_fallback: None,
         }],
     }
-    .save_atomic(&dir.join(".lns-connectors.yaml"))
+    .save_atomic(&dir.join("connectors.yaml"))
     .unwrap();
 }
 
@@ -221,7 +221,7 @@ fn write_credential_catalog(world: &mut BehaviourWorld, id: String) {
             token_fallback: None,
         }],
     }
-    .save_atomic(&dir.join(".lns-connectors.yaml"))
+    .save_atomic(&dir.join("connectors.yaml"))
     .unwrap();
 }
 
@@ -327,7 +327,7 @@ fn recorded(world: &mut BehaviourWorld, id: String) {
 fn connected_for(world: &mut BehaviourWorld) -> Vec<String> {
     use lns_policy::grants::GrantStore as _;
     let policy = policy_file(world);
-    lns_policy::grants::JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
+    lns_policy::grants::JsonFileGrantStore::new(cwd(world).join("workload-grants.json"))
         .load()
         .expect("the sidecar reads back")
         .connected_in(&lns_policy::grants::project_key(&policy))

--- a/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_grants.rs
@@ -13,7 +13,7 @@ fn cwd(world: &mut BehaviourWorld) -> PathBuf {
 }
 
 fn store(world: &mut BehaviourWorld) -> JsonFileGrantStore {
-    JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
+    JsonFileGrantStore::new(cwd(world).join("workload-grants.json"))
 }
 
 /// Derived the same way the commands derive it, so a seeded grant keys identically to one a real run would have left.
@@ -50,7 +50,7 @@ fn output(world: &BehaviourWorld) -> &str {
 #[given(regex = r#"^this project connects "([^"]+)"$"#)]
 fn project_connects(world: &mut BehaviourWorld, id: String) {
     let project = this_project(world);
-    let store = JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"));
+    let store = JsonFileGrantStore::new(cwd(world).join("workload-grants.json"));
     let mut file = store.load().expect("the sidecar reads back");
     file.connect(&project, &id);
     store.save(&file).expect("seeding the sidecar");
@@ -88,13 +88,13 @@ fn workload_denied(world: &mut BehaviourWorld, workload: String, id: String) {
 
 #[given("the grant sidecar cannot be updated")]
 fn grant_sidecar_unwritable(world: &mut BehaviourWorld) {
-    let lock = cwd(world).join(".lns-workload-grants.json.lock");
+    let lock = cwd(world).join("workload-grants.json.lock");
     std::fs::create_dir(&lock).expect("occupy the lock path");
 }
 
 #[then(regex = r#"^this project still connects "([^"]+)"$"#)]
 fn project_still_connects(world: &mut BehaviourWorld, id: String) {
-    let connected = JsonFileGrantStore::new(cwd(world).join(".lns-workload-grants.json"))
+    let connected = JsonFileGrantStore::new(cwd(world).join("workload-grants.json"))
         .load()
         .expect("the sidecar reads back")
         .connected_in(&project_key(&cwd(world).join("lns-local-mixin.yaml")));

--- a/crates/lns-cli/tests/behaviours/steps/login_web.rs
+++ b/crates/lns-cli/tests/behaviours/steps/login_web.rs
@@ -20,7 +20,7 @@ fn auth_path(world: &mut BehaviourWorld) -> PathBuf {
         .as_ref()
         .unwrap()
         .path()
-        .join(".lns-registry-auth.json")
+        .join("registry-auth.json")
 }
 
 /// Stands in for the running service's pull-auth handshake: records what it was asked and verifies everything.

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -16,8 +16,10 @@ pub use codec::{
 };
 pub use ledger::{ApprovalKind, AuthKind, Decision, LedgerEvent, LedgerRecord, fingerprint};
 pub use paths::{
-    CachePathError, audit_anchor_for_run, audit_log_for_run, audit_runs_root, build_cache_root,
-    cache_root, connection_ledger, connection_ledger_anchor, data_root, short_run_id,
+    NoLnsHome, audit_anchor_for_run, audit_log_for_run, audit_runs_root, build_cache_root,
+    config_path, connection_ledger, connection_ledger_anchor, connectors_path, credentials_path,
+    host_bind_decisions_path, host_path_decisions_path, lns_home, registry_auth_path, short_run_id,
+    workload_grants_path,
 };
 pub use protocol::{
     ArtifactInspection, BindMount, BindSpec, CachedKind, ContributionBlock, CredentialBindDecision,

--- a/crates/lns-ipc/src/paths.rs
+++ b/crates/lns-ipc/src/paths.rs
@@ -1,52 +1,91 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum CachePathError {
-    #[error("could not determine cache dir")]
-    NoCacheDir,
-    #[error("could not determine data dir")]
-    NoDataDir,
+#[error(
+    "could not determine your home directory; set LNS_HOME to the directory lns should keep its data in"
+)]
+pub struct NoLnsHome;
+
+/// Everything lns keeps for you lives in one directory, so there is one thing to back up and one thing `lns uninstall --purge` removes.
+pub fn lns_home() -> Result<PathBuf, NoLnsHome> {
+    lns_home_with(|key| std::env::var_os(key), dirs::home_dir())
 }
 
-pub fn cache_root() -> Result<PathBuf, CachePathError> {
-    dirs::cache_dir()
-        .map(|p| p.join("lns"))
-        .ok_or(CachePathError::NoCacheDir)
+pub fn lns_home_with(
+    env: impl Fn(&str) -> Option<OsString>,
+    home: Option<PathBuf>,
+) -> Result<PathBuf, NoLnsHome> {
+    match env("LNS_HOME") {
+        Some(overridden) => Ok(PathBuf::from(overridden)),
+        None => home.map(|home| home.join(".lns")).ok_or(NoLnsHome),
+    }
 }
 
-pub fn data_root() -> Result<PathBuf, CachePathError> {
-    dirs::data_dir()
-        .map(|p| p.join("lns"))
-        .ok_or(CachePathError::NoDataDir)
+fn in_lns_home(name: &str) -> PathBuf {
+    under(lns_home(), name)
 }
 
-pub fn build_cache_root() -> Result<PathBuf, CachePathError> {
-    Ok(cache_root()?.join("builds"))
+/// A per-machine file lns keeps for you; with no home to resolve it lands in the working directory rather than failing a command that only wanted to read one that may not exist.
+fn under(home: Result<PathBuf, NoLnsHome>, name: &str) -> PathBuf {
+    home.unwrap_or_else(|_| PathBuf::from(".lns")).join(name)
+}
+
+pub fn build_cache_root() -> Result<PathBuf, NoLnsHome> {
+    Ok(lns_home()?.join("builds"))
 }
 
 pub fn short_run_id(id: &str) -> &str {
     id.char_indices().nth(12).map_or(id, |(i, _)| &id[..i])
 }
 
-pub fn audit_runs_root() -> Result<PathBuf, CachePathError> {
-    Ok(data_root()?.join("runs"))
+pub fn audit_runs_root() -> Result<PathBuf, NoLnsHome> {
+    Ok(lns_home()?.join("runs"))
 }
 
-pub fn audit_log_for_run(run_id: &str) -> Result<PathBuf, CachePathError> {
+pub fn audit_log_for_run(run_id: &str) -> Result<PathBuf, NoLnsHome> {
     Ok(audit_runs_root()?.join(run_id).join("audit.jsonl"))
 }
 
-pub fn audit_anchor_for_run(run_id: &str) -> Result<PathBuf, CachePathError> {
+pub fn audit_anchor_for_run(run_id: &str) -> Result<PathBuf, NoLnsHome> {
     Ok(audit_runs_root()?.join(run_id).join("audit.anchor"))
 }
 
-pub fn connection_ledger() -> Result<PathBuf, CachePathError> {
-    Ok(data_root()?.join("ledger.jsonl"))
+pub fn connection_ledger() -> Result<PathBuf, NoLnsHome> {
+    Ok(lns_home()?.join("ledger.jsonl"))
 }
 
-pub fn connection_ledger_anchor() -> Result<PathBuf, CachePathError> {
-    Ok(data_root()?.join("ledger.anchor"))
+pub fn connection_ledger_anchor() -> Result<PathBuf, NoLnsHome> {
+    Ok(lns_home()?.join("ledger.anchor"))
+}
+
+pub fn config_path() -> Result<PathBuf, NoLnsHome> {
+    Ok(lns_home()?.join("config.yaml"))
+}
+
+pub fn connectors_path() -> PathBuf {
+    in_lns_home("connectors.yaml")
+}
+
+pub fn credentials_path() -> PathBuf {
+    in_lns_home("credentials.json")
+}
+
+pub fn registry_auth_path() -> PathBuf {
+    in_lns_home("registry-auth.json")
+}
+
+pub fn workload_grants_path() -> PathBuf {
+    in_lns_home("workload-grants.json")
+}
+
+pub fn host_path_decisions_path() -> PathBuf {
+    in_lns_home("host-path-decisions.json")
+}
+
+pub fn host_bind_decisions_path() -> PathBuf {
+    in_lns_home("host-bind-decisions.json")
 }
 
 #[cfg(test)]
@@ -70,93 +109,82 @@ mod tests {
     }
 
     #[test]
-    fn audit_log_lives_under_data_root_so_it_outlives_the_ephemeral_run_dir() {
-        let data = data_root().expect("data dir resolves in test env");
-        let p = audit_log_for_run("42").expect("audit_log_for_run");
-        assert_eq!(p, data.join("runs").join("42").join("audit.jsonl"));
-        assert!(
-            !p.starts_with(cache_root().expect("cache dir resolves in test env")),
-            "the audit trail must outlive ephemeral run dirs, so it cannot live under cache_root: {p:?}"
+    fn lns_home_is_a_dot_directory_beside_the_rest_of_your_home() {
+        let resolved = lns_home_with(|_| None, Some(PathBuf::from("/home/dev"))).unwrap();
+        assert_eq!(resolved, PathBuf::from("/home/dev/.lns"));
+    }
+
+    #[test]
+    fn lns_home_redirects_the_whole_directory_at_once() {
+        let resolved = lns_home_with(
+            |key| (key == "LNS_HOME").then(|| OsString::from("/tmp/elsewhere")),
+            Some(PathBuf::from("/home/dev")),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/elsewhere"),
+            "the override names the root itself, not a directory to put .lns inside"
         );
     }
 
     #[test]
-    fn audit_runs_root_is_the_shared_base_of_every_per_run_log() {
-        let root = audit_runs_root().expect("audit_runs_root");
-        assert_eq!(root, data_root().expect("data dir").join("runs"));
-        assert!(audit_log_for_run("42").expect("log").starts_with(&root));
+    fn with_no_home_and_no_override_there_is_nowhere_to_keep_anything() {
+        let err = lns_home_with(|_| None, None).unwrap_err();
         assert!(
-            audit_anchor_for_run("42")
-                .expect("anchor")
-                .starts_with(&root)
+            err.to_string().contains("LNS_HOME"),
+            "the answer must name the way out: {err}"
         );
     }
 
     #[test]
-    fn audit_anchor_path_is_a_sibling_of_the_audit_log() {
+    fn every_path_lns_keeps_for_you_is_inside_the_one_directory() {
+        let home = lns_home().expect("a home resolves in the test env");
+        for path in [
+            build_cache_root().unwrap(),
+            audit_runs_root().unwrap(),
+            audit_log_for_run("42").unwrap(),
+            audit_anchor_for_run("42").unwrap(),
+            connection_ledger().unwrap(),
+            connection_ledger_anchor().unwrap(),
+            config_path().unwrap(),
+            connectors_path(),
+            credentials_path(),
+            registry_auth_path(),
+            workload_grants_path(),
+            host_path_decisions_path(),
+            host_bind_decisions_path(),
+        ] {
+            assert!(
+                path.starts_with(&home),
+                "one directory, one thing to back up: {path:?} is outside {home:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_audit_anchor_is_a_sibling_of_the_log_it_anchors() {
         let log = audit_log_for_run("42").expect("audit_log_for_run");
         let anchor = audit_anchor_for_run("42").expect("audit_anchor_for_run");
         assert_eq!(anchor.parent(), log.parent());
         assert!(anchor.ends_with("runs/42/audit.anchor"));
-    }
-
-    #[test]
-    fn cache_root_is_non_empty_absolute_and_ends_with_lns() {
-        let root = cache_root().expect("cache dir resolves in test env");
-        assert!(
-            !root.as_os_str().is_empty(),
-            "cache_root must return a non-empty path"
-        );
-        assert!(
-            root.ends_with("lns"),
-            "cache_root must end with 'lns', got: {root:?}"
-        );
-        assert!(
-            root.is_absolute(),
-            "cache_root must be absolute, got: {root:?}"
-        );
-    }
-
-    #[test]
-    fn build_cache_root_lives_under_cache_root_not_data_root() {
-        let cache = cache_root().expect("cache dir resolves in test env");
-        let builds = build_cache_root().expect("build_cache_root");
-        assert_eq!(builds, cache.join("builds"));
-        assert!(
-            !builds.starts_with(data_root().expect("data dir resolves in test env")),
-            "the build cache is reconstructible content, so it belongs under cache_root, not data_root"
-        );
-    }
-
-    #[test]
-    fn data_root_is_absolute_and_ends_with_lns() {
-        let root = data_root().expect("data dir resolves in test env");
-        assert!(
-            root.ends_with("lns"),
-            "data_root must end with 'lns', got: {root:?}"
-        );
-        assert!(
-            root.is_absolute(),
-            "data_root must be absolute, got: {root:?}"
-        );
-    }
-
-    #[test]
-    fn connection_ledger_lives_under_data_root_not_cache_root() {
-        let data = data_root().expect("data dir resolves in test env");
         let ledger = connection_ledger().expect("connection_ledger");
-        assert_eq!(ledger, data.join("ledger.jsonl"));
-        assert!(
-            !ledger.starts_with(cache_root().expect("cache dir resolves in test env")),
-            "the ledger must outlive ephemeral run dirs, so it cannot live under cache_root: {ledger:?}"
+        assert_eq!(
+            connection_ledger_anchor().unwrap().parent(),
+            ledger.parent()
         );
     }
 
     #[test]
-    fn connection_ledger_anchor_is_a_sibling_of_the_ledger() {
-        let ledger = connection_ledger().expect("connection_ledger");
-        let anchor = connection_ledger_anchor().expect("connection_ledger_anchor");
-        assert_eq!(anchor.parent(), ledger.parent());
-        assert!(anchor.ends_with("ledger.anchor"));
+    fn a_per_machine_file_falls_back_to_the_working_directory_rather_than_failing_a_read() {
+        // These callers only ever want to read a file that may not exist, so nowhere to look is an empty answer rather than a broken command.
+        assert_eq!(
+            under(Err(NoLnsHome), "connectors.yaml"),
+            PathBuf::from(".lns/connectors.yaml")
+        );
+        assert_eq!(
+            under(Ok(PathBuf::from("/home/dev/.lns")), "connectors.yaml"),
+            PathBuf::from("/home/dev/.lns/connectors.yaml")
+        );
     }
 }

--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -253,16 +253,6 @@ pub fn bundled_connectors() -> &'static [Connector] {
     BUNDLED.as_slice()
 }
 
-/// Falls back to `./.lns-connectors.yaml` when `HOME` is unset rather than panicking.
-pub fn default_connectors_path() -> PathBuf {
-    if let Some(p) = std::env::var_os("LNS_CONNECTORS_PATH") {
-        return PathBuf::from(p);
-    }
-    std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".lns-connectors.yaml"))
-        .unwrap_or_else(|| PathBuf::from(".lns-connectors.yaml"))
-}
-
 /// The effective catalog is the bundled set extended with user entries whose id isn't already shipped — a bundled id can never be shadowed.
 pub fn effective_connectors(user: &Catalog) -> Vec<Connector> {
     let mut out: Vec<Connector> = bundled_connectors().to_vec();
@@ -1141,7 +1131,7 @@ mod tests {
     #[test]
     fn load_or_default_reads_an_existing_user_catalog() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         Catalog {
             connectors: vec![sample_connector()],
         }
@@ -1155,7 +1145,7 @@ mod tests {
     #[test]
     fn load_or_default_rejects_an_upstream_route_transport() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         let mut connector = sample_connector();
         connector.routes[0].transport = Some(Transport::Upstream);
         Catalog {
@@ -1249,7 +1239,7 @@ mod tests {
     #[test]
     fn save_atomic_round_trips_creates_parent_and_leaves_no_tmp() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("nested/dir/.lns-connectors.yaml");
+        let path = dir.path().join("nested/dir/connectors.yaml");
         let c = Catalog {
             connectors: vec![sample_connector()],
         };
@@ -1266,7 +1256,7 @@ mod tests {
         let victim = dir.path().join("victim");
         let victim_contents = b"victim-data-must-survive";
         fs::write(&victim, victim_contents).unwrap();
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         std::os::unix::fs::symlink(&victim, path.with_extension("yaml.tmp")).unwrap();
 
         let _ = Catalog {
@@ -1284,7 +1274,7 @@ mod tests {
     #[test]
     fn file_catalog_store_save_writes_yaml_readable_by_load_or_default() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         let store = FileCatalogStore::new(path.clone());
         let c = Catalog {
             connectors: vec![sample_connector()],
@@ -1298,7 +1288,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let not_a_dir = dir.path().join("file");
         fs::write(&not_a_dir, b"").unwrap();
-        let store = FileCatalogStore::new(not_a_dir.join("nested/.lns-connectors.yaml"));
+        let store = FileCatalogStore::new(not_a_dir.join("nested/connectors.yaml"));
         let err = store.save(&Catalog::default()).unwrap_err();
         assert!(!err.to_string().is_empty());
     }
@@ -1338,42 +1328,6 @@ mod tests {
             gitlab.credential.as_ref().unwrap().env_var,
             "EVIL",
             "the bundled gitlab definition must win over a user shadow"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_connectors_path_uses_override_when_set() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::set("LNS_CONNECTORS_PATH", "/tmp/custom-connectors.yaml");
-        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
-        assert_eq!(
-            default_connectors_path(),
-            PathBuf::from("/tmp/custom-connectors.yaml")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_connectors_path_falls_back_to_home_dotfile() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_CONNECTORS_PATH");
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_connectors_path(),
-            PathBuf::from("/home/dev/.lns-connectors.yaml")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_connectors_path_falls_back_to_cwd_when_home_unset() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_CONNECTORS_PATH");
-        let _g2 = EnvVarGuard::unset("HOME");
-        assert_eq!(
-            default_connectors_path(),
-            PathBuf::from(".lns-connectors.yaml")
         );
     }
 }

--- a/crates/lns-policy/src/credentials.rs
+++ b/crates/lns-policy/src/credentials.rs
@@ -1,4 +1,4 @@
-//! Credential rules live in `~/.lns-credentials.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine state.
+//! Credential rules live in `~/.lns/credentials.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine state.
 
 use std::collections::HashMap;
 use std::fs;
@@ -57,16 +57,6 @@ pub fn has_armed_entry(state: &CredentialStateFile, id: &str) -> bool {
         Some(CredentialEntry::Stored { value }) => !value.is_empty(),
         _ => false,
     }
-}
-
-/// Falls back to `./.lns-credentials.json` when `HOME` is unset rather than panicking.
-pub fn default_credentials_path() -> PathBuf {
-    if let Some(p) = std::env::var_os("LNS_CREDENTIALS_PATH") {
-        return PathBuf::from(p);
-    }
-    std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".lns-credentials.json"))
-        .unwrap_or_else(|| PathBuf::from(".lns-credentials.json"))
 }
 
 pub struct JsonFileCredentialStore {
@@ -283,42 +273,6 @@ mod tests {
         store.save(&second).unwrap();
         let loaded = store.load().unwrap();
         assert_eq!(loaded, second);
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_credentials_path_uses_override_when_set() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::set("LNS_CREDENTIALS_PATH", "/tmp/custom-creds.json");
-        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
-        assert_eq!(
-            default_credentials_path(),
-            PathBuf::from("/tmp/custom-creds.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_credentials_path_falls_back_to_home_dotfile() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_CREDENTIALS_PATH");
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_credentials_path(),
-            PathBuf::from("/home/dev/.lns-credentials.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_credentials_path_falls_back_to_cwd_when_home_unset() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_CREDENTIALS_PATH");
-        let _g2 = EnvVarGuard::unset("HOME");
-        assert_eq!(
-            default_credentials_path(),
-            PathBuf::from(".lns-credentials.json")
-        );
     }
 
     #[test]

--- a/crates/lns-policy/src/decision_store.rs
+++ b/crates/lns-policy/src/decision_store.rs
@@ -16,16 +16,6 @@ pub trait DecisionStore<T>: Send + Sync {
     fn save(&self, state: &DecisionFile<T>) -> io::Result<()>;
 }
 
-/// The override env var wins, then `$HOME/<filename>`; falls back to the working directory rather than panicking when `HOME` is unset.
-pub fn default_path(override_env: &str, filename: &str) -> PathBuf {
-    if let Some(path) = std::env::var_os(override_env) {
-        return PathBuf::from(path);
-    }
-    std::env::var_os("HOME")
-        .map(|home| PathBuf::from(home).join(filename))
-        .unwrap_or_else(|| PathBuf::from(filename))
-}
-
 pub struct JsonDecisionStore<T> {
     pub path: PathBuf,
     answer: PhantomData<fn() -> T>,
@@ -118,41 +108,5 @@ mod tests {
         second.insert("second".to_string(), SomeAnswer::No);
         store.save(&second).unwrap();
         assert_eq!(store.load().unwrap(), second);
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_uses_the_override_when_set() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::set("LNS_SOME_DECISIONS_PATH", "/tmp/custom.json");
-        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
-        assert_eq!(
-            default_path("LNS_SOME_DECISIONS_PATH", ".lns-some.json"),
-            PathBuf::from("/tmp/custom.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_falls_back_to_a_home_dotfile() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_SOME_DECISIONS_PATH");
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_path("LNS_SOME_DECISIONS_PATH", ".lns-some.json"),
-            PathBuf::from("/home/dev/.lns-some.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_falls_back_to_the_working_directory_when_home_is_unset() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_SOME_DECISIONS_PATH");
-        let _g2 = EnvVarGuard::unset("HOME");
-        assert_eq!(
-            default_path("LNS_SOME_DECISIONS_PATH", ".lns-some.json"),
-            PathBuf::from(".lns-some.json")
-        );
     }
 }

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -1,4 +1,4 @@
-//! Per-workload connector grants live in `~/.lns-workload-grants.json`, per-machine and never committed — a grant lets one workload spend a machine-global credential, which is a per-machine risk acceptance, not a shareable rule.
+//! Per-workload connector grants live in `~/.lns/workload-grants.json`, per-machine and never committed — a grant lets one workload spend a machine-global credential, which is a per-machine risk acceptance, not a shareable rule.
 
 use std::fs;
 use std::io;
@@ -335,16 +335,6 @@ pub fn project_key(policy_path: &Path) -> String {
         .unwrap_or_else(|_| policy_path.to_path_buf())
         .to_string_lossy()
         .into_owned()
-}
-
-/// Falls back to `./.lns-workload-grants.json` when `HOME` is unset rather than panicking.
-pub fn default_workload_grants_path() -> PathBuf {
-    if let Some(p) = std::env::var_os("LNS_WORKLOAD_GRANTS_PATH") {
-        return PathBuf::from(p);
-    }
-    std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".lns-workload-grants.json"))
-        .unwrap_or_else(|| PathBuf::from(".lns-workload-grants.json"))
 }
 
 pub struct JsonFileGrantStore {
@@ -968,42 +958,6 @@ mod tests {
     fn project_key_falls_back_to_the_raw_path_when_it_cannot_be_canonicalized() {
         let path = Path::new("/no/such/dir/lns-local-mixin.yaml");
         assert_eq!(project_key(path), "/no/such/dir/lns-local-mixin.yaml");
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_uses_override_when_set() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::set("LNS_WORKLOAD_GRANTS_PATH", "/tmp/custom-grants.json");
-        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
-        assert_eq!(
-            default_workload_grants_path(),
-            PathBuf::from("/tmp/custom-grants.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_falls_back_to_home_dotfile() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_WORKLOAD_GRANTS_PATH");
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_workload_grants_path(),
-            PathBuf::from("/home/dev/.lns-workload-grants.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_path_falls_back_to_cwd_when_home_unset() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_WORKLOAD_GRANTS_PATH");
-        let _g2 = EnvVarGuard::unset("HOME");
-        assert_eq!(
-            default_workload_grants_path(),
-            PathBuf::from(".lns-workload-grants.json")
-        );
     }
 
     struct FaultyStore {

--- a/crates/lns-policy/src/host_bind_decisions.rs
+++ b/crates/lns-policy/src/host_bind_decisions.rs
@@ -1,13 +1,8 @@
-//! Host-bind KEEP/DROP decisions live in `~/.lns-host-bind-decisions.json` — a KEEP exposes a real secret to the workload, which is a per-machine risk acceptance, not a shareable rule.
-
-use std::path::PathBuf;
+//! Host-bind KEEP/DROP decisions live in `~/.lns/host-bind-decisions.json` — a KEEP exposes a real secret to the workload, which is a per-machine risk acceptance, not a shareable rule.
 
 use serde::{Deserialize, Serialize};
 
-use crate::decision_store::{DecisionFile, DecisionStore, JsonDecisionStore, default_path};
-
-const OVERRIDE_ENV: &str = "LNS_HOST_BIND_DECISIONS_PATH";
-const FILENAME: &str = ".lns-host-bind-decisions.json";
+use crate::decision_store::{DecisionFile, DecisionStore, JsonDecisionStore};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -19,10 +14,6 @@ pub enum SecretDisposition {
 pub type HostBindDecisionFile = DecisionFile<SecretDisposition>;
 pub type HostBindDecisionStore = dyn DecisionStore<SecretDisposition>;
 pub type JsonFileHostBindDecisionStore = JsonDecisionStore<SecretDisposition>;
-
-pub fn default_host_bind_decisions_path() -> PathBuf {
-    default_path(OVERRIDE_ENV, FILENAME)
-}
 
 #[cfg(test)]
 mod tests {
@@ -47,19 +38,6 @@ mod tests {
         assert!(
             parsed.is_err(),
             "a decision file naming a disposition this version does not know must fail loudly, never read as keep"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn the_decisions_file_is_a_home_dotfile_of_its_own() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset(OVERRIDE_ENV);
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_host_bind_decisions_path(),
-            PathBuf::from("/home/dev/.lns-host-bind-decisions.json"),
-            "keep/drop answers must not share a file with the host-path answers"
         );
     }
 }

--- a/crates/lns-policy/src/host_path_decisions.rs
+++ b/crates/lns-policy/src/host_path_decisions.rs
@@ -1,13 +1,8 @@
-//! Whether a pulled sandbox may read one of this machine's files lives in `~/.lns-host-path-decisions.json` — a `hostPath` makes what a document mounts depend on the machine running it, which is a risk one developer accepts on one computer, not a rule a directory keeps.
-
-use std::path::PathBuf;
+//! Whether a pulled sandbox may read one of this machine's files lives in `~/.lns/host-path-decisions.json` — a `hostPath` makes what a document mounts depend on the machine running it, which is a risk one developer accepts on one computer, not a rule a directory keeps.
 
 use serde::{Deserialize, Serialize};
 
-use crate::decision_store::{DecisionFile, DecisionStore, JsonDecisionStore, default_path};
-
-const OVERRIDE_ENV: &str = "LNS_HOST_PATH_DECISIONS_PATH";
-const FILENAME: &str = ".lns-host-path-decisions.json";
+use crate::decision_store::{DecisionFile, DecisionStore, JsonDecisionStore};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -35,10 +30,6 @@ pub fn repository_of(reference: &str) -> &str {
         Some((repository, tag)) if !tag.contains('/') => repository,
         _ => reference,
     }
-}
-
-pub fn default_host_path_decisions_path() -> PathBuf {
-    default_path(OVERRIDE_ENV, FILENAME)
 }
 
 #[cfg(test)]
@@ -115,19 +106,6 @@ mod tests {
         assert_eq!(
             decision_key("ghcr.io/team/hermes", "~/.gitconfig"),
             "ghcr.io/team/hermes|~/.gitconfig"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn the_decisions_file_is_a_home_dotfile_of_its_own() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset(OVERRIDE_ENV);
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_host_path_decisions_path(),
-            PathBuf::from("/home/dev/.lns-host-path-decisions.json"),
-            "host-path answers must not share a file with the host-bind keep/drop answers"
         );
     }
 }

--- a/crates/lns-policy/src/registry_auth.rs
+++ b/crates/lns-policy/src/registry_auth.rs
@@ -1,4 +1,4 @@
-//! Registry logins live in `~/.lns-registry-auth.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine secrets.
+//! Registry logins live in `~/.lns/registry-auth.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine secrets.
 
 use std::collections::HashMap;
 use std::fs;
@@ -18,16 +18,6 @@ pub type RegistryAuthFile = HashMap<String, RegistryCredential>;
 pub trait RegistryAuthStore: Send + Sync {
     fn load(&self) -> io::Result<RegistryAuthFile>;
     fn save(&self, state: &RegistryAuthFile) -> io::Result<()>;
-}
-
-/// Falls back to `./.lns-registry-auth.json` when `HOME` is unset rather than panicking.
-pub fn default_registry_auth_path() -> PathBuf {
-    if let Some(p) = std::env::var_os("LNS_REGISTRY_AUTH_PATH") {
-        return PathBuf::from(p);
-    }
-    std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join(".lns-registry-auth.json"))
-        .unwrap_or_else(|| PathBuf::from(".lns-registry-auth.json"))
 }
 
 pub struct JsonFileRegistryAuthStore {
@@ -230,41 +220,5 @@ mod tests {
             "hubuser"
         );
         assert!(credential_for(&file, "ghcr.io").is_none());
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_registry_auth_path_uses_override_when_set() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::set("LNS_REGISTRY_AUTH_PATH", "/tmp/custom-auth.json");
-        let _g2 = EnvVarGuard::set("HOME", "/tmp/home-should-be-ignored");
-        assert_eq!(
-            default_registry_auth_path(),
-            PathBuf::from("/tmp/custom-auth.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_registry_auth_path_falls_back_to_home_dotfile() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_REGISTRY_AUTH_PATH");
-        let _g2 = EnvVarGuard::set("HOME", "/home/dev");
-        assert_eq!(
-            default_registry_auth_path(),
-            PathBuf::from("/home/dev/.lns-registry-auth.json")
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn default_registry_auth_path_falls_back_to_cwd_when_home_unset() {
-        use crate::test_env::EnvVarGuard;
-        let _g1 = EnvVarGuard::unset("LNS_REGISTRY_AUTH_PATH");
-        let _g2 = EnvVarGuard::unset("HOME");
-        assert_eq!(
-            default_registry_auth_path(),
-            PathBuf::from(".lns-registry-auth.json")
-        );
     }
 }

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -285,15 +285,13 @@ impl crate::artifact::mixin::MixinSource for RegistryMixins {
 }
 
 fn effective_machine_catalog() -> Vec<lns_policy::connectors::Connector> {
-    let user = lns_policy::connectors::Catalog::load_or_default(
-        &lns_policy::connectors::default_connectors_path(),
-    )
-    .unwrap_or_else(|e| {
-        crate::log::warn!(
-            "unreadable user connector catalog ({e}); using the bundled catalog only"
-        );
-        lns_policy::connectors::Catalog::default()
-    });
+    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+        .unwrap_or_else(|e| {
+            crate::log::warn!(
+                "unreadable user connector catalog ({e}); using the bundled catalog only"
+            );
+            lns_policy::connectors::Catalog::default()
+        });
     lns_policy::connectors::effective_connectors(&user)
 }
 

--- a/crates/lns-service/src/audit.rs
+++ b/crates/lns-service/src/audit.rs
@@ -466,7 +466,6 @@ mod tests {
     fn record_sandbox_run_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         record_sandbox_run(
             "aa125",
             "calm-finch",
@@ -587,7 +586,6 @@ mod tests {
     fn record_bind_attached_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         record_bind_attached(
             "aa123",
             "calm-finch",
@@ -611,7 +609,6 @@ mod tests {
     fn record_tool_provisioned_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let outcome = crate::tools::ProvisionOutcome {
             tool: "some-tool".into(),
             requested: "some-tool@1".into(),
@@ -661,7 +658,6 @@ mod tests {
     fn record_volume_attached_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         record_volume_attached("aa123", "calm-finch", "prism-data", "/data", &CLOCK).unwrap();
         let content = std::fs::read_to_string(audit_path("aa123").unwrap()).unwrap();
         assert!(content.contains("\"lns_name\":\"prism-data\""), "{content}");
@@ -673,7 +669,6 @@ mod tests {
     fn record_run_launched_writes_under_the_runs_audit_log() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         record_run_launched("aa124", "calm-finch", "alpine:latest", &CLOCK).unwrap();
         let content = std::fs::read_to_string(audit_path("aa124").unwrap()).unwrap();
         assert!(

--- a/crates/lns-service/src/cache.rs
+++ b/crates/lns-service/src/cache.rs
@@ -2,5 +2,5 @@ use anyhow::Result;
 use std::path::PathBuf;
 
 pub fn root() -> Result<PathBuf> {
-    Ok(lns_ipc::cache_root()?)
+    Ok(lns_ipc::lns_home()?)
 }

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -1,4 +1,4 @@
-//! The credential-rule source of truth lives in `~/.lns-credentials.json`, not `lns-local-mixin.yaml`.
+//! The credential-rule source of truth lives in `~/.lns/credentials.json`, not `lns-local-mixin.yaml`.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};

--- a/crates/lns-service/src/credential_flow/store.rs
+++ b/crates/lns-service/src/credential_flow/store.rs
@@ -2,5 +2,4 @@
 
 pub use lns_policy::credentials::{
     CredentialEntry, CredentialStateFile, CredentialStore, JsonFileCredentialStore,
-    default_credentials_path,
 };

--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context, Result};
-use lns_policy::registry_auth::{
-    JsonFileRegistryAuthStore, RegistryAuthStore, credential_for, default_registry_auth_path,
-};
+use lns_policy::registry_auth::{JsonFileRegistryAuthStore, RegistryAuthStore, credential_for};
 use oci_client::{
     Reference, RegistryOperation,
     manifest::{OciDescriptor, OciImageManifest},
@@ -39,7 +37,7 @@ pub(crate) fn registry_auth_for(image: &str) -> RegistryAuth {
     let Ok(reference) = image.parse::<Reference>() else {
         return RegistryAuth::Anonymous;
     };
-    let store = JsonFileRegistryAuthStore::new(default_registry_auth_path());
+    let store = JsonFileRegistryAuthStore::new(lns_ipc::registry_auth_path());
     let Ok(file) = store.load() else {
         return RegistryAuth::Anonymous;
     };

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -2171,7 +2171,6 @@ mod tests {
     async fn lifecycle_production_wrappers_round_trip_under_the_cache_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
 
         let reference: oci_client::Reference =
             "registry.example.test/cov/lifecycle:1".parse().unwrap();
@@ -2217,7 +2216,6 @@ mod tests {
     async fn record_artifact_run_persists_the_sandbox_dependency_under_the_cache_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let base = format!("registry.example.test/team/base@sha256:{}", "a".repeat(64));
 
         record_artifact_run("registry.example.test/team/agent:1", "sha256:m", &base)

--- a/crates/lns-service/src/initramfs.rs
+++ b/crates/lns-service/src/initramfs.rs
@@ -221,8 +221,6 @@ mod tests {
         let tmphome = tempfile::TempDir::new().unwrap();
         let target = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let _home = crate::test_env::EnvVarGuard::set("HOME", tmphome.path());
-        let _xdg =
-            crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", tmphome.path().join(".cache"));
         let _init = crate::test_env::EnvVarGuard::set("LNS_INIT_BIN", &target);
         let _broker = crate::test_env::EnvVarGuard::set("LNS_SESSION_BROKER_BIN", &target);
 

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -253,14 +253,10 @@ async fn run_credential_bind(id: &str) -> Response {
     use crate::credential_flow::bind::{
         BindResolution, bind_prompt, bind_provider, resolve_bind_decision,
     };
-    use crate::credential_flow::store::{
-        CredentialStore, JsonFileCredentialStore, default_credentials_path,
-    };
+    use crate::credential_flow::store::{CredentialStore, JsonFileCredentialStore};
 
-    let user = lns_policy::connectors::Catalog::load_or_default(
-        &lns_policy::connectors::default_connectors_path(),
-    )
-    .unwrap_or_default();
+    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+        .unwrap_or_default();
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let Some(integ) = catalog.iter().find(|i| i.id == id) else {
         return Response::CredentialBindFailed {
@@ -310,7 +306,7 @@ async fn run_credential_bind(id: &str) -> Response {
     };
     match resolve_bind_decision(delivery.request) {
         BindResolution::Persist(entry, decision) => {
-            let store = JsonFileCredentialStore::new(default_credentials_path());
+            let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
             let mut state = match store.load() {
                 Ok(state) => state,
                 Err(e) => {
@@ -338,10 +334,8 @@ pub(crate) async fn run_connector_sign_in(
 ) -> Response {
     use lns_policy::connectors::OauthFlow;
 
-    let user = lns_policy::connectors::Catalog::load_or_default(
-        &lns_policy::connectors::default_connectors_path(),
-    )
-    .unwrap_or_default();
+    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+        .unwrap_or_default();
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let Some(oauth) = catalog
         .iter()
@@ -461,10 +455,8 @@ fn persist_oauth_token(
     token: &crate::oauth::TokenSet,
     clock: &dyn crate::oauth::Clock,
 ) -> std::io::Result<()> {
-    use crate::credential_flow::store::{
-        CredentialStore, JsonFileCredentialStore, default_credentials_path,
-    };
-    let store = JsonFileCredentialStore::new(default_credentials_path());
+    use crate::credential_flow::store::{CredentialStore, JsonFileCredentialStore};
+    let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
     let mut state = store.load()?;
     state.insert(id.to_string(), crate::oauth::entry_from_token(clock, token));
     store.save(&state)
@@ -472,9 +464,9 @@ fn persist_oauth_token(
 
 fn persist_pkce_key(id: &str, key: String) -> std::io::Result<()> {
     use crate::credential_flow::store::{
-        CredentialEntry, CredentialStore, JsonFileCredentialStore, default_credentials_path,
+        CredentialEntry, CredentialStore, JsonFileCredentialStore,
     };
-    let store = JsonFileCredentialStore::new(default_credentials_path());
+    let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
     let mut state = store.load()?;
     state.insert(id.to_string(), CredentialEntry::Stored { value: key });
     store.save(&state)

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1444,7 +1444,6 @@ mod tests {
     async fn handle_request_volume_lifecycle_round_trips_through_the_store() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let now = Instant::now();
 
         let created = as_json(
@@ -1520,7 +1519,6 @@ mod tests {
     async fn handle_request_inspect_of_an_unknown_volume_surfaces_the_store_error() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let resp = as_json(
             handle_request(
                 &Request::InspectVolume {
@@ -2911,7 +2909,6 @@ mod tests {
     async fn handle_request_remove_of_an_unknown_image_surfaces_the_store_error() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let resp = as_json(
             handle_request(
                 &Request::RemoveImage {
@@ -2931,7 +2928,6 @@ mod tests {
     async fn handle_request_pull_of_a_mixin_caches_its_graph_and_records_no_row() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let now = Instant::now();
         let manifest_cache = crate::image::manifest_cache::ManifestCache::new(
             crate::cache::root().unwrap().join("manifests"),
@@ -3013,7 +3009,6 @@ mod tests {
     async fn handle_request_image_lifecycle_round_trips_offline_via_the_caches() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let now = Instant::now();
 
         use sha2::Digest;
@@ -3184,7 +3179,6 @@ mod tests {
     async fn handle_request_pull_of_a_sandbox_artifact_caches_it_with_its_base_image() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let now = Instant::now();
 
         use sha2::Digest;

--- a/crates/lns-service/src/kernel.rs
+++ b/crates/lns-service/src/kernel.rs
@@ -187,8 +187,6 @@ mod tests {
         let _path = crate::test_env::EnvVarGuard::unset("LNS_KERNEL_PATH");
         let _cdn = crate::test_env::EnvVarGuard::set("LNS_KERNEL_CDN", server.uri());
         let _home = crate::test_env::EnvVarGuard::set("HOME", cache_root.path());
-        let _xdg =
-            crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", cache_root.path().join("xdg"));
         let result = ensure().await;
 
         let err = result.expect_err("wiremock bytes won't match KERNEL_SHA256");
@@ -223,8 +221,6 @@ mod tests {
         let _path = crate::test_env::EnvVarGuard::unset("LNS_KERNEL_PATH");
         let _cdn = crate::test_env::EnvVarGuard::set("LNS_KERNEL_CDN", server.uri());
         let _home = crate::test_env::EnvVarGuard::set("HOME", cache_root.path());
-        let _xdg =
-            crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", cache_root.path().join("xdg"));
         let result = ensure().await;
 
         let err = result.expect_err("503 must bail");
@@ -248,8 +244,6 @@ mod tests {
         let _path = crate::test_env::EnvVarGuard::unset("LNS_KERNEL_PATH");
         let _cdn = crate::test_env::EnvVarGuard::set("LNS_KERNEL_CDN", format!("http://{addr}"));
         let _home = crate::test_env::EnvVarGuard::set("HOME", cache_root.path());
-        let _xdg =
-            crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", cache_root.path().join("xdg"));
         let result = ensure().await;
 
         let err = result.expect_err("connect-refused must bail");

--- a/crates/lns-service/src/ledger.rs
+++ b/crates/lns-service/src/ledger.rs
@@ -260,7 +260,6 @@ mod tests {
     fn a_pulled_sandboxs_tool_acquisition_is_readable_off_the_machine_chain() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_DATA_HOME", d.path().join("data"));
         let cx = crate::ocsf_audit::OcsfCtx::at_unix(
             "pull-1a2b3c4d5e6f".into(),
             String::new(),
@@ -301,7 +300,6 @@ mod tests {
     fn append_ledger_record_writes_under_data_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_DATA_HOME", d.path().join("data"));
         append_ledger_record(&sample("aa07")).unwrap();
         let content = std::fs::read_to_string(lns_ipc::connection_ledger().unwrap()).unwrap();
         assert!(content.contains("\"lns_run\":\"aa07\""), "{content}");
@@ -351,7 +349,6 @@ mod tests {
     fn the_file_recorder_persists_under_data_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_DATA_HOME", d.path().join("data"));
         let recorder = RunLedgerRecorder::new(
             "aa07".into(),
             "vm".into(),
@@ -439,7 +436,6 @@ mod tests {
     fn concurrent_runs_appending_produce_one_unbroken_chain() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_DATA_HOME", d.path().join("data"));
         let threads: u32 = 8;
         let per_thread: u32 = 25;
         std::thread::scope(|scope| {

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -611,25 +611,21 @@ async fn gate_declared_sign_ins(
     use crate::artifact::credential_boot::{
         BootGate, SlotPlan, boot_gate, plan_declared_connectors, sign_in_gate_ids,
     };
-    use crate::credential_flow::store::{
-        CredentialStore, JsonFileCredentialStore, default_credentials_path,
-    };
+    use crate::credential_flow::store::{CredentialStore, JsonFileCredentialStore};
     use lns_ipc::Response;
 
     let mut signed_in = Vec::new();
     if credentials.is_empty() {
         return Ok(signed_in);
     }
-    let user = lns_policy::connectors::Catalog::load_or_default(
-        &lns_policy::connectors::default_connectors_path(),
-    )
-    .unwrap_or_default();
+    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+        .unwrap_or_default();
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let declared = sign_in_gate_ids(credentials, &catalog);
     if declared.is_empty() {
         return Ok(signed_in);
     }
-    let state = JsonFileCredentialStore::new(default_credentials_path())
+    let state = JsonFileCredentialStore::new(lns_ipc::credentials_path())
         .load()
         .unwrap_or_default();
     let plans = plan_declared_connectors(&declared, &catalog, &state);

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -26,14 +26,13 @@ use crate::credential_flow::providers::{DefProvider, Provider};
 use crate::credential_flow::registry::expand_credentials_for_wire_with_custom;
 use crate::credential_flow::session::CredentialSession;
 use crate::credential_flow::store::{
-    CredentialStateFile, CredentialStore, JsonFileCredentialStore, default_credentials_path,
+    CredentialStateFile, CredentialStore, JsonFileCredentialStore,
 };
 use crate::credential_flow::watcher::CredentialWatcher;
 use crate::log;
 use crate::relay;
 use lns_policy::grants::{
-    GrantStore, JsonFileGrantStore, WorkloadGrantFile, WorkloadIdentity,
-    default_workload_grants_path, project_key,
+    GrantStore, JsonFileGrantStore, WorkloadGrantFile, WorkloadIdentity, project_key,
 };
 use lns_policy::{FilePolicyStore, Policy, RouteRule};
 
@@ -221,7 +220,7 @@ fn sweep_once(weak: &Weak<ApprovalSession>) -> bool {
     true
 }
 
-/// Defaults to empty and warns on store error, so a malformed `~/.lns-credentials.json` doesn't silently wipe the developer's rules at startup.
+/// Defaults to empty and warns on store error, so a malformed `~/.lns/credentials.json` doesn't silently wipe the developer's rules at startup.
 fn load_credentials_or_warn(store: &dyn CredentialStore, path: &Path) -> CredentialStateFile {
     match store.load() {
         Ok(state) => state,
@@ -233,7 +232,7 @@ fn load_credentials_or_warn(store: &dyn CredentialStore, path: &Path) -> Credent
     }
 }
 
-/// Defaults to an empty grant set and warns on load error, so a malformed `~/.lns-workload-grants.json` fails safe: every connector re-offers at first use rather than silently arming.
+/// Defaults to an empty grant set and warns on load error, so a malformed `~/.lns/workload-grants.json` fails safe: every connector re-offers at first use rather than silently arming.
 fn load_grants_or_warn(store: &dyn GrantStore, path: &Path) -> WorkloadGrantFile {
     match store.load() {
         Ok(grants) => grants,
@@ -309,7 +308,7 @@ fn record_boot_sign_in_grants(
 /// Each connector's forget count as it stands before a run's boot sign-in gate opens, so a `lns connector disconnect` landing during a browser device flow — minutes, not milliseconds — still wins over the grant that sign-in would earn.
 pub(crate) fn revocations_before_gate(policy_path: &Path) -> HashMap<String, u64> {
     let project = project_key(policy_path);
-    JsonFileGrantStore::new(default_workload_grants_path())
+    JsonFileGrantStore::new(lns_ipc::workload_grants_path())
         .load()
         .unwrap_or_default()
         .revocations
@@ -319,7 +318,7 @@ pub(crate) fn revocations_before_gate(policy_path: &Path) -> HashMap<String, u64
         .collect()
 }
 
-/// Defaults to an empty user catalog and warns on load error, so a malformed `~/.lns-connectors.yaml` doesn't break a run — the bundled catalog still applies.
+/// Defaults to an empty user catalog and warns on load error, so a malformed `~/.lns/connectors.yaml` doesn't break a run — the bundled catalog still applies.
 fn load_user_catalog_or_warn(path: &Path) -> lns_policy::connectors::Catalog {
     match lns_policy::connectors::Catalog::load_or_default(path) {
         Ok(catalog) => catalog,
@@ -523,7 +522,7 @@ async fn start_credential_subsystem(
     oauth: OauthWiring,
 ) -> Result<CredentialSubsystem> {
     // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
-    let credentials_path = default_credentials_path();
+    let credentials_path = lns_ipc::credentials_path();
     let credential_store: Arc<dyn CredentialStore> =
         Arc::new(JsonFileCredentialStore::new(credentials_path.clone()));
     let mut initial_credential_state =
@@ -679,11 +678,10 @@ pub(super) async fn start(
 ) -> Result<SupervisorSession> {
     let sandbox_credentials = consent.credentials;
     let workload = consent.workload;
-    let connected = connected_in(&default_workload_grants_path(), &project_key(policy_path));
+    let connected = connected_in(&lns_ipc::workload_grants_path(), &project_key(policy_path));
     let (mut policy, own_policy) = running_policies(policy_path, sandbox_policy, connected)?;
     // Applied connectors resolve against the effective catalog (bundled ∪ user) into both wire credentials and allow-routes, captured once at boot so a later edit can't reach an already-forked workload.
-    let user_catalog =
-        load_user_catalog_or_warn(&lns_policy::connectors::default_connectors_path());
+    let user_catalog = load_user_catalog_or_warn(&lns_ipc::connectors_path());
     let catalog = lns_policy::connectors::effective_connectors(&user_catalog);
     let applied = resolve_applied_with_credentials(&policy, sandbox_credentials, &catalog);
     // Un-connected catalog connectors resolve as connectable — detect-only unless definition-declared — so their use offers a live connect.
@@ -716,7 +714,7 @@ pub(super) async fn start(
     log::info!("Approvals", "window ready");
 
     // A machine-global value arms only for a value key this workload holds an allow grant for, so a cloned overlay or a declared credential re-offers at first use instead of silently spending the credential.
-    let grants_path = default_workload_grants_path();
+    let grants_path = lns_ipc::workload_grants_path();
     let grant_store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(grants_path.clone()));
     let mut grants = load_grants_or_warn(grant_store.as_ref(), &grants_path);
     let project = project_key(policy_path);
@@ -1384,7 +1382,7 @@ mod tests {
 
     fn seeded_sidecar(dir: &std::path::Path, policy_path: &Path) -> JsonFileGrantStore {
         Policy::default().save_atomic(policy_path).expect("policy");
-        let store = JsonFileGrantStore::new(dir.join("grants.json"));
+        let store = JsonFileGrantStore::new(dir.join("workload-grants.json"));
         store
             .update(&mut |file| {
                 file.revoke_project_connector(&project_key(policy_path), "acme");
@@ -1402,10 +1400,7 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let policy_path = dir.path().join("lns-local-mixin.yaml");
         seeded_sidecar(dir.path(), &policy_path);
-        let _g = crate::test_env::EnvVarGuard::set(
-            "LNS_WORKLOAD_GRANTS_PATH",
-            dir.path().join("grants.json"),
-        );
+        let _g = crate::test_env::EnvVarGuard::set("LNS_HOME", dir.path());
 
         let counts = revocations_before_gate(&policy_path);
 
@@ -1420,9 +1415,9 @@ mod tests {
     #[serial_test::serial(env)]
     fn revocations_before_gate_reads_nothing_from_an_unreadable_sidecar() {
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let sidecar = dir.path().join("grants.json");
-        std::fs::write(&sidecar, "{ not json").expect("corrupt sidecar");
-        let _g = crate::test_env::EnvVarGuard::set("LNS_WORKLOAD_GRANTS_PATH", &sidecar);
+        std::fs::write(dir.path().join("workload-grants.json"), "{ not json")
+            .expect("corrupt sidecar");
+        let _g = crate::test_env::EnvVarGuard::set("LNS_HOME", dir.path());
 
         assert!(
             revocations_before_gate(&dir.path().join("lns-local-mixin.yaml")).is_empty(),
@@ -1586,7 +1581,7 @@ mod tests {
     fn load_user_catalog_or_warn_reads_an_existing_user_catalog() {
         use lns_policy::connectors::{AuthKind, Catalog, Connector, CredentialAuth};
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         Catalog {
             connectors: vec![Connector {
                 id: "acme".into(),
@@ -1613,7 +1608,7 @@ mod tests {
     fn load_user_catalog_or_warn_defaults_to_empty_and_warns_on_load_error() {
         init_tracing_capture();
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let path = dir.path().join(".lns-connectors.yaml");
+        let path = dir.path().join("connectors.yaml");
         std::fs::write(&path, "connectors: not-a-list\n").unwrap();
         let catalog = load_user_catalog_or_warn(&path);
         assert!(
@@ -3043,9 +3038,7 @@ mod tests {
     #[serial_test::serial(env)]
     async fn ensure_without_embed_or_override_bails() {
         let cache_root = tempfile::TempDir::new().unwrap();
-        let _home = crate::test_env::EnvVarGuard::set("HOME", cache_root.path());
-        let _xdg =
-            crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", cache_root.path().join("xdg"));
+        let _home = crate::test_env::EnvVarGuard::set("LNS_HOME", cache_root.path());
 
         let err = ensure_with(|_| None, None)
             .await
@@ -3069,8 +3062,7 @@ mod tests {
         let cache_root = tempfile::TempDir::new().unwrap();
         // SAFETY: env mutation is serialized via #[serial(env)].
         unsafe {
-            std::env::set_var("HOME", cache_root.path());
-            std::env::set_var("XDG_CACHE_HOME", cache_root.path().join("xdg"));
+            std::env::set_var("LNS_HOME", cache_root.path());
         }
         let bytes = b"\x7fELF fake embedded supervisor".as_slice();
         // env_get returns None so the override is absent and the embedded
@@ -3079,8 +3071,7 @@ mod tests {
         let second = ensure_with(|_| None, Some(bytes)).await;
         // SAFETY: env mutation is serialized via #[serial(env)].
         unsafe {
-            std::env::remove_var("HOME");
-            std::env::remove_var("XDG_CACHE_HOME");
+            std::env::remove_var("LNS_HOME");
         }
 
         let first = first.expect("embedded install succeeds");

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -564,9 +564,7 @@ mod tests {
         let supervisor_bin = dir.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let guards = vec![
-            EnvVarGuard::set("HOME", dir.path()),
-            EnvVarGuard::unset("LNS_CONNECTORS_PATH"),
-            EnvVarGuard::unset("LNS_WORKLOAD_GRANTS_PATH"),
+            EnvVarGuard::set("LNS_HOME", dir.path()),
             EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin),
         ];
         let policy_path = dir.path().join("lns-local-mixin.yaml");
@@ -601,7 +599,7 @@ mod tests {
                 token_fallback: None,
             }],
         }
-        .save_atomic(&dir.path().join(".lns-connectors.yaml"))
+        .save_atomic(&dir.path().join("connectors.yaml"))
         .expect("user catalog");
         BootSignInFixture {
             dir,
@@ -652,7 +650,7 @@ mod tests {
 
         let session = start_with_boot_sign_in(&fixture, &workload).await;
 
-        let sidecar = JsonFileGrantStore::new(fixture.dir.path().join(".lns-workload-grants.json"));
+        let sidecar = JsonFileGrantStore::new(fixture.dir.path().join("workload-grants.json"));
         let grants = sidecar.load().expect("sidecar readable");
         let grant = grants
             .lookup(&project_key(&fixture.policy_path), &workload, "some-oauth")
@@ -672,7 +670,7 @@ mod tests {
         use crate::approval_flow::window;
         let fixture = boot_sign_in_fixture();
         // An unopenable lockfile path fails the sidecar update closed, standing in for any machine where it can't be written.
-        std::fs::create_dir(fixture.dir.path().join(".lns-workload-grants.json.lock"))
+        std::fs::create_dir(fixture.dir.path().join("workload-grants.json.lock"))
             .expect("occupy the lock path");
 
         let session = start_with_boot_sign_in(
@@ -697,7 +695,7 @@ mod tests {
         use crate::test_env::EnvVarGuard;
         window::install(WindowState::new());
         let d = tempfile::TempDir::new().expect("tempdir");
-        let _home = EnvVarGuard::set("HOME", d.path());
+        let _home = EnvVarGuard::set("LNS_HOME", d.path());
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);
@@ -728,7 +726,7 @@ mod tests {
         use crate::test_env::EnvVarGuard;
         window::install(WindowState::new());
         let d = tempfile::TempDir::new().expect("tempdir");
-        let _home = EnvVarGuard::set("HOME", d.path());
+        let _home = EnvVarGuard::set("LNS_HOME", d.path());
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);

--- a/crates/lns-service/src/update_check/real.rs
+++ b/crates/lns-service/src/update_check/real.rs
@@ -81,7 +81,7 @@ impl Fetcher for RealFetcher {
 struct RealStore;
 impl RealStore {
     fn root() -> Result<PathBuf> {
-        Ok(lns_ipc::data_root()?)
+        Ok(lns_ipc::lns_home()?)
     }
 }
 impl StateStore for RealStore {

--- a/crates/lns-service/src/volume_store/mod.rs
+++ b/crates/lns-service/src/volume_store/mod.rs
@@ -849,7 +849,6 @@ mod tests {
     async fn store_root_lives_under_the_cache_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         assert!(store_root().unwrap().ends_with("volumes"));
     }
 
@@ -858,7 +857,6 @@ mod tests {
     async fn acquire_production_wrapper_creates_under_store_and_releases_on_drop() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let acq = acquire("cov-acquire", "aa01").await.unwrap();
         assert!(acq.image_path.ends_with("cov-acquire.img"));
         drop(acq);
@@ -874,7 +872,6 @@ mod tests {
     async fn resolve_production_wrapper_maps_mounts_to_attachments() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let mounts = [lns_ipc::VolumeMount {
             name: "cov-resolve".to_string(),
             target: "/data".to_string(),
@@ -1228,7 +1225,6 @@ mod tests {
     async fn lifecycle_production_wrappers_round_trip_under_the_cache_root() {
         let d = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
-        let _x = crate::test_env::EnvVarGuard::set("XDG_CACHE_HOME", d.path().join("cache"));
         let info = create("cov-lifecycle").await.unwrap();
         assert_eq!(info.name, "cov-lifecycle");
         assert!(

--- a/crates/lns-service/tests/behaviours/credential_flow.feature
+++ b/crates/lns-service/tests/behaviours/credential_flow.feature
@@ -12,11 +12,11 @@ Feature: lns-service credential flow
   provider's per-service detection strategy, type one in, or deny.
   Every decision is sticky — there is no once/always distinction — but
   dismissing a card is not a decision and settles nothing.
-  Decisions and any typed values land in `~/.lns-credentials.json` (a
+  Decisions and any typed values land in `~/.lns/credentials.json` (a
   pluggable host-side store, JSON-file v1). They do NOT live in
   `lns-local-mixin.yaml`: the shareable policy file stays free of
   per-machine credential state. Manual edits to
-  `~/.lns-credentials.json` are picked up live and double as the
+  `~/.lns/credentials.json` are picked up live and double as the
   revocation mechanism.
 
   These scenarios illustrate the flow with an arbitrary `some-provider`
@@ -37,7 +37,7 @@ Feature: lns-service credential flow
 
   Scenario: A placeholder used in an outbound request prompts the developer when the host has the credential
     Given a workload is running with the seeded "some-provider" placeholder
-    And no credential rule exists in "~/.lns-credentials.json" for "some-provider"
+    And no credential rule exists in "~/.lns/credentials.json" for "some-provider"
     And the host has a "some-provider" credential reachable via the registered detection strategy
     When the workload sends a request carrying the some-provider placeholder
     Then a credential card appears for "some-provider" showing the provider, the originating sandbox, and the destination
@@ -46,7 +46,7 @@ Feature: lns-service credential flow
 
   Scenario: A placeholder used in an outbound request prompts the developer when the host has no credential
     Given a workload is running with the seeded "some-provider" placeholder
-    And no credential rule exists in "~/.lns-credentials.json" for "some-provider"
+    And no credential rule exists in "~/.lns/credentials.json" for "some-provider"
     And no "some-provider" credential is reachable on the host
     When the workload sends a request carrying the some-provider placeholder
     Then a credential card appears for "some-provider"
@@ -57,7 +57,7 @@ Feature: lns-service credential flow
   Scenario: Use from host arms the credential at the boundary and persists a host-detect rule
     Given a credential card for "some-provider" is visible with "use from host" available
     When the developer picks "use from host"
-    Then "~/.lns-credentials.json" gains an entry for "some-provider" with kind "host-detect"
+    Then "~/.lns/credentials.json" gains an entry for "some-provider" with kind "host-detect"
     And the workload's request leaves the boundary with the host-detected some-provider credential substituted in
     And the workload still sees only the placeholder
     And a future request carrying the some-provider placeholder is exchanged silently using the currently host-detected value
@@ -66,7 +66,7 @@ Feature: lns-service credential flow
   Scenario: A typed value arms the credential at the boundary and persists a stored rule
     Given a credential card for "some-provider" is visible
     When the developer types a value and submits
-    Then "~/.lns-credentials.json" gains an entry for "some-provider" with kind "stored" carrying the typed value
+    Then "~/.lns/credentials.json" gains an entry for "some-provider" with kind "stored" carrying the typed value
     And the workload's request leaves the boundary with the typed value substituted for the placeholder
     And a future request carrying the some-provider placeholder is exchanged silently using the stored value
     And "lns-local-mixin.yaml" is unchanged
@@ -78,7 +78,7 @@ Feature: lns-service credential flow
     And the card offers to use the value already bound on this machine
     When the developer picks "use the bound value"
     Then the workload's request leaves the boundary with the bound value substituted for the placeholder
-    And "~/.lns-credentials.json" still holds the value it was bound with
+    And "~/.lns/credentials.json" still holds the value it was bound with
 
   Scenario: A disconnect that lands while the card is open is not undone by answering it
     Given a credential card for "some-provider" is visible
@@ -101,7 +101,7 @@ Feature: lns-service credential flow
     When the developer closes the card without choosing
     Then the workload's held request is failed at the boundary
     And the credential card is removed from the approval window
-    And "~/.lns-credentials.json" is unchanged
+    And "~/.lns/credentials.json" is unchanged
     And the workload grant sidecar records no grant for "some-provider"
     And a future request carrying the some-provider placeholder fires a fresh credential card
 
@@ -109,13 +109,13 @@ Feature: lns-service credential flow
     Given a credential card for "some-provider" is visible
     When the developer closes the card without choosing
     Then a run in another project is still asked for "some-provider"
-    And "~/.lns-credentials.json" is unchanged
+    And "~/.lns/credentials.json" is unchanged
 
   Scenario: Closing every card at once decides nothing for any of them
     Given credential cards for "some-provider" and "some-other-provider" are visible
     When the developer closes every card at once
     Then both held requests are failed at the boundary
-    And "~/.lns-credentials.json" is unchanged
+    And "~/.lns/credentials.json" is unchanged
     And a future request carrying either the "some-provider" or "some-other-provider" placeholder fires a fresh credential card
 
   Scenario: A dismissed credential card records no approval in the audit chain
@@ -126,7 +126,7 @@ Feature: lns-service credential flow
   Scenario: A request needing both an unknown network rule and an unknown credential surfaces both cards in parallel
     Given a workload is running with the seeded "some-provider" placeholder
     And the policy has no rule for "api.some-provider.example"
-    And no credential rule exists in "~/.lns-credentials.json" for "some-provider"
+    And no credential rule exists in "~/.lns/credentials.json" for "some-provider"
     When the workload sends a request to "api.some-provider.example" carrying the some-provider placeholder
     Then a network card appears for "api.some-provider.example"
     And a credential card appears for "some-provider"
@@ -134,7 +134,7 @@ Feature: lns-service credential flow
     And a "deny" decision on either card fails the request at the boundary
 
   Scenario: A stored rule whose source no longer yields a value re-prompts
-    Given "~/.lns-credentials.json" has an entry for "some-provider" with kind "host-detect"
+    Given "~/.lns/credentials.json" has an entry for "some-provider" with kind "host-detect"
     And the host no longer yields a "some-provider" credential via the registered detection strategy
     When the workload sends a request carrying the some-provider placeholder
     Then a credential card for "some-provider" appears
@@ -142,8 +142,8 @@ Feature: lns-service credential flow
     And the workload's request is held pending a decision
 
   Scenario: A manual edit to the credentials file is picked up live and revokes the rule
-    Given a workload is running with a "stored" credential rule for "some-provider" in "~/.lns-credentials.json"
-    When the developer deletes the "some-provider" entry from "~/.lns-credentials.json"
+    Given a workload is running with a "stored" credential rule for "some-provider" in "~/.lns/credentials.json"
+    When the developer deletes the "some-provider" entry from "~/.lns/credentials.json"
     Then a subsequent request from the workload carrying the some-provider placeholder fires a fresh credential card for "some-provider"
     And no restart of the workload is required
 
@@ -159,18 +159,18 @@ Feature: lns-service credential flow
     When no decision is recorded before the configured approval timeout
     Then the workload's held request is failed at the boundary
     And the credential card is removed from the approval window
-    And "~/.lns-credentials.json" is unchanged
+    And "~/.lns/credentials.json" is unchanged
     And a future request carrying the some-provider placeholder fires a fresh credential card
 
   Scenario: A workload exit withdraws its open credential cards without persisting
     Given a workload has an open credential card for "some-provider"
     When the workload exits before a decision is recorded
     Then the credential card is removed from the approval window
-    And "~/.lns-credentials.json" is unchanged
+    And "~/.lns/credentials.json" is unchanged
 
   Scenario: A failed write to the credentials file keeps the rule in memory and informs the developer
     Given a credential card for "some-provider" is visible
-    And "~/.lns-credentials.json" cannot be written
+    And "~/.lns/credentials.json" cannot be written
     When the developer picks "use from host"
     Then the workload's held request leaves the boundary with the host-detected some-provider credential substituted in
     And the running credential rules contain a "host-detect" entry for "some-provider"

--- a/crates/lns-service/tests/behaviours/steps/credential_flow.rs
+++ b/crates/lns-service/tests/behaviours/steps/credential_flow.rs
@@ -70,7 +70,7 @@ fn given_workload_with_placeholder(world: &mut BehaviourWorld, _credential_id: S
     world.credential();
 }
 
-#[given(regex = r#"^no credential rule exists in "~/.lns-credentials.json" for "([^"]+)"$"#)]
+#[given(regex = r#"^no credential rule exists in "~/.lns/credentials.json" for "([^"]+)"$"#)]
 fn given_no_credential_rule(world: &mut BehaviourWorld, credential_id: String) {
     let rig = world.credential();
     assert!(
@@ -129,7 +129,7 @@ fn submit_if_not_visible(rig: &mut CredentialRig, credential_id: &str) {
     }
 }
 
-#[given(regex = r#"^"~/.lns-credentials.json" has an entry for "([^"]+)" with kind "([^"]+)"$"#)]
+#[given(regex = r#"^"~/.lns/credentials.json" has an entry for "([^"]+)" with kind "([^"]+)"$"#)]
 fn given_credentials_file_has_entry(
     world: &mut BehaviourWorld,
     credential_id: String,
@@ -151,7 +151,7 @@ fn given_host_no_longer_yields(world: &mut BehaviourWorld, credential_id: String
 }
 
 #[given(
-    regex = r#"^a workload is running with a "stored" credential rule for "([^"]+)" in "~/.lns-credentials.json"$"#
+    regex = r#"^a workload is running with a "stored" credential rule for "([^"]+)" in "~/.lns/credentials.json"$"#
 )]
 fn given_workload_with_stored_rule(world: &mut BehaviourWorld, credential_id: String) {
     let rig = world.credential();
@@ -183,7 +183,7 @@ fn given_open_credential_card(world: &mut BehaviourWorld, credential_id: String)
     let _ = drain_frames(rig);
 }
 
-#[given(r#""~/.lns-credentials.json" cannot be written"#)]
+#[given(r#""~/.lns/credentials.json" cannot be written"#)]
 fn given_credentials_file_cannot_be_written(world: &mut BehaviourWorld) {
     world.credential().store.break_next_save();
 }
@@ -303,7 +303,7 @@ fn then_request_leaves_with_bound_value(world: &mut BehaviourWorld) -> Result<()
     Ok(())
 }
 
-#[then(r#""~/.lns-credentials.json" still holds the value it was bound with"#)]
+#[then(r#""~/.lns/credentials.json" still holds the value it was bound with"#)]
 fn then_credentials_file_keeps_bound_value(world: &mut BehaviourWorld) -> Result<(), String> {
     let rig = world.credential();
     let on_disk = rig.store.load().map_err(|e| e.to_string())?;
@@ -323,7 +323,7 @@ fn when_developer_picks_deny_credential(world: &mut BehaviourWorld) {
         .record_decision(&id, CredentialDecisionRequest::Deny);
 }
 
-#[when(regex = r#"^the developer deletes the "([^"]+)" entry from "~/.lns-credentials.json"$"#)]
+#[when(regex = r#"^the developer deletes the "([^"]+)" entry from "~/.lns/credentials.json"$"#)]
 fn when_developer_deletes_entry(world: &mut BehaviourWorld, credential_id: String) {
     let rig = world.credential();
     let mut state = rig.session.current_state();
@@ -587,7 +587,7 @@ fn then_grant_sidecar_records_deny(
     }
 }
 
-#[then(regex = r#"^"~/.lns-credentials.json" gains an entry for "([^"]+)" with kind "([^"]+)"$"#)]
+#[then(regex = r#"^"~/.lns/credentials.json" gains an entry for "([^"]+)" with kind "([^"]+)"$"#)]
 fn then_credentials_file_has_entry(
     world: &mut BehaviourWorld,
     credential_id: String,
@@ -602,7 +602,7 @@ fn then_credentials_file_has_entry(
 }
 
 #[then(
-    regex = r#"^"~/.lns-credentials.json" gains an entry for "([^"]+)" with kind "stored" carrying the typed value$"#
+    regex = r#"^"~/.lns/credentials.json" gains an entry for "([^"]+)" with kind "stored" carrying the typed value$"#
 )]
 fn then_credentials_file_has_stored_with_value(
     world: &mut BehaviourWorld,
@@ -862,7 +862,7 @@ fn then_credential_card_removed(world: &mut BehaviourWorld) -> Result<(), String
     Ok(())
 }
 
-#[then(r#""~/.lns-credentials.json" is unchanged"#)]
+#[then(r#""~/.lns/credentials.json" is unchanged"#)]
 fn then_credentials_file_unchanged(world: &mut BehaviourWorld) -> Result<(), String> {
     let rig = world.credential();
     let state = rig.store.load().map_err(|e| e.to_string())?;

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -87,12 +87,12 @@ Audit logs and their anchors are kept per run under the service's data directory
 the trail outlives the ephemeral run overlay under the cache directory:
 
 ```text
-<data>/lns/runs/<run-id>/audit.jsonl
-<data>/lns/runs/<run-id>/audit.anchor
+~/.lns/runs/<run-id>/audit.jsonl
+~/.lns/runs/<run-id>/audit.anchor
 ```
 
-The connection ledger sits alongside them at `<data>/lns/ledger.jsonl`. On macOS
-`<data>` is `~/Library/Application Support`.
+The connection ledger sits alongside them at `~/.lns/ledger.jsonl`. `LNS_HOME`
+moves the whole directory, the audit trail with it.
 
 ## See also
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,6 +33,34 @@ Log levels: `error`, `warn`, `info`, `debug`.
 The three high codes exist so a failure of `lns` is never mistaken for the workload
 exiting with the same number. Detaching with the chord exits `0`.
 
+## Environment and files
+
+| Variable | Effect |
+| -------- | ------ |
+| `LNS_LOG` / `RUST_LOG` | Override the log threshold. |
+| `NO_COLOR` | Disable colour. |
+| `LNS_HOME` | The directory below, instead of `~/.lns`. |
+| `LNS_SOCKET_PATH` | The service socket to talk to. |
+| `LNS_NO_UPDATE_CHECK` | Suppress the update-and-security check and its announcement. |
+| `LNS_SERVICE_BIN` | The `lns-service` binary `lns service start` launches. |
+
+Everything `lns` keeps for you lives in one directory, `~/.lns/`:
+
+| Path | Holds |
+| ---- | ----- |
+| `~/.lns/config.yaml` | Your `lns config` defaults. |
+| `~/.lns/connectors.yaml` | The connectors declared on this machine. |
+| `~/.lns/credentials.json` | The per-machine credential values you bound. |
+| `~/.lns/workload-grants.json` | Which workload was granted which connector, per project. |
+| `~/.lns/registry-auth.json` | Registry logins, mode `0600`. |
+| `~/.lns/` (the rest) | Cached artifacts and layers, named volumes, the audit trail, and the kernel. |
+
+One directory, one thing to back up, one thing `lns uninstall --purge` removes.
+
+The project keeps two files, both in the directory you work in: `./lns.yaml`, the
+sandbox document, and `./lns-local-mixin.yaml`, what you decided here. Secrets are
+never written to the project.
+
 ## Machine-readable output
 
 The list and status verbs take `--format <table|json>`, so a script doesn't have to
@@ -261,8 +289,8 @@ login (such as `ghcr.io`) still take the flag-driven forms below.
 The registry is matched by host: a bare published-sandbox reference uses the
 `run.registry` default (or the Lens hub), while a fully-qualified
 `lns run ghcr.io/org/app` always targets that registry and uses its stored login if present. Credentials live in
-a per-user file (`~/.lns-registry-auth.json`, `0600`; override with
-`LNS_REGISTRY_AUTH_PATH`), separate from any shareable policy.
+a per-user file (`~/.lns/registry-auth.json`, `0600`), separate from any
+shareable policy.
 
 ## `lns audit`
 
@@ -329,7 +357,7 @@ lns update [--force] [--dry-run]
 ## `lns connector`
 
 Manage the credential-connector catalog — the services whose credentials reach a
-workload. The catalog is machine-global (`~/.lns-connectors.yaml`). A connector
+workload. The catalog is machine-global (`~/.lns/connectors.yaml`). A connector
 declared in a sandbox definition's `spec.connectors` seeds its placeholder env
 var but is only offered — the workload is prompted on first use, never armed
 automatically. Connecting one records the connection for that project on this
@@ -361,7 +389,7 @@ lns connector revoke <ID> [--policy <PATH>]
 `token_header`, `basic_x_access_token`, or `api_key_header` (which takes the header
 name as a third segment: `api_key_header:DOMAIN:HEADER`). Value decisions for a
 connected connector are made interactively in the approval window; grants are
-recorded per project and workload in `~/.lns-workload-grants.json`. See
+recorded per project and workload in `~/.lns/workload-grants.json`. See
 [Credentials](credentials.md) and [Connectors](connectors.md).
 
 ## `lns config`
@@ -394,6 +422,5 @@ variables, volumes, and ports are properties of a sandbox, not persistent config
 set them per run (`-e`, `-v`, `-p`) or in the sandbox definition's `spec`.
 
 Values are validated when stored, with the same parsers the run flags use.
-Defaults live in a per-user file — `~/Library/Application Support/lns/config.yaml`
-on macOS, `~/.config/lns/config.yaml` on Linux; override with `LNS_CONFIG_PATH`.
+Defaults live in `~/.lns/config.yaml`, with everything else lns keeps for you.
 A per-run flag always wins.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -13,8 +13,7 @@ The set of connectors Lens Sandbox knows about is a **catalog** with two layers:
 
 - **Bundled** — ships inside `lns` and grows with each release, so common services
   work without any setup on your part.
-- **User** — your own additions in `~/.lns-connectors.yaml`
-  (override the path with `LNS_CONNECTORS_PATH`).
+- **User** — your own additions in `~/.lns/connectors.yaml`.
 
 The effective catalog is the union of the two; a user entry can't shadow a bundled
 id. List everything Lens Sandbox can connect:

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -40,7 +40,7 @@ workload — see
 ## Value decisions
 
 A provider's *value decision* is per-machine — it's how the real secret is bound
-on your machine. It's stored in `~/.lns-credentials.json`, separate from the
+on your machine. It's stored in `~/.lns/credentials.json`, separate from the
 shareable `lns-local-mixin.yaml`, so secrets are never committed.
 
 Decisions are made interactively, at either of two moments:
@@ -60,7 +60,7 @@ the held request fails, and the next use asks again.
 
 Denying is the one choice whose reach depends on which card you answered.
 Denying the **proactive** card is a decision about the machine, and lands in
-`~/.lns-credentials.json` alongside the values. Declining a **reactive**
+`~/.lns/credentials.json` alongside the values. Declining a **reactive**
 first-use card is a decision about the workload in front of you, and is
 remembered as a per-workload deny instead — see
 [Workload grants](#workload-grants).
@@ -82,7 +82,7 @@ than the new shape inheriting the old approval. That holds for a decline as
 well as an approval — a redefined connector is a different question, so a
 standing no does not carry over to it either.
 
-Grants live in `~/.lns-workload-grants.json` — per-machine, alongside the
+Grants live in `~/.lns/workload-grants.json` — per-machine, alongside the
 credential values and equally outside anything you commit. Declining a card is
 remembered there too, as a standing no for that workload only; the same
 connector is still offered to your other projects, and to other workloads in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,7 +212,7 @@ lns uninstall --purge
 ```
 
 `--purge` keeps only files you authored yourself, such as your
-`~/.lns-connectors.yaml` catalog and each project's `lns-local-mixin.yaml`, and prints
+`~/.lns/connectors.yaml` catalog and each project's `lns-local-mixin.yaml`, and prints
 what it left behind.
 
 ## Where to go next


### PR DESCRIPTION
Stage 4 of 9, second half. This PR puts everything that `lns` keeps for you in one directory, `~/.lns`, and lets `LNS_HOME` move it.

> **Stacked on #281.** The base of this PR is `cli-spec-s4-output-exits`. The diff shows the second half of stage 4 only. Merge #281 first.

## What changes

Before this PR, `lns` used four places:

```text
<cache_dir>/lns       artifacts, layers, builds, volumes, the kernel
<data_dir>/lns        the audit chains and the connection ledger
<config_dir>/lns      config.yaml
~/.lns-*.yaml|json    connectors, credentials, registry logins,
                      workload grants, host-path and host-bind answers
```

All of it is now `~/.lns/`. `LNS_HOME` moves the root itself. It is not a directory that holds `.lns`.

| Before | Now |
|---|---|
| `<config_dir>/lns/config.yaml` | `~/.lns/config.yaml` |
| `~/.lns-connectors.yaml` | `~/.lns/connectors.yaml` |
| `~/.lns-credentials.json` | `~/.lns/credentials.json` |
| `~/.lns-registry-auth.json` | `~/.lns/registry-auth.json` |
| `~/.lns-workload-grants.json` | `~/.lns/workload-grants.json` |
| `~/.lns-host-path-decisions.json` | `~/.lns/host-path-decisions.json` |
| `~/.lns-host-bind-decisions.json` | `~/.lns/host-bind-decisions.json` |
| `<cache_dir>/lns`, `<data_dir>/lns` | `~/.lns/` |

## What you see

`lns config set` names the file that it wrote, and the file is in the one root:

```console
$ lns config set run.cpus 2
Set run.cpus to 2 in /Users/you/.lns/config.yaml

$ lns config list
run.cpus = 2
```

`LNS_HOME` moves the root, and every path follows it:

```console
$ export LNS_HOME=/tmp/demo/home
$ lns config set run.cpus 2
Set run.cpus to 2 in /tmp/demo/home/config.yaml

$ lns volume create some-cache
some-cache

$ find /tmp/demo/home
/tmp/demo/home
/tmp/demo/home/config.yaml
/tmp/demo/home/install-id
/tmp/demo/home/volumes
/tmp/demo/home/volumes/some-cache.img
```

One variable is now enough to isolate a test or a machine.

## What happens to an install that is already there

Nothing happens to it. From the first run, `lns` reads `~/.lns/` only. What the old locations hold stays on disk, and `lns` does not read it. Pull the artifacts again, log in again, and connect the connectors again.

There is no migration code, and there is no warning. The product is pre-1.0, so this is a deliberate clean break.

## Shape

`lns_ipc::paths` is now the one answer to "where does lns keep this on this machine". The six `default_*_path()` functions leave `lns-policy`. That crate keeps the stores, and it takes the path from its caller. So the policy crate is about policy again. No new crate edge was necessary, because every caller of those functions already depends on `lns-ipc`.

Six per-file environment overrides go with them: `LNS_CONFIG_PATH`, `LNS_CONNECTORS_PATH`, `LNS_CREDENTIALS_PATH`, `LNS_REGISTRY_AUTH_PATH`, `LNS_WORKLOAD_GRANTS_PATH`, and the two decision-store variables. §9 names one variable. The e2e harness now sets `LNS_HOME` where it set three `XDG_*` variables, and twelve unit tests lose their inert XDG guards.

`--purge` follows the same collapse. It removed two roots, a configuration directory and three named secret files, and it kept the connector catalog on purpose. §3.9 says that it "deletes everything under `~/.lns/`". So it now removes the one directory, and the directory of the socket. The socket belongs to the service, and not to your data. The guard that refuses to `rm -rf` an arbitrary parent stays, for the socket.

## Tests first

`lns-ipc/src/paths.rs`:

- `~/.lns` under a home directory.
- `LNS_HOME` names the root itself.
- No home and no override is an error that names the way out.
- Every path that `lns` keeps for you is inside the one directory.
- A per-machine file falls back to the working directory. It does not fail a read that only wanted a file that can be absent.

`uninstall/mod.rs`:

- Purge takes the one directory.
- An overridden socket loses only its own file, and the log beside it.

## Docs

`cli-reference.md` gets an **Environment and files** section: the variables, and the table of what lives where. `audit.md`, `credentials.md`, `connectors.md`, `getting-started.md` and the `lns config` / `lns login` / `lns connector` paragraphs name the new paths.
