### PR TITLE
fix: config get emits a single JSON object, null when unset

### DIFF
--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -196,31 +196,27 @@ fn set(args: &ConfigSetArgs, path: &Path, writer: &mut impl Write) -> Result<i32
 
 fn get(args: &ConfigKeyArgs, path: &Path, writer: &mut impl Write) -> Result<i32> {
     let cfg = load(path)?;
-    let values = values_of(&cfg, args.key);
+    let value = value_of(&cfg, args.key);
     if args.output.format == crate::output::Format::Json {
-        let rows = rows_for(args.key, &values);
-        crate::output::emit_object(&rows, writer)?;
-        return Ok(exit_code_for(&values));
+        crate::output::emit_object(&row_for(args.key, value.clone()), writer)?;
+        return Ok(exit_code_for(&value));
     }
-    for v in &values {
+    if let Some(v) = &value {
         writeln!(writer, "{v}")?;
     }
-    Ok(exit_code_for(&values))
+    Ok(exit_code_for(&value))
 }
 
 /// An unset key is reported by the exit code in both formats: --format changes the shape, never the semantics.
-fn exit_code_for(values: &[String]) -> i32 {
-    i32::from(values.is_empty())
+fn exit_code_for(value: &Option<String>) -> i32 {
+    i32::from(value.is_none())
 }
 
-fn rows_for(key: ConfigKey, values: &[String]) -> Vec<ConfigRow> {
-    values
-        .iter()
-        .map(|v| ConfigRow {
-            key: key.name(),
-            value: v.clone(),
-        })
-        .collect()
+fn row_for(key: ConfigKey, value: Option<String>) -> Option<ConfigRow> {
+    value.map(|value| ConfigRow {
+        key: key.name(),
+        value,
+    })
 }
 
 #[derive(serde::Serialize)]
@@ -232,7 +228,7 @@ struct ConfigRow {
 
 fn unset(key: ConfigKey, path: &Path, writer: &mut impl Write) -> Result<i32> {
     let mut cfg = load(path)?;
-    if values_of(&cfg, key).is_empty() {
+    if value_of(&cfg, key).is_none() {
         bail!("{} is not set in {}", key.name(), path.display());
     }
     clear(&mut cfg, key);
@@ -245,7 +241,7 @@ fn list(output: &crate::output::OutputArgs, path: &Path, writer: &mut impl Write
     let cfg = load(path)?;
     let rows: Vec<ConfigRow> = ConfigKey::ALL
         .iter()
-        .flat_map(|&key| rows_for(key, &values_of(&cfg, key)))
+        .filter_map(|&key| row_for(key, value_of(&cfg, key)))
         .collect();
     for legacy in legacy_entries(&cfg) {
         crate::log::warn!(
@@ -308,11 +304,11 @@ fn parse_mem(key: ConfigKey, value: &str) -> Result<usize> {
         .map_err(|e| anyhow!("invalid {} value {value:?}: {e}", key.name()))
 }
 
-fn values_of(cfg: &ConfigFile, key: ConfigKey) -> Vec<String> {
+fn value_of(cfg: &ConfigFile, key: ConfigKey) -> Option<String> {
     match key {
-        ConfigKey::RunCpus => cfg.run.cpus.map(|v| v.to_string()).into_iter().collect(),
-        ConfigKey::RunMem => cfg.run.mem.map(|v| v.to_string()).into_iter().collect(),
-        ConfigKey::RunRegistry => cfg.run.registry.clone().into_iter().collect(),
+        ConfigKey::RunCpus => cfg.run.cpus.map(|v| v.to_string()),
+        ConfigKey::RunMem => cfg.run.mem.map(|v| v.to_string()),
+        ConfigKey::RunRegistry => cfg.run.registry.clone(),
     }
 }
 

--- a/crates/lns-cli/tests/behaviours/config_cli.feature
+++ b/crates/lns-cli/tests/behaviours/config_cli.feature
@@ -68,15 +68,15 @@ Feature: lns config stores persistent run defaults
     Then the exit code is 0
     And the output is an empty JSON array
 
-  Scenario: Getting a set default as JSON gives the key alongside its value
+  Scenario: Getting a set default as JSON gives one object, not a list of one
     Given the default "run.cpus" is "4"
     When the developer gets the default "run.cpus" as JSON
     Then the exit code is 0
-    And the output is a JSON array of 1 rows
-    And JSON row 0 has "key" set to "run.cpus"
-    And JSON row 0 has "value" set to "4"
+    And the output is a JSON object
+    And the JSON object has "key" set to "run.cpus"
+    And the JSON object has "value" set to "4"
 
-  Scenario: Getting an unset default as JSON still exits 1, with an empty array
+  Scenario: Getting an unset default as JSON still exits 1, answering null
     When the developer gets the default "run.cpus" as JSON
     Then the exit code is 1
-    And the output is an empty JSON array
+    And the output is JSON null

--- a/crates/lns-cli/tests/behaviours/steps/machine_output.rs
+++ b/crates/lns-cli/tests/behaviours/steps/machine_output.rs
@@ -54,6 +54,40 @@ fn output_is_empty_json_array(world: &mut BehaviourWorld) -> Result<(), String> 
     }
 }
 
+#[then(regex = r"^the output is a JSON object$")]
+fn output_is_json_object(world: &mut BehaviourWorld) -> Result<(), String> {
+    let doc = parsed(world)?;
+    if doc.is_object() {
+        Ok(())
+    } else {
+        Err(format!("expected a single json object, got {doc}"))
+    }
+}
+
+#[then(regex = r"^the output is JSON null$")]
+fn output_is_json_null(world: &mut BehaviourWorld) -> Result<(), String> {
+    let doc = parsed(world)?;
+    if doc.is_null() {
+        Ok(())
+    } else {
+        Err(format!("expected json null, got {doc}"))
+    }
+}
+
+#[then(regex = r#"^the JSON object has "([^"]+)" set to "([^"]*)"$"#)]
+fn json_object_string(
+    world: &mut BehaviourWorld,
+    key: String,
+    expected: String,
+) -> Result<(), String> {
+    let found = field(&parsed(world)?, &key)?;
+    if found == serde_json::Value::String(expected.clone()) {
+        Ok(())
+    } else {
+        Err(format!("expected {key} to be {expected:?}, got {found}"))
+    }
+}
+
 #[then(regex = r#"^JSON row (\d+) has "([^"]+)" set to "([^"]*)"$"#)]
 fn json_row_string(
     world: &mut BehaviourWorld,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -85,13 +85,14 @@ works as an alias for `--format jsonl`.
 What the JSON gives you:
 
 - **A bare array of objects** for the list verbs, pretty-printed. `lns service status`,
-  `lns sandbox inspect`, and `lns volume inspect` emit a single object instead.
+  `lns sandbox inspect`, `lns volume inspect`, and `lns config get` emit a single
+  object instead.
 - **camelCase keys**, always present — a key with no value is `null`, never omitted, so
   `jq .inUseBy` needs no guard.
 - **Raw numbers**, so nothing has to be un-humanized: `sizeBytes: 92274688`, not
   `"88.0 MiB"`. Timestamps pass through as the service reports them.
 - **The same exit code as the table.** `--format` changes the shape and nothing else:
-  `lns config get` on an unset key still exits 1, emitting `[]`.
+  `lns config get` on an unset key still exits 1, emitting `null`.
 - Some verbs report more in JSON than the table has room for. `lns sandbox ls` is the
   clearest case: the table abbreviates the digest and formats the size, and the JSON
   adds the whole digest, the raw byte count, the layer count, and the pull time.


### PR DESCRIPTION
`lns config get <KEY> --format json` answers about one thing. It must print one object.
Before this change, it printed an array. This is a divergence from `docs/cli-spec.md`.

The specification says, in §3.5:

> `get` on an unset key exits `1`, printing nothing as a table and `null` as JSON.

And in §4.4:

> A command that answers about one thing emits a **single object**. […] An empty list is `[]`. A single thing that does not exist is `null`.

## What the user sees

A set key. Before:

```console
$ lns config get run.cpus --format json
[
  {
    "key": "run.cpus",
    "value": "4"
  }
]
```

After:

```console
$ lns config get run.cpus --format json
{
  "key": "run.cpus",
  "value": "4"
}
```

An unset key. Before:

```console
$ lns config get run.cpus --format json
[]
$ echo $?
1
```

After:

```console
$ lns config get run.cpus --format json
null
$ echo $?
1
```

A script now reads the value directly:

```bash
lns config get run.cpus --format json | jq -r '.value // empty'
```

## What changed

- `get` reads the key through a new single-valued accessor. The accessor returns
  `Option<String>`.
- `get` emits that value as `Option<ConfigRow>`. `None` serializes as `null`.
  `Some` serializes as one object with camelCase keys.
- The old array spelling is deleted. No compatibility shim remains.
- `list` keeps its array shape. It is a list verb.
- Table mode does not change.
- Exit codes do not change. `0` when the key is set. `1` when the key is not set.
- `docs/cli-reference.md` now records the shipped shape.

## Tests

Two Layer 2 scenarios in `crates/lns-cli/tests/behaviours/config_cli.feature` pinned
the array shape. The scenarios were rewritten first. They failed. Then the production
code changed. Three new step definitions support them:
"the output is a JSON object", "the output is JSON null", and
"the JSON object has <key> set to <value>".

## Known follow-up

`value` stays a string. §4.4 asks for raw numbers. A `run.mem` value such as `2g` is
a legitimate string, so a typed `value` needs its own decision. This is out of scope
here.
