### PR TITLE
docs(spec): record the shipped surface the spec omitted

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -402,9 +402,15 @@ One chronological timeline, newest first, across every sandbox — or scoped to 
 lns audit [SANDBOX] [--connector <ID>] [--kind <KIND>] [--format <table|jsonl>]
 ```
 
-`SANDBOX` is a `RUN`. `--kind` takes one of `launch`,
-`egress`, `env`, `volume`, `bind`, `approval`, `connection`, `credential`, or
-`tool`. Filters compose.
+`SANDBOX` is a `RUN`. `--kind` takes one of `launch`, `exit`, `restart`,
+`sandbox_run`, `run_removed`, `runs_pruned`, `egress`, `env`, `volume`, `bind`,
+`approval`, `connection`, `credential`, or `tool`. Filters compose.
+
+A sandbox's own life is in the timeline as much as what it reached for: `launch`
+is the workload starting, `exit` is it ending, `restart` is a stopped sandbox
+running again, `sandbox_run` records the run against the artifact it ran, and
+`run_removed` and `runs_pruned` are the sandbox being removed — one by name, or
+swept with every other stopped one.
 
 It is not `lns sandbox audit`, because half of what it reads is not a sandbox's:
 the timeline merges each sandbox's own chain with the durable ledger of

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -277,7 +277,7 @@ contributed it. That summary is the one thing you approve.
 | `start` | `lns start` | Runs a stopped sandbox again. The launch replays exactly as recorded — image, command, env, mounts, ports, resources, run-as — while the network rules and credentials re-resolve as they would for a fresh boot, and the **recorded** `pre-start` scripts run again — the ones the approved launch resolved, not a fresh resolution. Detached by default; `-a` attaches, `-i` also forwards stdin, and `--detach-keys <CHORD>` (default `ctrl-p,ctrl-q`) sets the chord that returns your terminal from an attached start. A conflict (a taken host port, a held volume, a missing bind source) aborts the start and leaves the sandbox stopped. |
 | `stop` | `lns stop` | Asks the workload to exit, then escalates to `SIGKILL` after `-t <SECONDS>` (default `10`). Reports whether it had to escalate. A run still inside its `pre-start` scripts has no workload yet; `stop` ends it too. |
 | `kill` | `lns kill` | Sends one signal and returns. `--signal` takes `TERM` (default), `INT`, `QUIT`, `HUP`, `WINCH`, or `KILL`, bare or `SIG`-prefixed, case-insensitive. |
-| `exec` | `lns exec` | Runs another command inside a running sandbox. `-i` and `-t` work as on `run`, `--detach-keys` closes only this session, and `-q` silences the status lines. |
+| `exec` | `lns exec` | Runs another command inside a running sandbox. `-i` and `-t` are spelled as on `run` but are off unless you ask for them ([§7.3](#73-terminals)), `--detach-keys` closes only this session, and `-q` silences the status lines. |
 | `logs` | `lns logs` | Prints the captured output. `-f`/`--follow` streams until the workload exits. The service keeps the most recent 2 MiB per sandbox. |
 | `attach` | `lns attach` | Re-joins the live session, most useful after `run -d`. The detach chord leaves the sandbox running and returns you to your shell; no signal is sent. Stdin reaches the workload only if the sandbox was started with stdin open. |
 | `ls` | `lns ps` | Lists running sandboxes with their state, CPU, and memory. `-a` includes stopped ones. |
@@ -596,9 +596,13 @@ has to be answerable while a sandbox is already running.
 
 ### 7.3 Terminals
 
-`-i` and `-t` are on by default, and pipe mode is selected automatically when
-stdin is not a terminal — an interactive session needs no flags, a scripted one
-needs no ceremony. `-d` conflicts with both.
+On `lns run`, `-i` and `-t` are on by default, and pipe mode is selected
+automatically when stdin is not a terminal — an interactive session needs no
+flags, a scripted one needs no ceremony. `-d` conflicts with both.
+
+On `lns exec` both are off by default. A run is the session you came for; an
+exec is usually one command whose output you are reading or piping, so it asks
+for a terminal only when you say `-it`.
 
 ---
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -455,7 +455,7 @@ lns logout [REGISTRY]
 | Form | What it does |
 |---|---|
 | `lns login [REGISTRY]` | Logs in to `REGISTRY`, defaulting to `run.registry`, else `hub.lns.run`. Give the secret with `--password-stdin` (recommended) or `-p`/`--password`, and the user with `-u`/`--username`. The credential is verified against the registry before it is stored, so the service must be running. |
-| `lns login --list` | Lists the registries you are logged in to, as `host  username`. Never secrets. |
+| `lns login --list` | Lists the registries you are logged in to. It is a list like any other ([§4.2](#42-human-output), [§4.3](#43-machine-output)): a table of registry and username, `--format <table\|json>`. Never secrets. |
 | `lns logout [REGISTRY]` | Removes the stored credential. |
 
 A registry is matched by host: a fully-qualified reference uses that host's stored

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -210,7 +210,7 @@ Create, run, watch, and remove sandboxes.
 
 ```bash
 lns sandbox run [OPTIONS] [REF] [-- COMMAND...]
