### PR TITLE
feat(lns-cli)!: give `lns connector` the part of §3.3 that needs no new kind

### DIFF
--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -26,16 +26,18 @@ pub struct ConnectorArgs {
 pub enum ConnectorCommand {
     #[command(about = "Declare a credential connector in your machine-global catalog.")]
     Add(ConnectorAddArgs),
-    #[command(about = "List the bundled and user-declared connectors.")]
+    #[command(
+        about = "List the connectors this machine knows, how each signs in, and which this project uses."
+    )]
     List(ConnectorListArgs),
     #[command(about = "Remove a user-declared connector; bundled ones cannot be removed.")]
     Remove(ConnectorRemoveArgs),
     #[command(
-        about = "Bind a connector's per-machine value decision (oauth connectors sign in); records the id in this directory's policy."
+        about = "Bind a connector's per-machine value decision (oauth connectors sign in), and record the connection for this project."
     )]
     Connect(ConnectArgs),
     #[command(
-        about = "Disconnect a connector from this directory's policy and forget its per-workload grants here."
+        about = "Withdraw a connector from this project and forget its per-workload grants here."
     )]
     Disconnect(DisconnectArgs),
     #[command(about = "List the per-workload connector grants remembered for this project.")]

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -81,9 +81,10 @@ pub struct ConnectArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
+        value_name = "PATH",
+        help = "Act on this project directory instead of the current one."
     )]
-    pub policy: Option<PathBuf>,
+    pub project: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -92,9 +93,10 @@ pub struct DisconnectArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path; defaults to `lns-local-mixin.yaml` in the current directory."
+        value_name = "PATH",
+        help = "Act on this project directory instead of the current one."
     )]
-    pub policy: Option<PathBuf>,
+    pub project: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -107,9 +109,10 @@ pub struct ConnectorListArgs {
 pub struct GrantsArgs {
     #[arg(
         long,
-        help = "Policy file path whose project the grants are listed for; defaults to `lns-local-mixin.yaml` in the current directory."
+        value_name = "PATH",
+        help = "List the grants of this project directory instead of the current one."
     )]
-    pub policy: Option<PathBuf>,
+    pub project: Option<PathBuf>,
     #[arg(
         long,
         help = "List grants for every project on this machine, not just this one."
@@ -125,9 +128,10 @@ pub struct RevokeArgs {
     pub id: String,
     #[arg(
         long,
-        help = "Policy file path whose project the grant is revoked from; defaults to `lns-local-mixin.yaml` in the current directory."
+        value_name = "PATH",
+        help = "Revoke in this project directory instead of the current one."
     )]
