### PR TITLE
fix: a config default no longer outranks the resources a document declares

### DIFF
--- a/crates/lns-artifact/src/resources.rs
+++ b/crates/lns-artifact/src/resources.rs
@@ -21,6 +21,24 @@ pub struct ResourceOverrides {
     pub mem_mib: Option<usize>,
 }
 
+/// The `run.cpus`/`run.mem` gap-fillers a machine configured; they sit below the document, so a sandbox that declares its own resources is not silently resized by whoever cloned it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConfiguredDefaults {
+    pub cpus: Option<u8>,
+    pub mem_mib: Option<usize>,
+}
+
+impl ConfiguredDefaults {
+    /// The floor a run lands on when neither a flag nor the document decided its size.
+    pub fn over(self, builtin: VmSize) -> VmSize {
+        VmSize {
+            cpus: self.cpus.unwrap_or(builtin.cpus),
+            mem_mib: self.mem_mib.unwrap_or(builtin.mem_mib),
+            disk_bytes: builtin.disk_bytes,
+        }
+    }
+}
+
 /// What a definition asked for, already read and range-checked — `None` where it asked for nothing the host can grant.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DeclaredSize {
@@ -177,6 +195,53 @@ mod tests {
     ) -> VmSize {
         let (declared, _) = DeclaredSize::from_resources(resources, None);
         resolve_declared(declared, overrides, defaults)
+    }
+
+    #[test]
+    fn a_configured_default_fills_a_size_the_builtin_would_have() {
+        let configured = ConfiguredDefaults {
+            cpus: Some(4),
+            mem_mib: Some(2048),
+        };
+        assert_eq!(
+            configured.over(DEFAULT_VM_SIZE),
+            VmSize {
+                cpus: 4,
+                mem_mib: 2048,
+                disk_bytes: DEFAULT_VM_SIZE.disk_bytes,
+            }
+        );
+    }
+
+    #[test]
+    fn an_unconfigured_machine_keeps_the_builtin_size() {
+        assert_eq!(
+            ConfiguredDefaults::default().over(DEFAULT_VM_SIZE),
+            DEFAULT_VM_SIZE
+        );
+    }
+
+    #[test]
+    fn a_configured_default_never_outranks_what_the_document_declared() {
+        let res = Resources {
+            cpu: Some(Quantity::Int(2)),
+            memory: Some(Quantity::Int(1024)),
+            disk: None,
+        };
+        let configured = ConfiguredDefaults {
+            cpus: Some(4),
+            mem_mib: Some(2048),
+        };
+        let size = resolve(
+            Some(&res),
+            &ResourceOverrides::default(),
+            configured.over(DEFAULT_VM_SIZE),
+        );
+        assert_eq!(
+            (size.cpus, size.mem_mib),
+            (2, 1024),
+            "a sandbox that declares its own resources must not be resized by whoever cloned it"
+        );
     }
 
     #[test]

--- a/crates/lns-cli/src/cli.rs
+++ b/crates/lns-cli/src/cli.rs
@@ -61,7 +61,7 @@ pub struct RunArgs {
     #[arg(
         long,
         value_parser = clap::value_parser!(u8).range(1..),
-        help = "Number of vCPUs; falls back to the `run.cpus` config default, then 1."
+        help = "Number of vCPUs; without it the document's `spec.resources` decides, then the `run.cpus` config default, then 1."
     )]
     pub cpus: Option<u8>,
 
@@ -71,9 +71,16 @@ pub struct RunArgs {
         visible_alias = "memory",
         value_name = "SIZE",
         value_parser = parse_mem_arg,
-        help = "RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`; b/k/m/g, rounded up to MiB); falls back to the `run.mem` config default, then 512."
+        help = "RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`, `-m 2Gi`; b/k/m/g and Mi/Gi, rounded up to MiB); without it the document's `spec.resources` decides, then the `run.mem` config default, then 512."
     )]
     pub mem: Option<usize>,
