### PR TITLE
fix!: refuse unsafe LNS_HOME roots and show what --purge deletes

### DIFF
--- a/crates/lns-cli/src/build/push.rs
+++ b/crates/lns-cli/src/build/push.rs
@@ -7,9 +7,9 @@ use oci_client::{Reference, RegistryOperation, client::ClientConfig, secrets::Re
 use crate::build::push_auth::{auth_error, push_error, select_auth};
 
 /// The stored login for `reference`'s registry, or anonymous when none is recorded.
-fn registry_auth_for(reference: &Reference) -> RegistryAuth {
-    let loaded = JsonFileRegistryAuthStore::new(lns_ipc::registry_auth_path()).load();
-    select_auth(loaded, reference.registry())
+fn registry_auth_for(reference: &Reference) -> Result<RegistryAuth> {
+    let loaded = JsonFileRegistryAuthStore::new(lns_ipc::registry_auth_path()?).load();
+    Ok(select_auth(loaded, reference.registry()))
 }
 
 /// Upload a built artifact's blobs and then its exact manifest bytes to `target`, reusing the stored `lns login` credential (which must carry push scope).
@@ -21,7 +21,7 @@ pub(crate) async fn push_artifact(built: &BuiltArtifact, target: &str) -> Result
         protocol: lns_artifact::client_protocol_for(reference.registry()),
         ..Default::default()
     });
-    let auth = registry_auth_for(&reference);
+    let auth = registry_auth_for(&reference)?;
     client
         .auth(&reference, &auth, RegistryOperation::Push)
         .await

