### PR TITLE
fix: print a sentence instead of an empty table on empty list output

### DIFF
--- a/crates/e2e-tests/features/sandbox_lifecycle.feature
+++ b/crates/e2e-tests/features/sandbox_lifecycle.feature
@@ -48,12 +48,12 @@ Feature: sandbox lifecycle verbs reach the service end to end
     Then the exit code is non-zero
     And the output contains "USR1"
 
-  Scenario: ps renders only its header when nothing is running
+  Scenario: ps says nothing is running rather than printing a bare header
     Given the Lens Sandbox service is running
     When I run lns "ps" against the service
     Then the exit code is 0
-    And the output contains "CPU"
-    And the output contains "MEM"
+    And the output contains "No running sandboxes."
+    And the output does not contain "CPU"
 
   Scenario: stopping an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running

--- a/crates/e2e-tests/features/sandbox_management.feature
+++ b/crates/e2e-tests/features/sandbox_management.feature
@@ -9,14 +9,11 @@ Feature: cached sandbox management end to end
     Given a clean lns cache home
     And the Lens Sandbox service is running in that home
 
-  Scenario: listing an empty cache renders only the table header
+  Scenario: listing an empty cache says so rather than printing a bare header
     When I run "lns artifact ls"
     Then the exit code is 0
-    And the output contains "ARTIFACT"
-    And the output contains "KIND"
-    And the output contains "DIGEST"
-    And the output contains "SIZE"
-    And the output contains "HOLDER"
+    And the output contains "No cached artifacts."
+    And the output does not contain "DIGEST"
 
   Scenario: removing a sandbox that is not cached fails cleanly
     When I run "lns artifact rm registry.example.test/absent:1"

--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -468,7 +468,7 @@ async fn ls<W: std::io::Write>(
                 .filter(|image| args.kind.is_none_or(|kind| kind.matches(image.kind)))
                 .map(ArtifactRow::new)
                 .collect();
-            crate::output::emit(args.output.format, &rows, out)?;
+            crate::output::emit(args.output.format, &rows, "No cached artifacts.", out)?;
             Ok(0)
         }
         Response::Error { message } => Err(crate::service::reply::failure(&message)),

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -319,7 +319,7 @@ fn list(args: &ConnectorListArgs, catalog_path: &Path, writer: &mut impl Write) 
             .filter(|i| !is_bundled(&i.id))
             .map(|i| ConnectorRow::new(i, "user")),
     );
-    crate::output::emit(args.output.format, &rows, writer)?;
+    crate::output::emit(args.output.format, &rows, "No connectors.", writer)?;
     Ok(0)
 }
 

--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -41,6 +41,8 @@ pub struct LoginArgs {
         help = "List the registries you are logged in to (hosts and usernames, never secrets)."
     )]
     pub list: bool,
+    #[command(flatten)]
+    pub output: crate::output::OutputArgs,
 }
 
 #[derive(clap::Args)]
@@ -142,7 +144,7 @@ pub async fn run(
     out: &mut impl Write,
 ) -> Result<i32> {
     if args.list {
-        return list(client, out).await;
+        return list(client, args.output.format, out).await;
     }
     login(args, default_registry, client, web, input, out).await
 }
@@ -193,18 +195,37 @@ pub async fn logout(
     Ok(0)
 }
 
-async fn list(client: &dyn RegistryAuthClient, out: &mut impl Write) -> Result<i32> {
+#[derive(serde::Serialize)]
+struct LoginRow {
+    registry: String,
+    username: String,
+}
+
+impl crate::output::TableRow for LoginRow {
+    const HEADERS: &'static [&'static str] = &["REGISTRY", "USERNAME"];
+
+    fn cells(&self) -> Vec<String> {
+        vec![self.registry.clone(), self.username.clone()]
+    }
+}
+
+async fn list(
+    client: &dyn RegistryAuthClient,
+    format: crate::output::Format,
+    out: &mut impl Write,
+) -> Result<i32> {
     let logins = match client.list().await? {
         ListLoginsOutcome::ServiceUnavailable => bail!("{SERVICE_REQUIRED}"),
         ListLoginsOutcome::Logins(logins) => logins,
     };
-    if logins.is_empty() {
-        writeln!(out, "Not logged in to any registry.")?;
-        return Ok(0);
-    }
-    for login in logins {
-        writeln!(out, "{}  {}", login.registry, login.username)?;
-    }
+    let rows: Vec<LoginRow> = logins
+        .into_iter()
+        .map(|login| LoginRow {
+            registry: login.registry,
+            username: login.username,
+        })
+        .collect();
+    crate::output::emit(format, &rows, "Not logged in to any registry.", out)?;
     Ok(0)
 }
 
