### PR TITLE
chore: build dependencies without debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ debug = "line-tables-only"
 [profile.test]
 debug = "line-tables-only"
 
+# Deps carry no debug info: Linux embeds dep DWARF into every artifact, and a full --all-targets build links them many times over.
+[profile.dev.package."*"]
+debug = false
+
 # `release-init` profile — for lns-init's static-musl PID-1 binary.
 # Inherits release (lto, strip) and adds size-killing options that
 # require a workspace-wide unification rule (`panic = "abort"` drops


### PR DESCRIPTION
## Problem

Development inside the lns sandbox shares a 95G volume across 2-4 git worktrees, and it runs out of space. A single worktree's `target/debug` reached **9.8G**, of which `target/debug/deps` was **8.6G**.

Incremental caches were not the cause — the Makefile already sets `CARGO_INCREMENTAL := 0` on gate targets, and the incremental dir measured 4K. The cost is debug info in dependencies. Linux defaults `split-debuginfo` to `off`, so dependency DWARF is embedded into every artifact that links it, and a `--workspace --all-targets` build links the dependency graph into every test binary.

## Change

Build all non-workspace dependencies with no debug info. Workspace crates keep `line-tables-only`, so our own frames are unaffected.

```toml
[profile.dev.package."*"]
debug = false
```

A `[profile.test.package."*"]` counterpart was written first and then removed: cargo builds dependencies of test targets under the **dev** profile, so a `test` package override never applies to any unit. The `dev` override alone produces the full effect, `cargo test` included.

## Measured, from clean

| | before | after | |
|---|---|---|---|
| Linux guest — `cargo build --workspace --exclude e2e-tests --all-targets`, `target/debug` | 9.8G | 3.0G | **−69%** |
| macOS host — `cargo build -p lns-cli --tests`, `debug/deps` | 1131 MB | 906 MB | −20% |
| macOS host — same, `debug` total | 1247 MB | 1007 MB | −19% |
| macOS host — same, build time | 33.8s | 28.9s | −15% |

The host saving is smaller because macOS defaults `split-debuginfo` to `unpacked`, so dependency DWARF already lived in separate object files there. Anyone measuring a debug-info setting on macOS will understate the Linux effect by roughly 3×.

## Cost

For non-workspace dependencies only:

- `RUST_BACKTRACE` backtraces lose `file:line` on dependency frames.
- lldb loses step-through detail for dependency code.

Panic **messages** keep `file:line` — that location comes from `core::panic::Location` at compile time, not from DWARF. Symbol names survive, because this emits `-C strip=debuginfo` rather than `strip=symbols`. Frames in our own crates are unchanged.

To debug into a dependency for one session, no file edit is needed:

```sh
cargo build --config 'profile.dev.package."*".debug="line-tables-only"'
```

## Verification

- `cargo build -v` confirms dependencies compile with `-C strip=debuginfo` and no `-C debuginfo` flag, while `lns-*` crates still get `-C debuginfo=line-tables-only` — the `"*"` glob does not match workspace members.
- `make coverage` is unaffected: `debug = false` drops DWARF only, whereas llvm-cov region mapping lives in `__llvm_covmap` / `__llvm_covfun`, and `coverage-strip-ast` parses source ASTs. A scoped coverage run produced a normal report with only `crates/` entries in the lcov.
- Full pre-push gate passed. `Cargo.toml` is in the `__FULL__` trigger set, so this ran full workspace coverage rather than the affected subset.
- `split-debuginfo = "unpacked"` was trialled on Linux on top of this change and made no further difference (3.0G either way), so it is deliberately not included.