-lns sandbox start <RUN> [-a] [-i]
+lns sandbox start <RUN> [-a] [-i] [--detach-keys <CHORD>]
 lns sandbox stop <RUN> [-t <SECONDS>]
 lns sandbox kill <RUN> [--signal <SIG>]
 lns sandbox exec [OPTIONS] <RUN> [-- COMMAND...]
@@ -274,7 +274,7 @@ contributed it. That summary is the one thing you approve.
 
 | Verb | Shortcut | What it does |
 |---|---|---|
-| `start` | `lns start` | Runs a stopped sandbox again. The launch replays exactly as recorded — image, command, env, mounts, ports, resources, run-as — while the network rules and credentials re-resolve as they would for a fresh boot, and the **recorded** `pre-start` scripts run again — the ones the approved launch resolved, not a fresh resolution. Detached by default; `-a` attaches, `-i` also forwards stdin. A conflict (a taken host port, a held volume, a missing bind source) aborts the start and leaves the sandbox stopped. |
+| `start` | `lns start` | Runs a stopped sandbox again. The launch replays exactly as recorded — image, command, env, mounts, ports, resources, run-as — while the network rules and credentials re-resolve as they would for a fresh boot, and the **recorded** `pre-start` scripts run again — the ones the approved launch resolved, not a fresh resolution. Detached by default; `-a` attaches, `-i` also forwards stdin, and `--detach-keys <CHORD>` (default `ctrl-p,ctrl-q`) sets the chord that returns your terminal from an attached start. A conflict (a taken host port, a held volume, a missing bind source) aborts the start and leaves the sandbox stopped. |
 | `stop` | `lns stop` | Asks the workload to exit, then escalates to `SIGKILL` after `-t <SECONDS>` (default `10`). Reports whether it had to escalate. A run still inside its `pre-start` scripts has no workload yet; `stop` ends it too. |
 | `kill` | `lns kill` | Sends one signal and returns. `--signal` takes `TERM` (default), `INT`, `QUIT`, `HUP`, `WINCH`, or `KILL`, bare or `SIG`-prefixed, case-insensitive. |
 | `exec` | `lns exec` | Runs another command inside a running sandbox. `-i` and `-t` work as on `run`, `--detach-keys` closes only this session, and `-q` silences the status lines. |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -187,7 +187,7 @@ lns artifact prune [-f]
 | Verb | Shortcut | What it does |
 |---|---|---|
 | `init` | `lns init` | Scaffolds a document in this directory. `--kind` chooses which — `sandbox` (the default), `mixin`, or `connector`; the file is `./lns.yaml` unless `-f` names another. Refuses to overwrite. |
