### PR TITLE
ci: run the PR suite on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 on:
+  # Label-only events must never re-report `CI / check` (they'd supersede a
+  # failing run with all-skipped green); the label gate lives in pr-labels.yml.
+  # No base-branch filter: stacked PRs target another PR's branch and need the
+  # same suite; every base-dependent job reads github.event.pull_request.base.
   pull_request:
-    # Label-only events must never re-report `CI / check` (they'd supersede a
-    # failing run with all-skipped green); the label gate lives in pr-labels.yml.
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -6,7 +6,6 @@ name: PR labels
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `pull_request` triggers in `ci.yml` and `pr-labels.yml` filtered on base `main`, so a stacked PR — whose base is the branch below it — got no CI until it was retargeted onto main at merge time. Reviews happened against unvalidated stages.

The base-dependent jobs already handle an arbitrary base: the kernel-drift check diffs against `github.event.pull_request.base.sha`, and the affected-crates coverage narrowing computes its merge-base from the same — so a stacked PR gets the suite scoped to exactly its layer's diff. The `branches: [main]` filter was the only blocker; this removes it from both workflows.

Cost note: a cascading stack rebase re-pushes every branch above the merged one, re-triggering their suites. The per-ref `concurrency` groups cancel superseded runs, so only the newest head of each branch completes.