### PR TITLE
fix: refuse prompts without a terminal and route prompts and status lines to stderr

### DIFF
--- a/crates/lns-cli/src/artifact/author.rs
+++ b/crates/lns-cli/src/artifact/author.rs
@@ -125,12 +125,12 @@ pub fn selected_definition_path(file: Option<&Path>, cwd: &Path) -> PathBuf {
     }
 }
 
-pub fn init<F: Fs, W: Write>(
+pub fn init<F: Fs, E: Write>(
     fs: &F,
     cwd: &Path,
     kind: DocumentKind,
     file: Option<&Path>,
-    out: &mut W,
+    err: &mut E,
 ) -> Result<i32> {
     let path = selected_definition_path(file, cwd);
     let name = file.map_or_else(|| LNS_YAML.to_string(), |f| f.display().to_string());
@@ -154,7 +154,7 @@ pub fn init<F: Fs, W: Write>(
         DocumentKind::Mixin => "mixin",
     };
     writeln!(
-        out,
+        err,
         "✓ created {name} — your {noun}, every field ready to edit\n\n{next_steps}"
     )?;
     Ok(0)

--- a/crates/lns-cli/src/artifact/real.rs
+++ b/crates/lns-cli/src/artifact/real.rs
@@ -254,9 +254,13 @@ fn run_author(command: &ArtifactCommand, ctx: RunCtx<'_>) -> Result<i32> {
     let cwd = ctx.cwd()?;
     let mut out = std::io::stdout();
     match command {
-        ArtifactCommand::Init(args) => {
-            super::author::init(&RealFs, &cwd, args.kind, args.file.as_deref(), &mut out)
-        }
+        ArtifactCommand::Init(args) => super::author::init(
+            &RealFs,
+            &cwd,
+            args.kind,
+            args.file.as_deref(),
+            &mut std::io::stderr(),
+        ),
         ArtifactCommand::Validate(args) => {
             super::author::validate(&RealFs, &cwd, args.kind, args.file.as_deref(), &mut out)
         }

--- a/crates/lns-cli/src/uninstall/mod.rs
+++ b/crates/lns-cli/src/uninstall/mod.rs
@@ -7,7 +7,7 @@ use lns_ipc::{Request, Response, RunStatus, short_run_id};
 
 use crate::command::{CommandSpec, subcommand};
 use crate::connector::LocalBoxFuture;
-use crate::service::{DisableOutcome, ServiceClient};
+use crate::service::{DisableOutcome, ServiceClient, TermInfo};
 
 mod real;
 
@@ -78,8 +78,10 @@ pub async fn run_with<S, C, A, F>(
     args: &UninstallArgs,
     plan: &UninstallPlan,
     deps: &Deps<'_, S, C, A, F>,
+    term: TermInfo,
     input: &mut dyn BufRead,
     writer: &mut impl Write,
+    err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<i32>
 where
     S: UninstallService,
@@ -87,9 +89,17 @@ where
     A: LoginAgent,
     F: Fs,
 {
-    if !args.yes && !confirm(args.purge, &plan.purge_dirs, input, writer)? {
-        writeln!(writer, "Uninstall cancelled.")?;
-        return Ok(0);
+    if !args.yes {
+        if !term.stdin_is_tty {
+            bail!(
+                "this stops your sandboxes and removes the lns binaries; there is no terminal to ask at, so pass -y/--yes to confirm"
+            );
+        }
+        if !confirm(args.purge, &plan.purge_dirs, input, err).await? {
+            err.write_all(b"Uninstall cancelled.\n").await?;
+            err.flush().await?;
+            return Ok(0);
+        }
     }
     if deps.client.ping().await {
         stop_running_sandboxes(deps.svc, writer).await?;
@@ -104,38 +114,38 @@ where
     Ok(0)
 }
 
-fn confirm(
+async fn confirm(
     purge: bool,
     purge_dirs: &[PathBuf],
     input: &mut dyn BufRead,
-    writer: &mut impl Write,
+    err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<bool> {
-    if purge {
-        let targets = purge_dirs
-            .iter()
-            .map(|dir| dir.display().to_string())
-            .collect::<Vec<_>>()
-            .join(" and ");
-        let data_clause = if targets.is_empty() {
-            "deletes all local data".to_string()
-        } else {
-            format!("deletes all local data under {targets}")
-        };
-        write!(
-            writer,
-            "This stops all running sandboxes, removes the lns binaries and background service, and {data_clause} (cached images, named volumes, the audit trail, and stored credentials). Continue? [y/N] "
-        )?;
-    } else {
-        write!(
-            writer,
-            "This stops all running sandboxes and removes the lns binaries and background service. Your local data and named volumes are kept — re-run with --purge to remove them too. Continue? [y/N] "
-        )?;
-    }
-    writer.flush()?;
+    err.write_all(question(purge, purge_dirs).as_bytes())
+        .await?;
+    err.flush().await?;
     let mut line = String::new();
     input.read_line(&mut line)?;
     let answer = line.trim();
     Ok(answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes"))
+}
+
+fn question(purge: bool, purge_dirs: &[PathBuf]) -> String {
+    if !purge {
+        return "This stops all running sandboxes and removes the lns binaries and background service. Your local data and named volumes are kept — re-run with --purge to remove them too. Continue? [y/N] ".to_string();
+    }
+    let targets = purge_dirs
+        .iter()
+        .map(|dir| dir.display().to_string())
+        .collect::<Vec<_>>()
+        .join(" and ");
+    let data_clause = if targets.is_empty() {
+        "deletes all local data".to_string()
+    } else {
+        format!("deletes all local data under {targets}")
+    };
+    format!(
+        "This stops all running sandboxes, removes the lns binaries and background service, and {data_clause} (cached images, named volumes, the audit trail, and stored credentials). Continue? [y/N] "
+    )
 }
 
 async fn stop_running_sandboxes(
@@ -482,6 +492,13 @@ mod tests {
         fs: FakeFs,
     }
 
+    fn at_a_terminal() -> TermInfo {
+        TermInfo {
+            stdin_is_tty: true,
+            stdout_is_terminal: true,
+        }
+    }
+
     impl Rig {
         async fn run(
             &self,
@@ -489,16 +506,32 @@ mod tests {
             plan: &UninstallPlan,
             input: &str,
         ) -> (Result<i32>, String) {
+            let (result, out, _err) = self.run_at(args, plan, at_a_terminal(), input).await;
+            (result, out)
+        }
+
+        async fn run_at(
+            &self,
+            args: &UninstallArgs,
+            plan: &UninstallPlan,
+            term: TermInfo,
+            input: &str,
+        ) -> (Result<i32>, String, String) {
             let mut reader = input.as_bytes();
             let mut out: Vec<u8> = Vec::new();
+            let mut err: Vec<u8> = Vec::new();
             let deps = Deps {
                 svc: &self.svc,
                 client: &self.client,
                 agent: &self.agent,
                 fs: &self.fs,
             };
-            let result = run_with(args, plan, &deps, &mut reader, &mut out).await;
-            (result, String::from_utf8(out).unwrap())
+            let result = run_with(args, plan, &deps, term, &mut reader, &mut out, &mut err).await;
+            (
+                result,
+                String::from_utf8(out).unwrap(),
+                String::from_utf8(err).unwrap(),
+            )
         }
     }
 
@@ -535,18 +568,64 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs::default(),
         );
-        let (code, out) = rig
-            .run(
+        let (code, out, err) = rig
+            .run_at(
                 &args(false, false),
                 &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
                 "n\n",
             )
             .await;
         assert_eq!(code.unwrap(), 0);
-        assert!(out.contains("Uninstall cancelled."), "got: {out}");
+        assert!(err.contains("Uninstall cancelled."), "got: {err}");
+        assert!(!out.contains("Uninstall cancelled."), "got: {out}");
         assert!(rig.client.calls().is_empty(), "service must not be pinged");
         assert!(rig.fs.removed().is_empty(), "nothing removed");
         assert_eq!(*rig.agent.calls.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn with_no_terminal_to_ask_at_the_uninstall_refuses_and_names_the_flag_that_answers_it() {
+        let rig = rig(
+            FakeService::default(),
+            stopped_client(),
+            FakeAgent::new(DisableOutcome::WasNotRegistered),
+            FakeFs::default(),
+        );
+        let (result, _out, _err) = rig
+            .run_at(
+                &args(false, false),
+                &plan_with_binaries(&["/bin/lns"]),
+                TermInfo::default(),
+                "",
+            )
+            .await;
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("--yes"), "got: {err}");
+        assert!(err.contains("no terminal to ask at"), "got: {err}");
+        assert!(rig.fs.removed().is_empty(), "nothing removed");
+        assert!(rig.client.calls().is_empty(), "service must not be pinged");
+    }
+
+    #[tokio::test]
+    async fn the_confirmation_question_is_asked_on_stderr_so_a_piped_stdout_never_hides_it() {
+        let rig = rig(
+            FakeService::default(),
+            stopped_client(),
+            FakeAgent::new(DisableOutcome::WasNotRegistered),
+            FakeFs::default(),
+        );
+        let (code, out, err) = rig
+            .run_at(
+                &args(false, false),
+                &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
+                "n\n",
+            )
+            .await;
+        assert_eq!(code.unwrap(), 0);
+        assert!(err.contains("Continue? [y/N]"), "got: {err}");
+        assert!(!out.contains("Continue?"), "got: {out}");
     }
 
     #[tokio::test]
@@ -557,15 +636,16 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs::default(),
         );
-        let (code, out) = rig
-            .run(
+        let (code, _out, err) = rig
+            .run_at(
                 &args(false, false),
                 &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
                 "\n",
             )
             .await;
         assert_eq!(code.unwrap(), 0);
-        assert!(out.contains("Uninstall cancelled."), "got: {out}");
+        assert!(err.contains("Uninstall cancelled."), "got: {err}");
     }
 
     #[tokio::test]
@@ -599,11 +679,16 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs::default(),
         );
-        let (code, out) = rig
-            .run(&args(false, true), &plan_with_binaries(&["/bin/lns"]), "")
+        let (code, out, err) = rig
+            .run_at(
+                &args(false, true),
+                &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
+                "",
+            )
             .await;
         assert_eq!(code.unwrap(), 0);
-        assert!(!out.contains("Continue?"), "prompt must be skipped: {out}");
+        assert!(!err.contains("Continue?"), "prompt must be skipped: {err}");
         assert!(out.contains("lns has been uninstalled."), "got: {out}");
     }
 
@@ -907,17 +992,18 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs::default(),
         );
-        let (code, out) = rig
-            .run(
+        let (code, _out, err) = rig
+            .run_at(
                 &args(true, false),
                 &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
                 "n\n",
             )
             .await;
         assert_eq!(code.unwrap(), 0);
         assert!(
-            out.contains("deletes all local data"),
-            "purge wording: {out}"
+            err.contains("deletes all local data"),
+            "purge wording: {err}"
         );
     }
 
@@ -937,11 +1023,13 @@ mod tests {
             ],
             purge_files: Vec::new(),
         };
-        let (code, out) = rig.run(&args(true, false), &plan, "n\n").await;
+        let (code, _out, err) = rig
+            .run_at(&args(true, false), &plan, at_a_terminal(), "n\n")
+            .await;
         assert_eq!(code.unwrap(), 0);
         assert!(
-            out.contains("/home/me/.lns") && out.contains("/run/user/1000/lns"),
-            "the prompt must show what will actually be deleted: {out}"
+            err.contains("/home/me/.lns") && err.contains("/run/user/1000/lns"),
+            "the prompt must show what will actually be deleted: {err}"
         );
     }
 
@@ -953,14 +1041,15 @@ mod tests {
             FakeAgent::new(DisableOutcome::WasNotRegistered),
             FakeFs::default(),
         );
-        let (_code, out) = rig
-            .run(
+        let (_code, _out, err) = rig
+            .run_at(
                 &args(false, false),
                 &plan_with_binaries(&["/bin/lns"]),
+                at_a_terminal(),
                 "n\n",
             )
             .await;
-        assert!(out.contains("kept"), "non-purge keeps data: {out}");
+        assert!(err.contains("kept"), "non-purge keeps data: {err}");
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/uninstall/real.rs
+++ b/crates/lns-cli/src/uninstall/real.rs
@@ -8,7 +8,7 @@ use super::{Deps, Fs, LoginAgent, PurgeSources, UninstallArgs, UninstallPlan, Un
 use crate::command::{RunCtx, RunFuture};
 use crate::connector::LocalBoxFuture;
 use crate::service::real::RealServiceClient;
-use crate::service::{DisableOutcome, disable_login_agent};
+use crate::service::{DisableOutcome, TermInfo, disable_login_agent};
 
 pub fn run_command<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> {
     Box::pin(async move {
@@ -32,8 +32,21 @@ async fn run(args: UninstallArgs, ctx: RunCtx<'_>) -> Result<i32> {
         agent: &agent,
         fs: &fs,
     };
+    let term = TermInfo {
+        stdin_is_tty: crate::raw_mode::stdin_is_tty(),
+        stdout_is_terminal: std::io::IsTerminal::is_terminal(&std::io::stdout()),
+    };
     let mut out = ctx.out;
-    super::run_with(&args, &plan, &deps, ctx.input, &mut out).await
+    super::run_with(
+        &args,
+        &plan,
+        &deps,
+        term,
+        ctx.input,
+        &mut out,
+        &mut tokio::io::stderr(),
+    )
+    .await
 }
 
 async fn build_plan(purge: bool) -> Result<UninstallPlan> {

--- a/crates/lns-cli/src/volume/mod.rs
+++ b/crates/lns-cli/src/volume/mod.rs
@@ -8,6 +8,7 @@ use crate::connector::LocalBoxFuture;
 
 mod real;
 
+pub use crate::service::TermInfo;
 pub use real::RealVolumeService;
 
 #[derive(clap::Args)]
@@ -96,6 +97,7 @@ pub trait VolumeService {
 pub async fn run(
     cmd: &VolumeCommand,
     svc: &dyn VolumeService,
+    term: TermInfo,
     input: &mut dyn BufRead,
     writer: &mut impl Write,
     err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
@@ -105,7 +107,7 @@ pub async fn run(
         VolumeCommand::Create(args) => create(svc, &args.name, writer).await,
         VolumeCommand::Inspect(args) => inspect(svc, &args.name, args.output.format, writer).await,
         VolumeCommand::Rm(args) => rm(svc, &args.name, writer).await,
-        VolumeCommand::Prune(args) => prune(svc, args.force, input, writer, err).await,
+        VolumeCommand::Prune(args) => prune(svc, args.force, term, input, writer, err).await,
     }
 }
 
@@ -226,11 +228,17 @@ async fn rm(svc: &dyn VolumeService, name: &str, writer: &mut impl Write) -> Res
 async fn prune(
     svc: &dyn VolumeService,
     force: bool,
+    term: TermInfo,
     input: &mut dyn BufRead,
     writer: &mut impl Write,
     err: &mut (impl tokio::io::AsyncWriteExt + Unpin),
 ) -> Result<i32> {
     if !force {
+        if !term.stdin_is_tty {
+            bail!(
+                "this removes every volume not attached to a running sandbox; there is no terminal to ask at, so pass --force to confirm"
+            );
+        }
         let unused = unused_volume_names(svc).await?;
         if unused.is_empty() {
             writeln!(writer, "No unused volumes.")?;
@@ -365,11 +373,26 @@ mod tests {
         }
     }
 
+    fn at_a_terminal() -> TermInfo {
+        TermInfo {
+            stdin_is_tty: true,
+            stdout_is_terminal: true,
+        }
+    }
+
     async fn run_cmd(cmd: &VolumeCommand, svc: &dyn VolumeService) -> Result<(i32, String)> {
+        run_cmd_at(cmd, svc, at_a_terminal()).await
+    }
+
+    async fn run_cmd_at(
+        cmd: &VolumeCommand,
+        svc: &dyn VolumeService,
+        term: TermInfo,
+    ) -> Result<(i32, String)> {
         let mut input = Cursor::new(String::new());
         let mut buf = Vec::new();
         let mut err_buf = Vec::new();
-        let code = run(cmd, svc, &mut input, &mut buf, &mut err_buf).await?;
+        let code = run(cmd, svc, term, &mut input, &mut buf, &mut err_buf).await?;
         buf.extend_from_slice(&err_buf);
         Ok((code, String::from_utf8(buf).unwrap()))
     }
@@ -411,18 +434,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prune_without_force_reads_eof_as_decline() {
-        let svc = CannedService::with([Some(Response::VolumeList {
-            volumes: vec![volume("scratch")],
-        })]);
-        let (code, out) = run_cmd(
+    async fn prune_without_a_terminal_refuses_and_names_the_flag_that_answers_it() {
+        let svc = CannedService::with([]);
+        let err = run_cmd_at(
             &VolumeCommand::Prune(VolumePruneArgs { force: false }),
             &svc,
+            TermInfo::default(),
         )
         .await
-        .unwrap();
-        assert_eq!(code, 0);
-        assert!(out.contains("Aborted."), "got: {out}");
+        .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("--force"), "got: {err}");
+        assert!(err.contains("no terminal to ask at"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/volume/real.rs
+++ b/crates/lns-cli/src/volume/real.rs
@@ -13,9 +13,14 @@ pub fn run<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFuture<'a> 
         crate::service::require_running().await?;
         let svc = RealVolumeService::new(crate::service::socket_path()?);
         let mut out = ctx.out;
+        let term = super::TermInfo {
+            stdin_is_tty: crate::raw_mode::stdin_is_tty(),
+            stdout_is_terminal: std::io::IsTerminal::is_terminal(&std::io::stdout()),
+        };
         crate::volume::run(
             &args.command,
             &svc,
+            term,
             ctx.input,
             &mut out,
             &mut tokio::io::stderr(),

--- a/crates/lns-cli/tests/behaviours/prune_lists.feature
+++ b/crates/lns-cli/tests/behaviours/prune_lists.feature
@@ -59,6 +59,7 @@ Feature: a prune lists what it would remove before asking
 
   Scenario: a volume prune with nothing unused never asks
     Given the service reports a volume "prism-data" using 1024 bytes on disk held by run 7
+    And volume input is a terminal
     When the user runs volume command "prune"
     Then the exit code is 0
     And the output contains "No unused volumes."

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -21,6 +21,13 @@ Feature: authoring a document
     And the file "lns.yaml" contains "ports:"
     And the file "lns.yaml" contains "tools: []"
 
+  Scenario: the created-file line lands on stderr, so a piped stdout stays the answer
+    Given the current directory has no lns.yaml
+    When the user runs artifact command "init"
+    Then the exit code is 0
+    And the command's stderr contains "✓ created lns.yaml"
+    And the command's stdout does not contain "✓"
+
   Scenario: the scaffolded definition is valid as written
     Given the current directory has no lns.yaml
     When the user runs artifact command "init"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -448,9 +448,10 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &ArtifactCommand) {
         files: RefCell::new(w.author_files.clone()),
     };
     let mut out: Vec<u8> = Vec::new();
+    let mut err: Vec<u8> = Vec::new();
     let result = match cmd {
         ArtifactCommand::Init(args) => {
-            author::init(&fs, cwd, args.kind, args.file.as_deref(), &mut out)
+            author::init(&fs, cwd, args.kind, args.file.as_deref(), &mut err)
         }
         ArtifactCommand::Validate(args) => {
             author::validate(&fs, cwd, args.kind, args.file.as_deref(), &mut out)
@@ -466,6 +467,11 @@ fn run_author_verb(w: &mut BehaviourWorld, cmd: &ArtifactCommand) {
         _ => unreachable!("run_author_verb is only called for the offline author verbs"),
     };
     w.author_files = fs.files.into_inner();
+    w.split_streams = Some((
+        String::from_utf8_lossy(&out).into_owned(),
+        String::from_utf8_lossy(&err).into_owned(),
+    ));
+    out.extend_from_slice(&err);
     w.result = Some(match result {
         Ok(exit_code) => CliRun {
             exit_code,

--- a/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/volume_cli.rs
@@ -200,6 +200,17 @@ fn service_unreachable(world: &mut BehaviourWorld) {
 #[given(expr = "the user will answer {string} to the prompt")]
 fn prompt_answer(world: &mut BehaviourWorld, answer: String) {
     world.volume.prompt_answer = Some(answer);
+    world.volume.stdin_is_tty = true;
+}
+
+#[given("volume input is a terminal")]
+fn volume_input_is_a_terminal(world: &mut BehaviourWorld) {
+    world.volume.stdin_is_tty = true;
+}
+
+#[given("volume input is non-interactive")]
+fn volume_input_is_noninteractive(world: &mut BehaviourWorld) {
+    world.volume.stdin_is_tty = false;
 }
 
 #[when(expr = "the user runs volume command {string}")]
@@ -218,21 +229,33 @@ async fn run_volume(world: &mut BehaviourWorld, tail: String) {
             let mut input = std::io::Cursor::new(stdin_text);
             let mut buf = Vec::<u8>::new();
             let mut err_buf = Vec::<u8>::new();
-            let run =
-                match volume::run(&args.command, &svc, &mut input, &mut buf, &mut err_buf).await {
-                    Ok(exit_code) => CliRun {
-                        exit_code,
-                        output: format!(
-                            "{}{}",
-                            String::from_utf8_lossy(&buf),
-                            String::from_utf8_lossy(&err_buf)
-                        ),
-                    },
-                    Err(e) => CliRun {
-                        exit_code: 1,
-                        output: format!("{}{e:#}", String::from_utf8_lossy(&buf)),
-                    },
-                };
+            let term = volume::TermInfo {
+                stdin_is_tty: world.volume.stdin_is_tty,
+                stdout_is_terminal: false,
+            };
+            let run = match volume::run(
+                &args.command,
+                &svc,
+                term,
+                &mut input,
+                &mut buf,
+                &mut err_buf,
+            )
+            .await
+            {
+                Ok(exit_code) => CliRun {
+                    exit_code,
+                    output: format!(
+                        "{}{}",
+                        String::from_utf8_lossy(&buf),
+                        String::from_utf8_lossy(&err_buf)
+                    ),
+                },
+                Err(e) => CliRun {
+                    exit_code: 1,
+                    output: format!("{}{e:#}", String::from_utf8_lossy(&buf)),
+                },
+            };
             world.split_streams = Some((
                 String::from_utf8_lossy(&buf).into_owned(),
                 String::from_utf8_lossy(&err_buf).into_owned(),

--- a/crates/lns-cli/tests/behaviours/volume_cli.feature
+++ b/crates/lns-cli/tests/behaviours/volume_cli.feature
@@ -100,6 +100,14 @@ Feature: managing named volumes from the CLI
     And the output contains "Aborted."
     And no prune request reached the service
 
+  Scenario: with no terminal to ask at, prune refuses rather than assuming
+    Given the volume "orphan" is held by no running sandbox and named by no cached sandbox
+    And volume input is non-interactive
+    When the user runs volume command "prune"
+    Then the command fails with an exit code other than 0
+    And the output contains "--force"
+    And no request reached the service
+
   Scenario: pruning with nothing to remove says so
     Given the service will prune no volumes
     When the user runs volume command "prune --force"

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -186,6 +186,7 @@ pub struct VolumeCliRig {
     pub unreachable: bool,
     pub requests: std::sync::Arc<std::sync::Mutex<Vec<lns_ipc::Request>>>,
     pub prompt_answer: Option<String>,
+    pub stdin_is_tty: bool,
 }
 
 /// Drives the in-process `lns run` target resolution: what image a run request would carry, and a service refusal to surface.


### PR DESCRIPTION
`docs/cli-spec.md` §7.2 says: "With no terminal to ask at, a command that would have asked refuses and names the flag that would have answered it. It never assumes." It also says: "A prompt is written to stderr." §4.1 and §4.2 say that stdout carries the answer, and that stderr carries the progress, status and ✓ lines.

Three commands did not obey these rules. This PR corrects them.

## 1. `lns volume prune` with no terminal

Before, the command read the end of the input as "no". It cancelled the prune and exited 0. The user saw a success exit code for work that did not happen.

```console
$ lns volume prune </dev/null
Would remove:
  orphan
This removes every volume not attached to a running sandbox. Continue? [y/N] Aborted.
$ echo $?
0
```

Now the command refuses and names `--force`:

```console
$ lns volume prune </dev/null
error: this removes every volume not attached to a running sandbox; there is no terminal to ask at, so pass --force to confirm
$ echo $?
1
```

`lns sandbox prune` and `lns artifact prune` already do this. `lns volume prune` now uses the same `TermInfo` seam.

## 2. `lns uninstall` with no terminal

Before, the command read the end of the input as "no" and exited 0:

```console
$ lns uninstall </dev/null
This stops all running sandboxes and removes the lns binaries and background service. [...] Continue? [y/N] Uninstall cancelled.
$ echo $?
0
```

Now the command refuses and names `-y`/`--yes`:

```console
$ lns uninstall </dev/null
error: this stops your sandboxes and removes the lns binaries; there is no terminal to ask at, so pass -y/--yes to confirm
$ echo $?
1
```

## 3. Prompts and status lines on stderr

The `lns uninstall` question went to stdout. A user who redirects stdout could not see the question, but the command still waited for an answer. The question and the `Uninstall cancelled.` notice now go to stderr, the same as the `Aborted.` notice of `lns volume prune`.

```console
$ lns uninstall > log.txt
This stops all running sandboxes and removes the lns binaries and background service. [...] Continue? [y/N]
```

The `✓ created` line of `lns init` and `lns artifact init` went to stdout too. It now goes to stderr, the same as the ✓ lines of `lns run` and `lns exec`. stdout stays empty for a command that writes a file.

```console
$ lns init > out.txt
✓ created lns.yaml — your sandbox definition, every field ready to edit

  1. set spec.image (scaffolded to alpine:3.20)
  2. boot it with `lns run`
  3. share it with `lns push`, e.g. `lns push ghcr.io/acme/my-sandbox:1.0.0`
$ cat out.txt
$
```

## Tests

Each change starts with a failing test.

- Layer 2: `volume_cli.feature` gets a refusal scenario that names `--force`. `sandbox_author.feature` gets a scenario that reads the `✓ created` line on stderr and finds no ✓ on stdout.
- Layer 3: `volume/mod.rs` replaces `prune_without_force_reads_eof_as_decline`, which pinned the wrong behaviour, with a test of the refusal. `uninstall/mod.rs` gets a test of the refusal and a test that the question lands on stderr.

Out of scope: a prompt still reads stdin. §7.2 asks for `/dev/tty`. That change needs a separate decision.
