### PR TITLE
fix(lns-cli)!: make the run, exec, and inspect shortcuts exact aliases again

### DIFF
--- a/crates/e2e-tests/features/inspect_shortcut_flags.feature
+++ b/crates/e2e-tests/features/inspect_shortcut_flags.feature
@@ -1,0 +1,17 @@
+Feature: the inspect shortcut carries both namespaces' flags
+
+  §1.3: `lns inspect` is an exact alias for whichever namespaced spelling
+  the target settles on, so it takes each namespace's flags, and refuses a
+  flag the settled target does not take — by name, not by parser accident.
+
+  Scenario: --format on a named document is refused by name, exit 2
+    Given a clean lns cache home
+    When I run "lns inspect ./lns.yaml --format json"
+    Then the exit code is 2
+    And the output contains "renders as its author wrote it"
+
+  Scenario: --format with no operand is the default document, refused the same way
+    Given a clean lns cache home
+    When I run "lns inspect --format json"
+    Then the exit code is 2
+    And the output contains "renders as its author wrote it"

--- a/crates/e2e-tests/features/pre_start_exit_code.feature
+++ b/crates/e2e-tests/features/pre_start_exit_code.feature
@@ -1,0 +1,30 @@
+Feature: a run or exec that fails before the workload answers 125
+
+  §5: an error before the workload starts is `lns` failing, never the
+  workload — so it must never be mistaken for a workload that exited 1.
+  §1.3: `lns run` and `lns exec` name the same commands as their
+  `lns sandbox` spellings, exit code included.
+
+  Scenario: lns run answers 125 when the service is unreachable
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns run some-image"
+    Then the exit code is 125
+
+  Scenario: lns sandbox run is the same command, 125 included
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns sandbox run some-image"
+    Then the exit code is 125
+
+  Scenario: lns exec answers 125 when the service is unreachable
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns exec 1 -- true"
+    Then the exit code is 125
+
+  Scenario: lns sandbox exec is the same command, 125 included
+    Given a clean lns cache home
+    And no Lens Sandbox service is running
+    When I run "lns sandbox exec 1 -- true"
+    Then the exit code is 125

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -300,7 +300,7 @@ fn add(args: &ConnectorAddArgs, catalog_path: &Path, writer: &mut impl Write) ->
     writeln!(writer, "Declared connector {:?} in your catalog", args.id)?;
     writeln!(
         writer,
-        "Connect it to a project with `lns connect {}`.",
+        "Connect it to a project with `lns connector connect {}`.",
         args.id
     )?;
     Ok(0)
@@ -818,6 +818,19 @@ mod tests {
             lns_spec::credential::validate_placeholder(&cred.placeholder, "acme"),
             Ok(()),
             "a generated placeholder must satisfy the same rule the catalog enforces on load"
+        );
+    }
+
+    #[test]
+    fn the_add_hint_names_a_spelling_the_cli_recognizes() {
+        let dir = TempDir::new().unwrap();
+        let path = catalog_at(dir.path());
+        let mut out = Vec::new();
+        add(&add_args("acme"), &path, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("`lns connector connect acme`"),
+            "there is no top-level `lns connect`, so the next step must be spelled in full: {text}"
         );
     }
 

--- a/crates/lns-cli/src/sandbox/real.rs
+++ b/crates/lns-cli/src/sandbox/real.rs
@@ -10,11 +10,22 @@ use crate::service::real::RealSandboxService;
 pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
         let args = super::SandboxArgs::from_arg_matches(matches)?;
-        if let super::SandboxCommand::Run(run_args) = args.command {
-            return crate::service::launch_run(*run_args, ctx.debug).await;
+        match args.command {
+            super::SandboxCommand::Run(run_args) => Ok(crate::service::as_pre_start_failure(
+                crate::service::launch_run(*run_args, ctx.debug).await,
+            )),
+            super::SandboxCommand::Exec(exec_args) => {
+                let started = async {
+                    crate::service::require_running().await?;
+                    crate::service::exec_image(exec_args).await
+                };
+                Ok(crate::service::as_pre_start_failure(started.await))
+            }
+            command => {
+                crate::service::require_running().await?;
+                dispatch(super::SandboxArgs { command }, ctx.input).await
+            }
         }
-        crate::service::require_running().await?;
-        dispatch(args, ctx.input).await
     })
 }
 
