### PR TITLE
fix(lns-cli): move the prune prompt to stderr where §4.1 says it lives

### DIFF
--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -531,12 +531,13 @@ pub(crate) async fn remove_cached<W: std::io::Write>(
     }
 }
 
-async fn prune<I: std::io::BufRead, W: std::io::Write>(
+async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>(
     svc: &impl SandboxService,
     args: &PruneArgs,
     term: TermInfo,
     input: &mut I,
     out: &mut W,
+    stderr: &mut E,
 ) -> Result<i32> {
     if !args.force {
         if !term.stdin_is_tty {
@@ -544,7 +545,7 @@ async fn prune<I: std::io::BufRead, W: std::io::Write>(
                 "this removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache; there is no terminal to ask at, so pass --force to confirm"
             );
         }
-        if !confirm_prune(input, out)? {
+        if !confirm_prune(input, stderr).await? {
             return Ok(0);
         }
     }
@@ -569,21 +570,22 @@ async fn prune<I: std::io::BufRead, W: std::io::Write>(
     }
 }
 
-fn confirm_prune<I: std::io::BufRead, W: std::io::Write>(
+async fn confirm_prune<I: std::io::BufRead, E: AsyncWriteExt + Unpin>(
     input: &mut I,
-    out: &mut W,
+    err: &mut E,
 ) -> Result<bool> {
-    write!(
-        out,
-        "This removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache. Continue? [y/N] "
-    )?;
-    out.flush()?;
+    err.write_all(
+        b"This removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache. Continue? [y/N] ",
+    )
+    .await?;
+    err.flush().await?;
     let mut line = String::new();
     input.read_line(&mut line)?;
     let answer = line.trim();
     let yes = answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes");
     if !yes {
-        writeln!(out, "Aborted.")?;
+        err.write_all(b"Aborted.\n").await?;
+        err.flush().await?;
     }
     Ok(yes)
 }
@@ -808,7 +810,7 @@ where
             inspect_cached(svc, reference, &args.mixins, out).await
         }
         ArtifactCommand::Rm(args) => remove_cached(svc, &args.reference, out).await,
-        ArtifactCommand::Prune(args) => prune(svc, args, term, input, out).await,
+        ArtifactCommand::Prune(args) => prune(svc, args, term, input, out, stderr).await,
     }
 }
 
@@ -1393,6 +1395,7 @@ mod tests {
     async fn declining_the_prune_prompt_reaches_no_service() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
+        let mut err = Vec::new();
         let code = prune(
             &svc,
             &PruneArgs { force: false },
@@ -1402,11 +1405,13 @@ mod tests {
             },
             &mut std::io::Cursor::new(b"n\n".to_vec()),
             &mut out,
+            &mut err,
         )
         .await
         .unwrap();
         assert_eq!(code, 0);
-        assert!(String::from_utf8(out).unwrap().contains("Aborted."));
+        assert!(String::from_utf8(err).unwrap().contains("Aborted."));
+        assert!(out.is_empty());
         assert!(svc.requests.lock().unwrap().is_empty());
     }
 
@@ -1423,6 +1428,7 @@ mod tests {
             TermInfo::default(),
             &mut std::io::empty(),
             &mut out,
+            &mut Vec::new(),
         )
         .await
         .unwrap();
@@ -1445,6 +1451,7 @@ mod tests {
             TermInfo::default(),
             &mut std::io::empty(),
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .await
         .unwrap_err();
@@ -1455,6 +1462,7 @@ mod tests {
             &PruneArgs { force: true },
             TermInfo::default(),
             &mut std::io::empty(),
+            &mut Vec::new(),
             &mut Vec::new(),
         )
         .await

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -319,7 +319,7 @@ where
         SandboxCommand::Exec(_) => bail!("sandbox exec is dispatched on its own interactive path"),
         SandboxCommand::Stop(args) => stop(svc, args, out).await,
         SandboxCommand::Start(args) => start(svc, args, term, out, stdout, stderr).await,
-        SandboxCommand::Prune(args) => prune(svc, args, term, input, out).await,
+        SandboxCommand::Prune(args) => prune(svc, args, term, input, out, stderr).await,
         SandboxCommand::Inspect(args) => inspect(svc, &args.run, args.output.format, out).await,
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
@@ -582,14 +582,15 @@ where
     .await
 }
 