-    pub policy: Option<PathBuf>,
+    pub project: Option<PathBuf>,
 }
 
 fn parse_injection(s: &str) -> Result<lns_policy::providers::InjectionDef, String> {
@@ -204,7 +208,10 @@ pub async fn run(
 ) -> Result<i32> {
     match cmd {
         ConnectorCommand::Add(args) => add(args, catalog_path, writer),
-        ConnectorCommand::List(args) => list(args, catalog_path, writer),
+        ConnectorCommand::List(args) => {
+            let connected = connected_here(cwd, grants_path);
+            list(args, catalog_path, &connected, writer)
+        }
         ConnectorCommand::Remove(args) => remove(args, catalog_path, writer),
         ConnectorCommand::Connect(args) => {
             connect(args, cwd, catalog_path, grants_path, signin, writer).await
@@ -215,16 +222,41 @@ pub async fn run(
     }
 }
 
-/// The decisions file a connector verb records itself in: the one `--policy` named, rooted where it was typed, else this directory's own.
+/// A connection is recorded against a project, and a project is a directory: the one `--project` names, rooted where it was typed, else the one you are in.
 fn project_decisions_path(explicit: Option<&Path>, cwd: &Path) -> PathBuf {
-    match explicit {
+    let dir = match explicit {
         Some(p) if p.is_absolute() => p.to_path_buf(),
         Some(p) => cwd.join(p),
-        None => crate::run::summary::policy_path(cwd),
-    }
+        None => cwd.to_path_buf(),
+    };
+    crate::run::summary::policy_path(&dir)
 }
 
 /// Self-identifying so the MITM can detect it without false positives; explicit `--placeholder` is for shape-sensitive providers.
+/// One connector per domain: two claiming the same destination is ambiguous, and nothing downstream could say which value a request should carry.
+fn refuse_a_claimed_domain(
+    installed: &[Connector],
+    claiming: &[lns_policy::providers::InjectionDef],
+) -> Result<()> {
+    for wanted in claiming {
+        let holder = installed.iter().find(|connector| {
+            connector
+                .credential
+                .iter()
+                .flat_map(|credential| &credential.injections)
+                .any(|held| held.domain == wanted.domain)
+        });
+        if let Some(holder) = holder {
+            bail!(
+                "{:?} is already claimed by the connector {:?}; one connector per domain, so remove that one first if this should own it",
+                wanted.domain,
+                holder.id
+            );
+        }
+    }
+    Ok(())
+}
+
 fn generate_placeholder(id: &str) -> String {
     format!("lns-placeholder-{id}-0000000000000000000000")
 }
@@ -261,6 +293,7 @@ fn add(args: &ConnectorAddArgs, catalog_path: &Path, writer: &mut impl Write) ->
     if catalog.connectors.iter().any(|i| i.id == args.id) {
         bail!("connector {:?} already exists in your catalog", args.id);
     }
+    refuse_a_claimed_domain(&effective_connectors(&catalog), &args.inject)?;
     let placeholder = match &args.placeholder {
         Some(p) => {
             if let Err(problem) = lns_spec::credential::validate_placeholder(p, &args.id) {
@@ -306,18 +339,31 @@ fn add(args: &ConnectorAddArgs, catalog_path: &Path, writer: &mut impl Write) ->
     Ok(0)
 }
 
-fn list(args: &ConnectorListArgs, catalog_path: &Path, writer: &mut impl Write) -> Result<i32> {
+/// What this project has connected, read from the sidecar; an unreadable one answers "nothing connected" rather than failing a listing.
+fn connected_here(cwd: &Path, grants_path: &Path) -> Vec<String> {
+    JsonFileGrantStore::new(grants_path.to_path_buf())
+        .load()
+        .map(|file| file.connected_in(&project_key(&project_decisions_path(None, cwd))))
+        .unwrap_or_default()
+}
+
+fn list(
+    args: &ConnectorListArgs,
+    catalog_path: &Path,
+    connected: &[String],
+    writer: &mut impl Write,
+) -> Result<i32> {
     let user = load_catalog(catalog_path)?;
     let mut rows: Vec<ConnectorRow> = bundled_connectors()
         .iter()
-        .map(|i| ConnectorRow::new(i, "bundled"))
+        .map(|i| ConnectorRow::new(i, "bundled", connected))
         .collect();
     // A user id that shadows a bundled one is inert (bundled wins), so don't list it as live.
     rows.extend(
         user.connectors
             .iter()
             .filter(|i| !is_bundled(&i.id))
-            .map(|i| ConnectorRow::new(i, "user")),
+            .map(|i| ConnectorRow::new(i, "user", connected)),
     );
     crate::output::emit(args.output.format, &rows, writer)?;
     Ok(0)
@@ -329,26 +375,30 @@ struct ConnectorRow {
     id: String,
     source: &'static str,
     auth_kind: &'static str,
+    /// Installing grants nothing, so what a reader wants to know first is whether this project uses it.
+    connected: bool,
 }
 
 impl ConnectorRow {
-    fn new(connector: &Connector, source: &'static str) -> Self {
+    fn new(connector: &Connector, source: &'static str, connected: &[String]) -> Self {
         Self {
             id: connector.id.clone(),
             source,
             auth_kind: kind_word(connector.auth_kind),
+            connected: connected.contains(&connector.id),
         }
     }
 }
 
 impl crate::output::TableRow for ConnectorRow {
-    const HEADERS: &'static [&'static str] = &["CONNECTOR", "SOURCE", "AUTH"];
+    const HEADERS: &'static [&'static str] = &["CONNECTOR", "SOURCE", "SIGN-IN", "CONNECTED"];
 
     fn cells(&self) -> Vec<String> {
         vec![
             self.id.clone(),
             self.source.to_string(),
             self.auth_kind.to_string(),
+            if self.connected { "yes" } else { "no" }.to_string(),
         ]
     }
 }
@@ -410,7 +460,7 @@ pub async fn connect(
             BindOutcome::Completed(decision) => bind_message(&args.id, decision),
         }
     };
-    let path = project_decisions_path(args.policy.as_deref(), cwd);
+    let path = project_decisions_path(args.project.as_deref(), cwd);
     connect_project(grants_path, &project_key(&path), &args.id)?;
     writeln!(writer, "{closing}")?;
     // Binding the value cannot lift a workload's decline, so say what will: otherwise the connect reports success and the workload goes on being refused with nothing on screen explaining it.
@@ -456,7 +506,7 @@ pub fn disconnect(
     grants_path: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let path = project_decisions_path(args.policy.as_deref(), cwd);
+    let path = project_decisions_path(args.project.as_deref(), cwd);
     let project = project_key(&path);
     let cleared = disconnect_project(grants_path, &project, &args.id)?
         .ok_or_else(|| anyhow::anyhow!("{:?} is not connected in {project}", args.id))?;
@@ -515,7 +565,7 @@ fn grants(
     let file = store
         .load()
         .with_context(|| format!("reading grants from {}", grants_path.display()))?;
-    let project = project_key(&project_decisions_path(args.policy.as_deref(), cwd));
+    let project = project_key(&project_decisions_path(args.project.as_deref(), cwd));
     let rows: Vec<&GrantRecord> = if args.all {
         file.grants.iter().collect()
     } else {
@@ -581,7 +631,7 @@ fn revoke(
     grants_path: &Path,
     writer: &mut impl Write,
 ) -> Result<i32> {
-    let project = project_key(&project_decisions_path(args.policy.as_deref(), cwd));
+    let project = project_key(&project_decisions_path(args.project.as_deref(), cwd));
     let cleared = clear_project_grants(grants_path, &project, &args.id)?;
     if cleared == 0 {
         bail!(
@@ -612,22 +662,21 @@ mod tests {
     }
 
     #[test]
-    fn a_named_decisions_file_roots_where_the_developer_typed_it() {
-        // A verb records the connection in the project it names, so the path is theirs and roots at their cwd — the run's own file is found beside a document instead, and never named.
+    fn a_named_project_roots_where_the_developer_typed_it() {
+        // `--project` names a directory, and it is theirs, so a relative one roots at their cwd rather than at any project a document names.
         assert_eq!(
-            project_decisions_path(
-                Some(Path::new("../team/lns-local-mixin.yaml")),
-                Path::new("/w")
-            ),
+            project_decisions_path(Some(Path::new("../team")), Path::new("/w")),
             PathBuf::from("/w/../team/lns-local-mixin.yaml"),
         );
         assert_eq!(
-            project_decisions_path(
-                Some(Path::new("/team/lns-local-mixin.yaml")),
-                Path::new("/w")
-            ),
+            project_decisions_path(Some(Path::new("/team")), Path::new("/w")),
             PathBuf::from("/team/lns-local-mixin.yaml"),
             "an absolute path is already rooted, so the cwd must not be prepended",
+        );
+        assert_eq!(
+            project_decisions_path(None, Path::new("/w")),
+            PathBuf::from("/w/lns-local-mixin.yaml"),
+            "with no --project, the project is the one you are in",
         );
     }
 
@@ -892,16 +941,38 @@ mod tests {
         let path = catalog_at(dir.path());
         add(&add_args("acme"), &path, &mut Vec::new()).unwrap();
         let mut out = Vec::new();
-        list(&list_args(), &path, &mut out).unwrap();
+        list(&list_args(), &path, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("CONNECTOR"), "{text}");
         assert!(
-            row_for(&text, "gitlab").ends_with("bundled  credential"),
+            row_for(&text, "gitlab").contains("bundled  credential"),
             "{text}"
         );
         assert!(
-            row_for(&text, "acme").ends_with("user     credential"),
+            row_for(&text, "acme").contains("user     credential"),
             "{text}"
+        );
+    }
+
+    #[test]
+    fn a_domain_a_bundled_connector_already_claims_is_refused_too() {
+        // The rule is about the effective catalog, not only about what the user typed into it.
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        let claimed = effective_connectors(&Catalog::default())
+            .iter()
+            .find_map(|c| c.credential.as_ref()?.injections.first().cloned())
+            .expect("the shipped catalog claims at least one domain");
+        let mut rival = add_args("some-rival");
+        rival.inject = vec![claimed.clone()];
+        let err = add(&rival, &path, &mut Vec::new()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains(&claimed.domain),
+            "the refusal names the domain: {err:#}"
+        );
+        assert!(
+            !path.exists(),
+            "a refused add writes nothing, not even an empty catalog"
         );
     }
 
@@ -911,7 +982,7 @@ mod tests {
         let path = catalog_at(dir.path());
         write_user_catalog(&path, vec![oauth_connector("somesaas")]);
         let mut out = Vec::new();
-        list(&list_args(), &path, &mut out).unwrap();
+        list(&list_args(), &path, &[], &mut out).unwrap();
         assert!(
             String::from_utf8(out).unwrap().contains("somesaas"),
             "oauth kind must be labelled"
@@ -939,7 +1010,7 @@ mod tests {
             }],
         );
         let mut out = Vec::new();
-        list(&list_args(), &path, &mut out).unwrap();
+        list(&list_args(), &path, &[], &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(row_for(&text, "gitlab").contains("bundled"), "{text}");
         assert!(
@@ -953,7 +1024,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = catalog_at(dir.path());
         std::fs::write(&path, "connectors: not-a-list\n").unwrap();
-        let err = list(&list_args(), &path, &mut Vec::new()).unwrap_err();
+        let err = list(&list_args(), &path, &[], &mut Vec::new()).unwrap_err();
         assert!(format!("{err:#}").contains("loading"));
     }
 
@@ -1055,7 +1126,7 @@ mod tests {
         connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog,
@@ -1078,7 +1149,7 @@ mod tests {
         let err = connect(
             &ConnectArgs {
                 id: "nope".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog_at(dir.path()),
@@ -1099,7 +1170,7 @@ mod tests {
         connect(
             &ConnectArgs {
                 id: "somesaas".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog,
@@ -1124,7 +1195,7 @@ mod tests {
         let err = connect(
             &ConnectArgs {
                 id: "somesaas".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog,
@@ -1148,7 +1219,7 @@ mod tests {
         connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog_at(dir.path()),
@@ -1178,7 +1249,7 @@ mod tests {
         connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog_at(dir.path()),
@@ -1200,7 +1271,7 @@ mod tests {
         let err = connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog_at(dir.path()),
@@ -1223,7 +1294,7 @@ mod tests {
         let err = connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog_at(dir.path()),
@@ -1247,7 +1318,7 @@ mod tests {
         let err = connect(
             &ConnectArgs {
                 id: "somesaas".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog,
@@ -1270,7 +1341,7 @@ mod tests {
         connect(
             &ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &catalog,
@@ -1283,7 +1354,7 @@ mod tests {
         disconnect(
             &DisconnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &dir.path().join("grants.json"),
@@ -1299,7 +1370,7 @@ mod tests {
         let err = disconnect(
             &DisconnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             },
             dir.path(),
             &dir.path().join("grants.json"),
@@ -1361,7 +1432,7 @@ mod tests {
         run(
             &ConnectorCommand::Connect(ConnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             }),
             dir.path(),
             &path,
@@ -1375,7 +1446,7 @@ mod tests {
         run(
             &ConnectorCommand::Disconnect(DisconnectArgs {
                 id: "gitlab".into(),
-                policy: None,
+                project: None,
             }),
             dir.path(),
             &path,

--- a/crates/lns-cli/tests/behaviours/connector_cli.feature
+++ b/crates/lns-cli/tests/behaviours/connector_cli.feature
@@ -7,8 +7,9 @@ Feature: connecting connectors from the CLI
   decision lands in the per-machine credential store, never in
   `lns-local-mixin.yaml`; the connection is recorded for the directory in
   the per-machine sidecar only once the bind or sign-in completes.
-  `lns connector list` shows, per connector, whether it authenticates
-  by sign-in or a value.
+  `lns connector list` shows, per connector, how it signs in and whether
+  it is connected here. `--project <PATH>` acts on another project
+  directory instead of the current one.
 
   These scenarios use arbitrary user-declared connectors, so nothing
   here pins a shipped service.
@@ -75,3 +76,34 @@ Feature: connecting connectors from the CLI
     When the user runs connector command "list --format json"
     Then the JSON row for "some-provider" has "source" set to "user"
     And the JSON row for "some-provider" has "authKind" set to "credential"
+
+  Scenario: The listing says whether each connector is connected in this project
+    Given a user catalog declares the "some-provider" credential connector
+    And "some-provider" is already connected in this project
+    When the developer runs "lns connector list"
+    Then the output contains "CONNECTED"
+    And "some-provider" is listed as connected here
+    And "gitlab" is listed as not connected here
+
+  Scenario: The JSON listing carries the same answer for a script
+    Given a user catalog declares the "some-provider" credential connector
+    And "some-provider" is already connected in this project
+    When the user runs connector command "list --format json"
+    Then the JSON row for "some-provider" has "connected" set to true
+    And the JSON row for "gitlab" has "connected" set to false
+
+  Scenario: --project acts on another project directory
+    When the developer runs "lns connector connect some-oauth --project /other"
+    Then "some-oauth" is recorded as connected for the project at "/other"
+    And "some-oauth" is not recorded as connected
+
+  Scenario: --policy is gone; the flag names a project, not a file
+    When I run "lns connector connect some-oauth --policy team.yaml"
+    Then the exit code is 2
+    And the output contains "unexpected argument"
+
+  Scenario: adding a connector that claims a domain another already claims is refused
+    Given a user catalog declares the "some-provider" credential connector
+    When the developer adds a connector claiming "api.some-provider.example"
+    Then the command fails naming "some-provider" as the connector that already claims it
+    And the catalog is left unchanged

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -293,6 +293,11 @@ async fn run_connect(world: &mut BehaviourWorld, id: String) {
     run_connector(world, &["connect", &id]).await;
 }
 
+#[when(regex = r#"^the developer runs "lns connector connect (\S+) --project (\S+)"$"#)]
+async fn run_connect_in_project(world: &mut BehaviourWorld, id: String, project: String) {
+    run_connector(world, &["connect", &id, "--project", &project]).await;
+}
+
 #[when(regex = r#"^the developer runs "lns connector list"$"#)]
 async fn run_list(world: &mut BehaviourWorld) {
     run_connector(world, &["list"]).await;
@@ -408,8 +413,94 @@ fn listed_as_kind(world: &mut BehaviourWorld, id: String, kind: String) {
         .lines()
         .find(|l| l.starts_with(&id))
         .unwrap_or_else(|| panic!("no listing line for {id} in:\n{out}"));
-    assert!(
-        line.trim_end().ends_with(&kind),
+    let sign_in = line.split_whitespace().nth(2);
+    assert_eq!(
+        sign_in,
+        Some(kind.as_str()),
         "expected {id} listed as {kind}, got line: {line}"
     );
+}
+
+#[given(regex = r#"^"([^"]+)" is already connected in this project$"#)]
+fn already_connected_here(world: &mut BehaviourWorld, id: String) {
+    use lns_policy::grants::GrantStore as _;
+    let dir = cwd(world);
+    let project = lns_policy::grants::project_key(&dir.join("lns-local-mixin.yaml"));
+    lns_policy::grants::JsonFileGrantStore::new(dir.join("workload-grants.json"))
+        .update(&mut |file| {
+            file.connect(&project, &id);
+            true
+        })
+        .expect("seed the sidecar");
+}
+
+#[then(regex = r#"^"([^"]+)" is listed as (connected|not connected) here$"#)]
+fn listed_as_connected(world: &mut BehaviourWorld, id: String, state: String) {
+    let out = &world
+        .result
+        .as_ref()
+        .expect("a run must have happened")
+        .output;
+    let row = out
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some(id.as_str()))
+        .unwrap_or_else(|| panic!("no row for {id:?} in:\n{out}"));
+    let wanted = if state == "connected" { "yes" } else { "no" };
+    assert_eq!(
+        row.split_whitespace().last(),
+        Some(wanted),
+        "installing grants nothing, so the listing has to say whether this project uses it: {row}"
+    );
+}
+
+#[then(regex = r#"^"([^"]+)" is recorded as connected for the project at "([^"]+)"$"#)]
+fn recorded_for_other_project(world: &mut BehaviourWorld, id: String, project: String) {
+    use lns_policy::grants::GrantStore as _;
+    let dir = cwd(world);
+    let key = lns_policy::grants::project_key(
+        &std::path::Path::new(&project).join("lns-local-mixin.yaml"),
+    );
+    let connected = lns_policy::grants::JsonFileGrantStore::new(dir.join("workload-grants.json"))
+        .load()
+        .expect("the sidecar reads back")
+        .connected_in(&key);
+    assert!(
+        connected.contains(&id),
+        "--project names the directory the connection is recorded against; got {connected:?} for {key}"
+    );
+}
+
+#[when(regex = r#"^the developer adds a connector claiming "([^"]+)"$"#)]
+async fn adds_a_connector_claiming(world: &mut BehaviourWorld, domain: String) {
+    let catalog_before = std::fs::read_to_string(cwd(world).join("connectors.yaml")).ok();
+    world.catalog_before = catalog_before;
+    run_connector(
+        world,
+        &[
+            "add",
+            "some-rival",
+            "--env-var",
+            "SOME_RIVAL_TOKEN",
+            "--inject",
+            &format!("bearer_header:{domain}"),
+        ],
+    )
+    .await;
+}
+
+#[then(regex = r#"^the command fails naming "([^"]+)" as the connector that already claims it$"#)]
+fn fails_naming_the_holder(world: &mut BehaviourWorld, holder: String) {
+    let run = world.result.as_ref().expect("a run must have happened");
+    assert_ne!(run.exit_code, 0, "got: {}", run.output);
+    assert!(
+        run.output.contains(&holder),
+        "the refusal has to name which connector already owns the domain; got: {}",
+        run.output
+    );
+}
+
+#[then("the catalog is left unchanged")]
+fn catalog_unchanged(world: &mut BehaviourWorld) {
+    let after = std::fs::read_to_string(cwd(world).join("connectors.yaml")).ok();
+    assert_eq!(world.catalog_before, after, "a refused add writes nothing");
 }

--- a/crates/lns-cli/tests/behaviours/steps/machine_output.rs
+++ b/crates/lns-cli/tests/behaviours/steps/machine_output.rs
@@ -107,6 +107,31 @@ fn json_row_non_empty(world: &mut BehaviourWorld, index: usize, key: String) -> 
     }
 }
 
+#[then(regex = r#"^the JSON row for "([^"]+)" has "([^"]+)" set to (true|false)$"#)]
+fn json_row_for_bool(
+    world: &mut BehaviourWorld,
+    id: String,
+    key: String,
+    expected: String,
+) -> Result<(), String> {
+    let doc = parsed(world)?;
+    let rows = doc
+        .as_array()
+        .ok_or_else(|| format!("output is not a json array: {doc}"))?;
+    let found = rows
+        .iter()
+        .find(|r| r.get("id").and_then(serde_json::Value::as_str) == Some(id.as_str()))
+        .ok_or_else(|| format!("no row with id {id:?} in {doc}"))?;
+    let value = field(found, &key)?;
+    if value == serde_json::Value::Bool(expected == "true") {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {id}'s {key} to be {expected}, got {value}"
+        ))
+    }
+}
+
 #[then(regex = r#"^the JSON row for "([^"]+)" has "([^"]+)" set to "([^"]*)"$"#)]
 fn json_row_by_id(
     world: &mut BehaviourWorld,

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -35,6 +35,8 @@ pub struct BehaviourWorld {
     pub signin_outcome: Option<lns_cli::connector::SignInOutcome>,
     /// True when the connector under test signs in via the pkce browser redirect, so the fake sign-in renders the browser-opened prompt instead of a device code.
     pub signin_is_pkce: bool,
+    /// The catalog as it stood before a refused `add`, so the refusal can be shown to have written nothing.
+    pub catalog_before: Option<String>,
     pub resolved_run: Option<ResolvedRunView>,
     pub volume: VolumeCliRig,
     pub merged_env: Option<Result<Vec<String>, String>>,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -408,21 +408,21 @@ value.
 
 ```bash
 lns connector add <ID> --env-var <VAR> --inject <KIND:DOMAIN>... [--route <HOST>]... [--placeholder <P>]
-lns connector list
+lns connector list [--format <table|json>]
 lns connector remove <ID>
-lns connector connect <ID> [--policy <PATH>]
-lns connector disconnect <ID> [--policy <PATH>]
-lns connector grants [--policy <PATH>] [--all]
-lns connector revoke <ID> [--policy <PATH>]
+lns connector connect <ID> [--project <PATH>]
+lns connector disconnect <ID> [--project <PATH>]
+lns connector grants [--project <PATH>] [--all]
+lns connector revoke <ID> [--project <PATH>]
 ```
 
 | Subcommand   | Meaning                                                                       |
 | ------------ | ----------------------------------------------------------------------------- |
-| `add`        | Declare a credential connector in your machine-global catalog.              |
-| `list`       | List the bundled and user-declared connectors and their auth kind.          |
+| `add`        | Declare a credential connector in your machine-global catalog. Refused when a domain it claims is already claimed by another connector: two claiming the same destination is ambiguous, so remove the other one first if this should own it. |
+| `list`       | List the bundled and user-declared connectors, how each signs in, and whether it is connected in this project. Installing grants nothing, so `CONNECTED` is the column that says whether this project uses it. |
 | `remove`     | Remove a user-declared connector; bundled ones cannot be removed.           |
-| `connect`    | Bind a connector's per-machine value decision: a credential connector prompts in the approval window (use the host value, store one, or deny) and an `oauth` connector signs in. Also records the id in this directory's policy — the bind path for ids a definition declares. |
-| `disconnect` | Disconnect a connector from this directory's policy, forgetting its per-workload grants here. The grants go first, so a run that cannot update them leaves the connector connected to retry rather than stranding grants a later reconnect would inherit. |
+| `connect`    | Bind a connector's per-machine value decision: a credential connector prompts in the approval window (use the host value, store one, or deny) and an `oauth` connector signs in. Also records the connection for this project — the bind path for ids a definition declares. |
+| `disconnect` | Withdraw a connector from this project, forgetting its per-workload grants here. The grants go first, so a run that cannot update them leaves the connector connected to retry rather than stranding grants a later reconnect would inherit. |
 | `grants`     | List the per-workload grants remembered for this project as `workload  connector  verdict`; `--all` adds a project column and covers every project on this machine. |
 | `revoke`     | Forget one connector's per-workload grants in this project, so its next use asks again; exits `1` when there is nothing to forget. |
 
@@ -430,7 +430,12 @@ lns connector revoke <ID> [--policy <PATH>]
 `token_header`, `basic_x_access_token`, or `api_key_header` (which takes the header
 name as a third segment: `api_key_header:DOMAIN:HEADER`). Value decisions for a
 connected connector are made interactively in the approval window; grants are
-recorded per project and workload in `~/.lns/workload-grants.json`. See
+recorded per project and workload in `~/.lns/workload-grants.json`.
+
+`--project <PATH>` acts on another project directory instead of the current one.
+Three steps stay separate, and no flag collapses them: declaring a connector makes
+it available, connecting decides this project uses it, and the workload still meets
+a first-use card the first time it reaches for the value. See
 [Credentials](credentials.md) and [Connectors](connectors.md).
 
 ## `lns config`

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -16,11 +16,22 @@ The set of connectors Lens Sandbox knows about is a **catalog** with two layers:
 - **User** — your own additions in `~/.lns/connectors.yaml`.
 
 The effective catalog is the union of the two; a user entry can't shadow a bundled
-id. List everything Lens Sandbox can connect:
+id. List everything Lens Sandbox can connect, how each signs in, and which ones
+this project uses:
 
 ```bash
 lns connector list
 ```
+
+```text
+CONNECTOR    SOURCE   SIGN-IN     CONNECTED
+gitlab       bundled  credential  yes
+github       bundled  oauth       no
+acme         user     credential  no
+```
+
+Declaring a connector grants nothing: `CONNECTED` is the column that says whether
+this project uses it.
 
 ### Declaring your own
 
@@ -32,6 +43,11 @@ lns connector add acme \
   --inject bearer_header:api.acme.internal \
   --route api.acme.internal
 ```
+
+One connector per domain: an `--inject` naming a destination another connector
+already claims is refused, and the error names the one that holds it. Two
+connectors claiming the same host would make the value a request carries
+ambiguous.
 
 - `id` — the connector id; must not collide with a bundled or existing user id.
 - `--env-var` — the environment variable the placeholder is seeded into.
@@ -88,7 +104,11 @@ A connector reaches a project's workloads in any of three ways:
 ```bash
 lns connector connect gitlab
 lns connector disconnect gitlab
+lns connector connect gitlab --project ../other-project
 ```
+
+`--project <PATH>` acts on another project directory instead of the one you are
+in; `connect`, `disconnect`, `grants` and `revoke` all take it.
 
 The connection is recorded by id for the project, per machine, so the
 definition resolves from the catalog at run time and nothing about which


### PR DESCRIPTION
Stage 8 of 9. This PR gives `lns connector` the part of §3.3 that needs no new document kind.

> **Stacked on #285.** The base of this PR is `cli-spec-s7-finish-sandbox`. The diff shows stage 8 only. Merge #285 first.

## What is here, and what is not

The specification marks §3.3 as **work in progress**. Two of its four verbs need a document format that does not exist. `install <REF|PATH>` and `uninstall <ID>` take a **published connector artifact**, and `lns_artifact` still cannot parse `kind: connector`. This is the same gap that held `init --kind connector` back in stage 3. So `add` and `remove` keep their names, and the rest of §3.3 lands now.

| §3.3 | Here |
|---|---|
| `--project <PATH>` replaces `--policy` | ✅ |
| `list` shows the sign-in method, and whether the connector is connected here | ✅ |
| install refuses a domain that another connector claims | ✅ as `add`, the verb that ships |
| `install` / `uninstall` | waits for `kind: connector` |

## `--policy <FILE>` becomes `--project <PATH>`

§3.3 says: "`--project <PATH>` acts on another project directory instead of the current one." A project **is** a directory. `lns` finds the decisions file beside it, and you never name that file. This is true of `lns run` since stage 2. `lns connector` was the last verb that took a path to the file itself.

```console
$ lns connector connect --help
Bind a connector's per-machine value decision (oauth connectors sign in), and record
the connection for this project.

Usage: lns connector connect [OPTIONS] <ID>

Arguments:
  <ID>  Connector id to connect (from `lns connector list`).

Options:
      --project <PATH>  Act on this project directory instead of the current one.
```

`connect`, `disconnect`, `grants` and `revoke` all take the flag:

```console
$ lns connector grants --project /tmp/other-project
No connector grants for this project.
```

## `list` answers the question that a reader has

```console
$ lns connector list
CONNECTOR                 SOURCE   SIGN-IN     CONNECTED
gitlab                    bundled  credential  no
huggingface               bundled  credential  no
github                    bundled  oauth       no
google                    bundled  oauth       no
openai                    bundled  credential  no
anthropic                 bundled  credential  no
claude-code-subscription  bundled  credential  no
bedrock                   bundled  credential  no
linear                    bundled  credential  no
telegram                  bundled  credential  no
openrouter                bundled  oauth       no
some-provider             user     credential  no
```

To declare a connector grants nothing. The three steps of §3.3 stay separate. So `CONNECTED` is the column that says whether **this project** uses the connector.

A script gets the same answer as a boolean:

```console
$ lns connector list --format json
[
  {
    "id": "gitlab",
    "source": "bundled",
    "authKind": "credential",
    "connected": false
  },
  ...
]
```

A sidecar that `lns` cannot read answers "nothing connected". It does not fail the listing.

## One connector per domain

`sandbox-spec.md` §7.1: two connectors that claim the same destination are ambiguous. Nothing after that point could say which value a request must carry. So `add` refuses an `--inject` that names a domain that another connector holds, and the message names the holder:

```console
$ lns connector add some-provider --env-var SOME_TOKEN --inject bearer_header:api.openai.com
Error: "api.openai.com" is already claimed by the connector "openai"; one connector
per domain, so remove that one first if this should own it

$ echo $?
1
```

A free domain is accepted:

```console
$ lns connector add some-provider --env-var SOME_TOKEN --inject bearer_header:api.some-provider.example
Declared connector "some-provider" in your catalog
Connect it to a project with `lns connect some-provider`.
```

The check reads the **effective** catalog, so the claim of a bundled connector also counts. A test picks a claimed domain out of the shipped catalog, and it does not hard-code one. So the test survives when the shipped set becomes smaller. An `add` that is refused writes nothing, and it does not write an empty catalog.

## Docs

`cli-reference.md` — the synopsis, the `add` and `list` rows, and `--project` with the note that the three steps of §3.3 stay separate. `connectors.md` — the listing with its new columns, the one-connector-per-domain rule beside `add`, and `--project` beside `connect`.