-| `validate` | | Checks the document named by `-f`, or `./lns.yaml`, offline — schema, cross-field, and secret checks — and lists every problem it found, not just the first. Exits non-zero when the document is broken. `--kind <KIND>` also requires the document to be that kind. |
+| `validate` | | Checks the document named by `-f`, or `./lns.yaml`, offline — schema, cross-field, and secret checks — and lists every problem it found, not just the first. That list is the answer, so it goes to stdout ([§4.1](#41-streams)), and the exit code is non-zero when the document is broken. `--kind <KIND>` also requires the document to be that kind. |
 | `push` | `lns push` | Publishes the document as one OCI artifact at `<REF>`. Each `spec.filesets` `path` directory is packed into a layer of that same artifact, so the files and the declaration that mounts them share one digest; a `README.md` beside the document is packed into a `text/markdown` layer (`sandbox-spec.md` §7.2); each fuzzy `spec.tools` version is resolved and published as an exact pin. For a `spec.mixins` entry that names a local path, the document it names publishes first as its own artifact, beside `<REF>` and under the mixin's own `name`, tagged with its own digest, and the entry is pinned to that digest — the command lists those mixins and asks before it uploads anything, which `--yes` accepts without prompting. `--dry-run` does everything except the upload, stays offline, prints the digests that would publish for every artifact, and says when a declared tool means a real digest may differ. |
 | `pull` | `lns pull` | Shows you what the reference resolves to, then fetches it and its base image into the local store. A sandbox that declares tools asks before running their installers in a disposable provisioning guest; `--yes` accepts that without prompting. The fetch is bound to the digest you were shown, so a tag that moves in between is refused. |
 | `tag` | `lns tag` | Re-references a cached artifact under a new tag, in its own registry and repository. |
@@ -491,6 +491,9 @@ lines, warnings, errors, prompts, and log output at every level.
 
 So `lns ps --format json | jq` works, `lns logs 7 > file` captures the workload
 and nothing else, and redirecting stdout never hides a warning or a prompt.
+`lns artifact validate` follows the same rule rather than the shape of what it
+prints: the problem report is the answer you asked for, so it is stdout, and the
+non-zero exit is what says the document is broken.
 
 ### 4.2 Human output
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -252,7 +252,7 @@ keeping its `ENTRYPOINT`; `--` is accepted but not required.
 | `-u`, `--user <USER[:GROUP]>` | image `USER`, else `sandbox` | Run-as user or uid inside the sandbox. Outranks `spec.user`, which outranks the image. `HOME` and `USER` follow that user's guest passwd entry unless `env:` or `-e` sets them. |
 | `--entrypoint <COMMAND>` | image `ENTRYPOINT` | Override the image entrypoint; the `COMMAND` after the reference becomes its arguments. `--entrypoint ""` clears it. |
 | `-h`, `--hostname <NAME>` | | Guest hostname for this sandbox. |
-| `--yes` | `false` | Accept the tool installers, host binds, named volumes, and filesets a pulled sandbox declares. Required for a non-interactive run that declares any of them. |
+| `--yes` | `false` | Accept the tool installers, `pre-start` scripts, host binds, named volumes, and filesets a pulled sandbox declares. Required for a non-interactive run that declares any of them. |
 | `-q`, `--quiet` | `false` | Suppress the launch banner and `✓` lines. Warnings, errors, and the workload's output still print. |
 
 Two things a run does without being asked to:

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -194,7 +194,7 @@ lns artifact prune [-f]
 | `ls` | | Lists cached artifacts: reference, kind, digest, size, and what holds each. `--kind` filters. |
 | `inspect` | `lns inspect` | Renders one artifact's resolved content, offline for a local path. `--mixin <REF>` resolves that mixin in first (repeatable), so you can preview a composition without running it. With no operand it renders `./lns.yaml`. |
 | `rm` | `lns rm` | Removes one cached artifact and frees its now-unreferenced layers. Refused while a sandbox holds it — running or stopped — and the message names the holder. |
-| `prune` | | Removes every cached artifact nothing holds. Lists them and asks, unless `-f`/`--force`. |
+| `prune` | | Removes every cached artifact nothing holds, and — when no sandbox is live — the provisioned tool cache, which any running sandbox may still be using. Lists them and asks, unless `-f`/`--force`. |
 
 `-f`/`--file` selects a document other than `./lns.yaml`; its directory is the
 project, so it roots the document's relative binds and filesets and holds the


### PR DESCRIPTION
The CLI specification is the decision for the CLI surface. Seven parts of the shipped surface were not in it. Each commit records one decision.

- **Audit kinds.** `--kind` named nine kinds. The service also writes `exit`, `restart`, `sandbox_run`, `run_removed`, and `runs_pruned` — for example `workload exited with code 0` and `restarted alpine:latest on its preserved state; policy and credentials re-resolved live`. All fourteen are now the vocabulary.
- **`artifact prune`.** `lns artifact prune --help` says "Remove every cached artifact nothing holds, and the provisioned tool cache when no sandbox is live." The specification said only the first half.
- **`sandbox start --detach-keys`.** `start` takes the same chord flag as `run`, `exec`, and `attach`: "With -a: detach chord; on match the CLI detaches, leaving the sandbox running", default `ctrl-p,ctrl-q`.
- **`--yes`.** `lns run --help` says the flag accepts "the tool installers, pre-start scripts, host binds, named volumes, and filesets". The specification's own approval paragraph names the pre-start scripts, but the flag list did not.
- **`--purge`.** Everything under `~/.lns/` goes, connectors included. The list did not name them.
- **Terminal defaults.** `-i` and `-t` default to on for `lns run` and to off for `lns exec`. The rule was written once, for both.
- **`validate` output.** The problem report is the answer you asked for, so it goes to stdout. The non-zero exit code says the document is broken.

Documents only. No code changes, and no guide changes: each item is what ships today.