-async fn prune<I: std::io::BufRead, W: std::io::Write>(
+async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>(
     svc: &impl SandboxService,
     args: &SandboxPruneArgs,
     term: TermInfo,
     input: &mut I,
     out: &mut W,
+    stderr: &mut E,
 ) -> Result<i32> {
-    if !args.force && !confirm_prune(term, input, out)? {
+    if !args.force && !confirm_prune(term, input, stderr).await? {
         return Ok(0);
     }
     match svc.one_shot(Request::PruneRuns).await? {
@@ -609,27 +610,28 @@ async fn prune<I: std::io::BufRead, W: std::io::Write>(
 }
 
 /// §7.2: with no terminal to ask at, a command that would have asked refuses and names the flag that would have answered it.
-fn confirm_prune<I: std::io::BufRead, W: std::io::Write>(
+async fn confirm_prune<I: std::io::BufRead, E: AsyncWriteExt + Unpin>(
     term: TermInfo,
     input: &mut I,
-    out: &mut W,
+    err: &mut E,
 ) -> Result<bool> {
     if !term.stdin_is_tty {
         bail!(
             "this removes every stopped sandbox, writable layers included; there is no terminal to ask at, so pass --force to confirm"
         );
     }
-    write!(
-        out,
-        "This removes every stopped sandbox, writable layers included. Continue? [y/N] "
-    )?;
-    out.flush()?;
+    err.write_all(
+        b"This removes every stopped sandbox, writable layers included. Continue? [y/N] ",
+    )
+    .await?;
+    err.flush().await?;
     let mut line = String::new();
     input.read_line(&mut line)?;
     let answer = line.trim();
     let yes = answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes");
     if !yes {
-        writeln!(out, "Aborted.")?;
+        err.write_all(b"Aborted.\n").await?;
+        err.flush().await?;
     }
     Ok(yes)
 }
@@ -1150,6 +1152,7 @@ mod tests {
             TermInfo::default(),
             &mut std::io::empty(),
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .await
         .unwrap_err();
@@ -1161,6 +1164,7 @@ mod tests {
             &SandboxPruneArgs { force: true },
             TermInfo::default(),
             &mut std::io::empty(),
+            &mut Vec::new(),
             &mut Vec::new(),
         )
         .await

--- a/crates/lns-cli/src/volume/mod.rs
+++ b/crates/lns-cli/src/volume/mod.rs
@@ -98,13 +98,14 @@ pub async fn run(
     svc: &dyn VolumeService,
     input: &mut dyn BufRead,
     writer: &mut impl Write,
+    err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<i32> {
     match cmd {
         VolumeCommand::Ls(args) => ls(svc, args, writer).await,
         VolumeCommand::Create(args) => create(svc, &args.name, writer).await,
         VolumeCommand::Inspect(args) => inspect(svc, &args.name, args.output.format, writer).await,
         VolumeCommand::Rm(args) => rm(svc, &args.name, writer).await,
-        VolumeCommand::Prune(args) => prune(svc, args.force, input, writer).await,
+        VolumeCommand::Prune(args) => prune(svc, args.force, input, writer, err).await,
     }
 }
 
@@ -227,8 +228,9 @@ async fn prune(
     force: bool,
     input: &mut dyn BufRead,
     writer: &mut impl Write,
+    err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<i32> {
-    if !force && !confirm_prune(input, writer)? {
+    if !force && !confirm_prune(input, err).await? {
         return Ok(0);
     }
     match send(svc, Request::PruneVolumes).await? {
@@ -259,18 +261,20 @@ async fn prune(
     }
 }
 
-fn confirm_prune(input: &mut dyn BufRead, writer: &mut impl Write) -> Result<bool> {
-    write!(
-        writer,
-        "This removes every volume not attached to a running sandbox. Continue? [y/N] "
-    )?;
-    writer.flush()?;
+async fn confirm_prune(
+    input: &mut dyn BufRead,
+    err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
+) -> Result<bool> {
+    err.write_all(b"This removes every volume not attached to a running sandbox. Continue? [y/N] ")
+        .await?;
+    err.flush().await?;
     let mut line = String::new();
     input.read_line(&mut line)?;
     let answer = line.trim();
     let yes = answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes");
     if !yes {
-        writeln!(writer, "Aborted.")?;
+        err.write_all(b"Aborted.\n").await?;
+        err.flush().await?;
     }
     Ok(yes)
 }
@@ -341,7 +345,9 @@ mod tests {
     async fn run_cmd(cmd: &VolumeCommand, svc: &dyn VolumeService) -> Result<(i32, String)> {
         let mut input = Cursor::new(String::new());
         let mut buf = Vec::new();
-        let code = run(cmd, svc, &mut input, &mut buf).await?;
+        let mut err_buf = Vec::new();
+        let code = run(cmd, svc, &mut input, &mut buf, &mut err_buf).await?;
+        buf.extend_from_slice(&err_buf);
         Ok((code, String::from_utf8(buf).unwrap()))
     }
 
@@ -399,7 +405,10 @@ mod tests {
         for answer in ["y\n", "Y\n", "yes\n", "YES\n"] {
             let mut input = Cursor::new(answer.to_string());
             let mut buf = Vec::new();
-            assert!(confirm_prune(&mut input, &mut buf).unwrap(), "{answer:?}");
+            assert!(
+                confirm_prune(&mut input, &mut buf).await.unwrap(),
+                "{answer:?}"
+            );
         }
     }
 
@@ -408,7 +417,10 @@ mod tests {
         for answer in ["n\n", "no\n", "\n", "yep\n"] {
             let mut input = Cursor::new(answer.to_string());
             let mut buf = Vec::new();
-            assert!(!confirm_prune(&mut input, &mut buf).unwrap(), "{answer:?}");
+            assert!(
+                !confirm_prune(&mut input, &mut buf).await.unwrap(),
+                "{answer:?}"
+            );
             let out = String::from_utf8(buf).unwrap();
             assert!(out.contains("Aborted."), "got: {out}");
         }

--- a/crates/lns-cli/src/volume/real.rs
+++ b/crates/lns-cli/src/volume/real.rs
@@ -13,7 +13,14 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
         crate::service::require_running().await?;
         let svc = RealVolumeService::new(crate::service::socket_path()?);
         let mut out = ctx.out;
-        crate::volume::run(&args.command, &svc, ctx.input, &mut out).await
+        crate::volume::run(
+            &args.command,
+            &svc,
+            ctx.input,
+            &mut out,
+            &mut tokio::io::stderr(),
+        )
+        .await
     })
 }
 

--- a/crates/lns-cli/tests/behaviours/prompt_streams.feature
+++ b/crates/lns-cli/tests/behaviours/prompt_streams.feature
@@ -1,0 +1,39 @@
+Feature: a prune prompt lands on stderr, never stdout
+
+  §4.1: stdout carries the answer, stderr carries everything else —
+  prompts included — so redirecting stdout never hides the question.
+  §7.2: a prompt is written to stderr. A prune whose stdout is piped to
+  a file must still show "Continue? [y/N]" on the terminal instead of
+  burying it in the capture and waiting on an invisible question.
+
+  Scenario: artifact prune asks on stderr and keeps stdout for the result
+    Given two cached sandboxes and one running sandbox
+    And the user will answer "y" to the sandbox prompt
+    When the user runs artifact command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "Continue? [y/N]"
+    And the command's stdout does not contain "Continue?"
+
+  Scenario: declining an artifact prune reports Aborted. on stderr
+    Given two cached sandboxes and one running sandbox
+    And the user will answer "n" to the sandbox prompt
+    When the user runs artifact command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "Aborted."
+    And the command's stdout does not contain "Aborted."
+
+  Scenario: sandbox prune asks on stderr and keeps stdout for the sweep report
+    Given the service will sweep the stopped sandboxes "scribe" and "hermes"
+    And the user will answer "y" to the sandbox prompt
+    When the user runs sandbox command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "Continue? [y/N]"
+    And the command's stdout does not contain "Continue?"
+
+  Scenario: volume prune asks on stderr and keeps stdout for the removals
+    Given the volume "orphan" is held by no running sandbox and named by no cached sandbox
+    And the user will answer "y" to the prompt
+    When the user runs volume command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "Continue? [y/N]"
+    And the command's stdout does not contain "Continue?"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -169,6 +169,36 @@ fn then_kill_request(w: &mut BehaviourWorld, run_id: u32) -> Result<(), String> 
     }
 }
 
+#[then(regex = r#"^the command's stderr contains "([^"]*)"$"#)]
+fn then_stderr_contains(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let (_, stderr) = w
+        .split_streams
+        .as_ref()
+        .ok_or("no split streams captured")?;
+    if stderr.contains(&needle) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected stderr to contain {needle:?}, got {stderr:?}"
+        ))
+    }
+}
+
+#[then(regex = r#"^the command's stdout does not contain "([^"]*)"$"#)]
+fn then_stdout_does_not_contain(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let (stdout, _) = w
+        .split_streams
+        .as_ref()
+        .ok_or("no split streams captured")?;
+    if stdout.contains(&needle) {
+        Err(format!(
+            "expected stdout not to contain {needle:?}, got {stdout:?}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 #[then(regex = r#"^the output does not contain "([^"]*)"$"#)]
 fn then_output_does_not_contain(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
     let output = &w.result.as_ref().ok_or("no CLI run captured")?.output;
@@ -437,6 +467,14 @@ pub(crate) async fn drive_sandbox_command(w: &mut BehaviourWorld, cmd: &str) {
     )
     .await;
     w.sandbox.workload_stdout = stdout;
+    w.split_streams = Some((
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out),
+            String::from_utf8_lossy(&w.sandbox.workload_stdout)
+        ),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    ));
     out.extend_from_slice(&stderr);
     w.result = Some(match result {
         Ok(exit_code) => CliRun {
@@ -492,6 +530,11 @@ pub(crate) async fn drive_artifact_command(w: &mut BehaviourWorld, cmd: &str) {
         &mut stderr,
     )
     .await;
+    w.split_streams = Some((
+        String::from_utf8_lossy(&out).into_owned(),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    ));
+    out.extend_from_slice(&stderr);
     w.result = Some(match result {
         Ok(exit_code) => CliRun {
             exit_code,

--- a/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
@@ -205,16 +205,27 @@ async fn run_volume(world: &mut BehaviourWorld, tail: String) {
                 .unwrap_or_default();
             let mut input = std::io::Cursor::new(stdin_text);
             let mut buf = Vec::<u8>::new();
-            match volume::run(&args.command, &svc, &mut input, &mut buf).await {
-                Ok(exit_code) => CliRun {
-                    exit_code,
-                    output: String::from_utf8_lossy(&buf).into_owned(),
-                },
-                Err(e) => CliRun {
-                    exit_code: 1,
-                    output: format!("{}{e:#}", String::from_utf8_lossy(&buf)),
-                },
-            }
+            let mut err_buf = Vec::<u8>::new();
+            let run =
+                match volume::run(&args.command, &svc, &mut input, &mut buf, &mut err_buf).await {
+                    Ok(exit_code) => CliRun {
+                        exit_code,
+                        output: format!(
+                            "{}{}",
+                            String::from_utf8_lossy(&buf),
+                            String::from_utf8_lossy(&err_buf)
+                        ),
+                    },
+                    Err(e) => CliRun {
+                        exit_code: 1,
+                        output: format!("{}{e:#}", String::from_utf8_lossy(&buf)),
+                    },
+                };
+            world.split_streams = Some((
+                String::from_utf8_lossy(&buf).into_owned(),
+                String::from_utf8_lossy(&err_buf).into_owned(),
+            ));
+            run
         }
         Err(e) => CliRun {
             exit_code: e.exit_code(),

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -15,6 +15,7 @@ use tokio::io::DuplexStream;
 #[derive(Debug, Default, World)]
 pub struct BehaviourWorld {
     pub result: Option<CliRun>,
+    pub split_streams: Option<(String, String)>,
     /// The stopped run a start scenario targets.
     pub start_target: Option<String>,
     pub argv: Vec<String>,


### PR DESCRIPTION
Fixes the actionable half of a review finding on #280 (the prune prompt thread): the prompt was written to stdout and violated §4.1/§7.2 — a prune with stdout redirected waited on an invisible question and leaked the prompt into the capture.

## What changed

All three prune confirms (artifact, sandbox, volume) now write `Continue? [y/N]` and the declining `Aborted.` to **stderr** — the stream §4.1 assigns to prompts — leaving stdout for the sweep report. `volume::run` gains the async stderr writer the artifact/sandbox dispatchers already carried; the prompt text and answer handling are unchanged.

## What's covered

A new `prompt_streams.feature` (Layer 2) pins, for each of the three namespaces, that the prompt lands on stderr and never stdout, plus the declining `Aborted.` case. The behaviours harness now captures the two streams separately so scenarios can tell them apart (merged `output` assertions keep working). The volume Layer 3 confirm tests moved to the async writer with the same assertions.

## Not in this PR

§7.2's other half — "read from your terminal. It never consumes stdin" — still doesn't hold: answers come from the process stdin lock, and the run-path consent prompts (pull confirm, host-path consent, mixin plan, uninstall) share the same caller-supplied-writer pattern. That's a `/dev/tty` port and a sweep of every prompt site — tracked in a follow-up issue rather than smuggled in here.

## Gates

`make lint`, 442 Layer 2 scenarios, full coverage gate — all green.
