### PR TITLE
fix(lns-cli): list what a prune would remove before asking

### DIFF
--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -545,6 +545,8 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
                 "this removes every cached sandbox not held by a running one and, when none is live, the provisioned tool cache; there is no terminal to ask at, so pass --force to confirm"
             );
         }
+        let candidates = prunable_references(svc).await?;
+        crate::output::announce_prune_candidates(&candidates, stderr).await?;
         if !confirm_prune(input, stderr).await? {
             return Ok(0);
         }
@@ -564,6 +566,19 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
                 crate::output::format_bytes(reclaimed_bytes)
             )?;
             Ok(0)
+        }
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+async fn prunable_references(svc: &impl SandboxService) -> Result<Vec<String>> {
+    match svc.one_shot(Request::ListPrunableImages).await? {
+        Response::ImageList { images } => {
+            let mut references: Vec<String> =
+                images.into_iter().map(|image| image.reference).collect();
+            references.sort_unstable();
+            Ok(references)
         }
         Response::Error { message } => bail!("daemon error: {message}"),
         other => bail!("unexpected response from daemon: {other:?}"),
@@ -1392,7 +1407,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn declining_the_prune_prompt_reaches_no_service() {
+    async fn declining_the_prune_prompt_sends_no_prune() {
         let svc = CannedService::new(Response::Pong);
         let mut out = Vec::new();
         let mut err = Vec::new();
@@ -1412,7 +1427,42 @@ mod tests {
         assert_eq!(code, 0);
         assert!(String::from_utf8(err).unwrap().contains("Aborted."));
         assert!(out.is_empty());
-        assert!(svc.requests.lock().unwrap().is_empty());
+        let requests = svc.requests.lock().unwrap();
+        assert!(
+            !requests.iter().any(|r| matches!(r, Request::PruneImages)),
+            "a declined prune must sweep nothing, got {requests:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prunable_references_come_back_sorted() {
+        let svc = CannedService::with_list_prunable(
+            Response::Pong,
+            Response::ImageList {
+                images: vec![
+                    crate::test_service::cached_info("z:2"),
+                    crate::test_service::cached_info("a:1"),
+                ],
+            },
+        );
+        let references = prunable_references(&svc).await.unwrap();
+        assert_eq!(references, vec!["a:1".to_string(), "z:2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn prunable_listing_surfaces_a_daemon_error_and_rejects_an_unrelated_variant() {
+        let refused = CannedService::with_list_prunable(
+            Response::Pong,
+            Response::Error {
+                message: "index unreadable".into(),
+            },
+        );
+        let err = prunable_references(&refused).await.unwrap_err();
+        assert!(format!("{err:#}").contains("index unreadable"));
+
+        let odd = CannedService::with_list_prunable(Response::Pong, Response::Pong);
+        let err = prunable_references(&odd).await.unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/output.rs
+++ b/crates/lns-cli/src/output.rs
@@ -139,6 +139,25 @@ pub fn format_bytes(n: u64) -> String {
     }
 }
 
+/// The prune candidates ride with the question on stderr, so a piped stdout still shows what's on the line.
+pub async fn announce_prune_candidates<E: tokio::io::AsyncWriteExt + Unpin>(
+    names: &[String],
+    err: &mut E,
+) -> Result<()> {
+    if names.is_empty() {
+        return Ok(());
+    }
+    let mut block = String::from("Would remove:\n");
+    for name in names {
+        block.push_str("  ");
+        block.push_str(name);
+        block.push('\n');
+    }
+    err.write_all(block.as_bytes()).await?;
+    err.flush().await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -590,8 +590,21 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
     out: &mut W,
     stderr: &mut E,
 ) -> Result<i32> {
-    if !args.force && !confirm_prune(term, input, stderr).await? {
-        return Ok(0);
+    if !args.force {
+        if !term.stdin_is_tty {
+            bail!(
+                "this removes every stopped sandbox, writable layers included; there is no terminal to ask at, so pass --force to confirm"
+            );
+        }
+        let stopped = stopped_run_names(svc).await?;
+        if stopped.is_empty() {
+            writeln!(out, "No stopped sandboxes.")?;
+            return Ok(0);
+        }
+        crate::output::announce_prune_candidates(&stopped, stderr).await?;
+        if !confirm_prune(input, stderr).await? {
+            return Ok(0);
+        }
     }
     match svc.one_shot(Request::PruneRuns).await? {
         Response::RunsPruned { mut removed } => {
@@ -609,17 +622,32 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
     }
 }
 
-/// §7.2: with no terminal to ask at, a command that would have asked refuses and names the flag that would have answered it.
+async fn stopped_run_names(svc: &impl SandboxService) -> Result<Vec<String>> {
+    match svc.one_shot(Request::ListRuns).await? {
+        Response::RunList { runs } => {
+            let mut names: Vec<String> = runs
+                .into_iter()
+                .filter(|run| !matches!(run.status, lns_ipc::RunStatus::Running))
+                .map(|run| {
+                    if run.name.is_empty() {
+                        lns_ipc::short_run_id(&run.id).to_string()
+                    } else {
+                        run.name
+                    }
+                })
+                .collect();
+            names.sort_unstable();
+            Ok(names)
+        }
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
 async fn confirm_prune<I: std::io::BufRead, E: AsyncWriteExt + Unpin>(
-    term: TermInfo,
     input: &mut I,
     err: &mut E,
 ) -> Result<bool> {
-    if !term.stdin_is_tty {
-        bail!(
-            "this removes every stopped sandbox, writable layers included; there is no terminal to ask at, so pass --force to confirm"
-        );
-    }
     err.write_all(
         b"This removes every stopped sandbox, writable layers included. Continue? [y/N] ",
     )
@@ -1169,6 +1197,52 @@ mod tests {
         )
         .await
         .unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[tokio::test]
+    async fn stopped_run_names_skip_the_running_and_fall_back_to_the_short_id() {
+        let svc = CannedService::new(Response::RunList {
+            runs: vec![
+                lns_ipc::RunSummary {
+                    id: format!("{:032x}", 0xbeefu32),
+                    name: String::new(),
+                    image: "some-image".into(),
+                    command: "cmd".into(),
+                    status: lns_ipc::RunStatus::Exited { code: 0 },
+                    started: "2026-01-01T00:00:00Z".into(),
+                },
+                running_run(),
+                lns_ipc::RunSummary {
+                    id: format!("{:032x}", 3),
+                    name: "scribe".into(),
+                    image: "some-image".into(),
+                    command: "cmd".into(),
+                    status: lns_ipc::RunStatus::Exited { code: 1 },
+                    started: "2026-01-01T00:00:00Z".into(),
+                },
+            ],
+        });
+        let names = stopped_run_names(&svc).await.unwrap();
+        assert_eq!(
+            names,
+            vec![
+                lns_ipc::short_run_id(&format!("{:032x}", 0xbeefu32)).to_string(),
+                "scribe".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn stopped_run_listing_surfaces_a_daemon_error_and_rejects_an_unrelated_variant() {
+        let refused = CannedService::new(Response::Error {
+            message: "runs dir unreadable".into(),
+        });
+        let err = stopped_run_names(&refused).await.unwrap_err();
+        assert!(format!("{err:#}").contains("runs dir unreadable"));
+
+        let odd = CannedService::new(Response::Pong);
+        let err = stopped_run_names(&odd).await.unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
     }
 

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -14,6 +14,7 @@ pub(crate) struct CannedService {
     stats_response: Option<Response>,
     inspect_image_response: Option<Response>,
     remove_image_response: Option<Response>,
+    list_prunable_response: Option<Response>,
     frames: Vec<Vec<u8>>,
     pub requests: Arc<Mutex<Vec<Request>>>,
 }
@@ -25,8 +26,16 @@ impl CannedService {
             stats_response: None,
             inspect_image_response: None,
             remove_image_response: None,
+            list_prunable_response: None,
             frames: Vec::new(),
             requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn with_list_prunable(response: Response, list_prunable: Response) -> Self {
+        Self {
+            list_prunable_response: Some(list_prunable),
+            ..Self::new(response)
         }
     }
 
@@ -90,6 +99,18 @@ pub(crate) fn sandbox_inspection_with_digest(tools: Vec<String>, digest: String)
     }
 }
 
+pub(crate) fn cached_info(reference: &str) -> lns_ipc::ImageInfo {
+    lns_ipc::ImageInfo {
+        reference: reference.to_string(),
+        kind: lns_ipc::CachedKind::Sandbox,
+        digest: format!("sha256:{}", "a".repeat(64)),
+        size_bytes: 0,
+        layers: 0,
+        pulled: "2026-01-01T00:00:00Z".into(),
+        in_use_by: None,
+    }
+}
+
 pub(crate) fn pulled_response() -> Response {
     Response::ImagePulled {
         image: lns_ipc::ImageInfo {
@@ -121,6 +142,10 @@ impl SandboxService for CannedService {
                 .remove_image_response
                 .clone()
                 .unwrap_or_else(|| self.response.clone()),
+            Request::ListPrunableImages => self
+                .list_prunable_response
+                .clone()
+                .unwrap_or(Response::ImageList { images: Vec::new() }),
             _ => self.response.clone(),
         };
         self.requests.lock().unwrap().push(request);

--- a/crates/lns-cli/src/volume/mod.rs
+++ b/crates/lns-cli/src/volume/mod.rs
@@ -230,8 +230,16 @@ async fn prune(
     writer: &mut impl Write,
     err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<i32> {
-    if !force && !confirm_prune(input, err).await? {
-        return Ok(0);
+    if !force {
+        let unused = unused_volume_names(svc).await?;
+        if unused.is_empty() {
+            writeln!(writer, "No unused volumes.")?;
+            return Ok(0);
+        }
+        crate::output::announce_prune_candidates(&unused, err).await?;
+        if !confirm_prune(input, err).await? {
+            return Ok(0);
+        }
     }
     match send(svc, Request::PruneVolumes).await? {
         Response::VolumesPruned {
@@ -256,6 +264,21 @@ async fn prune(
                 writeln!(writer, "No unused volumes.")?;
             }
             Ok(if failed.is_empty() { 0 } else { 1 })
+        }
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+async fn unused_volume_names(svc: &dyn VolumeService) -> Result<Vec<String>> {
+    match send(svc, Request::ListVolumes).await? {
+        Response::VolumeList { volumes } => {
+            let mut names: Vec<String> = volumes
+                .into_iter()
+                .filter(|volume| volume.in_use_by.is_none())
+                .map(|volume| volume.name)
+                .collect();
+            names.sort_unstable();
+            Ok(names)
         }
         other => bail!("unexpected response from daemon: {other:?}"),
     }
@@ -389,7 +412,9 @@ mod tests {
 
     #[tokio::test]
     async fn prune_without_force_reads_eof_as_decline() {
-        let svc = CannedService::with([]);
+        let svc = CannedService::with([Some(Response::VolumeList {
+            volumes: vec![volume("scratch")],
+        })]);
         let (code, out) = run_cmd(
             &VolumeCommand::Prune(VolumePruneArgs { force: false }),
             &svc,
@@ -398,6 +423,32 @@ mod tests {
         .unwrap();
         assert_eq!(code, 0);
         assert!(out.contains("Aborted."), "got: {out}");
+    }
+
+    #[tokio::test]
+    async fn prune_without_force_says_so_when_every_volume_is_held() {
+        let svc = CannedService::with([Some(Response::VolumeList {
+            volumes: vec![VolumeInfo {
+                in_use_by: Some("aa07".into()),
+                ..volume("held")
+            }],
+        })]);
+        let (code, out) = run_cmd(
+            &VolumeCommand::Prune(VolumePruneArgs { force: false }),
+            &svc,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert!(out.contains("No unused volumes."), "got: {out}");
+        assert!(!out.contains("Continue?"), "got: {out}");
+    }
+
+    #[tokio::test]
+    async fn unused_volume_listing_rejects_an_unrelated_variant() {
+        let svc = CannedService::with([Some(Response::Pong)]);
+        let err = unused_volume_names(&svc).await.unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
     }
 
     #[tokio::test]

--- a/crates/lns-cli/tests/behaviours/prune_lists.feature
+++ b/crates/lns-cli/tests/behaviours/prune_lists.feature
@@ -1,0 +1,66 @@
+Feature: a prune lists what it would remove before asking
+
+  "Lists them and asks, unless -f/--force" — the question is only
+  answerable when the candidates are on screen. The list rides with the
+  prompt on stderr, so stdout stays reserved for what actually happened.
+
+  Scenario: artifact prune lists the prune candidates before asking
+    Given two cached sandboxes and one running sandbox
+    And the user will answer "y" to the sandbox prompt
+    When the user runs artifact command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "hermes:1.0"
+    And the command's stderr contains "scribe:1.0"
+    And the command's stderr shows "Would remove:" before "Continue? [y/N]"
+    And the service received a PruneImages request
+
+  Scenario: an artifact prune with nothing removable still asks, for the tool cache
+    Given every cached artifact is held by a running sandbox
+    And the user will answer "y" to the sandbox prompt
+    When the user runs artifact command "prune"
+    Then the exit code is 0
+    And the command's stderr does not contain "Would remove:"
+    And the command's stderr contains "Continue? [y/N]"
+    And the service received a PruneImages request
+
+  Scenario: forcing an artifact prune skips the listing with the question
+    Given two cached sandboxes and one running sandbox
+    When the user runs artifact command "prune --force"
+    Then the exit code is 0
+    And the service received no ListPrunableImages request
+
+  Scenario: sandbox prune lists the stopped sandboxes before asking
+    Given the service reports one running sandbox and one that stopped
+    And the user will answer "y" to the sandbox prompt
+    When the user runs sandbox command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "scribe"
+    And the command's stderr does not contain "reviewer"
+    And the command's stderr shows "Would remove:" before "Continue? [y/N]"
+
+  Scenario: a sandbox prune with nothing stopped never asks
+    Given the service reports one running sandbox and none stopped
+    And sandbox input is a terminal
+    When the user runs sandbox command "prune"
+    Then the exit code is 0
+    And the output contains "No stopped sandboxes."
+    And the command's stderr does not contain "Continue?"
+    And the service received no PruneRuns request
+
+  Scenario: volume prune lists the unused volumes before asking
+    Given the service reports a volume "prism-data" using 1024 bytes on disk held by run 7
+    And the volume "orphan" is held by no running sandbox and named by no cached sandbox
+    And the user will answer "y" to the prompt
+    When the user runs volume command "prune"
+    Then the exit code is 0
+    And the command's stderr contains "orphan"
+    And the command's stderr does not contain "prism-data"
+    And the command's stderr shows "Would remove:" before "Continue? [y/N]"
+
+  Scenario: a volume prune with nothing unused never asks
+    Given the service reports a volume "prism-data" using 1024 bytes on disk held by run 7
+    When the user runs volume command "prune"
+    Then the exit code is 0
+    And the output contains "No unused volumes."
+    And the command's stderr does not contain "Continue?"
+    And no prune request reached the service

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -103,7 +103,7 @@ Feature: managing cached sandboxes
     When the user runs artifact command "prune"
     Then the exit code is 0
     And the output contains "Aborted."
-    And the service received no request
+    And the service received no PruneImages request
 
   Scenario: prune never removes a named volume
     Given a cached sandbox that names a volume "claude-home"
@@ -156,7 +156,7 @@ Feature: managing cached sandboxes
     When the user runs sandbox command "prune"
     Then the exit code is 0
     And the output contains "Aborted."
-    And the service received no request
+    And the service received no PruneRuns request
 
   Scenario: with no terminal to ask at, prune refuses rather than assuming
     Given the service will sweep the stopped sandboxes "scribe" and "hermes"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -24,6 +24,8 @@ pub(crate) struct FakeSandboxService {
     inspect_image_response: Option<Response>,
     remove_image_response: Option<Response>,
     cached_references: Vec<String>,
+    prunable_references: Vec<String>,
+    list_runs_response: Option<Response>,
     remove_run_response: Option<Response>,
     frames: Vec<Vec<u8>>,
     unreachable: bool,
@@ -61,6 +63,17 @@ impl SandboxService for FakeSandboxService {
                             .collect(),
                     })
                 }),
+            Request::ListPrunableImages => Some(Response::ImageList {
+                images: self
+                    .prunable_references
+                    .iter()
+                    .map(|reference| cached_entry(reference))
+                    .collect(),
+            }),
+            Request::ListRuns => self
+                .list_runs_response
+                .clone()
+                .or_else(|| self.response.clone()),
             Request::RemoveRun { .. } => self
                 .remove_run_response
                 .clone()
@@ -182,6 +195,62 @@ fn then_stderr_contains(w: &mut BehaviourWorld, needle: String) -> Result<(), St
             "expected stderr to contain {needle:?}, got {stderr:?}"
         ))
     }
+}
+
+#[then(regex = r#"^the command's stderr does not contain "([^"]*)"$"#)]
+fn then_stderr_does_not_contain(w: &mut BehaviourWorld, needle: String) -> Result<(), String> {
+    let (_, stderr) = w
+        .split_streams
+        .as_ref()
+        .ok_or("no split streams captured")?;
+    if stderr.contains(&needle) {
+        Err(format!(
+            "expected stderr not to contain {needle:?}, got {stderr:?}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[then(regex = r#"^the command's stderr shows "([^"]*)" before "([^"]*)"$"#)]
+fn then_stderr_order(w: &mut BehaviourWorld, first: String, second: String) -> Result<(), String> {
+    let (_, stderr) = w
+        .split_streams
+        .as_ref()
+        .ok_or("no split streams captured")?;
+    let first_at = stderr
+        .find(&first)
+        .ok_or_else(|| format!("expected stderr to contain {first:?}, got {stderr:?}"))?;
+    let second_at = stderr
+        .find(&second)
+        .ok_or_else(|| format!("expected stderr to contain {second:?}, got {stderr:?}"))?;
+    if first_at < second_at {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected {first:?} before {second:?} on stderr, got {stderr:?}"
+        ))
+    }
+}
+
+#[then(regex = r"^the service received no (PruneImages|PruneRuns|ListPrunableImages) request$")]
+fn then_no_such_request(w: &mut BehaviourWorld, variant: String) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().unwrap();
+    let hit = requests.iter().any(|request| match variant.as_str() {
+        "PruneImages" => matches!(request, Request::PruneImages),
+        "PruneRuns" => matches!(request, Request::PruneRuns),
+        _ => matches!(request, Request::ListPrunableImages),
+    });
+    if hit {
+        Err(format!("expected no {variant} request among {requests:?}"))
+    } else {
+        Ok(())
+    }
+}
+
+#[given("sandbox input is a terminal")]
+fn sandbox_input_is_a_terminal(w: &mut BehaviourWorld) {
+    w.sandbox.stdin_is_tty = true;
 }
 
 #[then(regex = r#"^the command's stdout does not contain "([^"]*)"$"#)]
@@ -426,6 +495,8 @@ pub(crate) fn fake_sandbox_service(w: &BehaviourWorld) -> FakeSandboxService {
         inspect_image_response: w.sandbox.inspect_image_response.clone(),
         remove_image_response: w.sandbox.remove_image_response.clone(),
         cached_references: w.sandbox.cached_references.clone(),
+        prunable_references: w.sandbox.prunable_references.clone(),
+        list_runs_response: w.sandbox.list_runs_response.clone(),
         remove_run_response: w.sandbox.remove_run_response.clone(),
         frames: w.sandbox.frames.clone(),
         unreachable: w.sandbox.unreachable,

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -81,14 +81,24 @@ fn cached_sandbox_sole_owner(w: &mut BehaviourWorld, reference: String) {
 
 #[given("two cached sandboxes and one running sandbox")]
 fn two_cached_one_running(w: &mut BehaviourWorld) {
+    w.sandbox.prunable_references = vec!["hermes:1.0".into(), "scribe:1.0".into()];
     w.sandbox.response = Some(Response::ImagesPruned {
         removed: vec!["hermes:1.0".into(), "scribe:1.0".into()],
         reclaimed_bytes: 64 * 1024 * 1024,
     });
 }
 
+#[given("every cached artifact is held by a running sandbox")]
+fn every_artifact_held(w: &mut BehaviourWorld) {
+    w.sandbox.response = Some(Response::ImagesPruned {
+        removed: Vec::new(),
+        reclaimed_bytes: 128 * 1024 * 1024,
+    });
+}
+
 #[given(regex = r#"^a cached sandbox that names a volume "([^"]+)"$"#)]
 fn cached_sandbox_names_a_volume(w: &mut BehaviourWorld, _volume: String) {
+    w.sandbox.prunable_references = vec!["hermes:1.0".into()];
     w.sandbox.response = Some(Response::ImagesPruned {
         removed: vec!["hermes:1.0".into()],
         reclaimed_bytes: 32 * 1024 * 1024,
@@ -306,9 +316,37 @@ fn stats_asked_once(w: &mut BehaviourWorld) -> Result<(), String> {
 
 #[given(regex = r#"^the service will sweep the stopped sandboxes "([^"]+)" and "([^"]+)"$"#)]
 fn service_will_sweep(w: &mut BehaviourWorld, first: String, second: String) {
+    w.sandbox.list_runs_response = Some(Response::RunList {
+        runs: vec![stopped_run(5, &first), stopped_run(6, &second)],
+    });
     w.sandbox.response = Some(Response::RunsPruned {
         removed: vec![first, second],
     });
+}
+
+#[given("the service reports one running sandbox and none stopped")]
+fn one_running_none_stopped(w: &mut BehaviourWorld) {
+    w.sandbox.list_runs_response = Some(Response::RunList {
+        runs: vec![RunSummary {
+            id: hexid(3),
+            name: "reviewer".into(),
+            image: "some-image".into(),
+            command: "some-command".into(),
+            status: RunStatus::Running,
+            started: "2026-01-01T00:00:00Z".into(),
+        }],
+    });
+}
+
+fn stopped_run(n: u32, name: &str) -> RunSummary {
+    RunSummary {
+        id: hexid(n),
+        name: name.into(),
+        image: "some-image".into(),
+        command: "some-command".into(),
+        status: RunStatus::Exited { code: 0 },
+        started: "2026-01-01T00:00:00Z".into(),
+    }
 }
 
 #[given("the service reports no stopped sandboxes to sweep")]

--- a/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
@@ -119,6 +119,14 @@ fn service_refuses(world: &mut BehaviourWorld, message: String) {
 
 #[given(expr = "the service will prune volumes {string} and {string} reclaiming {int} bytes")]
 fn prune_plan(world: &mut BehaviourWorld, a: String, b: String, bytes: u64) {
+    world
+        .volume
+        .volumes
+        .push(fixture_volume(&a, bytes / 2, None));
+    world
+        .volume
+        .volumes
+        .push(fixture_volume(&b, bytes / 2, None));
     world.volume.prune_plan = Some((vec![a, b], bytes));
 }
 
@@ -136,6 +144,10 @@ fn volume_held_by_running_sandbox(world: &mut BehaviourWorld, name: String) {
 
 #[given(expr = "the volume {string} is held by no running sandbox and named by no cached sandbox")]
 fn volume_is_prunable(world: &mut BehaviourWorld, name: String) {
+    world
+        .volume
+        .volumes
+        .push(fixture_volume(&name, 33_554_432, None));
     let plan = world
         .volume
         .prune_plan
@@ -263,4 +275,13 @@ fn listed_row_ends_with(world: &mut BehaviourWorld, name: String, suffix: String
 fn no_request_sent(world: &mut BehaviourWorld) {
     let requests = world.volume.requests.lock().unwrap();
     assert!(requests.is_empty(), "got {requests:?}");
+}
+
+#[then(expr = "no prune request reached the service")]
+fn no_prune_request_sent(world: &mut BehaviourWorld) {
+    let requests = world.volume.requests.lock().unwrap();
+    assert!(
+        !requests.iter().any(|r| matches!(r, Request::PruneVolumes)),
+        "got {requests:?}"
+    );
 }

--- a/crates/lns-cli/tests/behaviours/volume_cli.feature
+++ b/crates/lns-cli/tests/behaviours/volume_cli.feature
@@ -86,11 +86,12 @@ Feature: managing named volumes from the CLI
     And the output contains "Total reclaimed space: 64 MiB"
 
   Scenario: declining the prune prompt aborts without touching the service
-    Given the user will answer "n" to the prompt
+    Given the volume "orphan" is held by no running sandbox and named by no cached sandbox
+    And the user will answer "n" to the prompt
     When the user runs volume command "prune"
     Then the exit code is 0
     And the output contains "Aborted."
-    And no request reached the service
+    And no prune request reached the service
 
   Scenario: pruning with nothing to remove says so
     Given the service will prune no volumes

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -204,6 +204,10 @@ pub struct SandboxCliRig {
     pub remove_image_response: Option<lns_ipc::Response>,
     /// What the cache holds, so the `lns rm` / `lns inspect` arbitration can ask the store rather than a registry.
     pub cached_references: Vec<String>,
+    /// What a prune would remove right now, served for a `ListPrunableImages` request.
+    pub prunable_references: Vec<String>,
+    /// Response the fake returns for a `ListRuns` request specifically, so prune can canned-serve both the stopped listing and the sweep.
+    pub list_runs_response: Option<lns_ipc::Response>,
     /// Response the fake returns for a `RemoveRun` request, so a scenario can pin the service's own refusal of a running sandbox.
     pub remove_run_response: Option<lns_ipc::Response>,
     pub frames: Vec<Vec<u8>>,

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -97,6 +97,8 @@ pub enum Request {
         image: String,
     },
     PruneImages,
+    /// The references `PruneImages` would remove right now, so a prune can list them and ask first.
+    ListPrunableImages,
     /// Resolve a local definition's mixins, since only the service can pull a reference and read a directory the same way a run will.
     ResolveDefinition {
         definition: String,
@@ -1637,6 +1639,7 @@ mod tests {
                 image: "registry.example.test/some/image:1.0".into(),
             },
             Request::PruneImages,
+            Request::ListPrunableImages,
         ] {
             let frame = crate::encode_frame(&req).unwrap();
             let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -354,6 +354,34 @@ pub async fn tag_with<F: Fs>(fs: &F, images_root: &Path, from: &str, to: &str) -
     record_with(fs, images_root, &record).await
 }
 
+fn removable_partition(
+    records: Vec<ImageRecord>,
+    active: &[lns_ipc::RunSummary],
+) -> (Vec<ImageRecord>, Vec<ImageRecord>) {
+    let active_roots: HashSet<String> = records
+        .iter()
+        .filter(|record| pinning_holder(active, &record.reference).is_some())
+        .map(|record| record.reference.clone())
+        .collect();
+    let kept_references = dependency_closure(&records, &active_roots);
+    records
+        .into_iter()
+        .partition(|record| kept_references.contains(&record.reference))
+}
+
+pub async fn list_prunable_with<F: Fs>(
+    fs: &F,
+    images_root: &Path,
+    active: &[lns_ipc::RunSummary],
+) -> Result<Vec<lns_ipc::ImageInfo>> {
+    let records = load_records(fs, images_root).await?;
+    let (_, removable) = removable_partition(records, active);
+    Ok(removable
+        .iter()
+        .map(|record| info_from(record, active))
+        .collect())
+}
+
 pub async fn prune_with<F: RuntimeCacheFs, C: Caches>(
     fs: &F,
     caches: &C,
@@ -362,15 +390,7 @@ pub async fn prune_with<F: RuntimeCacheFs, C: Caches>(
     active: &[lns_ipc::RunSummary],
 ) -> Result<PruneReport> {
     let records = load_records(fs, images_root).await?;
-    let active_roots: HashSet<String> = records
-        .iter()
-        .filter(|record| pinning_holder(active, &record.reference).is_some())
-        .map(|record| record.reference.clone())
-        .collect();
-    let kept_references = dependency_closure(&records, &active_roots);
-    let (kept, removable): (Vec<_>, Vec<_>) = records
-        .into_iter()
-        .partition(|record| kept_references.contains(&record.reference));
+    let (kept, removable) = removable_partition(records, active);
     let kept_manifests = manifest_keep_set(kept.iter())?;
     let mut removable_manifests = HashSet::new();
     let mut removed = Vec::with_capacity(removable.len());
@@ -642,6 +662,15 @@ mod consent_tests {
 
 pub async fn list() -> Result<Vec<lns_ipc::ImageInfo>> {
     list_with(
+        &real::RealFs,
+        &images_root()?,
+        &crate::run_registry::snapshot(),
+    )
+    .await
+}
+
+pub async fn list_prunable() -> Result<Vec<lns_ipc::ImageInfo>> {
+    list_prunable_with(
         &real::RealFs,
         &images_root()?,
         &crate::run_registry::snapshot(),

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -497,6 +497,11 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
                     }),
             )
         }
+        Request::ListPrunableImages => image_response(
+            crate::image_store::list_prunable()
+                .await
+                .map(|images| Response::ImageList { images }),
+        ),
         Request::ResolveDefinition {
             definition,
             project_dir,
@@ -3721,6 +3726,16 @@ mod tests {
         assert_eq!(resp["type"], "Error", "got {resp}");
         let message = resp["message"].as_str().expect("an error message");
         assert!(message.contains("no such image"), "got: {message}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env)]
+    async fn handle_request_prunable_listing_of_an_empty_cache_is_an_empty_image_list() {
+        let d = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("HOME", d.path());
+        let resp = as_json(handle_request(&Request::ListPrunableImages, Instant::now()).await);
+        assert_eq!(resp["type"], "ImageList", "got {resp}");
+        assert_eq!(resp["images"], serde_json::json!([]));
     }
 
     #[tokio::test]

--- a/crates/lns-service/tests/behaviours/image_management.feature
+++ b/crates/lns-service/tests/behaviours/image_management.feature
@@ -84,6 +84,25 @@ Feature: image cache lifecycle — list, remove, prune
     When the images are pruned
     Then the prune removes no images
 
+  Scenario: Listing prune candidates names removable images without touching them
+    Given image "registry.example.test/held/image:1.0" is cached with layer "sha256:held" of 3000 bytes
+    And image "registry.example.test/idle/image:1.0" is cached with layer "sha256:idle" of 1000 bytes
+    And a live run uses image "registry.example.test/held/image:1.0"
+    When the prunable images are listed
+    Then the prunable listing names only "registry.example.test/idle/image:1.0"
+    And layer "sha256:idle" remains in the layer cache
+
+  Scenario: A base image a live sandbox depends on is not a prune candidate
+    Given image "registry.example.test/base/image:1.0" is cached with layer "sha256:base" of 2000 bytes
+    And sandbox "registry.example.test/team/agent:1.0" with layer "sha256:app" of 500 bytes is cached on base "registry.example.test/base/image:1.0"
+    And a live run uses image "registry.example.test/team/agent:1.0"
+    When the prunable images are listed
+    Then the prunable listing is empty
+
+  Scenario: An empty cache has no prune candidates
+    When the prunable images are listed
+    Then the prunable listing is empty
+
   Scenario: Pruning reclaims the provisioned tool cache
     Given a provisioned tool cache of 700 bytes
     When the images are pruned

--- a/crates/lns-service/tests/behaviours/image_rig.rs
+++ b/crates/lns-service/tests/behaviours/image_rig.rs
@@ -129,6 +129,7 @@ pub struct ImageRig {
     next_run_id: u32,
     seeded: HashMap<String, Vec<(String, u64)>>,
     pub last_list: Option<Vec<lns_ipc::ImageInfo>>,
+    pub last_prunable: Option<Vec<lns_ipc::ImageInfo>>,
     pub last_removed: Option<RemovedImage>,
     pub last_prune: Option<PruneReport>,
     pub last_pull: Option<lns_ipc::ImageInfo>,
@@ -148,6 +149,7 @@ impl ImageRig {
             next_run_id: 1,
             seeded: HashMap::new(),
             last_list: None,
+            last_prunable: None,
             last_removed: None,
             last_prune: None,
             last_pull: None,
@@ -261,6 +263,33 @@ impl ImageRig {
         match image_store::list_with(&self.fs, &self.images_root, &self.active).await {
             Ok(images) => {
                 self.last_list = Some(images);
+                self.last_error = None;
+            }
+            Err(e) => self.last_error = Some(e.to_string()),
+        }
+    }
+
+    pub async fn seed_dependent(&mut self, reference: &str, digest: &str, size: u64, base: &str) {
+        self.caches.add_layer(digest, size);
+        let record = ImageRecord {
+            reference: reference.to_string(),
+            digest: format!("sha256:{}", "f".repeat(64)),
+            dependencies: vec![base.to_string()],
+            layers: vec![LayerRef {
+                digest: digest.to_string(),
+                size_bytes: size,
+            }],
+            pulled_unix_secs: 1_765_022_400,
+        };
+        image_store::record_with(&self.fs, &self.images_root, &record)
+            .await
+            .expect("seeding a dependent sandbox record");
+    }
+
+    pub async fn list_prunable(&mut self) {
+        match image_store::list_prunable_with(&self.fs, &self.images_root, &self.active).await {
+            Ok(images) => {
+                self.last_prunable = Some(images);
                 self.last_error = None;
             }
             Err(e) => self.last_error = Some(e.to_string()),

--- a/crates/lns-service/tests/behaviours/steps/image_management.rs
+++ b/crates/lns-service/tests/behaviours/steps/image_management.rs
@@ -58,6 +58,47 @@ async fn prune_images(w: &mut BehaviourWorld) {
     w.image().prune().await;
 }
 
+#[given(expr = "sandbox {string} with layer {string} of {int} bytes is cached on base {string}")]
+async fn dependent_sandbox_cached(
+    w: &mut BehaviourWorld,
+    reference: String,
+    digest: String,
+    size: u64,
+    base: String,
+) {
+    w.image()
+        .seed_dependent(&reference, &digest, size, &base)
+        .await;
+}
+
+#[when(expr = "the prunable images are listed")]
+async fn list_prunable_images(w: &mut BehaviourWorld) {
+    w.image().list_prunable().await;
+}
+
+#[then(expr = "the prunable listing names only {string}")]
+fn prunable_names_only(w: &mut BehaviourWorld, reference: String) {
+    let rig = w.image();
+    let listed: Vec<&str> = rig
+        .last_prunable
+        .as_deref()
+        .expect("a prunable listing was taken")
+        .iter()
+        .map(|i| i.reference.as_str())
+        .collect();
+    assert_eq!(listed, vec![reference.as_str()]);
+}
+
+#[then(expr = "the prunable listing is empty")]
+fn prunable_empty(w: &mut BehaviourWorld) {
+    let rig = w.image();
+    let listed = rig
+        .last_prunable
+        .as_deref()
+        .expect("a prunable listing was taken");
+    assert!(listed.is_empty(), "got {listed:?}");
+}
+
 fn listing(rig: &ImageRig) -> &[lns_ipc::ImageInfo] {
     rig.last_list.as_deref().expect("a listing was taken")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -233,7 +233,7 @@ bare reference is qualified by `run.registry`, else the Lens hub (`hub.lns.run`)
 | `ls`       | —            | List what the local store holds — reference, kind, digest, size, and the sandbox holding each. `--kind` filters to `sandbox` (a pulled or built artifact) or `image` (the base OCI image one runs on). Alias: `list`. |
 | `inspect`  | `lns inspect`| Render one artifact's resolved content. With no operand, a path-shaped one (`.`, `lns.yaml`, `./dir`, `./lns.dev.yaml`), or `-f`/`--file`: that local document's effective form, offline — a `mixin` renders as one, not as a broken sandbox. For a cached reference: the artifact's kind and definition — a `sandbox`'s image, workdir, mounts, declared ports, filesets (`fileset: <source> -> <guestPath>`), connectors, declared tools (`tool: node@22.11.0`), its `pre-start` scripts with the user each asks for and its body printed whole, the mixins it resolved into (`mixin: <ref>`), and any over-broad-policy flag; a `mixin`'s own blocks as its author wrote them, unresolved; or a plain `image`. `--mixin <REF>` resolves that mixin in first (repeatable), so a composition can be previewed without starting a run. |
 | `rm`       | `lns rm`     | Remove one cached artifact and free its now-unreferenced layers. |
-| `prune`    | —            | Remove every cached artifact nothing holds and, when no sandbox is live, reclaim the provisioned tool cache. Asks first, unless `-f`/`--force`. |
+| `prune`    | —            | Remove every cached artifact nothing holds and, when no sandbox is live, reclaim the provisioned tool cache. Lists what it would remove and asks first, unless `-f`/`--force`. |
 
 The `./lns.yaml` document (`apiVersion: lns.run/v1`, `kind: sandbox`) carries a
 `spec` with `image` (**required** base OCI image), and the optional `command`,
@@ -278,7 +278,7 @@ workload does.
 | `ls`       | `lns ps`     | List running sandboxes with their state, CPU, and memory. `-a`/`--all` includes the stopped ones; a stopped sandbox has no guest to sample, so its CPU and memory read `-`. Alias: `list`. |
 | `inspect`  | `lns inspect`| Print one sandbox's live state and launch configuration. `--format <table\|json>` chooses the shape: `table` summarises it, `json` carries the whole launch configuration and the resolved policy. |
 | `rm`       | `lns rm`     | Remove a sandbox: its record and its writable layer go together, the name frees up, and the artifact it held is released. Refuses a running one; `-f`/`--force` stops it first. |
-| `prune`    | —            | Remove every stopped sandbox, writable layers included. Asks first, unless `-f`/`--force`. |
+| `prune`    | —            | Remove every stopped sandbox, writable layers included. Lists them and asks first, unless `-f`/`--force`. |
 
 ## `lns volume`
 
@@ -298,7 +298,7 @@ lns volume prune [-f]
 | `create <NAME>`  | Create a named volume ahead of its first `lns run -v` attach. No-op if it exists.    |
 | `inspect <NAME>` | Show a volume's capacity, on-disk bytes, age, and holder.                            |
 | `rm <NAME>`      | Remove a volume and its data; refused while a run holds it.                          |
-| `prune`          | Remove every volume not attached to a running sandbox. Prompts unless `-f`/`--force`.|
+| `prune`          | Remove every volume not attached to a running sandbox. Lists them and asks first, unless `-f`/`--force`.|
 
 See [Running workloads — volumes](running-workloads.md#volumes).
 


### PR DESCRIPTION
Stacked on #293.

The cli-spec prune rows (§ artifact `prune`, § sandbox `prune`, § volume `prune`) all say **"Lists them and asks, unless `-f`/`--force`"** — but every prune asked blind. This closes the gap for all three namespaces.

## What changed

- **The candidate list rides with the prompt on stderr.** The list is context for the question, not the command's answer, so per §4.1 it lands on the same stream as the prompt. A piped stdout still shows both.

  ```
  Would remove:
    hermes:1.0
    scribe:1.0
  This removes every cached sandbox not held by a running one ... Continue? [y/N]
  ```

- **Artifact candidates come from the service** via a new `Request::ListPrunableImages` (reply reuses `Response::ImageList`). The CLI cannot compute them from `ls` data: `ImageInfo.in_use_by` only names a *running* holder, while prune keeps the whole dependency closure of the actively-held roots — a base image whose sandbox is running shows `in_use_by: None` but is not removable. The service-side partition is extracted from `prune_with` into `removable_partition`, shared by prune and the new listing, so the list is exactly what the sweep would remove.

- **Sandbox and volume candidates reuse existing requests** (`ListRuns` filtered to stopped; `ListVolumes` filtered to `in_use_by: None`) — both match the service's own prune semantics exactly.

- **Empty candidate sets:** a sandbox or volume prune with nothing to remove prints the existing no-op line (`No stopped sandboxes.` / `No unused volumes.`) and never asks. An artifact prune still asks with nothing removable, because it also reclaims the provisioned tool cache when no sandbox is live — the prompt already says so.

- **Unchanged:** `-f`/`--force` skips the listing with the question; the §7.2 non-tty refusal still fires before any service call (the "no request reached the service" pins survive verbatim).

## Tests (red-first)

- New Layer 2 feature `prune_lists.feature` (8 scenarios): listing precedes the prompt on stderr (order-asserted), held candidates excluded, empty sets never prompt, `--force` sends no listing request.
- Service Layer 2: three new `image_management.feature` scenarios pinning that the prunable listing names only what prune would remove — including a base image protected solely through a live sandbox's dependency edge — and touches nothing.
- Layer 3: `prunable_references` / `stopped_run_names` / `unused_volume_names` sorting, filtering, short-id fallback, daemon-error and unexpected-variant paths; IPC round-trip pin for the new request; `handle_request` wiring pin.
- Amended pins: the decline scenarios now assert "no `PruneImages`/`PruneRuns` request" (a listing request legitimately precedes the prompt).

`make lint`, `make complexity`, and the full coverage gate are green; 449 lns-cli scenarios + 912 unit tests, 274 lns-service scenarios pass.

Closes #291
