### PR TITLE
fix: exit-code truth for pre-start failures and missing interpreters

### DIFF
--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -1428,7 +1428,7 @@ where
             )?;
             Ok(PrePhaseStep::Continue)
         }
-        WireFrame::Json(Response::RunExit { code }) => Ok(PrePhaseStep::EarlyExit(code)),
+        WireFrame::Json(Response::RunExit { .. }) => Ok(PrePhaseStep::EarlyExit(PRE_START_FAILURE)),
         WireFrame::Json(Response::Error { message }) => {
             anyhow::bail!("daemon error: {message}")
         }
@@ -1884,7 +1884,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drive_pre_phase_returns_early_exit_when_run_exits_before_session_ready() {
+    async fn a_run_exit_before_session_ready_is_lns_failing_never_the_workload() {
         let (mut client, mut server) = tokio::io::duplex(4096);
         tokio::spawn(async move {
             write_response(&mut server, run_log("Resolving", "ubuntu:latest")).await;
@@ -1894,7 +1894,11 @@ mod tests {
         let outcome = drive_pre_phase(&mut client, &mut buf, &mut no_progress(), false)
             .await
             .unwrap();
-        assert_eq!(outcome, PrePhaseOutcome::EarlyExit(42));
+        assert_eq!(
+            outcome,
+            PrePhaseOutcome::EarlyExit(PRE_START_FAILURE),
+            "the workload never started, so its encoded code must not leak through as a workload status"
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-session-broker/src/session.rs
+++ b/crates/lns-session-broker/src/session.rs
@@ -241,12 +241,28 @@ pub(crate) fn validate_argv(argv: &[String]) -> Option<Vec<CString>> {
     (cargs.len() == argv.len()).then_some(cargs)
 }
 
-/// A command the sandbox does not have exits 127 and one it has but cannot execute exits 126, so a caller can tell a typo from a file that is there but unusable.
-pub(crate) fn exec_failure_code(kind: io::ErrorKind) -> i32 {
-    match kind {
-        io::ErrorKind::NotFound => 127,
-        _ => 126,
+/// A command the sandbox does not have exits 127 and one it has but cannot execute exits 126, so a caller can tell a typo from a file that is there but unusable; execvp reports ENOENT for a missing interpreter too, so NotFound alone is not enough to claim 127.
+pub(crate) fn exec_failure_code(kind: io::ErrorKind, command_found: bool) -> i32 {
+    if kind == io::ErrorKind::NotFound && !command_found {
+        127
+    } else {
+        126
     }
+}
+
+pub(crate) fn command_is_present(
+    command: &str,
+    path: Option<&str>,
+    exists: &dyn Fn(&std::path::Path) -> bool,
+) -> bool {
+    if command.contains('/') {
+        return exists(std::path::Path::new(command));
+    }
+    path.is_some_and(|entries| {
+        entries
+            .split(':')
+            .any(|dir| exists(&std::path::Path::new(dir).join(command)))
+    })
 }
 
 pub fn read_client_frame(fd: RawFd) -> Option<ClientFrame> {
@@ -746,17 +762,54 @@ mod tests {
 
     #[test]
     fn a_missing_command_is_127_and_one_that_cannot_run_is_126() {
-        assert_eq!(exec_failure_code(io::ErrorKind::NotFound), 127);
+        assert_eq!(exec_failure_code(io::ErrorKind::NotFound, false), 127);
         for kind in [
             io::ErrorKind::PermissionDenied,
             io::ErrorKind::InvalidData,
             io::ErrorKind::IsADirectory,
         ] {
             assert_eq!(
-                exec_failure_code(kind),
+                exec_failure_code(kind, true),
                 126,
                 "{kind:?} means the command was found; only a missing one is 127"
             );
         }
+    }
+
+    #[test]
+    fn a_present_command_whose_interpreter_is_missing_is_126_not_127() {
+        assert_eq!(
+            exec_failure_code(io::ErrorKind::NotFound, true),
+            126,
+            "execvp reports ENOENT for a missing shebang interpreter or ELF loader too; the command itself was found, so it is not the 127 case"
+        );
+    }
+
+    #[test]
+    fn a_pathless_command_is_looked_up_through_every_path_entry() {
+        let exists = |p: &std::path::Path| p == std::path::Path::new("/usr/local/bin/tool");
+        assert!(command_is_present(
+            "tool",
+            Some("/bin:/usr/local/bin"),
+            &exists
+        ));
+        assert!(!command_is_present("tool", Some("/bin:/sbin"), &exists));
+        assert!(
+            !command_is_present("tool", None, &exists),
+            "no PATH means nowhere to find a pathless command"
+        );
+    }
+
+    #[test]
+    fn an_empty_path_entry_means_the_working_directory_like_execvp() {
+        let exists = |p: &std::path::Path| p == std::path::Path::new("tool");
+        assert!(command_is_present("tool", Some(":/bin"), &exists));
+    }
+
+    #[test]
+    fn a_command_with_a_slash_is_checked_directly_and_never_path_searched() {
+        let exists = |p: &std::path::Path| p == std::path::Path::new("./tool");
+        assert!(command_is_present("./tool", Some("/bin"), &exists));
+        assert!(!command_is_present("/bin/tool", Some("/bin"), &exists));
     }
 }

--- a/crates/lns-session-broker/src/session/real.rs
+++ b/crates/lns-session-broker/src/session/real.rs
@@ -576,7 +576,11 @@ fn exec_child(spec: &WorkloadSpec) -> ! {
     unsafe { libc::execvp(argv_ptrs[0], argv_ptrs.as_ptr()) };
     let failure = io::Error::last_os_error();
     let _ = writeln_stderr(&format!("execvp({:?}): {failure}", spec.argv[0]));
-    child_exit(super::exec_failure_code(failure.kind()));
+    let found =
+        super::command_is_present(&spec.argv[0], std::env::var("PATH").ok().as_deref(), &|p| {
+            p.exists()
+        });
+    child_exit(super::exec_failure_code(failure.kind(), found));
 }
 
 fn set_guest_hostname(hostname: Option<&str>) {


### PR DESCRIPTION
Fixes the two remaining findings from review of #281 (the other two were already addressed by #307: `lns sandbox run`/`exec` pre-start parity, and the inspect shortcut's `--format` refusal).

## A `RunExit` before `SessionReady` is `lns` failing, never the workload

The service encodes boot and session-setup failures as plain exit codes (`emit_completion` maps any pre-start error to `RunExit { code: 1 }`), and the CLI's pre-phase passed that code through as though the workload had produced it. §5 reserves 125 for a `run` or `exec` that fails before the workload starts, precisely so an infrastructure failure is never mistaken for a workload status.

`SessionReady` is the protocol marker for "the workload can now run" — the service emits it before the broker session that carries the workload's real status, so any `RunExit` that arrives earlier is by construction not a workload exit. `pre_phase_step` now maps every early `RunExit` to `PRE_START_FAILURE` (125); the error text the service logged alongside still reaches stderr.

## `execvp` ENOENT is only 127 when the command itself is absent

`execvp` reports ENOENT both for a command that is not there and for one that is there but names a missing shebang interpreter or ELF loader. The latter is the "found but cannot execute" case and must be 126. After an exec failure the broker child now probes whether the command resolves — directly for a name containing a slash, through each `PATH` entry otherwise (an empty entry meaning the working directory, as `execvp` treats it) — and only answers 127 when it does not.

The probe is a pure function (`command_is_present`) host-tested with an injected existence check; the guest leaf passes `Path::exists`.

## Tests

Red-first:

- `a_run_exit_before_session_ready_is_lns_failing_never_the_workload` — failed with `EarlyExit(42)` leaking through, now 125.
- `a_present_command_whose_interpreter_is_missing_is_126_not_127` plus `command_is_present` truth-table tests (PATH walk, empty-entry-is-cwd, slash-means-direct-check) — red via the new contract, green after.

Gates: `make lint`, `make complexity`, full-workspace `make coverage` all green.

Closes the two open review threads on #281.
