### PR TITLE
fix!: land the review repairs for the artifact-namespace split (#283) — arbitration, --mixin rooting, docs

### DIFF
--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -309,6 +309,14 @@ pub struct InspectArgs {
     pub mixins: Vec<String>,
 }
 
+impl InspectArgs {
+    /// A `--mixin` directory is the user's, so it roots where they typed it; the service reads an absolute path or nothing.
+    pub fn root_mixins(&mut self, cwd: &std::path::Path) -> Result<()> {
+        self.mixins = crate::run::target::root_named_directories(&self.mixins, cwd)?;
+        Ok(())
+    }
+}
+
 #[derive(clap::Args)]
 pub struct RmArgs {
     #[arg(value_name = "REF", help = "Cached artifact reference to remove.")]
@@ -1518,6 +1526,21 @@ mod tests {
         .await
         .unwrap_err();
         assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[test]
+    fn a_relative_mixin_directory_roots_at_the_invocation_directory() {
+        let mut args = InspectArgs {
+            reference: Some("ghcr.io/team/hermes:1.4.0".into()),
+            file: None,
+            mixins: vec!["./obs".into(), "ghcr.io/team/obs:1".into()],
+        };
+        args.root_mixins(std::path::Path::new("/project/sub")).unwrap();
+        assert_eq!(
+            args.mixins,
+            vec!["/project/sub/obs".to_string(), "ghcr.io/team/obs:1".to_string()],
+            "a directory roots where the user typed it; a registry reference passes untouched"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -1535,10 +1535,14 @@ mod tests {
             file: None,
             mixins: vec!["./obs".into(), "ghcr.io/team/obs:1".into()],
         };
-        args.root_mixins(std::path::Path::new("/project/sub")).unwrap();
+        args.root_mixins(std::path::Path::new("/project/sub"))
+            .unwrap();
         assert_eq!(
             args.mixins,
-            vec!["/project/sub/obs".to_string(), "ghcr.io/team/obs:1".to_string()],
+            vec![
+                "/project/sub/obs".to_string(),
+                "ghcr.io/team/obs:1".to_string()
+            ],
             "a directory roots where the user typed it; a registry reference passes untouched"
         );
     }

--- a/crates/lns-cli/src/artifact/real.rs
+++ b/crates/lns-cli/src/artifact/real.rs
@@ -28,6 +28,11 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
             )
             .await;
         }
+        if let ArtifactCommand::Inspect(inspect) = &mut args.command
+            && !inspect.mixins.is_empty()
+        {
+            inspect.root_mixins(&ctx.cwd()?)?;
+        }
         crate::service::require_running().await?;
         dispatch(args.command, ctx.input).await
     })

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -1339,6 +1339,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inspect_answers_the_typed_miss_as_no_such_run() {
+        let svc = CannedService::new(Response::RunUnknown {
+            run: "ghost".into(),
+        });
+        let mut out = Vec::new();
+        let err = inspect(&svc, "ghost", crate::output::Format::Table, &mut out)
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("no such run: ghost"));
+    }
+
+    #[tokio::test]
     async fn inspect_surfaces_a_daemon_error() {
         let svc = CannedService::new(Response::Error {
             message: "no active run with id 1".into(),

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -685,6 +685,7 @@ async fn inspect<W: std::io::Write>(
             render_inspect(&details, policy, format, out)?;
             Ok(0)
         }
+        Response::RunUnknown { run } => bail!("no such run: {run}"),
         Response::Error { message } => bail!("daemon error: {message}"),
         other => bail!("unexpected response from daemon: {other:?}"),
     }

--- a/crates/lns-cli/src/shortcut.rs
+++ b/crates/lns-cli/src/shortcut.rs
@@ -64,18 +64,23 @@ fn with_default_tag(reference: &str) -> Option<String> {
     (!name.contains(':') && !name.contains('@')).then(|| format!("{reference}:latest"))
 }
 
+/// Only an explicit miss counts as one: an ambiguity or a failed probe must reach the user, or the other namespace acts on a word it never settled.
 async fn ask_both(
     svc: &impl SandboxService,
     operand: &str,
     default_registry: Option<&str>,
 ) -> Result<Owner> {
-    let is_a_sandbox = matches!(
-        svc.one_shot(Request::InspectRun {
+    let is_a_sandbox = match svc
+        .one_shot(Request::InspectRun {
             run: operand.to_string(),
         })
-        .await?,
-        Response::RunInspect { .. }
-    );
+        .await?
+    {
+        Response::RunInspect { .. } => true,
+        Response::RunUnknown { .. } => false,
+        Response::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    };
     let is_an_artifact = match svc.one_shot(Request::ListImages).await? {
         Response::ImageList { images } => cache_holds(&images, operand, default_registry),
         Response::Error { message } => {
@@ -316,20 +321,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_cache_listing_error_refuses_arbitration_instead_of_guessing() {
-        let svc = crate::test_service::CannedService::new(Response::Error {
-            message: "cache unavailable".to_string(),
-        });
-        let err = which(&svc, "rm", "ghost", None).await.unwrap_err();
-        assert!(
-            format!("{err:#}").contains("cache unavailable"),
-            "a lookup failure fails closed and names its cause, never 'no artifact': {err:#}"
-        );
-    }
-
-    #[tokio::test]
     async fn an_off_script_cache_reply_refuses_arbitration_too() {
-        let svc = crate::test_service::CannedService::new(Response::Acknowledged);
+        let svc = crate::test_service::CannedService::with_list_images(
+            Response::RunUnknown {
+                run: "ghost".to_string(),
+            },
+            Response::Acknowledged,
+        );
         let err = which(&svc, "rm", "ghost", None).await.unwrap_err();
         assert!(
             format!("{err:#}").contains("cannot be arbitrated"),
@@ -371,5 +369,67 @@ mod tests {
         assert_eq!(refusal(InspectTarget::Document, false, true), None);
         assert_eq!(refusal(InspectTarget::Artifact, false, true), None);
         assert_eq!(refusal(InspectTarget::Document, false, false), None);
+    }
+
+    #[tokio::test]
+    async fn an_ambiguous_run_prefix_is_surfaced_never_settled_as_an_artifact() {
+        let svc = crate::test_service::CannedService::with_list_images(
+            Response::Error {
+                message: "ambiguous run id prefix: 1a2b".to_string(),
+            },
+            Response::ImageList {
+                images: vec![cached("1a2b")],
+            },
+        );
+        let err = which(&svc, "rm", "1a2b", None).await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("ambiguous run id prefix: 1a2b"),
+            "an ambiguity must reach the user, or `lns rm` deletes an artifact it never named: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_run_miss_is_an_answer_so_the_cached_artifact_wins_arbitration() {
+        let svc = crate::test_service::CannedService::with_list_images(
+            Response::RunUnknown {
+                run: "hermes:1.4.0".to_string(),
+            },
+            Response::ImageList {
+                images: vec![cached("ghcr.io/team/hermes:1.4.0")],
+            },
+        );
+        assert_eq!(
+            which(&svc, "inspect", "ghcr.io/team/hermes:1.4.0", None)
+                .await
+                .unwrap(),
+            Owner::Artifact
+        );
+    }
+
+    #[tokio::test]
+    async fn a_service_that_cannot_list_the_cache_fails_the_arbitration_aloud() {
+        let svc = crate::test_service::CannedService::with_list_images(
+            Response::RunUnknown {
+                run: "ghost".to_string(),
+            },
+            Response::Error {
+                message: "cache unavailable".to_string(),
+            },
+        );
+        let err = which(&svc, "rm", "ghost", None).await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("cache unavailable"),
+            "an operational failure is not a miss — `rm` must not fall through to the sandbox namespace: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unexpected_reply_to_either_probe_is_refused_by_name() {
+        let svc = crate::test_service::CannedService::new(Response::Pong);
+        let err = which(&svc, "rm", "ghost", None).await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("unexpected response"),
+            "a reply neither probe understands cannot settle ownership: {err:#}"
+        );
     }
 }

--- a/crates/lns-cli/src/shortcut/real.rs
+++ b/crates/lns-cli/src/shortcut/real.rs
@@ -68,8 +68,12 @@ pub(super) fn run_inspect<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) ->
                 if let Some(message) = refuse(super::InspectTarget::Artifact) {
                     return usage_error(&message);
                 }
+                let mut inspect = args.artifact;
+                if !inspect.mixins.is_empty() {
+                    inspect.root_mixins(&ctx.cwd()?)?;
+                }
                 crate::artifact::real::dispatch(
-                    crate::artifact::ArtifactCommand::Inspect(args.artifact),
+                    crate::artifact::ArtifactCommand::Inspect(inspect),
                     ctx.input,
                 )
                 .await

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -15,6 +15,7 @@ pub(crate) struct CannedService {
     inspect_image_response: Option<Response>,
     remove_image_response: Option<Response>,
     list_prunable_response: Option<Response>,
+    list_images_response: Option<Response>,
     frames: Vec<Vec<u8>>,
     pub requests: Arc<Mutex<Vec<Request>>>,
 }
@@ -27,8 +28,16 @@ impl CannedService {
             inspect_image_response: None,
             remove_image_response: None,
             list_prunable_response: None,
+            list_images_response: None,
             frames: Vec::new(),
             requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn with_list_images(response: Response, list_images: Response) -> Self {
+        Self {
+            list_images_response: Some(list_images),
+            ..Self::new(response)
         }
     }
 
@@ -146,6 +155,10 @@ impl SandboxService for CannedService {
                 .list_prunable_response
                 .clone()
                 .unwrap_or(Response::ImageList { images: Vec::new() }),
+            Request::ListImages => self
+                .list_images_response
+                .clone()
+                .unwrap_or_else(|| self.response.clone()),
             _ => self.response.clone(),
         };
         self.requests.lock().unwrap().push(request);

--- a/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_inspect_cli.feature
@@ -66,6 +66,12 @@ Feature: inspecting a typed artifact before running it
     Then the exit code is 0
     And the output contains "credential: SOME_TOKEN -> api.some-provider.example"
 
+  Scenario: a mixin directory named by a relative path is rooted before it reaches the service
+    Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox with launch settings
+    When the user runs "lns inspect registry.example.test/some-sandbox:1.0 --mixin ./obs"
+    Then the exit code is 0
+    And the inspect request names the "obs" mixin directory by its absolute path
+
   Scenario: a mixin the user names reads as the tag and the digest it pinned to
     Given the service inspects "registry.example.test/some-sandbox:1.0" as a sandbox the user's mixin "obs-tools:2" resolved into "ghcr.io/acme/obs@sha256:5b9e1f0a7c3d284e6b15f907a2c8d63b40e19a7c25f8b0d3e6a94c17f582aa41"
     When the user runs "lns inspect registry.example.test/some-sandbox:1.0 --mixin obs-tools:2"

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -87,8 +87,8 @@ fn published_sandbox_declaring_tools(w: &mut BehaviourWorld) {
         mem_mib: None,
         disk_bytes: None,
     };
-    w.sandbox.response = Some(Response::Error {
-        message: format!("no active run with id {TOOLS_REFERENCE}"),
+    w.sandbox.response = Some(Response::RunUnknown {
+        run: TOOLS_REFERENCE.to_string(),
     });
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Sandbox(Box::new(view.clone())),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -801,6 +801,20 @@ fn service_received_no_pull(w: &mut BehaviourWorld) {
     );
 }
 
+#[then(regex = r#"^the inspect request names the "([^"]+)" mixin directory by its absolute path$"#)]
+fn inspect_request_roots_the_mixin(w: &mut BehaviourWorld, name: String) {
+    let requests = w.sandbox.requests.lock().unwrap();
+    let mixins = requests
+        .iter()
+        .find_map(|request| match request {
+            Request::InspectImage { mixins, .. } => Some(mixins.clone()),
+            _ => None,
+        })
+        .expect("an inspect request");
+    let expected = w.cwd.as_ref().expect("cwd").path().join(&name);
+    assert_eq!(mixins, vec![expected.to_str().expect("utf-8 path").to_string()]);
+}
+
 #[then("the pull request is bound to the inspected digest")]
 fn pull_is_bound_to_inspected_digest(w: &mut BehaviourWorld) {
     let requests = w.sandbox.requests.lock().unwrap();
@@ -886,12 +900,21 @@ async fn run_lns_inspect(w: &mut BehaviourWorld, tail: String) {
     let mut stdout: Vec<u8> = Vec::new();
     let mut stderr: Vec<u8> = Vec::new();
     let result = if owner == lns_cli::shortcut::Owner::Artifact {
+        let mut inspect_args = lns_cli::artifact::InspectArgs {
+            reference: Some(reference),
+            mixins,
+            file: None,
+        };
+        if !inspect_args.mixins.is_empty() {
+            if w.cwd.is_none() {
+                w.cwd = Some(tempfile::TempDir::new().expect("create tempdir"));
+            }
+            inspect_args
+                .root_mixins(w.cwd.as_ref().expect("cwd").path())
+                .expect("root mixins");
+        }
         lns_cli::artifact::run_with_writers(
-            &lns_cli::artifact::ArtifactCommand::Inspect(lns_cli::artifact::InspectArgs {
-                reference: Some(reference),
-                mixins,
-                file: None,
-            }),
+            &lns_cli::artifact::ArtifactCommand::Inspect(inspect_args),
             &svc,
             TermInfo::default(),
             &mut std::io::Cursor::new(""),

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -812,7 +812,10 @@ fn inspect_request_roots_the_mixin(w: &mut BehaviourWorld, name: String) {
         })
         .expect("an inspect request");
     let expected = w.cwd.as_ref().expect("cwd").path().join(&name);
-    assert_eq!(mixins, vec![expected.to_str().expect("utf-8 path").to_string()]);
+    assert_eq!(
+        mixins,
+        vec![expected.to_str().expect("utf-8 path").to_string()]
+    );
 }
 
 #[then("the pull request is bound to the inspected digest")]

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_inspect_cli.rs
@@ -10,8 +10,8 @@ fn full_digest() -> String {
 }
 
 fn not_running(reference: &str) -> Response {
-    Response::Error {
-        message: format!("no active run with id {reference}"),
+    Response::RunUnknown {
+        run: reference.to_string(),
     }
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -30,8 +30,8 @@ fn reference_resolves_to_running(w: &mut BehaviourWorld, name: String) {
 #[given(regex = r#"^the reference "([^"]+)" resolves to a cached sandbox$"#)]
 fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.cached_references = vec![reference.clone()];
-    w.sandbox.response = Some(Response::Error {
-        message: format!("no active run with id {reference}"),
+    w.sandbox.response = Some(Response::RunUnknown {
+        run: reference.to_string(),
     });
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Sandbox(Box::new(SandboxView {
@@ -64,8 +64,8 @@ fn reference_resolves_to_cached(w: &mut BehaviourWorld, reference: String) {
 )]
 fn cached_sandbox_sole_owner(w: &mut BehaviourWorld, reference: String) {
     w.sandbox.cached_references = vec![reference.clone()];
-    w.sandbox.response = Some(Response::Error {
-        message: format!("no active run with id {reference}"),
+    w.sandbox.response = Some(Response::RunUnknown {
+        run: reference.to_string(),
     });
     w.sandbox.inspect_image_response = Some(Response::ImageInspected {
         inspection: ArtifactInspection::Image(lns_ipc::ImageView {
@@ -215,8 +215,8 @@ fn names_both(w: &mut BehaviourWorld, name: String) {
 
 #[given(regex = r#"^"([^"]+)" names neither a sandbox nor a cached artifact$"#)]
 fn names_neither(w: &mut BehaviourWorld, name: String) {
-    w.sandbox.response = Some(Response::Error {
-        message: format!("no active run with id {name}"),
+    w.sandbox.response = Some(Response::RunUnknown {
+        run: name.to_string(),
     });
     w.sandbox.inspect_image_response = Some(Response::Error {
         message: format!("no such image: {name}"),

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -204,6 +204,10 @@ pub enum Response {
     RunInspect {
         details: Box<RunDetails>,
     },
+    /// No run answers to the handle — distinct from `Error` so a caller can treat a miss as an answer, never as a fault.
+    RunUnknown {
+        run: String,
+    },
     RunStats {
         stats: RunStatsInfo,
     },

--- a/crates/lns-service/src/ipc/adapter.rs
+++ b/crates/lns-service/src/ipc/adapter.rs
@@ -258,8 +258,8 @@ impl super::StartHost for RealStartHost {
 async fn handle_stats(mut stream: UnixStream, run: String) -> anyhow::Result<()> {
     let run_id = match crate::run_registry::resolve(&run) {
         Ok(id) => id,
-        Err(message) => {
-            let _ = write_error(&mut stream, message).await;
+        Err(e) => {
+            let _ = write_error(&mut stream, e.to_string()).await;
             return Ok(());
         }
     };
@@ -283,8 +283,8 @@ async fn handle_stats(mut stream: UnixStream, run: String) -> anyhow::Result<()>
 async fn handle_logs(mut stream: UnixStream, run: String, follow: bool) -> anyhow::Result<()> {
     let run_id = match crate::run_registry::resolve(&run) {
         Ok(id) => id,
-        Err(message) => {
-            let _ = write_error(&mut stream, message).await;
+        Err(e) => {
+            let _ = write_error(&mut stream, e.to_string()).await;
             return Ok(());
         }
     };
@@ -300,8 +300,8 @@ async fn handle_logs(mut stream: UnixStream, run: String, follow: bool) -> anyho
 async fn handle_attach(mut stream: UnixStream, run: String) -> anyhow::Result<()> {
     let run_id = match crate::run_registry::resolve(&run) {
         Ok(id) => id,
-        Err(message) => {
-            let _ = write_error(&mut stream, message).await;
+        Err(e) => {
+            let _ = write_error(&mut stream, e.to_string()).await;
             return Ok(());
         }
     };
@@ -823,8 +823,8 @@ where
 async fn handle_exec(mut stream: UnixStream, args: lns_ipc::ExecImageArgs) -> anyhow::Result<()> {
     let target_run_id = match crate::run_registry::resolve(&args.run) {
         Ok(id) => id,
-        Err(message) => {
-            let _ = write_error(&mut stream, message).await;
+        Err(e) => {
+            let _ = write_error(&mut stream, e.to_string()).await;
             return Ok(());
         }
     };

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -566,7 +566,11 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
 async fn kill_request(run: &str, signal: lns_ipc::SignalKind) -> Response {
     let id = match crate::run_registry::resolve(run) {
         Ok(id) => id,
-        Err(message) => return Response::Error { message },
+        Err(e) => {
+            return Response::Error {
+                message: e.to_string(),
+            };
+        }
     };
     kill_resolved(&id, signal).await
 }
@@ -586,7 +590,11 @@ async fn kill_resolved(id: &str, signal: lns_ipc::SignalKind) -> Response {
 async fn stop_run_request(run: &str, timeout_secs: u64) -> Response {
     let id = match crate::run_registry::resolve(run) {
         Ok(id) => id,
-        Err(message) => return Response::Error { message },
+        Err(e) => {
+            return Response::Error {
+                message: e.to_string(),
+            };
+        }
     };
     stop_run_with(
         &id,
@@ -600,7 +608,12 @@ async fn stop_run_request(run: &str, timeout_secs: u64) -> Response {
 fn inspect_run_request(run: &str) -> Response {
     match crate::run_registry::resolve(run) {
         Ok(id) => inspect_resolved(&id),
-        Err(message) => Response::Error { message },
+        Err(crate::run_registry::ResolveError::Unknown { handle }) => {
+            Response::RunUnknown { run: handle }
+        }
+        Err(ambiguous) => Response::Error {
+            message: ambiguous.to_string(),
+        },
     }
 }
 
@@ -609,8 +622,8 @@ fn inspect_resolved(id: &str) -> Response {
         Some(details) => Response::RunInspect {
             details: Box::new(details),
         },
-        None => Response::Error {
-            message: format!("no active run with id {id}"),
+        None => Response::RunUnknown {
+            run: id.to_string(),
         },
     }
 }
@@ -672,7 +685,11 @@ where
 {
     let id = match crate::run_registry::resolve(run) {
         Ok(id) => id,
-        Err(message) => return Response::Error { message },
+        Err(e) => {
+            return Response::Error {
+                message: e.to_string(),
+            };
+        }
     };
     remove_resolved_run_with(
         &id,
@@ -2172,9 +2189,6 @@ mod tests {
                 run: "ghost".into(),
                 signal: lns_ipc::SignalKind::Term,
             },
-            Request::InspectRun {
-                run: "ghost".into(),
-            },
             Request::RemoveRun {
                 run: "ghost".into(),
                 force: false,
@@ -2186,6 +2200,43 @@ mod tests {
                 }
                 other => unreachable!("expected Error for {req:?}, got {other:?}"),
             }
+        }
+        match handle_request(
+            &Request::InspectRun {
+                run: "ghost".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::RunUnknown { run } => assert_eq!(run, "ghost"),
+            other => unreachable!("an inspect miss is an answer, not a fault, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_request_inspect_run_keeps_an_ambiguous_prefix_an_error() {
+        let first = "5417ab0000000000000000000000000a";
+        let second = "5417ab0000000000000000000000000b";
+        register_running(first);
+        register_running(second);
+        let resp = handle_request(
+            &Request::InspectRun {
+                run: "5417ab".into(),
+            },
+            Instant::now(),
+        )
+        .await;
+        crate::run_registry::deregister(first);
+        crate::run_registry::deregister(second);
+        match resp {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("ambiguous run id prefix: 5417ab"),
+                    "got: {message}"
+                );
+            }
+            other => unreachable!("an ambiguity is a fault to surface, got {other:?}"),
         }
     }
 
@@ -2641,7 +2692,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_request_inspect_run_for_unknown_run_returns_error() {
+    async fn handle_request_inspect_run_for_unknown_run_answers_run_unknown() {
         let resp = handle_request(
             &Request::InspectRun {
                 run: "999998".into(),
@@ -2650,10 +2701,8 @@ mod tests {
         )
         .await;
         match resp {
-            Response::Error { message } => {
-                assert!(message.contains("no such run"), "got: {message}");
-            }
-            other => unreachable!("expected Error, got {other:?}"),
+            Response::RunUnknown { run } => assert_eq!(run, "999998"),
+            other => unreachable!("expected RunUnknown, got {other:?}"),
         }
     }
 
@@ -3154,11 +3203,11 @@ mod tests {
     }
 
     #[test]
-    fn inspect_resolved_reports_no_active_run_when_the_id_vanished_after_resolution() {
+    fn inspect_resolved_answers_run_unknown_when_the_id_vanished_after_resolution() {
         let resp = inspect_resolved("ffffffffffffffffffffffffffffffff");
         assert!(
-            matches!(&resp, Response::Error { message } if message.contains("no active run with id")),
-            "got {resp:?}"
+            matches!(&resp, Response::RunUnknown { run } if run == "ffffffffffffffffffffffffffffffff"),
+            "a run that vanished between resolve and inspect is a miss, not a fault: {resp:?}"
         );
     }
 

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -241,13 +241,29 @@ fn name_holder(map: &HashMap<String, RunEntry>, name: &str) -> Option<String> {
         .map(|(id, _)| id.clone())
 }
 
-pub fn resolve(handle: &str) -> Result<String, String> {
+/// A miss and an ambiguity are different answers: a caller may treat the first as settled, never the second.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    Unknown { handle: String },
+    Ambiguous { handle: String },
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown { handle } => write!(f, "no such run: {handle}"),
+            Self::Ambiguous { handle } => write!(f, "ambiguous run id prefix: {handle}"),
+        }
+    }
+}
+
+pub fn resolve(handle: &str) -> Result<String, ResolveError> {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     resolve_in(g.as_ref(), handle)
 }
 
 /// Resolve a handle and read its status under one lock, so the answer can never name a run that vanished in between.
-pub fn resolve_status(handle: &str) -> Result<(String, RunStatus), String> {
+pub fn resolve_status(handle: &str) -> Result<(String, RunStatus), ResolveError> {
     let g = ACTIVE.lock().expect("ACTIVE poisoned");
     let id = resolve_in(g.as_ref(), handle)?;
     let status = g
@@ -258,12 +274,18 @@ pub fn resolve_status(handle: &str) -> Result<(String, RunStatus), String> {
     Ok((id, status))
 }
 
-fn resolve_in(map: Option<&HashMap<String, RunEntry>>, handle: &str) -> Result<String, String> {
+fn resolve_in(
+    map: Option<&HashMap<String, RunEntry>>,
+    handle: &str,
+) -> Result<String, ResolveError> {
+    let unknown = || ResolveError::Unknown {
+        handle: handle.to_string(),
+    };
     if handle.is_empty() {
-        return Err(format!("no such run: {handle}"));
+        return Err(unknown());
     }
     let Some(map) = map else {
-        return Err(format!("no such run: {handle}"));
+        return Err(unknown());
     };
     if map.contains_key(handle) {
         return Ok(handle.to_string());
@@ -274,8 +296,10 @@ fn resolve_in(map: Option<&HashMap<String, RunEntry>>, handle: &str) -> Result<S
     let mut prefix_matches = map.keys().filter(|k| k.starts_with(handle));
     match (prefix_matches.next(), prefix_matches.next()) {
         (Some(id), None) => Ok(id.clone()),
-        (Some(_), Some(_)) => Err(format!("ambiguous run id prefix: {handle}")),
-        (None, _) => Err(format!("no such run: {handle}")),
+        (Some(_), Some(_)) => Err(ResolveError::Ambiguous {
+            handle: handle.to_string(),
+        }),
+        (None, _) => Err(unknown()),
     }
 }
 
@@ -291,7 +315,7 @@ fn rename_in(
 ) -> Result<(), String> {
     validate_run_name(new_name)?;
     let map = map.ok_or_else(|| format!("no such run: {handle}"))?;
-    let target = resolve_in(Some(&*map), handle)?;
+    let target = resolve_in(Some(&*map), handle).map_err(|e| e.to_string())?;
     if let Some(holder) = name_holder(map, new_name)
         && holder != target
     {
@@ -774,11 +798,13 @@ mod tests {
         assert!(
             resolve_in(Some(&map), "ghost")
                 .unwrap_err()
+                .to_string()
                 .contains("no such run: ghost")
         );
         assert!(
             resolve_in(None, "reviewer")
                 .unwrap_err()
+                .to_string()
                 .contains("no such run")
         );
     }
@@ -787,7 +813,7 @@ mod tests {
     async fn resolve_in_rejects_an_empty_handle_instead_of_matching_the_only_run() {
         let mut map = HashMap::new();
         named_handle(&mut map, "1a2b3c4d0000000000000000000000aa", "reviewer").await;
-        let err = resolve_in(Some(&map), "").unwrap_err();
+        let err = resolve_in(Some(&map), "").unwrap_err().to_string();
         assert!(
             err.contains("no such run"),
             "an empty handle must not wildcard-match the sole run, got: {err}"
@@ -800,7 +826,16 @@ mod tests {
         named_handle(&mut map, "1a2b3c4d0000000000000000000000aa", "reviewer").await;
         named_handle(&mut map, "1a2b9999000000000000000000000bbb", "auditor").await;
         let err = resolve_in(Some(&map), "1a2b").unwrap_err();
-        assert!(err.contains("ambiguous run id prefix: 1a2b"), "got: {err}");
+        assert_eq!(
+            err,
+            ResolveError::Ambiguous {
+                handle: "1a2b".to_string()
+            }
+        );
+        assert!(
+            err.to_string().contains("ambiguous run id prefix: 1a2b"),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]
@@ -819,6 +854,7 @@ mod tests {
         assert!(
             resolve_in(Some(&map), "reviewer")
                 .unwrap_err()
+                .to_string()
                 .contains("no such run")
         );
     }
@@ -1716,7 +1752,12 @@ mod tests {
         assert_eq!(resolved, id);
         assert_eq!(status, RunStatus::Exited { code: 3 });
         deregister(&id);
-        assert!(resolve_status(&id).unwrap_err().contains("no such run"));
+        assert!(
+            resolve_status(&id)
+                .unwrap_err()
+                .to_string()
+                .contains("no such run")
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-service/tests/behaviours/run_lifecycle.feature
+++ b/crates/lns-service/tests/behaviours/run_lifecycle.feature
@@ -16,11 +16,10 @@ Feature: run lifecycle — graceful stop over IPC
     When a StopRun request for that run arrives
     Then the response is RunStopped without force
 
-  Scenario: Inspecting an unknown run surfaces an Error
+  Scenario: Inspecting an unknown run answers a typed RunUnknown
     Given a fresh service handler
     When an InspectRun request for run 99999 arrives
-    Then the response is Error
-    And the error message contains "no such run: 99999"
+    Then the response is RunUnknown for run "99999"
 
   Scenario: Inspecting a registered run reports its state and launch configuration
     Given a registered run launched from "some-image:1" with 2 cpus and 1024 MiB

--- a/crates/lns-service/tests/behaviours/steps/ipc.rs
+++ b/crates/lns-service/tests/behaviours/steps/ipc.rs
@@ -79,6 +79,14 @@ fn then_error(world: &mut BehaviourWorld) -> Result<(), String> {
     }
 }
 
+#[then(expr = "the response is RunUnknown for run {string}")]
+fn then_run_unknown(world: &mut BehaviourWorld, run: String) -> Result<(), String> {
+    match world.response.as_ref().ok_or("no response captured")? {
+        lns_ipc::Response::RunUnknown { run: named } if *named == run => Ok(()),
+        other => Err(format!("expected RunUnknown for {run:?}, got {other:?}")),
+    }
+}
+
 #[then("the response is Acknowledged")]
 fn then_acknowledged(world: &mut BehaviourWorld) -> Result<(), String> {
     match world.response.as_ref().ok_or("no response captured")? {

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -219,7 +219,7 @@ No command edits the rules. A decision is recorded one of two ways: you answer t
 card a run raises, or you open `lns-local-mixin.yaml` and write the rule yourself.
 Both write the same document, and because it is a `kind: mixin` document,
 `lns artifact validate -f lns-local-mixin.yaml` checks what you wrote and
-`lns sandbox inspect -f lns-local-mixin.yaml` renders it.
+`lns artifact inspect -f lns-local-mixin.yaml` renders it.
 
 ### Add an allow or deny rule
 

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -1407,7 +1407,7 @@ egress, not each contributor's opinion of it.
 
 ## 5. Validation summary
 
-Offline validation (`lns sandbox validate`, and every load path including
+Offline validation (`lns artifact validate`, and every load path including
 `lns run` preflight) enforces, in addition to the per-field rules above:
 
 - **Document**: `apiVersion` is `lns.run/v1`; `kind` is one of the three;
@@ -1468,7 +1468,7 @@ there, because they depend on state no document carries — they run at launch:
 | The resolved source list in [§3.3.2](#332-merge-rules) | The mixin graph — its depth, its cycles, and which source wins each setting — is only known once each mixin, and each mixin it declares, is pulled. |
 
 The last one is why a merge collision refuses the **run** rather than the
-document: `lns sandbox validate` cannot see it.
+document: `lns artifact validate` cannot see it.
 
 ---
 
@@ -1699,5 +1699,5 @@ gave.
 - [Credentials](credentials.md) — placeholders, and the per-machine values a
   credential resolves against.
 - [Connectors](connectors.md) — connecting a workload to an external service.
-- [CLI reference](cli-reference.md) — `lns sandbox init`, `validate`, `inspect`,
+- [CLI reference](cli-reference.md) — `lns artifact init`, `validate`, `inspect`,
   `push`.


### PR DESCRIPTION
The review of #283 (the `lns artifact` / `lns sandbox` split) raised five findings. Two were already repaired by #307 (the `--format` shortcut break and the silently dropped `--mixin`); this PR lands the remaining three.

## 1. An ambiguous run prefix could delete a cached artifact

`ask_both` treated every InspectRun reply other than `RunInspect` as "not a sandbox". The service answers an ambiguous run-id prefix with `Response::Error`, so if the operand also matched a cached artifact, `lns rm <prefix>` settled on the artifact and deleted something the user never named.

The wire now says what it means: `InspectRun` answers the new `Response::RunUnknown` for a genuine miss (nothing resolved, or resolved-then-vanished), and `run_registry::resolve` returns a typed `ResolveError` (`Unknown` / `Ambiguous`) instead of a string, so the handler classifies without parsing messages. The shortcut's probe treats only `RunUnknown` as a namespace miss; an ambiguity, a daemon failure, or an unexpected reply surfaces:

```console
$ lns rm 1a2b        # two runs share the prefix; "1a2b" is also a cached artifact
Error: daemon error: ambiguous run id prefix: 1a2b
```

Written red first: the new shortcut test reproduced the review's exact failure (`Ok(Artifact)` on an ambiguous prefix) before the fix. `lns sandbox inspect ghost` now answers `no such run: ghost` from the typed miss; the other run-addressed verbs (stop, kill, logs, attach, exec, stats) keep their `Error` wording unchanged.

## 2. A relative `--mixin` reached the service unrooted

Published-artifact inspection forwarded user-named mixins verbatim, so `lns artifact inspect <REF> --mixin ./obs` handed the service a relative path that `mixin::locate` refuses. Both the namespaced command and the shortcut now root path-shaped mixins against the invocation directory before dispatch — the same `root_named_directories` the run path already uses — via the new `InspectArgs::root_mixins`. A registry reference passes untouched.

## 3. The docs still named the pre-split spellings

`docs/policy.md` recommended `lns sandbox inspect -f`, and `docs/sandbox-spec.md` still said `lns sandbox validate` (×2) and listed `lns sandbox init, validate, inspect, push` in its cross-references. All now use the `lns artifact` spellings `docs/cli-spec.md` settled.

## Tests

- Layer 3: shortcut arbitration truth table (ambiguity surfaces, a miss settles, a failed cache listing fails aloud, an unexpected reply is refused), the typed `ResolveError` in `run_registry`, `inspect_run_request` / `inspect_resolved` answering `RunUnknown`, and `InspectArgs::root_mixins`.
- Layer 2: a new scenario pins that a relative `--mixin` reaches the service as an absolute path; the inspect fixtures now fake a miss with `RunUnknown` instead of a worded `Error`, which is exactly the distinction the review asked for.