+
+    /// This machine's `run.cpus`/`run.mem` defaults, kept apart from the flags because the document outranks them.
+    #[arg(skip)]
+    pub cpus_config: Option<u8>,
+
+    #[arg(skip)]
+    pub mem_config: Option<usize>,
 
     #[arg(
         short = 'u',

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -375,8 +375,8 @@ where
 }
 
 pub fn apply_run_defaults(mut args: RunArgs, defaults: RunDefaults) -> RunArgs {
-    args.cpus = args.cpus.or(defaults.cpus);
-    args.mem = args.mem.or(defaults.mem);
+    args.cpus_config = defaults.cpus;
+    args.mem_config = defaults.mem;
     args.registry = args.registry.or(defaults.registry);
     if let Some(image) = args.image.take() {
         args.image = Some(if crate::run::target::is_definition_path(&image) {
@@ -660,6 +660,8 @@ mod tests {
             registry: None,
             cpus: None,
             mem: None,
+            cpus_config: None,
+            mem_config: None,
             user: None,
             auto_remove: false,
             interactive: true,
@@ -872,6 +874,27 @@ mod tests {
         );
         assert_eq!(resolved.cpus, Some(2));
         assert_eq!(resolved.mem, Some(1024));
+        assert_eq!(resolved.cpus_config, Some(8));
+        assert_eq!(resolved.mem_config, Some(4096));
+    }
+
+    #[test]
+    fn apply_run_defaults_carries_a_configured_size_in_its_own_slot() {
+        let resolved = apply_run_defaults(
+            bare_run_args(),
+            RunDefaults {
+                cpus: Some(8),
+                mem: Some(4096),
+                ..RunDefaults::default()
+            },
+        );
+        assert_eq!(
+            (resolved.cpus, resolved.mem),
+            (None, None),
+            "folding a configured default into the flags tells the service the user typed it, which would outrank the document"
+        );
+        assert_eq!(resolved.cpus_config, Some(8));
+        assert_eq!(resolved.mem_config, Some(4096));
     }
 
     #[test]

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -37,18 +37,22 @@ pub fn resolve_policy(project: &Path) -> Result<(PathBuf, PolicySource)> {
     }
 }
 
-/// The size the run will boot with: an explicit flag outranks what the definition declared, which outranks the built-in default.
+/// The size the run will boot with: an explicit flag outranks what the definition declared, which outranks this machine's config defaults, which outrank the built-in size.
 pub fn resolved_size(
     declared: lns_artifact::resources::DeclaredSize,
     args: &RunArgs,
 ) -> lns_artifact::resources::VmSize {
+    let configured = lns_artifact::resources::ConfiguredDefaults {
+        cpus: args.cpus_config,
+        mem_mib: args.mem_config,
+    };
     lns_artifact::resources::resolve_declared(
         declared,
         &lns_artifact::resources::ResourceOverrides {
             cpus: args.cpus,
             mem_mib: args.mem,
         },
-        lns_artifact::resources::DEFAULT_VM_SIZE,
+        configured.over(lns_artifact::resources::DEFAULT_VM_SIZE),
     )
 }
 
@@ -790,6 +794,8 @@ mod tests {
             registry: None,
             cpus: None,
             mem: None,
+            cpus_config: None,
+            mem_config: None,
             user: None,
             auto_remove: false,
             interactive: true,
@@ -1777,6 +1783,38 @@ mod tests {
             &PolicySource::Found,
         );
         assert!(s.contains("3 vCPU · 6144 MiB"), "resources line wrong: {s}");
+    }
+
+    #[test]
+    fn resolved_size_ranks_the_flag_over_the_document_over_the_config_default() {
+        let declared = lns_artifact::resources::DeclaredSize {
+            cpus: Some(2),
+            mem_mib: Some(1024),
+            disk_bytes: None,
+        };
+        let mut args = run_args(Some("ubuntu"));
+        args.cpus_config = Some(4);
+        args.mem_config = Some(4096);
+        let size = resolved_size(declared, &args);
+        assert_eq!(
+            (size.cpus, size.mem_mib),
+            (2, 1024),
+            "a sandbox that declares its own resources must not be resized by whoever cloned it"
+        );
+
+        args.cpus = Some(8);
+        args.mem = Some(8192);
+        let size = resolved_size(declared, &args);
+        assert_eq!((size.cpus, size.mem_mib), (8, 8192));
+    }
+
+    #[test]
+    fn resolved_size_falls_back_to_a_config_default_when_the_document_is_silent() {
+        let mut args = run_args(Some("ubuntu"));
+        args.cpus_config = Some(4);
+        args.mem_config = Some(4096);
+        let size = resolved_size(Default::default(), &args);
+        assert_eq!((size.cpus, size.mem_mib), (4, 4096));
     }
 
     #[test]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -536,6 +536,8 @@ pub async fn run_image(
         mem: args.effective_mem(),
         cpus_explicit: args.cpus.is_some(),
         mem_explicit: args.mem.is_some(),
+        cpus_config: args.cpus_config,
+        mem_config: args.mem_config,
         cmd: args.cmd,
         env: args.env,
         image: Some(target.image()),

--- a/crates/lns-cli/tests/behaviours/run_config_defaults.feature
+++ b/crates/lns-cli/tests/behaviours/run_config_defaults.feature
@@ -18,3 +18,22 @@ Feature: lns run falls back to configured defaults
   Scenario: Built-in defaults apply when nothing is configured
     When the user resolves `lns run alpine` against the configured defaults
     Then the run summary shows "1 vCPU · 512 MiB"
+
+  Scenario: The resources a document declares outrank a configured default
+    Given the default "run.cpus" is "4"
+    And the default "run.mem" is "2048"
+    And an lns.yaml declaring 3 vCPU and 6Gi of memory
+    When the local run summary is composed against the configured defaults
+    Then the run summary shows "3 vCPU · 6144 MiB"
+
+  Scenario: A per-run flag outranks both the document and a configured default
+    Given the default "run.cpus" is "4"
+    And an lns.yaml declaring 3 vCPU and 6Gi of memory
+    When the local run summary is composed against the configured defaults with "--cpus 8"
+    Then the run summary shows "8 vCPU · 6144 MiB"
+
+  Scenario: A configured default fills what the document leaves unsaid
+    Given the default "run.cpus" is "4"
+    And an lns.yaml declaring a 40Gi disk
+    When the local run summary is composed against the configured defaults
+    Then the run summary shows "4 vCPU · 512 MiB · 40 GiB disk"

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -10,7 +10,7 @@ use lns_policy::host_bind_decisions::{HostBindDecisionFile, SecretDisposition};
 
 use crate::world::{BehaviourWorld, HostBindOutcome, ResolvedRunView, TEST_HOST};
 
-fn definition(world: &BehaviourWorld) -> lns_artifact::sandbox::Definition {
+pub fn definition(world: &BehaviourWorld) -> lns_artifact::sandbox::Definition {
     let yaml = world
         .author_files
         .get(Path::new("/work/lns.yaml"))

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -34,6 +34,42 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
     });
 }
 
+#[when(regex = r"^the local run summary is composed against the configured defaults$")]
+fn compose_local_summary_against_defaults(world: &mut BehaviourWorld) {
+    compose_declared_summary_against_defaults(world, String::new());
+}
+
+#[when(
+    regex = r#"^the local run summary is composed against the configured defaults with "([^"]+)"$"#
+)]
+fn compose_local_summary_against_defaults_with(world: &mut BehaviourWorld, flags: String) {
+    compose_declared_summary_against_defaults(world, flags);
+}
+
+fn compose_declared_summary_against_defaults(world: &mut BehaviourWorld, flags: String) {
+    let path = config_path(world);
+    let declared = lns_cli::run::declarative::Defaults::from_definition(
+        &crate::steps::declarative_run::definition(world),
+        Some(crate::world::TEST_HOST),
+    );
+    let mut argv = vec!["lns".to_string(), "run".to_string()];
+    argv.extend(flags.split_whitespace().map(str::to_string));
+    argv.push("alpine".to_string());
+    let args: RunArgs = parse_args(&argv).expect("argv must parse against the CLI grammar");
+    let defaults = config::load_run_defaults(&path).expect("gap-filler defaults load");
+    let resolved = config::apply_run_defaults(args, defaults);
+    world.resolved_run = Some(ResolvedRunView {
+        summary: format_summary(
+            &resolved,
+            lns_cli::run::summary::resolved_size(declared.size, &resolved),
+            &Policy::default(),
+            Path::new("./lns-local-mixin.yaml"),
+            &PolicySource::Found,
+        ),
+        ..Default::default()
+    });
+}
+
 #[then(regex = r#"^the run summary shows "([^"]+)"$"#)]
 fn run_summary_shows(world: &mut BehaviourWorld, needle: String) -> Result<(), String> {
     let view = world

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -657,6 +657,11 @@ pub struct RunImageArgs {
     pub cpus_explicit: bool,
     #[serde(default)]
     pub mem_explicit: bool,
+    /// This machine's `run.cpus`/`run.mem` defaults, carried apart from the flag because they rank below the document: a sandbox that declares its own resources is not silently resized by whoever cloned it.
+    #[serde(default)]
+    pub cpus_config: Option<u8>,
+    #[serde(default)]
+    pub mem_config: Option<usize>,
     pub policy_path: Option<String>,
     #[serde(default)]
     pub sandbox_user: Option<String>,
@@ -1140,6 +1145,8 @@ mod tests {
             mem: 512,
             cpus_explicit: false,
             mem_explicit: false,
+            cpus_config: None,
+            mem_config: None,
             policy_path: None,
             sandbox_user: Some("sandbox".into()),
             sandbox_uid: Some(65534),
@@ -1181,6 +1188,8 @@ mod tests {
             mem: 512,
             cpus_explicit: false,
             mem_explicit: false,
+            cpus_config: None,
+            mem_config: None,
             policy_path: None,
             sandbox_user: None,
             sandbox_uid: None,
@@ -1324,6 +1333,8 @@ mod tests {
             mem: 1024,
             cpus_explicit: true,
             mem_explicit: true,
+            cpus_config: None,
+            mem_config: None,
             policy_path: Some("/work/lns-local-mixin.yaml".into()),
             sandbox_user: Some("sandbox".into()),
             sandbox_uid: Some(65534),
@@ -1541,6 +1552,27 @@ mod tests {
         });
         let parsed: RunImageArgs = serde_json::from_value(frame).unwrap();
         assert_eq!(parsed.name, None);
+    }
+
+    #[test]
+    fn a_config_default_travels_in_its_own_slot_apart_from_the_flags() {
+        let mut args = sample_run_args();
+        args.cpus_explicit = false;
+        args.mem_explicit = false;
+        args.cpus_config = Some(4);
+        args.mem_config = Some(4096);
+        let frame = crate::encode_frame(&args).unwrap();
+        let decoded: RunImageArgs = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(
+            (
+                decoded.cpus_explicit,
+                decoded.mem_explicit,
+                decoded.cpus_config,
+                decoded.mem_config
+            ),
+            (false, false, Some(4), Some(4096)),
+            "a configured default must not reach the service as an explicit flag, or it would outrank the document"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1160,6 +1160,8 @@ mod tests {
                 mem: 0,
                 cpus_explicit: false,
                 mem_explicit: false,
+                cpus_config: None,
+                mem_config: None,
                 policy_path: None,
                 sandbox_user: None,
                 sandbox_uid: None,

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -159,22 +159,51 @@ pub(super) struct SandboxLaunch {
     pub env: Vec<String>,
 }
 
-/// Size a sandbox run's VM: the sandbox's resources are authoritative unless the user set `--cpus`/`-m` explicitly (even to a value equal to the built-in default), in which case the explicit request wins.
+/// What the caller asked for, kept in the three layers the CLI can tell apart: the flags as typed, and the config defaults the machine fills gaps from.
+pub(super) struct RequestedSize {
+    pub cpus: u8,
+    pub cpus_explicit: bool,
+    pub mem_mib: usize,
+    pub mem_explicit: bool,
+    pub cpus_config: Option<u8>,
+    pub mem_config: Option<usize>,
+}
+
+impl RequestedSize {
+    pub fn from_args(args: &lns_ipc::RunImageArgs) -> Self {
+        Self {
+            cpus: args.cpus,
+            cpus_explicit: args.cpus_explicit,
+            mem_mib: args.mem,
+            mem_explicit: args.mem_explicit,
+            cpus_config: args.cpus_config,
+            mem_config: args.mem_config,
+        }
+    }
+}
+
+/// Size a sandbox run's VM: an explicit `--cpus`/`-m` wins (even at a value equal to the built-in default), then the sandbox's own resources, then the machine's config defaults, then the built-in size.
 pub(super) fn sandbox_vm_size(
     resources: Option<&lns_artifact::spec::Resources>,
-    requested_cpus: u8,
-    cpus_explicit: bool,
-    requested_mem_mib: usize,
-    mem_explicit: bool,
+    requested: &RequestedSize,
     host: Option<lns_artifact::resources::HostCapacity>,
 ) -> lns_artifact::resources::VmSize {
     use crate::artifact::resources::resolve_size;
-    use lns_artifact::resources::{DEFAULT_VM_SIZE, ResourceOverrides};
+    use lns_artifact::resources::{ConfiguredDefaults, DEFAULT_VM_SIZE, ResourceOverrides};
     let overrides = ResourceOverrides {
-        cpus: cpus_explicit.then_some(requested_cpus),
-        mem_mib: mem_explicit.then_some(requested_mem_mib),
+        cpus: requested.cpus_explicit.then_some(requested.cpus),
+        mem_mib: requested.mem_explicit.then_some(requested.mem_mib),
     };
-    resolve_size(resources, &overrides, DEFAULT_VM_SIZE, host)
+    let configured = ConfiguredDefaults {
+        cpus: requested.cpus_config,
+        mem_mib: requested.mem_config,
+    };
+    resolve_size(
+        resources,
+        &overrides,
+        configured.over(DEFAULT_VM_SIZE),
+        host,
+    )
 }
 
 /// Merge a resolved sandbox's workload with the user's run args: boot the sandbox base image, take the sandbox command unless the user gave one after `--`, and layer env base-image < sandbox < user `-e`.
@@ -320,15 +349,116 @@ mod tests {
         }
     }
 
+    fn requested(cpus: Option<u8>, mem_mib: Option<usize>) -> RequestedSize {
+        RequestedSize {
+            cpus: cpus.unwrap_or(lns_artifact::resources::DEFAULT_VM_SIZE.cpus),
+            cpus_explicit: cpus.is_some(),
+            mem_mib: mem_mib.unwrap_or(lns_artifact::resources::DEFAULT_VM_SIZE.mem_mib),
+            mem_explicit: mem_mib.is_some(),
+            cpus_config: None,
+            mem_config: None,
+        }
+    }
+
+    fn configured(cpus: Option<u8>, mem_mib: Option<usize>) -> RequestedSize {
+        RequestedSize {
+            cpus_config: cpus,
+            mem_config: mem_mib,
+            ..requested(None, None)
+        }
+    }
+
     #[test]
     fn sandbox_vm_size_uses_the_sandbox_resources_when_no_flag_is_set() {
         let res = resources(4, 2048);
         assert_eq!(
             {
-                let s = sandbox_vm_size(Some(&res), 1, false, 512, false, Some(TEST_HOST));
+                let s = sandbox_vm_size(Some(&res), &requested(None, None), Some(TEST_HOST));
                 (s.cpus, s.mem_mib)
             },
             (4, 2048)
+        );
+    }
+
+    #[test]
+    fn sandbox_vm_size_keeps_the_sandbox_resources_over_a_config_default() {
+        let res = resources(2, 1024);
+        assert_eq!(
+            {
+                let s = sandbox_vm_size(
+                    Some(&res),
+                    &configured(Some(4), Some(4096)),
+                    Some(TEST_HOST),
+                );
+                (s.cpus, s.mem_mib)
+            },
+            (2, 1024),
+            "a sandbox that declares its own resources must not be resized by whoever cloned it"
+        );
+    }
+
+    #[test]
+    fn sandbox_vm_size_lets_a_flag_outrank_both_the_sandbox_and_a_config_default() {
+        let res = resources(2, 1024);
+        let request = RequestedSize {
+            cpus_config: Some(4),
+            mem_config: Some(4096),
+            ..requested(Some(8), Some(8192))
+        };
+        assert_eq!(
+            {
+                let s = sandbox_vm_size(Some(&res), &request, Some(TEST_HOST));
+                (s.cpus, s.mem_mib)
+            },
+            (8, 8192)
+        );
+    }
+
+    #[test]
+    fn sandbox_vm_size_falls_back_to_a_config_default_when_nothing_else_decides() {
+        assert_eq!(
+            {
+                let s = sandbox_vm_size(None, &configured(Some(4), Some(4096)), Some(TEST_HOST));
+                (s.cpus, s.mem_mib)
+            },
+            (4, 4096)
+        );
+    }
+
+    #[test]
+    fn sandbox_vm_size_falls_back_to_the_builtin_when_no_source_says_anything() {
+        assert_eq!(
+            {
+                let s = sandbox_vm_size(None, &requested(None, None), Some(TEST_HOST));
+                (s.cpus, s.mem_mib)
+            },
+            (
+                lns_artifact::resources::DEFAULT_VM_SIZE.cpus,
+                lns_artifact::resources::DEFAULT_VM_SIZE.mem_mib
+            )
+        );
+    }
+
+    #[test]
+    fn requested_size_reads_the_three_layers_the_wire_carries() {
+        let mut args = run_args(None, &[]);
+        args.cpus = 8;
+        args.cpus_explicit = true;
+        args.mem = 8192;
+        args.mem_explicit = false;
+        args.cpus_config = Some(4);
+        args.mem_config = Some(4096);
+        let request = RequestedSize::from_args(&args);
+        assert_eq!(
+            (
+                request.cpus,
+                request.cpus_explicit,
+                request.mem_mib,
+                request.mem_explicit,
+                request.cpus_config,
+                request.mem_config
+            ),
+            (8, true, 8192, false, Some(4), Some(4096))
         );
     }
 
@@ -476,7 +606,8 @@ mod tests {
         let res = resources(4, 2048);
         assert_eq!(
             {
-                let s = sandbox_vm_size(Some(&res), 2, true, 1024, true, Some(TEST_HOST));
+                let s =
+                    sandbox_vm_size(Some(&res), &requested(Some(2), Some(1024)), Some(TEST_HOST));
                 (s.cpus, s.mem_mib)
             },
             (2, 1024)
@@ -488,7 +619,8 @@ mod tests {
         let res = resources(4, 2048);
         assert_eq!(
             {
-                let s = sandbox_vm_size(Some(&res), 1, true, 512, true, Some(TEST_HOST));
+                let s =
+                    sandbox_vm_size(Some(&res), &requested(Some(1), Some(512)), Some(TEST_HOST));
                 (s.cpus, s.mem_mib)
             },
             (1, 512),
@@ -500,14 +632,7 @@ mod tests {
     fn sandbox_vm_size_falls_back_to_the_request_when_the_sandbox_is_silent() {
         assert_eq!(
             {
-                let s = sandbox_vm_size(None, 1, false, 512, false, Some(TEST_HOST));
-                (s.cpus, s.mem_mib)
-            },
-            (1, 512)
-        );
-        assert_eq!(
-            {
-                let s = sandbox_vm_size(None, 8, true, 4096, true, Some(TEST_HOST));
+                let s = sandbox_vm_size(None, &requested(Some(8), Some(4096)), Some(TEST_HOST));
                 (s.cpus, s.mem_mib)
             },
             (8, 4096)

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -289,10 +289,7 @@ async fn orchestrate(
         sandbox_plan
             .as_ref()
             .and_then(|p| p.workload.resources.as_ref()),
-        args.cpus,
-        args.cpus_explicit,
-        args.mem,
-        args.mem_explicit,
+        &super::RequestedSize::from_args(&args),
         lns_artifact::resources::host::probe(),
     );
 

--- a/crates/lns-service/src/run_record.rs
+++ b/crates/lns-service/src/run_record.rs
@@ -215,6 +215,8 @@ mod tests {
             mem: 512,
             cpus_explicit: false,
             mem_explicit: false,
+            cpus_config: None,
+            mem_config: None,
             policy_path: None,
             denied_host_paths: Vec::new(),
             sandbox_user: None,

--- a/crates/lns-service/tests/behaviours/steps/run_start_refusal.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_start_refusal.rs
@@ -59,6 +59,8 @@ fn args_named(name: &str) -> RunImageArgs {
         mem: 0,
         cpus_explicit: false,
         mem_explicit: false,
+        cpus_config: None,
+        mem_config: None,
         policy_path: None,
         sandbox_user: None,
         sandbox_uid: None,

--- a/crates/lns-service/tests/behaviours/steps/run_start_stopped.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_start_stopped.rs
@@ -76,6 +76,8 @@ fn sample_args() -> lns_ipc::RunImageArgs {
         mem: 0,
         cpus_explicit: false,
         mem_explicit: false,
+        cpus_config: None,
+        mem_config: None,
         policy_path: None,
         denied_host_paths: Vec::new(),
         sandbox_user: None,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -174,8 +174,8 @@ the `./lns.yaml` definition with its command overridden.
 
 | Option                       | Default          | Meaning                                                                 |
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------- |
-| `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1); falls back to the `run.cpus` config default. |
-| `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`, `-m 38Gi` — the same sizes `spec.resources.memory` accepts, all binary, rounded up to a whole MiB); falls back to the `run.mem` config default. |
+| `--cpus <N>`                 | `1`              | Number of vCPUs (at least 1). Without it the document's `spec.resources` decides, then the `run.cpus` config default, then `1`. |
+| `-m`, `--mem`, `--memory <SIZE>` | `512`        | RAM in MiB, or with a unit suffix (`-m 2g`, `-m 512m`, `-m 38Gi` — the same sizes `spec.resources.memory` accepts, all binary, rounded up to a whole MiB). Without it the document's `spec.resources` decides, then the `run.mem` config default, then `512`. |
 | `-f`, `--file <FILE>`        | `./lns.yaml`     | Definition file to run instead of `./lns.yaml` (e.g. `lns.dev.yaml`); its directory is the project, so it roots the definition's relative binds and filesets and holds the decisions file. Cannot be combined with `REF`. |
 | `--name <NAME>`              | auto             | Name the run, addressable by every `lns sandbox` verb in place of its id. Auto-generated (`adjective_noun`) when omitted; must not be all digits. |
 | `--registry <HOST>`          | `hub.lns.run`    | Registry to qualify a bare published-sandbox reference (e.g. `ghcr.io`); falls back to the `run.registry` config default, else the Lens hub. A fully-qualified reference is used as-is. |
@@ -468,4 +468,5 @@ set them per run (`-e`, `-v`, `-p`) or in the sandbox definition's `spec`.
 
 Values are validated when stored, with the same parsers the run flags use.
 Defaults live in `~/.lns/config.yaml`, with everything else lns keeps for you.
-A per-run flag always wins.
+A per-run flag always wins, and so do the resources a document declares in
+`spec.resources` — a configured default only fills what no one else decided.

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -316,14 +316,17 @@ digits (so it is never mistaken for an id). Names are unique among the runs
 ### Persistent defaults
 
 The resource gap-fillers you'd otherwise repeat on every run can be stored once
-with [`lns config`](cli-reference.md#lns-config). A per-run flag always overrides
-its configured default:
+with [`lns config`](cli-reference.md#lns-config). A configured default fills a
+gap only: a per-run flag wins, and so do the resources the document declares in
+`spec.resources`, so a sandbox that sizes itself is not resized by whoever
+cloned it:
 
 ```bash
 lns config set run.cpus 4
 lns config set run.mem 2048
 lns run ghcr.io/acme/builder            # boots with 4 vCPUs · 2048 MiB
 lns run --cpus 2 ghcr.io/acme/builder   # per-run flag wins: 2 vCPUs
+lns run .                               # a document declaring cpu: 2 boots 2 vCPUs
 ```
 
 The settable defaults are `run.cpus`, `run.mem`, and `run.registry`. Environment


### PR DESCRIPTION
## Problem

`docs/cli-spec.md` §8 makes the order clear:

> Your config sits **below** the document on purpose: a sandbox that declares its
> own resources is not silently resized by whoever cloned it.

The code did the opposite. A `run.cpus` / `run.mem` default won against a
document that declares `spec.resources`.

## What you see

Set a default, and run a document that sizes itself:

```bash
lns config set run.cpus 4
lns config set run.mem 2048
cat lns.yaml
```

```yaml
apiVersion: lns.run/v1
kind: sandbox
name: builder
spec:
  image: example.test/runtime:1
  resources:
    cpu: 2
    memory: 1Gi
```

Before — the machine's default resizes the sandbox:

```
$ lns run .
  Resources: 4 vCPU · 2048 MiB · 10 GiB disk
```

After — the document decides:

```
$ lns run .
  Resources: 2 vCPU · 1024 MiB · 10 GiB disk
```

A flag still wins over both:

```
$ lns run --cpus 8 .
  Resources: 8 vCPU · 1024 MiB · 10 GiB disk
```

A config default still fills what nobody else decided:

```
$ lns run alpine
  Resources: 4 vCPU · 2048 MiB · 10 GiB disk
```

The order is now flag > document > config > built-in, in the launch banner and
in the size the microVM boots with.

## Cause

`apply_run_defaults` wrote the config defaults into `args.cpus` / `args.mem`.
The CLI then computed `cpus_explicit: args.cpus.is_some()` from those same
fields, so the service saw a configured default as a typed flag. An explicit
flag outranks `spec.resources`, so the default did too.

## Change

- `RunImageArgs` carries the config layer in its own slot (`cpus_config`,
  `mem_config`). `cpus_explicit` / `mem_explicit` keep their meaning and are
  computed from the raw flags.
- `apply_run_defaults` no longer touches `args.cpus` / `args.mem`. Registry
  handling is unchanged.
- `lns_artifact::resources::ConfiguredDefaults::over` puts the config layer
  under the built-in size. Both resolvers — the CLI banner (`resolved_size`)
  and the service (`sandbox_vm_size`) — pass it as the fallback, so the
  document keeps its rank.
- `lns run --help` says the new chain for `--cpus` and `-m`, and `-m` now
  lists the `Mi` / `Gi` forms the parser already accepts.

## Tests

Red first:

- Layer 2 (`run_config_defaults.feature`): a document that declares 3 vCPU and
  6Gi beats a `run.cpus` default of 4; a flag beats both; a default fills what
  the document leaves unsaid.
- Layer 3 `lns-cli`: `apply_run_defaults` keeps the flags empty and fills the
  config slot; `resolved_size` ranks the three layers.
- Layer 3 `lns-service`: `sandbox_vm_size` with a document plus a config
  default returns the document's size; with a flag, the flag's; with nothing,
  the built-in.
- Layer 3 `lns-ipc`: a config default survives the wire without becoming an
  explicit flag.

## Docs

`docs/cli-reference.md` and `docs/running-workloads.md` describe the shipped
order. `docs/cli-spec.md` is unchanged — it was already right.