--- a/crates/lns-cli/src/connector/real.rs
+++ b/crates/lns-cli/src/connector/real.rs
@@ -14,8 +14,8 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
     Box::pin(async move {
         let args = super::ConnectorArgs::from_arg_matches(matches)?;
         let cwd = ctx.cwd()?;
-        let catalog_path = lns_ipc::connectors_path();
-        let grants_path = lns_ipc::workload_grants_path();
+        let catalog_path = lns_ipc::connectors_path()?;
+        let grants_path = lns_ipc::workload_grants_path()?;
         let signin = RealConnectorSignIn::new(crate::service::socket_path()?);
         let mut out = ctx.out;
         crate::connector::run(

--- a/crates/lns-cli/src/login/real.rs
+++ b/crates/lns-cli/src/login/real.rs
@@ -14,7 +14,7 @@ pub fn run_login<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutur
     Box::pin(async move {
         let args = LoginArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let auth_path = lns_ipc::registry_auth_path();
+        let auth_path = lns_ipc::registry_auth_path()?;
         let verifier = RealRegistryVerifier::new(crate::service::socket_path()?);
         let input = ctx.input;
         let mut out = ctx.out;
@@ -35,7 +35,7 @@ pub fn run_logout<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutu
     Box::pin(async move {
         let args = LogoutArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let auth_path = lns_ipc::registry_auth_path();
+        let auth_path = lns_ipc::registry_auth_path()?;
         let mut out = ctx.out;
         super::logout(&args, &default_registry, &auth_path, &mut out)
     })

--- a/crates/lns-cli/src/run/host_path_consent.rs
+++ b/crates/lns-cli/src/run/host_path_consent.rs
@@ -101,7 +101,7 @@ fn apply(
     if !entry.optional {
         bail!(
             "declined: {host_path} is required by this sandbox, so there is nothing to run without it — allow it, or edit {}",
-            lns_ipc::host_path_decisions_path().display()
+            lns_ipc::host_path_decisions_path()?.display()
         );
     }
     grant.denied.push(host_path.to_string());

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -496,11 +496,11 @@ pub async fn run_image(
         origin,
         filesets: &args.filesets,
         host_paths: &lns_policy::host_path_decisions::JsonFileHostPathDecisionStore::new(
-            lns_ipc::host_path_decisions_path(),
+            lns_ipc::host_path_decisions_path()?,
         ),
         bind_specs: &bind_specs,
         bind_decisions: &lns_policy::host_bind_decisions::JsonFileHostBindDecisionStore::new(
-            lns_ipc::host_bind_decisions_path(),
+            lns_ipc::host_bind_decisions_path()?,
         ),
         assume_yes: args.assume_yes,
         interactive,

--- a/crates/lns-cli/src/uninstall/mod.rs
+++ b/crates/lns-cli/src/uninstall/mod.rs
@@ -87,7 +87,7 @@ where
     A: LoginAgent,
     F: Fs,
 {
-    if !args.yes && !confirm(args.purge, input, writer)? {
+    if !args.yes && !confirm(args.purge, &plan.purge_dirs, input, writer)? {
         writeln!(writer, "Uninstall cancelled.")?;
         return Ok(0);
     }
@@ -104,11 +104,26 @@ where
     Ok(0)
 }
 
-fn confirm(purge: bool, input: &mut dyn BufRead, writer: &mut impl Write) -> Result<bool> {
+fn confirm(
+    purge: bool,
+    purge_dirs: &[PathBuf],
+    input: &mut dyn BufRead,
+    writer: &mut impl Write,
+) -> Result<bool> {
     if purge {
+        let targets = purge_dirs
+            .iter()
+            .map(|dir| dir.display().to_string())
+            .collect::<Vec<_>>()
+            .join(" and ");
+        let data_clause = if targets.is_empty() {
+            "deletes all local data".to_string()
+        } else {
+            format!("deletes all local data under {targets}")
+        };
         write!(
             writer,
-            "This stops all running sandboxes, removes the lns binaries and background service, and deletes all local data (cached images, named volumes, the audit trail, and stored credentials). Continue? [y/N] "
+            "This stops all running sandboxes, removes the lns binaries and background service, and {data_clause} (cached images, named volumes, the audit trail, and stored credentials). Continue? [y/N] "
         )?;
     } else {
         write!(
@@ -240,11 +255,21 @@ async fn remove_binaries(
 /// What `--purge` clears: the one directory lns keeps everything in, and the socket, which lives with the service rather than with your data.
 pub(crate) struct PurgeSources {
     pub lns_home: PathBuf,
+    pub home: Option<PathBuf>,
     pub socket: PathBuf,
     pub socket_overridden: bool,
 }
 
-pub(crate) fn purge_targets(src: PurgeSources) -> (Vec<PathBuf>, Vec<PathBuf>) {
+pub(crate) fn purge_targets(src: PurgeSources) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+    if !src.lns_home.is_absolute()
+        || src.lns_home.parent().is_none()
+        || src.home.as_deref() == Some(src.lns_home.as_path())
+    {
+        bail!(
+            "refusing to purge {}: the lns data root must be an absolute directory of its own, not the filesystem root or your home directory — check LNS_HOME",
+            src.lns_home.display()
+        );
+    }
     let mut dirs = vec![src.lns_home];
     let mut files = Vec::new();
     // A socket at its default lns-owned location takes its whole parent directory; an env-overridden one may live anywhere, so only the socket and the log beside it go.
@@ -257,7 +282,7 @@ pub(crate) fn purge_targets(src: PurgeSources) -> (Vec<PathBuf>, Vec<PathBuf>) {
             files.push(src.socket);
         }
     }
-    (dirs, files)
+    Ok((dirs, files))
 }
 
 #[cfg(test)]
@@ -897,6 +922,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn purge_confirmation_shows_the_resolved_roots_it_will_delete() {
+        let rig = rig(
+            FakeService::default(),
+            stopped_client(),
+            FakeAgent::new(DisableOutcome::WasNotRegistered),
+            FakeFs::default(),
+        );
+        let plan = UninstallPlan {
+            binaries: vec![PathBuf::from("/bin/lns")],
+            purge_dirs: vec![
+                PathBuf::from("/home/me/.lns"),
+                PathBuf::from("/run/user/1000/lns"),
+            ],
+            purge_files: Vec::new(),
+        };
+        let (code, out) = rig.run(&args(true, false), &plan, "n\n").await;
+        assert_eq!(code.unwrap(), 0);
+        assert!(
+            out.contains("/home/me/.lns") && out.contains("/run/user/1000/lns"),
+            "the prompt must show what will actually be deleted: {out}"
+        );
+    }
+
+    #[tokio::test]
     async fn non_purge_confirmation_says_data_is_kept() {
         let rig = rig(
             FakeService::default(),
@@ -1013,14 +1062,56 @@ mod tests {
     fn sources() -> PurgeSources {
         PurgeSources {
             lns_home: PathBuf::from("/home/me/.lns"),
+            home: Some(PathBuf::from("/home/me")),
             socket: PathBuf::from("/run/user/1000/lns/service.sock"),
             socket_overridden: false,
         }
     }
 
     #[test]
+    fn purge_refuses_the_filesystem_root_as_a_data_root() {
+        let err = purge_targets(PurgeSources {
+            lns_home: PathBuf::from("/"),
+            ..sources()
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains('/') && err.to_string().contains("refusing"),
+            "an LNS_HOME of / must never become an rm -rf target: {err}"
+        );
+    }
+
+    #[test]
+    fn purge_refuses_your_home_directory_itself_as_a_data_root() {
+        let err = purge_targets(PurgeSources {
+            lns_home: PathBuf::from("/home/me"),
+            ..sources()
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("/home/me"),
+            "LNS_HOME=$HOME must be refused, not deleted: {err}"
+        );
+    }
+
+    #[test]
+    fn purge_refuses_a_relative_data_root() {
+        for bad in [".", "relative/dir"] {
+            let err = purge_targets(PurgeSources {
+                lns_home: PathBuf::from(bad),
+                ..sources()
+            })
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("refusing"),
+                "{bad:?} must be refused: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn purge_takes_the_one_directory_lns_keeps_everything_in() {
-        let (dirs, files) = purge_targets(sources());
+        let (dirs, files) = purge_targets(sources()).unwrap();
         assert_eq!(
             dirs,
             vec![
@@ -1037,7 +1128,8 @@ mod tests {
         let (dirs, files) = purge_targets(PurgeSources {
             socket_overridden: true,
             ..sources()
-        });
+        })
+        .unwrap();
         assert!(
             !dirs.contains(&PathBuf::from("/run/user/1000/lns")),
             "an override's arbitrary parent must never be rm -rf'd"
@@ -1051,7 +1143,8 @@ mod tests {
         let (dirs, files) = purge_targets(PurgeSources {
             socket: PathBuf::from("/"),
             ..sources()
-        });
+        })
+        .unwrap();
         assert_eq!(dirs, vec![PathBuf::from("/home/me/.lns")]);
         assert_eq!(files, vec![PathBuf::from("/")]);
     }

--- a/crates/lns-cli/src/uninstall/real.rs
+++ b/crates/lns-cli/src/uninstall/real.rs
@@ -62,11 +62,12 @@ async fn build_plan(purge: bool) -> Result<UninstallPlan> {
 }
 
 fn purge_targets_from_env() -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
-    Ok(super::purge_targets(PurgeSources {
+    super::purge_targets(PurgeSources {
         lns_home: lns_ipc::lns_home().context("resolving the lns home directory")?,
+        home: dirs::home_dir(),
         socket: crate::service::socket_path()?,
         socket_overridden: std::env::var_os("LNS_SOCKET_PATH").is_some(),
-    }))
+    })
 }
 
 struct RealUninstallService {

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -16,7 +16,7 @@ pub use codec::{
 };
 pub use ledger::{ApprovalKind, AuthKind, Decision, LedgerEvent, LedgerRecord, fingerprint};
 pub use paths::{
-    NoLnsHome, audit_anchor_for_run, audit_log_for_run, audit_runs_root, build_cache_root,
+    LnsHomeError, audit_anchor_for_run, audit_log_for_run, audit_runs_root, build_cache_root,
     config_path, connection_ledger, connection_ledger_anchor, connectors_path, credentials_path,
     host_bind_decisions_path, host_path_decisions_path, lns_home, registry_auth_path, short_run_id,
     workload_grants_path,

--- a/crates/lns-ipc/src/paths.rs
+++ b/crates/lns-ipc/src/paths.rs
@@ -3,36 +3,55 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[error(
-    "could not determine your home directory; set LNS_HOME to the directory lns should keep its data in"
-)]
-pub struct NoLnsHome;
+pub enum LnsHomeError {
+    #[error(
+        "could not determine your home directory; set LNS_HOME to the absolute directory lns should keep its data in"
+    )]
+    NoHome,
+    #[error(
+        "LNS_HOME must be a non-empty absolute path, got {0:?}; lns keeps everything in one directory and will not scatter it relative to the working directory"
+    )]
+    NotAbsolute(String),
+}
 
 /// Everything lns keeps for you lives in one directory, so there is one thing to back up and one thing `lns uninstall --purge` removes.
-pub fn lns_home() -> Result<PathBuf, NoLnsHome> {
+pub fn lns_home() -> Result<PathBuf, LnsHomeError> {
     lns_home_with(|key| std::env::var_os(key), dirs::home_dir())
 }
 
 pub fn lns_home_with(
     env: impl Fn(&str) -> Option<OsString>,
     home: Option<PathBuf>,
-) -> Result<PathBuf, NoLnsHome> {
+) -> Result<PathBuf, LnsHomeError> {
     match env("LNS_HOME") {
-        Some(overridden) => Ok(PathBuf::from(overridden)),
-        None => home.map(|home| home.join(".lns")).ok_or(NoLnsHome),
+        Some(overridden) => {
+            let path = PathBuf::from(&overridden);
+            if path.as_os_str().is_empty() || !path.is_absolute() {
+                return Err(LnsHomeError::NotAbsolute(
+                    overridden.to_string_lossy().into_owned(),
+                ));
+            }
+            Ok(path)
+        }
+        None => home
+            .map(|home| home.join(".lns"))
+            .ok_or(LnsHomeError::NoHome),
     }
 }
 
-fn in_lns_home(name: &str) -> PathBuf {
-    under(lns_home(), name)
+/// These paths also feed secret writes, so no resolvable home is a refusal, never a project-relative fallback.
+fn per_machine_path(
+    home: Result<PathBuf, LnsHomeError>,
+    name: &str,
+) -> Result<PathBuf, LnsHomeError> {
+    Ok(home?.join(name))
 }
 
-/// A per-machine file lns keeps for you; with no home to resolve it lands in the working directory rather than failing a command that only wanted to read one that may not exist.
-fn under(home: Result<PathBuf, NoLnsHome>, name: &str) -> PathBuf {
-    home.unwrap_or_else(|_| PathBuf::from(".lns")).join(name)
+fn in_lns_home(name: &str) -> Result<PathBuf, LnsHomeError> {
+    per_machine_path(lns_home(), name)
 }
 
-pub fn build_cache_root() -> Result<PathBuf, NoLnsHome> {
+pub fn build_cache_root() -> Result<PathBuf, LnsHomeError> {
     Ok(lns_home()?.join("builds"))
 }
 
@@ -41,51 +60,51 @@ pub fn short_run_id(id: &str) -> &str {
 }
 
 /// A sandbox's chain outlives the sandbox, so it cannot live in `runs/`, which is what removing one deletes.
-pub fn audit_runs_root() -> Result<PathBuf, NoLnsHome> {
+pub fn audit_runs_root() -> Result<PathBuf, LnsHomeError> {
     Ok(lns_home()?.join("audit"))
 }
 
-pub fn audit_log_for_run(run_id: &str) -> Result<PathBuf, NoLnsHome> {
+pub fn audit_log_for_run(run_id: &str) -> Result<PathBuf, LnsHomeError> {
     Ok(audit_runs_root()?.join(run_id).join("audit.jsonl"))
 }
 
-pub fn audit_anchor_for_run(run_id: &str) -> Result<PathBuf, NoLnsHome> {
+pub fn audit_anchor_for_run(run_id: &str) -> Result<PathBuf, LnsHomeError> {
     Ok(audit_runs_root()?.join(run_id).join("audit.anchor"))
 }
 
-pub fn connection_ledger() -> Result<PathBuf, NoLnsHome> {
+pub fn connection_ledger() -> Result<PathBuf, LnsHomeError> {
     Ok(lns_home()?.join("ledger.jsonl"))
 }
 
-pub fn connection_ledger_anchor() -> Result<PathBuf, NoLnsHome> {
+pub fn connection_ledger_anchor() -> Result<PathBuf, LnsHomeError> {
     Ok(lns_home()?.join("ledger.anchor"))
 }
 
-pub fn config_path() -> Result<PathBuf, NoLnsHome> {
+pub fn config_path() -> Result<PathBuf, LnsHomeError> {
     Ok(lns_home()?.join("config.yaml"))
 }
 
-pub fn connectors_path() -> PathBuf {
+pub fn connectors_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("connectors.yaml")
 }
 
-pub fn credentials_path() -> PathBuf {
+pub fn credentials_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("credentials.json")
 }
 
-pub fn registry_auth_path() -> PathBuf {
+pub fn registry_auth_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("registry-auth.json")
 }
 
-pub fn workload_grants_path() -> PathBuf {
+pub fn workload_grants_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("workload-grants.json")
 }
 
-pub fn host_path_decisions_path() -> PathBuf {
+pub fn host_path_decisions_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("host-path-decisions.json")
 }
 
-pub fn host_bind_decisions_path() -> PathBuf {
+pub fn host_bind_decisions_path() -> Result<PathBuf, LnsHomeError> {
     in_lns_home("host-bind-decisions.json")
 }
 
@@ -107,6 +126,47 @@ mod tests {
     fn short_run_id_truncates_on_a_char_boundary_for_tampered_multibyte_ids() {
         assert_eq!(short_run_id("abcdefghijké"), "abcdefghijké");
         assert_eq!(short_run_id("aaaaaaaaaaaéz"), "aaaaaaaaaaaé");
+    }
+
+    #[test]
+    fn an_empty_lns_home_override_is_rejected_not_a_cwd_relative_root() {
+        let err = lns_home_with(
+            |key| (key == "LNS_HOME").then(|| OsString::from("")),
+            Some(PathBuf::from("/home/dev")),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("absolute"),
+            "an empty override must be refused with the way out named: {err}"
+        );
+    }
+
+    #[test]
+    fn a_relative_lns_home_override_is_rejected_before_it_can_scatter_data() {
+        for bad in ["relative/dir", ".", "./here"] {
+            let err = lns_home_with(
+                |key| (key == "LNS_HOME").then(|| OsString::from(bad)),
+                Some(PathBuf::from("/home/dev")),
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("absolute"),
+                "{bad:?} must be refused: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_per_machine_file_with_no_home_is_an_error_not_a_project_relative_write() {
+        let err = per_machine_path(Err(LnsHomeError::NoHome), "connectors.yaml").unwrap_err();
+        assert!(
+            err.to_string().contains("LNS_HOME"),
+            "these paths feed secret writes, so nowhere to keep them is a refusal: {err}"
+        );
+        assert_eq!(
+            per_machine_path(Ok(PathBuf::from("/home/dev/.lns")), "connectors.yaml").unwrap(),
+            PathBuf::from("/home/dev/.lns/connectors.yaml")
+        );
     }
 
     #[test]
@@ -149,12 +209,12 @@ mod tests {
             connection_ledger().unwrap(),
             connection_ledger_anchor().unwrap(),
             config_path().unwrap(),
-            connectors_path(),
-            credentials_path(),
-            registry_auth_path(),
-            workload_grants_path(),
-            host_path_decisions_path(),
-            host_bind_decisions_path(),
+            connectors_path().unwrap(),
+            credentials_path().unwrap(),
+            registry_auth_path().unwrap(),
+            workload_grants_path().unwrap(),
+            host_path_decisions_path().unwrap(),
+            host_bind_decisions_path().unwrap(),
         ] {
             assert!(
                 path.starts_with(&home),
@@ -183,19 +243,6 @@ mod tests {
         assert_eq!(
             connection_ledger_anchor().unwrap().parent(),
             ledger.parent()
-        );
-    }
-
-    #[test]
-    fn a_per_machine_file_falls_back_to_the_working_directory_rather_than_failing_a_read() {
-        // These callers only ever want to read a file that may not exist, so nowhere to look is an empty answer rather than a broken command.
-        assert_eq!(
-            under(Err(NoLnsHome), "connectors.yaml"),
-            PathBuf::from(".lns/connectors.yaml")
-        );
-        assert_eq!(
-            under(Ok(PathBuf::from("/home/dev/.lns")), "connectors.yaml"),
-            PathBuf::from("/home/dev/.lns/connectors.yaml")
         );
     }
 }

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -285,7 +285,11 @@ impl crate::artifact::mixin::MixinSource for RegistryMixins {
 }
 
 fn effective_machine_catalog() -> Vec<lns_policy::connectors::Connector> {
-    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+    let user = lns_ipc::connectors_path()
+        .map_err(|e| e.to_string())
+        .and_then(|path| {
+            lns_policy::connectors::Catalog::load_or_default(&path).map_err(|e| e.to_string())
+        })
         .unwrap_or_else(|e| {
             crate::log::warn!(
                 "unreadable user connector catalog ({e}); using the bundled catalog only"

--- a/crates/lns-service/src/image/real.rs
+++ b/crates/lns-service/src/image/real.rs
@@ -37,7 +37,10 @@ pub(crate) fn registry_auth_for(image: &str) -> RegistryAuth {
     let Ok(reference) = image.parse::<Reference>() else {
         return RegistryAuth::Anonymous;
     };
-    let store = JsonFileRegistryAuthStore::new(lns_ipc::registry_auth_path());
+    let Ok(auth_path) = lns_ipc::registry_auth_path() else {
+        return RegistryAuth::Anonymous;
+    };
+    let store = JsonFileRegistryAuthStore::new(auth_path);
     let Ok(file) = store.load() else {
         return RegistryAuth::Anonymous;
     };

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -352,8 +352,14 @@ async fn run_credential_bind(id: &str) -> Response {
     };
     use crate::credential_flow::store::{CredentialStore, JsonFileCredentialStore};
 
-    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
-        .unwrap_or_default();
+    let user = match lns_ipc::connectors_path() {
+        Ok(path) => lns_policy::connectors::Catalog::load_or_default(&path).unwrap_or_default(),
+        Err(e) => {
+            return Response::CredentialBindFailed {
+                reason: e.to_string(),
+            };
+        }
+    };
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let Some(integ) = catalog.iter().find(|i| i.id == id) else {
         return Response::CredentialBindFailed {
@@ -403,7 +409,14 @@ async fn run_credential_bind(id: &str) -> Response {
     };
     match resolve_bind_decision(delivery.request) {
         BindResolution::Persist(entry, decision) => {
-            let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
+            let store = match lns_ipc::credentials_path() {
+                Ok(path) => JsonFileCredentialStore::new(path),
+                Err(e) => {
+                    return Response::CredentialBindFailed {
+                        reason: e.to_string(),
+                    };
+                }
+            };
             let mut state = match store.load() {
                 Ok(state) => state,
                 Err(e) => {
@@ -431,8 +444,14 @@ pub(crate) async fn run_connector_sign_in(
 ) -> Response {
     use lns_policy::connectors::OauthFlow;
 
-    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
-        .unwrap_or_default();
+    let user = match lns_ipc::connectors_path() {
+        Ok(path) => lns_policy::connectors::Catalog::load_or_default(&path).unwrap_or_default(),
+        Err(e) => {
+            return Response::OauthSignInFailed {
+                reason: e.to_string(),
+            };
+        }
+    };
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let Some(oauth) = catalog
         .iter()
@@ -553,7 +572,8 @@ fn persist_oauth_token(
     clock: &dyn crate::oauth::Clock,
 ) -> std::io::Result<()> {
     use crate::credential_flow::store::{CredentialStore, JsonFileCredentialStore};
-    let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
+    let store =
+        JsonFileCredentialStore::new(lns_ipc::credentials_path().map_err(std::io::Error::other)?);
     let mut state = store.load()?;
     state.insert(id.to_string(), crate::oauth::entry_from_token(clock, token));
     store.save(&state)
@@ -563,7 +583,8 @@ fn persist_pkce_key(id: &str, key: String) -> std::io::Result<()> {
     use crate::credential_flow::store::{
         CredentialEntry, CredentialStore, JsonFileCredentialStore,
     };
-    let store = JsonFileCredentialStore::new(lns_ipc::credentials_path());
+    let store =
+        JsonFileCredentialStore::new(lns_ipc::credentials_path().map_err(std::io::Error::other)?);
     let mut state = store.load()?;
     state.insert(id.to_string(), CredentialEntry::Stored { value: key });
     store.save(&state)

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -208,6 +208,7 @@ async fn orchestrate(
         revocations_at_gate = policy
             .as_deref()
             .map(supervisor::revocations_before_gate)
+            .transpose()?
             .unwrap_or_default();
         signed_in = gate_declared_sign_ins(&plan.workload.credentials, &frame_tx).await?;
     }
@@ -702,14 +703,14 @@ async fn gate_declared_sign_ins(
     if credentials.is_empty() {
         return Ok(signed_in);
     }
-    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path())
+    let user = lns_policy::connectors::Catalog::load_or_default(&lns_ipc::connectors_path()?)
         .unwrap_or_default();
     let catalog = lns_policy::connectors::effective_connectors(&user);
     let declared = sign_in_gate_ids(credentials, &catalog);
     if declared.is_empty() {
         return Ok(signed_in);
     }
-    let state = JsonFileCredentialStore::new(lns_ipc::credentials_path())
+    let state = JsonFileCredentialStore::new(lns_ipc::credentials_path()?)
         .load()
         .unwrap_or_default();
     let plans = plan_declared_connectors(&declared, &catalog, &state);

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -306,16 +306,16 @@ fn record_boot_sign_in_grants(
 }
 
 /// Each connector's forget count as it stands before a run's boot sign-in gate opens, so a `lns connector disconnect` landing during a browser device flow — minutes, not milliseconds — still wins over the grant that sign-in would earn.
-pub(crate) fn revocations_before_gate(policy_path: &Path) -> HashMap<String, u64> {
+pub(crate) fn revocations_before_gate(policy_path: &Path) -> Result<HashMap<String, u64>> {
     let project = project_key(policy_path);
-    JsonFileGrantStore::new(lns_ipc::workload_grants_path())
+    Ok(JsonFileGrantStore::new(lns_ipc::workload_grants_path()?)
         .load()
         .unwrap_or_default()
         .revocations
         .iter()
         .filter(|r| r.project == project)
         .map(|r| (r.connector.clone(), r.count))
-        .collect()
+        .collect())
 }
 
 /// Defaults to an empty user catalog and warns on load error, so a malformed `~/.lns/connectors.yaml` doesn't break a run — the bundled catalog still applies.
@@ -522,7 +522,7 @@ async fn start_credential_subsystem(
     oauth: OauthWiring,
 ) -> Result<CredentialSubsystem> {
     // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
-    let credentials_path = lns_ipc::credentials_path();
+    let credentials_path = lns_ipc::credentials_path()?;
     let credential_store: Arc<dyn CredentialStore> =
         Arc::new(JsonFileCredentialStore::new(credentials_path.clone()));
     let mut initial_credential_state =
@@ -678,10 +678,10 @@ pub(super) async fn start(
 ) -> Result<SupervisorSession> {
     let sandbox_credentials = consent.credentials;
     let workload = consent.workload;
-    let connected = connected_in(&lns_ipc::workload_grants_path(), &project_key(policy_path));
+    let connected = connected_in(&lns_ipc::workload_grants_path()?, &project_key(policy_path));
     let (mut policy, own_policy) = running_policies(policy_path, sandbox_policy, connected)?;
     // Applied connectors resolve against the effective catalog (bundled ∪ user) into both wire credentials and allow-routes, captured once at boot so a later edit can't reach an already-forked workload.
-    let user_catalog = load_user_catalog_or_warn(&lns_ipc::connectors_path());
+    let user_catalog = load_user_catalog_or_warn(&lns_ipc::connectors_path()?);
     let catalog = lns_policy::connectors::effective_connectors(&user_catalog);
     let applied = resolve_applied_with_credentials(&policy, sandbox_credentials, &catalog);
     // Un-connected catalog connectors resolve as connectable — detect-only unless definition-declared — so their use offers a live connect.
@@ -714,7 +714,7 @@ pub(super) async fn start(
     log::info!("Approvals", "window ready");
 
     // A machine-global value arms only for a value key this workload holds an allow grant for, so a cloned overlay or a declared credential re-offers at first use instead of silently spending the credential.
-    let grants_path = lns_ipc::workload_grants_path();
+    let grants_path = lns_ipc::workload_grants_path()?;
     let grant_store: Arc<dyn GrantStore> = Arc::new(JsonFileGrantStore::new(grants_path.clone()));
     let mut grants = load_grants_or_warn(grant_store.as_ref(), &grants_path);
     let project = project_key(policy_path);
@@ -1402,7 +1402,7 @@ mod tests {
         seeded_sidecar(dir.path(), &policy_path);
         let _g = crate::test_env::EnvVarGuard::set("LNS_HOME", dir.path());
 
-        let counts = revocations_before_gate(&policy_path);
+        let counts = revocations_before_gate(&policy_path).expect("resolved counts");
 
         assert_eq!(
             counts,
@@ -1420,7 +1420,9 @@ mod tests {
         let _g = crate::test_env::EnvVarGuard::set("LNS_HOME", dir.path());
 
         assert!(
-            revocations_before_gate(&dir.path().join("lns-local-mixin.yaml")).is_empty(),
+            revocations_before_gate(&dir.path().join("lns-local-mixin.yaml"))
+                .expect("resolved counts")
+                .is_empty(),
             "a corrupt sidecar must not stop a launch here; the write that follows surfaces the same corruption with something the developer can act on"
         );
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -211,9 +211,10 @@ To delete that data too, add `--purge`:
 lns uninstall --purge
 ```
 
-`--purge` keeps only files you authored yourself, such as your
-`~/.lns/connectors.yaml` catalog and each project's `lns-local-mixin.yaml`, and prints
-what it left behind.
+`--purge` deletes the whole data directory — including the `~/.lns/connectors.yaml`
+connector catalog and stored credentials — and shows the resolved directory in its
+confirmation prompt. Files in your projects, such as each directory's `lns.yaml`
+and `lns-local-mixin.yaml`, are never touched.
 
 ## Where to go next
 


### PR DESCRIPTION
Addresses three of the four review findings on #282 (the fourth — service-owned credential storage — follows in its own PR).

## LNS_HOME resolution is now strict (`lns-ipc/src/paths.rs`)

- An empty or relative `LNS_HOME` is rejected with `LNS_HOME must be a non-empty absolute path` instead of silently resolving against whatever the current working directory happens to be.
- The cwd fallback in the per-machine path helpers is gone. `connectors_path`, `credentials_path`, `registry_auth_path`, `workload_grants_path`, `host_path_decisions_path`, and `host_bind_decisions_path` now return `Result` and surface the resolution failure to their caller — no more writing sidecars or credential files into a random working directory when the home directory can't be determined.
- `NoLnsHome` is replaced by the `LnsHomeError` enum (`NoHome`, `NotAbsolute`). Breaking, no shim.

Every call site across lns-cli and lns-service now propagates the error with context appropriate to its surface (IPC handlers answer with a failure response, catalog loads warn and fall back to the bundled catalog, registry-auth lookups fall back to anonymous).

## `lns uninstall --purge` validates the data root before deleting it

`purge_targets` now refuses to act when the resolved data root is not an absolute path, is the filesystem root, or is your home directory itself:

```
error: refusing to purge /home/me: the lns data root must be an absolute
directory of its own, not the filesystem root or your home directory — check LNS_HOME
```

And the confirmation prompt names the resolved directories it is about to remove, so a misconfigured `LNS_HOME` is visible before the `rm -rf`, not after:

```
This stops all running sandboxes, removes the lns binaries and background service,
and deletes all local data under /home/me/.lns and /home/me/.local/share/lns
(cached images, named volumes, the audit trail, and stored credentials). Continue? [y/N]
```

## Docs

`docs/getting-started.md` claimed `--purge` keeps `~/.lns/connectors.yaml`. It never did — the catalog lives inside the data root that purge deletes. The guide now says what ships: purge deletes the whole data directory and only project-local authored files (`lns.yaml`, `lns-local-mixin.yaml`) remain.

## Tests

Red-first throughout: new Layer 3 units pin the empty/relative `LNS_HOME` rejections, the `per_machine_path` error path, the three purge refusals (root `/`, home directory, relative root), and the resolved-roots confirmation prompt. The old cwd-fallback test is deleted with the behaviour.

Closes out findings 1, 3, and 4 of the #282 review.