@@ -77,12 +88,7 @@ pub fn run_attach<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutu
 
 // The caller already holds the process-wide stdin lock (run_from_matches), so this must borrow it — a second Stdin::lock on the same thread deadlocks every dispatched verb.
 pub async fn dispatch(args: super::SandboxArgs, input: &mut dyn std::io::BufRead) -> Result<i32> {
-    let command = match args.command {
-        super::SandboxCommand::Exec(exec_args) => {
-            return crate::service::exec_image(exec_args).await;
-        }
-        other => other,
-    };
+    let command = args.command;
     let svc = RealSandboxService::new(crate::service::socket_path()?);
     let term = TermInfo {
         stdin_is_tty: crate::raw_mode::stdin_is_tty(),

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -23,10 +23,10 @@ const NOT_RUNNING_MESSAGE: &str =
 
 mod orchestrator;
 pub use orchestrator::{
-    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, build_exec_request, dispatch,
-    drive_attached_session_with_writers, drive_pre_phase, exec_command, exec_image,
-    exec_image_on_stream, launch_run, pre_phase_step, render_started_run, render_status_line,
-    require_running, run_command, run_image,
+    DetachBehaviour, PrePhaseOutcome, PrePhaseStep, StdinForwarding, as_pre_start_failure,
+    build_exec_request, dispatch, drive_attached_session_with_writers, drive_pre_phase,
+    exec_command, exec_image, exec_image_on_stream, launch_run, pre_phase_step, render_started_run,
+    render_status_line, require_running, run_command, run_image,
 };
 
 use crate::command::{CommandSpec, subcommand};

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -33,7 +33,7 @@ fn primary_target(run_id: impl Into<String>) -> lns_ipc::SessionTarget {
 /// §5: a `run` or `exec` that fails is `lns` failing, never the workload — the workload's own status comes back as a code, so an error here is always the 125 case and is never mistaken for a workload that exited 1.
 pub const PRE_START_FAILURE: i32 = 125;
 
-fn as_pre_start_failure(result: Result<i32>) -> i32 {
+pub fn as_pre_start_failure(result: Result<i32>) -> i32 {
     match result {
         Ok(code) => code,
         Err(e) => {

--- a/crates/lns-cli/src/shortcut.rs
+++ b/crates/lns-cli/src/shortcut.rs
@@ -143,9 +143,46 @@ pub const RM_SPEC: CommandSpec = CommandSpec {
 };
 
 pub fn augment_inspect(app: clap::Command) -> clap::Command {
-    app.subcommand(subcommand::<crate::artifact::InspectArgs>("inspect").about(
+    app.subcommand(subcommand::<ShortcutInspectArgs>("inspect").about(
         "Inspect a sandbox or an artifact (shortcut for `lns sandbox inspect` / `lns artifact inspect`).",
     ))
+}
+
+#[derive(clap::Args)]
+pub struct ShortcutInspectArgs {
+    #[command(flatten)]
+    pub artifact: crate::artifact::InspectArgs,
+
+    #[arg(
+        long = "format",
+        value_name = "FORMAT",
+        help = "Output format, for a sandbox target. A document or cached artifact renders as itself."
+    )]
+    pub format: Option<crate::output::Format>,
+}
+
+/// What one `lns inspect` settled on, each the exact alias of a different namespaced spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InspectTarget {
+    Document,
+    Artifact,
+    Sandbox,
+}
+
+/// §1.3: the shortcut carries both namespaces' flags, so one the settled target does not take is refused by name, never dropped.
+pub fn refusal(target: InspectTarget, format: bool, mixin: bool) -> Option<String> {
+    match target {
+        InspectTarget::Document if format => Some(
+            "a local document renders as its author wrote it, so `lns artifact inspect` takes no `--format`; for a sandbox: `lns sandbox inspect <RUN> --format json`".to_string(),
+        ),
+        InspectTarget::Artifact if format => Some(
+            "a cached artifact renders as itself, so `lns artifact inspect` takes no `--format`; for a sandbox: `lns sandbox inspect <RUN> --format json`".to_string(),
+        ),
+        InspectTarget::Sandbox if mixin => Some(
+            "`--mixin` previews a document's composition, so `lns sandbox inspect` takes no `--mixin`; for an artifact: `lns artifact inspect <REF> --mixin <REF>`".to_string(),
+        ),
+        _ => None,
+    }
 }
 
 pub const INSPECT_SPEC: CommandSpec = CommandSpec {
@@ -307,5 +344,32 @@ mod tests {
         assert!(names_a_document(Some("./lns.dev.yaml")));
         assert!(!names_a_document(Some("reviewer")));
         assert!(!names_a_document(Some("ghcr.io/team/hermes:1.4.0")));
+    }
+
+    #[test]
+    fn a_flag_the_settled_target_does_not_take_is_refused_by_name() {
+        let doc = refusal(InspectTarget::Document, true, false).unwrap();
+        assert!(
+            doc.contains("renders as its author wrote it") && doc.contains("--format"),
+            "a document refusal says why the flag has no meaning there: {doc}"
+        );
+        let cached = refusal(InspectTarget::Artifact, true, false).unwrap();
+        assert!(
+            cached.contains("renders as itself") && cached.contains("--format"),
+            "a cached-artifact refusal says why: {cached}"
+        );
+        let run = refusal(InspectTarget::Sandbox, false, true).unwrap();
+        assert!(
+            run.contains("--mixin") && run.contains("lns sandbox inspect"),
+            "a sandbox refusal names the flag and the spelling that lacks it: {run}"
+        );
+    }
+
+    #[test]
+    fn a_flag_the_settled_target_takes_passes_without_a_word() {
+        assert_eq!(refusal(InspectTarget::Sandbox, true, false), None);
+        assert_eq!(refusal(InspectTarget::Document, false, true), None);
+        assert_eq!(refusal(InspectTarget::Artifact, false, true), None);
+        assert_eq!(refusal(InspectTarget::Document, false, false), None);
     }
 }

--- a/crates/lns-cli/src/shortcut/real.rs
+++ b/crates/lns-cli/src/shortcut/real.rs
@@ -45,11 +45,18 @@ pub(super) fn run_rm<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunF
 
 pub(super) fn run_inspect<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
-        let args = crate::artifact::InspectArgs::from_arg_matches(matches)?;
-        if args.file.is_some() || names_a_document(args.reference.as_deref()) {
-            return crate::artifact::real::run_inspect_offline(args, ctx);
+        let args = super::ShortcutInspectArgs::from_arg_matches(matches)?;
+        let format_given = args.format.is_some();
+        let mixin_given = !args.artifact.mixins.is_empty();
+        let refuse = |target| super::refusal(target, format_given, mixin_given);
+        if args.artifact.file.is_some() || names_a_document(args.artifact.reference.as_deref()) {
+            if let Some(message) = refuse(super::InspectTarget::Document) {
+                return usage_error(&message);
+            }
+            return crate::artifact::real::run_inspect_offline(args.artifact, ctx);
         }
         let reference = args
+            .artifact
             .reference
             .clone()
             .expect("a reference-less inspect is a local document, settled above");
@@ -58,20 +65,26 @@ pub(super) fn run_inspect<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) ->
         let default_registry = crate::artifact::real::configured_registry()?;
         match which(&svc, "inspect", &reference, default_registry.as_deref()).await? {
             Owner::Artifact => {
+                if let Some(message) = refuse(super::InspectTarget::Artifact) {
+                    return usage_error(&message);
+                }
                 crate::artifact::real::dispatch(
-                    crate::artifact::ArtifactCommand::Inspect(args),
+                    crate::artifact::ArtifactCommand::Inspect(args.artifact),
                     ctx.input,
                 )
                 .await
             }
             _ => {
+                if let Some(message) = refuse(super::InspectTarget::Sandbox) {
+                    return usage_error(&message);
+                }
                 crate::sandbox::real::dispatch(
                     crate::sandbox::SandboxArgs {
                         command: crate::sandbox::SandboxCommand::Inspect(
                             crate::sandbox::SandboxInspectArgs {
                                 run: reference,
                                 output: crate::output::OutputArgs {
-                                    format: crate::output::Format::Table,
+                                    format: args.format.unwrap_or(crate::output::Format::Table),
                                 },
                             },
                         ),
@@ -82,4 +95,9 @@ pub(super) fn run_inspect<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) ->
             }
         }
     })
+}
+
+fn usage_error(message: &str) -> anyhow::Result<i32> {
+    eprintln!("error: {message}");
+    Ok(2)
 }

--- a/crates/lns-cli/tests/behaviours/parse_errors.feature
+++ b/crates/lns-cli/tests/behaviours/parse_errors.feature
@@ -53,11 +53,9 @@ Feature: clap rejects bad input with exit code 2
     And the output contains "unexpected argument"
     And the output contains "--format"
 
-  Scenario: the lns inspect shortcut refuses --format the same way as its namespaced artifact spelling
-    When I run "lns inspect ./lns.yaml --format json"
-    Then the exit code is 2
-    And the output contains "unexpected argument"
-    And the output contains "--format"
+  Scenario: the lns inspect shortcut parses --format, because a sandbox target takes it
+    When I run "lns inspect 3 --format json"
+    Then the exit code is 0
 
   Scenario: lns policy is not a command — a rule is recorded by answering the run's prompt
     When I run "lns policy list"

--- a/crates/lns-policy/src/grants.rs
+++ b/crates/lns-policy/src/grants.rs
@@ -346,7 +346,7 @@ impl JsonFileGrantStore {
         Self { path }
     }
 
-    /// Suffixed rather than `with_extension`, which would replace the sidecar's own extension on an arbitrary `LNS_WORKLOAD_GRANTS_PATH`.
+    /// Suffixed rather than `with_extension`, which would replace the sidecar's own extension on an arbitrary caller-supplied path.
     fn lock_path(&self) -> PathBuf {
         let mut p = self.path.clone().into_os_string();
         p.push(".lock");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -74,7 +74,9 @@ parse the human table:
 
 `table` is the default everywhere, including the two `inspect` verbs — the table is
 a summary a reader scans, the JSON is the record. `lns artifact inspect` renders a
-document as its author wrote it and takes no `--format`.
+document as its author wrote it and takes no `--format`. The `lns inspect` shortcut
+takes it, passes it through when the target settles as a sandbox, and refuses it —
+saying why — when the target is a document or a cached artifact.
 
 `lns audit` takes `--format <table|jsonl>` instead — a timeline is an event stream, so
 its machine-readable form is one JSON event per line. The older `--json` spelling still


### PR DESCRIPTION
This PR makes the `lns sandbox` spellings of `run` and `exec` answer `125` for a pre-start failure, the way their top-level shortcuts already do.

## The gap

§5 says a `run` or `exec` that fails before the workload starts is `lns` failing, never the workload — exit `125`, so it is never mistaken for a workload that exited `1`. §1.3 says a shortcut and its namespaced spelling are the same command — same arguments, same output.

`lns run` and `lns exec` kept that promise. Their `lns sandbox` spellings did not: the alias paths bubbled a pre-start error straight to the generic exit `1`.

```console
$ lns run some-image        # service not running
Error: Lens Sandbox is not running. Run `lns service start` to start it.
$ echo $?
125
$ lns sandbox run some-image
Error: Lens Sandbox is not running. Run `lns service start` to start it.
$ echo $?
1        # ← before this PR
```

## The fix

`sandbox::real::run` now wraps both alias launches in the same `as_pre_start_failure` the top-level `run` and `exec` specs use. The `Exec` interception moves up from `dispatch` to sit beside `Run`, so both spellings share one shape: parse, wrap, launch. `as_pre_start_failure` becomes `pub` so the sandbox wiring can name it.

## Tests

The fix sites are production wiring (`sandbox/real.rs`, `orchestrator.rs` — both IGNORES-exempt), so the pin is Layer 1: a new `pre_start_exit_code.feature` drives all four spellings against a dead service socket and asserts `125` for each. Written red first — the two alias scenarios failed with exit `1` before the fix.


## Second repair: the inspect shortcut lost `--format` in #283

#283 gave the `lns inspect` shortcut the artifact namespace's arguments, and `lns artifact inspect` takes no `--format`. So `lns inspect <RUN> --format json` became a parse error, while `lns sandbox inspect <RUN> --format json` works — the same §1.3 break, in the other direction.

The shortcut now carries both namespaces' flags, and refuses the one the settled target does not take — by name, not by parser accident:

```console
$ lns inspect ./lns.yaml --format json
error: a local document renders as its author wrote it, so `lns artifact inspect`
takes no `--format`; for a sandbox: `lns sandbox inspect <RUN> --format json`
$ echo $?
2
```

- A **sandbox** target takes `--format` and passes it through; `--mixin` is refused there the same way, instead of being dropped without a word.
- A **document** or **cached artifact** target refuses `--format`, saying why, exit `2` — the usage-error code its namespaced spelling answers.

The decision (`InspectTarget` × flags → refusal) lives in `shortcut.rs` under the 100% gate, with Layer 3 truth-table tests. A new Layer 1 `inspect_shortcut_flags.feature` pins the document refusal through the real binary (red first: the old message was clap's `unexpected argument`). The existing #283 parse pin flips to assert the shortcut now parses `--format`.

Also swept in: a stale comment in `lns-policy/src/grants.rs` still naming the `LNS_WORKLOAD_GRANTS_PATH` variable #282 deleted.


## Third repair: the `add` hint names a spelling the CLI recognizes

A successful `lns connector add` closed with "Connect it to a project with `lns connect <id>`." — but there is no top-level `lns connect`, and §3.3 defines no such shortcut. The next step is now spelled in full: `lns connector connect <id>`. A Layer 3 test pins the hint (red first: the old text named the spelling that does not parse).
