### PR TITLE
feat(lns-cli): say which command takes a document when a RUN verb gets one

### DIFF
--- a/crates/e2e-tests/features/wrong_kind_operand.feature
+++ b/crates/e2e-tests/features/wrong_kind_operand.feature
@@ -1,0 +1,20 @@
+Feature: a RUN verb given a document redirects before touching the service
+
+  §2.4: given the wrong kind of operand, a command says which it wanted
+  and which command takes the one you typed. The redirect is a client-side
+  decision, so it answers 2 even when no service is running — never 125.
+
+  Scenario: lns exec given a document names the artifact reader instead
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns exec ./lns.yaml -- true"
+    Then the exit code is 2
+    And the output contains "takes a RUN"
+    And the output contains "lns artifact inspect"
+
+  Scenario: lns sandbox logs given a document is the same refusal
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns sandbox logs ./lns.yaml"
+    Then the exit code is 2
+    And the output contains "lns artifact inspect"

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -305,6 +305,13 @@ where
     O: AsyncWriteExt + Unpin,
     E: AsyncWriteExt + Unpin,
 {
+    if let Some(refusal) = wrong_kind_refusal(cmd) {
+        stderr
+            .write_all(format!("error: {refusal}\n").as_bytes())
+            .await?;
+        stderr.flush().await?;
+        return Ok(2);
+    }
     match cmd {
         SandboxCommand::Ls(args) => ps(svc, args, out).await,
         SandboxCommand::Kill(args) => kill(svc, args, out).await,
@@ -318,6 +325,33 @@ where
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
     }
+}
+
+fn run_operand(cmd: &SandboxCommand) -> Option<(&'static str, &str)> {
+    match cmd {
+        SandboxCommand::Exec(args) => Some(("exec", args.run.as_str())),
+        SandboxCommand::Kill(args) => Some(("kill", args.run.as_str())),
+        SandboxCommand::Stop(args) => Some(("stop", args.run.as_str())),
+        SandboxCommand::Start(args) => Some(("start", args.run.as_str())),
+        SandboxCommand::Inspect(args) => Some(("inspect", args.run.as_str())),
+        SandboxCommand::Logs(args) => Some(("logs", args.run.as_str())),
+        SandboxCommand::Attach(args) => Some(("attach", args.run.as_str())),
+        SandboxCommand::Rm(args) => Some(("rm", args.run.as_str())),
+        _ => None,
+    }
+}
+
+pub(crate) fn document_refusal(verb: &str, operand: &str) -> Option<String> {
+    crate::run::target::is_definition_path(operand).then(|| {
+        format!(
+            "`lns sandbox {verb}` takes a RUN — a sandbox id or name — and \"{operand}\" names a document; `lns artifact inspect` is what reads one"
+        )
+    })
+}
+
+pub(crate) fn wrong_kind_refusal(cmd: &SandboxCommand) -> Option<String> {
+    let (verb, operand) = run_operand(cmd)?;
+    document_refusal(verb, operand)
 }
 
 pub(crate) fn run_label(run: &str) -> String {
@@ -822,6 +856,48 @@ mod tests {
     use super::*;
     use crate::test_service::{CannedService, stream_with};
     use lns_ipc::encode_frame;
+
+    fn parsed_command(argv: &[&str]) -> SandboxCommand {
+        let mut full = vec!["lns", "sandbox"];
+        full.extend_from_slice(argv);
+        let args: SandboxArgs = crate::command::parse_args(full).unwrap();
+        args.command
+    }
+
+    #[test]
+    fn every_run_verb_refuses_a_document_operand_by_naming_the_artifact_reader() {
+        for argv in [
+            vec!["exec", "./lns.yaml", "sh"],
+            vec!["kill", "./lns.yaml"],
+            vec!["stop", "../lns.yaml"],
+            vec!["start", "/tmp/lns.yaml"],
+            vec!["inspect", "."],
+            vec!["logs", "sub/lns.yaml"],
+            vec!["attach", ".."],
+            vec!["rm", "./lns.dev.yaml"],
+        ] {
+            let refusal = wrong_kind_refusal(&parsed_command(&argv))
+                .unwrap_or_else(|| panic!("{argv:?} must refuse a document operand"));
+            assert!(refusal.contains("takes a RUN"), "{argv:?}: {refusal}");
+            assert!(
+                refusal.contains("lns artifact inspect"),
+                "{argv:?}: {refusal}"
+            );
+            assert!(
+                refusal.contains(&format!("lns sandbox {}", argv[0])),
+                "{argv:?}: {refusal}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_dotted_name_or_a_verb_without_a_run_operand_is_not_redirected() {
+        assert_eq!(
+            wrong_kind_refusal(&parsed_command(&["inspect", "v1.2-agent"])),
+            None
+        );
+        assert_eq!(wrong_kind_refusal(&parsed_command(&["ls"])), None);
+    }
 
     fn running_run() -> lns_ipc::RunSummary {
         lns_ipc::RunSummary {

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -10,6 +10,10 @@ use crate::service::real::RealSandboxService;
 pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = super::SandboxArgs::from_arg_matches(matches)?;
+        if let Some(refusal) = super::wrong_kind_refusal(&args.command) {
+            eprintln!("error: {refusal}");
+            return Ok(2);
+        }
         match args.command {
             super::SandboxCommand::Run(run_args) => Ok(crate::service::as_pre_start_failure(
                 crate::service::launch_run(*run_args, ctx.debug).await,
@@ -40,6 +44,10 @@ async fn dispatch_command(
     command: super::SandboxCommand,
     input: &mut dyn std::io::BufRead,
 ) -> Result<i32> {
+    if let Some(refusal) = super::wrong_kind_refusal(&command) {
+        eprintln!("error: {refusal}");
+        return Ok(2);
+    }
     crate::service::require_running().await?;
     dispatch(super::SandboxArgs { command }, input).await
 }

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -74,6 +74,10 @@ pub fn exec_command<'a>(matches: &'a clap::ArgMatches, _ctx: RunCtx<'a>) -> RunF
     Box::pin(async move {
         let started = async {
             let args = ExecArgs::from_arg_matches(matches)?;
+            if let Some(refusal) = crate::sandbox::document_refusal("exec", &args.run) {
+                eprintln!("error: {refusal}");
+                return Ok(2);
+            }
             require_running().await?;
             exec_image(args).await
         };

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -437,6 +437,7 @@ pub(crate) async fn drive_sandbox_command(w: &mut BehaviourWorld, cmd: &str) {
     )
     .await;
     w.sandbox.workload_stdout = stdout;
+    out.extend_from_slice(&stderr);
     w.result = Some(match result {
         Ok(exit_code) => CliRun {
             exit_code,

--- a/crates/lns-cli/tests/behaviours/wrong_kind_operand.feature
+++ b/crates/lns-cli/tests/behaviours/wrong_kind_operand.feature
@@ -1,0 +1,32 @@
+Feature: a RUN verb given a document says which command takes it
+  §2.4: a command takes a REF or a RUN, never either. Given the wrong
+  kind, it says which it wanted and which command takes the one you
+  typed. A path names a document, and a document is never a RUN, so
+  the sandbox verbs redirect to `lns artifact inspect` — the command
+  that reads one — instead of asking the service for a run that
+  cannot exist.
+
+  Scenario: inspect redirects a path-shaped operand to the artifact namespace
+    When the user runs sandbox command "inspect ./lns.yaml"
+    Then the exit code is 2
+    And the output contains "takes a RUN"
+    And the output contains "lns artifact inspect"
+
+  Scenario: rm says a document is not a sandbox
+    When the user runs sandbox command "rm ./lns.dev.yaml"
+    Then the exit code is 2
+    And the output contains "takes a RUN"
+    And the output contains "lns artifact inspect"
+
+  Scenario: logs has no artifact counterpart, and still names the way out
+    When the user runs sandbox command "logs ."
+    Then the exit code is 2
+    And the output contains "takes a RUN"
+    And the output contains "lns artifact inspect"
+
+  Scenario: a name that merely contains a dot is a RUN, not a document
+    Given the service will answer an error "no run named v1.2-agent"
+    When the user runs sandbox command "inspect v1.2-agent"
+    Then the command fails with an exit code other than 0
+    And the output contains "no run named v1.2-agent"
+    And the output does not contain "takes a RUN"


### PR DESCRIPTION
Stacked on #289. Closes the last cheap gap from the cli-spec conformance pass.

## The gap

cli-spec §2.4: *"a command takes a REF or a RUN, never either. Given the wrong kind, it says which it wanted and which command takes the one you typed."* Before this, `lns sandbox inspect ./lns.yaml` asked the service for a run named `./lns.yaml` and surfaced whatever error came back — or 125 if no service was running.

A path-shaped operand (`.`, `..`, `./…`, `../…`, `/…`, `lns.yaml`, `…/lns.yaml` — the same `is_definition_path` test the run/shortcut arbitration already uses) names a document, and a document is never a RUN. That makes the RUN verbs the one deterministic wrong-kind case, so they now answer:

```
error: `lns sandbox inspect` takes a RUN — a sandbox id or name — and "./lns.yaml" names a document; `lns artifact inspect` is what reads one
```

exit 2 (unparsable invocation), on stderr, client-side — before `require_running`, so it never depends on a service.

## What's covered

- **Decision** — `document_refusal` / `wrong_kind_refusal` in `sandbox/mod.rs`, 100%-gated: Layer 3 truth table over all eight RUN verbs (exec, kill, stop, start, inspect, logs, attach, rm) plus the boundary (`v1.2-agent` is a name, `ls` has no operand); Layer 2 scenarios pin the user-visible refusal for inspect/rm/logs and that a dotted *name* still reaches the service.
- **Wiring** — three IGNORES-exempt interception points: `sandbox/real.rs` `run()` (the `lns sandbox …` namespace incl. exec), `dispatch_command` (the top-level `lns start/stop/kill/rm/logs/attach` wrappers), and `orchestrator.rs` `exec_command` (top-level `lns exec`). Pinned by a Layer 1 feature proving `lns exec ./lns.yaml -- true` and `lns sandbox logs ./lns.yaml` exit 2 with **no service running** — the check demonstrably precedes any socket contact.
- The Layer 2 harness now folds captured stderr into the assertable output, matching where §4.1 says errors go.

## Not in scope

The REF verbs have no deterministic converse: a bare word is a valid REF, so `lns artifact inspect reviewer` can't know `reviewer` is a run name without asking — the service's not-found answer stays the right response there. `lns run` takes a REF and a document *is* one of its operand kinds, so it's untouched. The top-level `rm`/`inspect` shortcuts already arbitrate path-shaped operands into the artifact namespace (#288).

## Gates

`make lint`, 440 Layer 2 scenarios, full coverage gate, targeted `make e2e` — all green.