@@ -394,6 +415,9 @@ mod tests {
             password: password.map(str::to_string),
             password_stdin: false,
             list: false,
+            output: crate::output::OutputArgs {
+                format: crate::output::Format::Table,
+            },
         }
     }
 
@@ -562,7 +586,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_dispatches_to_list_and_renders_hosts_and_usernames() {
+    async fn run_dispatches_to_list_and_renders_a_table_of_hosts_and_usernames() {
         let client = FakeClient::listing(ListLoginsOutcome::Logins(vec![
             lns_ipc::RegistryLoginSummary {
                 registry: "ghcr.io".into(),
@@ -590,8 +614,8 @@ mod tests {
         assert_eq!(code, 0);
         assert_eq!(
             String::from_utf8(out).unwrap(),
-            "ghcr.io  octocat\nquay.io  robot\n",
-            "hosts + usernames as the service reported them"
+            "REGISTRY  USERNAME\nghcr.io   octocat\nquay.io   robot\n",
+            "an uppercase header row over the hosts and usernames the service reported"
         );
         assert!(
             client.calls.lock().unwrap().is_empty(),
@@ -622,7 +646,9 @@ mod tests {
     async fn list_reports_when_no_registries_are_logged_in() {
         let client = FakeClient::listing(ListLoginsOutcome::Logins(Vec::new()));
         let mut out = Vec::new();
-        let code = list(&client, &mut out).await.unwrap();
+        let code = list(&client, crate::output::Format::Table, &mut out)
+            .await
+            .unwrap();
         assert_eq!(code, 0);
         assert_eq!(
             String::from_utf8(out).unwrap(),
@@ -634,7 +660,9 @@ mod tests {
     async fn list_requires_the_service_that_keeps_the_logins() {
         let client = FakeClient::listing(ListLoginsOutcome::ServiceUnavailable);
         let mut out = Vec::new();
-        let err = list(&client, &mut out).await.unwrap_err();
+        let err = list(&client, crate::output::Format::Table, &mut out)
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("service must be running"));
     }
 

--- a/crates/lns-cli/src/output.rs
+++ b/crates/lns-cli/src/output.rs
@@ -26,32 +26,23 @@ pub trait TableRow {
     fn cells(&self) -> Vec<String>;
 }
 
+/// Every list verb states its own empty case, so a human reading nothing gets prose where a script still gets `[]`.
 pub fn emit<T: TableRow + serde::Serialize>(
     format: Format,
     rows: &[T],
+    empty_note: &str,
     out: &mut dyn Write,
 ) -> Result<()> {
     match format {
+        Format::Table if rows.is_empty() => {
+            writeln!(out, "{empty_note}").context("writing the empty-list note")
+        }
         Format::Table => {
             let cells: Vec<Vec<String>> = rows.iter().map(TableRow::cells).collect();
             render_table(out, T::HEADERS, &cells).context("writing the table")
         }
         Format::Json => emit_object(&rows, out),
     }
-}
-
-/// Like `emit`, but a human reading an empty list gets prose where a script still gets `[]`.
-pub fn emit_or_note<T: TableRow + serde::Serialize>(
-    format: Format,
-    rows: &[T],
-    note: &str,
-    out: &mut dyn Write,
-) -> Result<()> {
-    if rows.is_empty() && format == Format::Table {
-        writeln!(out, "{note}").context("writing the empty-list note")?;
-        return Ok(());
-    }
-    emit(format, rows, out)
 }
 
 /// One thing rather than a list: the JSON is a single object, and the table is the FIELD/VALUE summary of it that a reader can scan.
@@ -189,7 +180,7 @@ mod tests {
 
     fn emitted(format: Format, rows: &[Sample]) -> String {
         let mut buf = Vec::new();
-        emit(format, rows, &mut buf).unwrap();
+        emit(format, rows, "Nothing here.", &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -237,31 +228,14 @@ mod tests {
     }
 
     #[test]
-    fn the_table_format_still_prints_the_header_when_there_is_nothing_to_list() {
-        let text = emitted(Format::Table, &[]);
-        assert_eq!(text, "NAME  SIZE\n");
-    }
-
-    fn noted(format: Format, rows: &[Sample]) -> String {
-        let mut buf = Vec::new();
-        emit_or_note(format, rows, "Nothing here.", &mut buf).unwrap();
-        String::from_utf8(buf).unwrap()
-    }
-
-    #[test]
-    fn an_empty_list_reads_as_prose_for_a_human_and_as_an_empty_array_for_a_script() {
-        assert_eq!(noted(Format::Table, &[]), "Nothing here.\n");
-        assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&noted(Format::Json, &[])).unwrap(),
-            serde_json::json!([]),
-            "prose would break a json consumer"
-        );
+    fn the_table_format_says_there_is_nothing_to_list_instead_of_printing_a_bare_header() {
+        assert_eq!(emitted(Format::Table, &[]), "Nothing here.\n");
     }
 
     #[test]
     fn a_non_empty_list_ignores_the_note_in_both_formats() {
-        assert!(!noted(Format::Table, &[sample()]).contains("Nothing here."));
-        assert!(!noted(Format::Json, &[sample()]).contains("Nothing here."));
+        assert!(!emitted(Format::Table, &[sample()]).contains("Nothing here."));
+        assert!(!emitted(Format::Json, &[sample()]).contains("Nothing here."));
     }
 
     #[test]

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -389,7 +389,12 @@ async fn ps<W: std::io::Write>(
         };
         rows.push(PsRow::new(run, stats));
     }
-    crate::output::emit(args.output.format, &rows, out)?;
+    let nothing_listed = if args.all {
+        "No sandboxes."
+    } else {
+        "No running sandboxes."
+    };
+    crate::output::emit(args.output.format, &rows, nothing_listed, out)?;
     Ok(0)
 }
 
@@ -1049,7 +1054,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ps_renders_only_the_header_when_nothing_is_running() {
+    async fn ps_says_nothing_is_running_rather_than_listing_an_exited_run() {
         let svc = CannedService::new(Response::RunList {
             runs: vec![lns_ipc::RunSummary {
                 status: lns_ipc::RunStatus::Exited { code: 0 },
@@ -1060,11 +1065,7 @@ mod tests {
         let code = ps(&svc, &ps_args(), &mut out).await.unwrap();
         assert_eq!(code, 0);
         let text = String::from_utf8(out).unwrap();
-        assert!(text.contains("CPU"), "got: {text}");
-        assert!(
-            !text.contains("reviewer"),
-            "an exited run must not list: {text}"
-        );
+        assert_eq!(text, "No running sandboxes.\n");
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/volume/mod.rs
+++ b/crates/lns-cli/src/volume/mod.rs
@@ -124,7 +124,7 @@ async fn ls(svc: &dyn VolumeService, args: &VolumeLsArgs, writer: &mut impl Writ
     match send(svc, Request::ListVolumes).await? {
         Response::VolumeList { volumes } => {
             let rows: Vec<VolumeRow> = volumes.iter().map(VolumeRow::new).collect();
-            crate::output::emit(args.output.format, &rows, writer)?;
+            crate::output::emit(args.output.format, &rows, "No volumes.", writer)?;
             Ok(0)
         }
         other => bail!("unexpected response from daemon: {other:?}"),
@@ -474,18 +474,6 @@ mod tests {
             );
             let out = String::from_utf8(buf).unwrap();
             assert!(out.contains("Aborted."), "got: {out}");
-        }
-    }
-
-    #[tokio::test]
-    async fn ls_renders_an_empty_table_with_headers_only() {
-        let svc = CannedService::with([Some(Response::VolumeList {
-            volumes: Vec::new(),
-        })]);
-        let (code, out) = run_cmd(&VolumeCommand::Ls(ls_args()), &svc).await.unwrap();
-        assert_eq!(code, 0);
-        for header in ["NAME", "ON DISK", "CREATED", "IN USE"] {
-            assert!(out.contains(header), "missing {header} in {out:?}");
         }
     }
 

--- a/crates/lns-cli/tests/behaviours/login_list.feature
+++ b/crates/lns-cli/tests/behaviours/login_list.feature
@@ -1,0 +1,35 @@
+Feature: listing the registries you are logged in to
+  `lns login --list` answers with data, so it is a list verb like any
+  other: a table with an uppercase header row by default, `--format json`
+  for a script, and one sentence when there is nothing to list. It reports
+  hosts and usernames only — a stored secret never leaves the service.
+
+  Scenario: the list is a table with an uppercase header row
+    Given the service reports a login to "ghcr.io" as "octocat"
+    When I log in with "lns login --list"
+    Then the exit code is 0
+    And the output contains "REGISTRY"
+    And the output contains "USERNAME"
+    And the output contains "ghcr.io"
+    And the output contains "octocat"
+
+  Scenario: --format json answers with an array a script can read
+    Given the service reports a login to "ghcr.io" as "octocat"
+    When I log in with "lns login --list --format json"
+    Then the exit code is 0
+    And the output is a JSON array of 1 rows
+    And JSON row 0 has "registry" set to "ghcr.io"
+    And JSON row 0 has "username" set to "octocat"
+
+  Scenario: with no logins, the table says so instead of printing a bare header
+    Given the service reports no registry logins
+    When I log in with "lns login --list"
+    Then the exit code is 0
+    And the output contains "Not logged in to any registry."
+    And the output does not contain "REGISTRY"
+
+  Scenario: with no logins, json stays an empty array
+    Given the service reports no registry logins
+    When I log in with "lns login --list --format json"
+    Then the exit code is 0
+    And the output is an empty JSON array

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -41,6 +41,13 @@ Feature: managing cached sandboxes
     And the output contains "team/lint:1.0"
     And the output does not contain "hermes:1.4.0"
 
+  Scenario: with an empty cache, ls says so instead of printing a bare header
+    Given the service reports no cached sandboxes
+    When the user runs artifact command "ls"
+    Then the exit code is 0
+    And the output contains "No cached artifacts."
+    And the output does not contain "DIGEST"
+
   Scenario: ls --kind rejects a kind the cache cannot hold
     When I run "lns artifact ls --kind sorcery"
     Then the exit code is 2
@@ -146,6 +153,20 @@ Feature: managing cached sandboxes
     And the output contains "scribe"
     And the output contains "STATE"
     And the output contains "stopped (0)"
+
+  Scenario: with nothing running, ls says so instead of printing a bare header
+    Given the service reports no runs
+    When the user runs sandbox command "ls"
+    Then the exit code is 0
+    And the output contains "No running sandboxes."
+    And the output does not contain "STATE"
+
+  Scenario: with nothing to list at all, ls -a says so rather than naming only the running ones
+    Given the service reports no runs
+    When the user runs sandbox command "ls -a"
+    Then the exit code is 0
+    And the output contains "No sandboxes."
+    And the output does not contain "STATE"
 
   Scenario: a stopped sandbox is listed without sampling a guest that is not there
     Given the service reports one running sandbox and one that stopped

--- a/crates/lns-cli/tests/behaviours/steps/login_web.rs
+++ b/crates/lns-cli/tests/behaviours/steps/login_web.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 /// Stands in for the running service: records what it was asked to store and accepts everything.
 struct RecordingAuthClient {
     calls: Arc<Mutex<Vec<(String, String, String)>>>,
+    logins: Vec<lns_ipc::RegistryLoginSummary>,
 }
 impl RegistryAuthClient for RecordingAuthClient {
     fn available<'a>(&'a self) -> LocalBoxFuture<'a, anyhow::Result<bool>> {
@@ -41,7 +42,8 @@ impl RegistryAuthClient for RecordingAuthClient {
     }
 
     fn list<'a>(&'a self) -> LocalBoxFuture<'a, anyhow::Result<ListLoginsOutcome>> {
-        Box::pin(async move { Ok(ListLoginsOutcome::Logins(Vec::new())) })
+        let logins = self.logins.clone();
+        Box::pin(async move { Ok(ListLoginsOutcome::Logins(logins)) })
     }
 }
 
@@ -77,6 +79,19 @@ fn given_web_issues(world: &mut BehaviourWorld, username: String) {
     });
 }
 
+#[given(regex = r#"^the service reports a login to "([^"]+)" as "([^"]+)"$"#)]
+fn given_service_reports_login(world: &mut BehaviourWorld, registry: String, username: String) {
+    world
+        .web_login
+        .logins
+        .push(lns_ipc::RegistryLoginSummary { registry, username });
+}
+
+#[given("the service reports no registry logins")]
+fn given_service_reports_no_logins(world: &mut BehaviourWorld) {
+    world.web_login.logins.clear();
+}
+
 #[given("the web flow would panic if it were consulted")]
 fn given_web_panics(world: &mut BehaviourWorld) {
     world.web_login.outcome = None;
@@ -101,6 +116,7 @@ fn given_web_expired(world: &mut BehaviourWorld) {
 async fn when_log_in(world: &mut BehaviourWorld, command: String) {
     let client = RecordingAuthClient {
         calls: world.web_login.verifier_calls.clone(),
+        logins: world.web_login.logins.clone(),
     };
     let web = FakeWebLoginFlow {
         outcome: world.web_login.outcome.clone(),

--- a/crates/lns-cli/tests/behaviours/volume_cli.feature
+++ b/crates/lns-cli/tests/behaviours/volume_cli.feature
@@ -39,6 +39,13 @@ Feature: managing named volumes from the CLI
     Then the exit code is 0
     And the listed row for "prism-data" ends with "-"
 
+  Scenario: with no volumes to list, ls says so instead of printing a bare header
+    Given the service reports no volumes
+    When the user runs volume command "ls"
+    Then the exit code is 0
+    And the output contains "No volumes."
+    And the output does not contain "ON DISK"
+
   Scenario: creating a volume confirms it by name
     When the user runs volume command "create prism-data"
     Then the exit code is 0

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -89,6 +89,7 @@ pub struct ExecCliRig {
 pub struct WebLoginRig {
     pub outcome: Option<lns_cli::login::WebLoginOutcome>,
     pub verifier_calls: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+    pub logins: Vec<lns_ipc::RegistryLoginSummary>,
 }
 
 /// Drives `decide_host_paths`: what the artifact declares, what this machine already recorded, and what the developer answers.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -70,7 +70,7 @@ parse the human table:
 
 `lns ps`, `lns sandbox ls`, `lns sandbox inspect <RUN>`, `lns artifact ls`,
 `lns volume ls`, `lns volume inspect`, `lns connector list`, `lns connector grants`,
-`lns config list`, `lns config get`, `lns service status`.
+`lns login --list`, `lns config list`, `lns config get`, `lns service status`.
 
 `table` is the default everywhere, including the two `inspect` verbs — the table is
 a summary a reader scans, the JSON is the record. `lns artifact inspect` renders a
@@ -313,7 +313,7 @@ registries can be logged in at once.
 ```bash
 lns login
 echo "$TOKEN" | lns login -u <USERNAME> --password-stdin <REGISTRY>
-lns login --list
+lns login --list [--format <table|json>]
 lns logout <REGISTRY>
 ```
 
@@ -327,7 +327,7 @@ login (such as `ghcr.io`) still take the flag-driven forms below.
 | Form                                  | Meaning                                                                 |
 | ------------------------------------- | ----------------------------------------------------------------------- |
 | `lns login [REGISTRY]`                | Log in to `REGISTRY` (defaults to `run.registry`, else `hub.lns.run`). With no credential flags, runs the browser login; pass `-u`/`--username` and the secret via `--password-stdin` (recommended) or `-p`/`--password` to log in with an existing token. |
-| `lns login --list`                    | List the registries you are logged in to, as `host  username` — never secrets. |
+| `lns login --list`                    | List the registries you are logged in to, as a `REGISTRY`/`USERNAME` table — never secrets. Takes `--format <table\|json>`. |
 | `lns logout [REGISTRY]`               | Remove the stored credential for `REGISTRY`.                            |
 
 The registry is matched by host: a bare published-sandbox reference uses the


### PR DESCRIPTION
`docs/cli-spec.md` §4.2 says:

> A list prints a table with an uppercase header row.
> An empty list prints one sentence saying so, not an empty table.

The list verbs printed a bare header row when they had nothing to list.
`lns login --list` printed no header row at all, and took no `--format`
flag. This PR corrects both.

## 1. An empty list prints a sentence

Before:

```console
$ lns volume ls
NAME  ON DISK  CREATED  IN USE
```

After:

```console
$ lns volume ls
No volumes.
```

Before:

```console
$ lns ps
ID  NAME  STATE  CPU %  MEMORY  UPTIME
```

After:

```console
$ lns ps
No running sandboxes.

$ lns ps -a
No sandboxes.

$ lns artifact ls
No cached artifacts.
```

JSON output does not change. An empty list is still `[]`:

```console
$ lns volume ls --format json
[]
```

Sentences per command:

| Command | Sentence |
|---|---|
| `lns ps`, `lns sandbox ls` | `No running sandboxes.` |
| `lns ps -a`, `lns sandbox ls -a` | `No sandboxes.` |
| `lns artifact ls` | `No cached artifacts.` |
| `lns volume ls` | `No volumes.` |
| `lns connector list` | `No connectors.` |
| `lns login --list` | `Not logged in to any registry.` |

## 2. `lns login --list` is a normal list

Before, the command printed bare pairs. It took no `--format` flag:

```console
$ lns login --list
ghcr.io  octocat
quay.io  robot

$ lns login --list --format json
error: unexpected argument '--format' found
```

After, it prints a table with a header row and answers JSON on request:

```console
$ lns login --list
REGISTRY  USERNAME
ghcr.io   octocat
quay.io   robot

$ lns login --list --format json
[
  {
    "registry": "ghcr.io",
    "username": "octocat"
  }
]

$ lns login --list
Not logged in to any registry.

$ lns login --list --format json
[]
```

The JSON carries hosts and usernames only. A stored secret stays in the
service.

## How the rule is enforced

`output::emit` now takes the empty-list sentence as a parameter. The
unused `emit_or_note` helper is deleted. A new list verb cannot skip the
rule, because it cannot call `emit` without a sentence.

## Tests

Three tests pinned the old behaviour. Each one is flipped first, and
watched fail:

- `output::tests::the_table_format_still_prints_the_header_when_there_is_nothing_to_list`
- `volume::tests::ls_renders_an_empty_table_with_headers_only`
- `login::tests::run_dispatches_to_list_and_renders_hosts_and_usernames`

Two Layer 1 scenarios pinned it as well, and are flipped the same way:
`ps renders only its header when nothing is running` and
`listing an empty cache renders only the table header`.

New Layer 2 scenarios cover the empty table case for `volume ls`,
`artifact ls`, `sandbox ls`, and `sandbox ls -a`. A new
`login_list.feature` covers the `lns login --list` table, its JSON array,
and both empty cases. The `machine_output.feature` scenarios keep the
JSON `[]` contract green.

## Note for the reviewer

`docs/cli-spec.md` §3.8 still describes `lns login --list` as `host
username` and shows no `--format` flag. §4.2 and §4.3 decide otherwise
for every command that answers with data. This PR follows §4.2/§4.3. The
§3.8 wording needs a separate decision commit.
