### PR TITLE
fix(lns-cli)!: give ls one spelling — the list alias is removed

### DIFF
--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -118,7 +118,6 @@ pub enum ArtifactCommand {
     #[command(about = "Add a tag to a cached artifact within its current repository.")]
     Tag(TagArgs),
     #[command(
-        visible_alias = "list",
         about = "List what the local store holds: reference, kind, digest, size, and holder."
     )]
     Ls(LsArgs),

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -34,10 +34,7 @@ pub enum SandboxCommand {
     Logs(SandboxLogsArgs),
     #[command(about = "Re-attach to a running sandbox's output (detach chord to leave again).")]
     Attach(SandboxAttachArgs),
-    #[command(
-        visible_alias = "list",
-        about = "List running sandboxes with their state, CPU and memory."
-    )]
+    #[command(about = "List running sandboxes with their state, CPU and memory.")]
     Ls(SandboxLsArgs),
     #[command(about = "Print one sandbox's live state and launch configuration.")]
     Inspect(SandboxInspectArgs),

--- a/crates/lns-cli/tests/behaviours/parse_errors.feature
+++ b/crates/lns-cli/tests/behaviours/parse_errors.feature
@@ -61,3 +61,13 @@ Feature: clap rejects bad input with exit code 2
     When I run "lns policy list"
     Then the exit code is 2
     And the output contains "unrecognized subcommand"
+
+  Scenario: ls has one spelling — lns artifact list is not quietly kept working
+    When I run "lns artifact list"
+    Then the exit code is 2
+    And the output contains "unrecognized subcommand"
+
+  Scenario: ls has one spelling — lns sandbox list is not quietly kept working
+    When I run "lns sandbox list"
+    Then the exit code is 2
+    And the output contains "unrecognized subcommand"


### PR DESCRIPTION
A follow-up to the cli-spec series, stacked on #288.

`lns artifact ls` and `lns sandbox ls` carried a visible `list` alias. The specification names no such spelling: §3.1 and §3.2.2 say `ls`, and §10 says an old spelling is removed rather than quietly kept working. (`lns connector list` and `lns config list` are unaffected — there, `list` **is** the verb the spec names.)

Two parse pins in `parse_errors.feature` went red first — both spellings parsed — and the alias is gone. The flag aliases `--memory` and `--mount` stay: §3.2.1 names them.

> **Stacked on #288.** Merge #288 first.