### PR TITLE
fix: wrong-kind operands get a clean error that names the other namespace

### DIFF
--- a/crates/e2e-tests/features/sandbox_lifecycle.feature
+++ b/crates/e2e-tests/features/sandbox_lifecycle.feature
@@ -30,7 +30,7 @@ Feature: sandbox lifecycle verbs reach the service end to end
     And the output contains "attach"
     And the output contains "kill"
 
-  Scenario: sandbox kill of an unknown run reports the daemon's error
+  Scenario: sandbox kill of an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running
     When I run sandbox command "kill 4242" against the service
     Then the exit code is non-zero
@@ -55,41 +55,41 @@ Feature: sandbox lifecycle verbs reach the service end to end
     And the output contains "CPU"
     And the output contains "MEM"
 
-  Scenario: stopping an unknown run reports the daemon's error
+  Scenario: stopping an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running
     When I run sandbox command "stop 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
   Scenario: stop accepts a --timeout override while reporting an unknown run
     Given the Lens Sandbox service is running
     When I run lns "stop --timeout 1 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
-  Scenario: requesting logs of an unknown run reports the daemon's error
+  Scenario: requesting logs of an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running
     When I run sandbox command "logs 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
-  Scenario: logs -f of an unknown run reports the daemon's error
+  Scenario: logs -f of an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running
     When I run lns "logs -f 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
-  Scenario: attaching to an unknown run reports the daemon's error
+  Scenario: attaching to an unknown run reports the miss in one sentence
     Given the Lens Sandbox service is running
     When I run sandbox command "attach 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
   Scenario: attach accepts a custom detach chord while reporting an unknown run
     Given the Lens Sandbox service is running
     When I run lns "attach --detach-keys ctrl-a,ctrl-b 4242" against the service
     Then the exit code is non-zero
-    And the output contains "no such run: 4242"
+    And the output contains "no such sandbox: 4242"
 
   Scenario: attach rejects an unparseable detach chord
     When I run lns "attach --detach-keys bogus 4242" against the service

--- a/crates/e2e-tests/features/sandbox_management.feature
+++ b/crates/e2e-tests/features/sandbox_management.feature
@@ -21,7 +21,7 @@ Feature: cached sandbox management end to end
   Scenario: removing a sandbox that is not cached fails cleanly
     When I run "lns artifact rm registry.example.test/absent:1"
     Then the exit code is non-zero
-    And the output contains "no such image"
+    And the output contains "no such artifact: registry.example.test/absent:1"
 
   Scenario: pruning an empty cache reclaims nothing
     When I run "lns artifact prune --force"

--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -381,7 +381,7 @@ where
             "{} is an OCI image, not a published sandbox",
             args.reference
         ),
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => return Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     };
     crate::run::pull_confirm::confirm_pulled_effects(
@@ -429,7 +429,7 @@ where
             }
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -450,7 +450,7 @@ async fn tag<W: std::io::Write>(
             writeln!(out, "tagged {from} as {to}")?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::artifact_failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -471,7 +471,7 @@ async fn ls<W: std::io::Write>(
             crate::output::emit(args.output.format, &rows, out)?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -551,7 +551,7 @@ pub(crate) async fn remove_cached<W: std::io::Write>(
             )?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::artifact_failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -592,7 +592,7 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
             )?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -605,7 +605,7 @@ async fn prunable_references(svc: &impl SandboxService) -> Result<Vec<String>> {
             references.sort_unstable();
             Ok(references)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -648,7 +648,7 @@ pub(crate) async fn inspect_cached<W: std::io::Write>(
             render_cached_inspect(&inspection, mixins, out)?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::artifact_failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -1402,7 +1402,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rm_of_a_cached_sandbox_surfaces_the_daemon_error() {
+    async fn rm_of_an_uncached_reference_says_so_without_naming_the_wire() {
         let svc = CannedService::with_remove_image(
             Response::Error {
                 message: "no such run: ghcr.io/team/x:1".into(),
@@ -1415,7 +1415,8 @@ mod tests {
         let err = remove_cached(&svc, "ghcr.io/team/x:1", &mut out)
             .await
             .unwrap_err();
-        assert!(format!("{err:#}").contains("no such image"));
+        let message = format!("{err:#}");
+        assert_eq!(message, "no such artifact: ghcr.io/team/x:1");
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/config/mod.rs
+++ b/crates/lns-cli/src/config/mod.rs
@@ -410,7 +410,7 @@ fn image_has_registry(image: &str) -> bool {
     }
 }
 
-fn is_registry_host(first: &str) -> bool {
+pub(crate) fn is_registry_host(first: &str) -> bool {
     first.contains('.') || first.contains(':') || first == "localhost"
 }
 

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -369,7 +369,7 @@ async fn ps<W: std::io::Write>(
             .into_iter()
             .filter(|r| args.all || matches!(r.status, lns_ipc::RunStatus::Running))
             .collect::<Vec<_>>(),
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => return Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     };
     let mut rows = Vec::with_capacity(listed.len());
@@ -478,7 +478,9 @@ async fn kill<W: std::io::Write>(
             writeln!(out, "killed run {}", run_label(&args.run))?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "kill", &args.run, &message,
+        )),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -508,7 +510,9 @@ async fn stop<W: std::io::Write>(
             )?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "stop", &args.run, &message,
+        )),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -535,7 +539,9 @@ async fn rm<W: std::io::Write>(
             writeln!(out, "removed sandbox {}", args.run)?;
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "rm", &args.run, &message,
+        )),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -561,7 +567,7 @@ where
             stdin: args.interactive,
         })
         .await?;
-    let run_id = expect_run_started(&mut stream).await?;
+    let run_id = expect_run_started(&mut stream, "start", &args.run).await?;
     if !args.attach {
         writeln!(out, "{}", run_label(&args.run))?;
         return Ok(0);
@@ -617,7 +623,7 @@ async fn prune<I: std::io::BufRead, W: std::io::Write, E: AsyncWriteExt + Unpin>
             }
             Ok(0)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -639,7 +645,7 @@ async fn stopped_run_names(svc: &impl SandboxService) -> Result<Vec<String>> {
             names.sort_unstable();
             Ok(names)
         }
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -685,8 +691,12 @@ async fn inspect<W: std::io::Write>(
             render_inspect(&details, policy, format, out)?;
             Ok(0)
         }
-        Response::RunUnknown { run } => bail!("no such run: {run}"),
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::RunUnknown { run } => {
+            Err(crate::service::reply::unknown_sandbox("inspect", &run, ""))
+        }
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "inspect", target, &message,
+        )),
         other => bail!("unexpected response from daemon: {other:?}"),
     }
 }
@@ -806,7 +816,7 @@ where
             follow: args.follow,
         })
         .await?;
-    expect_run_started(&mut stream).await?;
+    expect_run_started(&mut stream, "logs", &args.run).await?;
     drive_logs(stream, stdout, stderr).await
 }
 
@@ -827,7 +837,7 @@ where
             run: args.run.clone(),
         })
         .await?;
-    let run_id = expect_run_started(&mut stream).await?;
+    let run_id = expect_run_started(&mut stream, "attach", &args.run).await?;
     crate::service::drive_attached_session_with_writers(
         stream,
         svc.aux_socket(),
@@ -844,13 +854,19 @@ where
     .await
 }
 
-async fn expect_run_started<S: AsyncRead + Unpin>(stream: &mut S) -> Result<String> {
+async fn expect_run_started<S: AsyncRead + Unpin>(
+    stream: &mut S,
+    verb: &str,
+    run: &str,
+) -> Result<String> {
     let bytes = read_frame_bytes_async(stream)
         .await
         .context("reading stream handshake")?;
     match decode_wire_frame_from_bytes(&bytes).context("decoding stream handshake")? {
         WireFrame::Json(Response::RunStarted { run_id }) => Ok(run_id),
-        WireFrame::Json(Response::Error { message }) => bail!("daemon error: {message}"),
+        WireFrame::Json(Response::Error { message }) => {
+            Err(crate::service::reply::sandbox_failure(verb, run, &message))
+        }
         other => bail!("expected RunStarted, got {other:?}"),
     }
 }
@@ -876,7 +892,9 @@ where
             }
             WireFrame::Json(Response::Acknowledged) => return Ok(0),
             WireFrame::Json(Response::RunExit { .. }) => return Ok(0),
-            WireFrame::Json(Response::Error { message }) => bail!("daemon error: {message}"),
+            WireFrame::Json(Response::Error { message }) => {
+                return Err(crate::service::reply::failure(&message));
+            }
             other => bail!("unexpected logs frame: {other:?}"),
         }
     }
@@ -1339,7 +1357,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inspect_answers_the_typed_miss_as_no_such_run() {
+    async fn inspect_answers_the_typed_miss_in_the_product_s_own_word() {
         let svc = CannedService::new(Response::RunUnknown {
             run: "ghost".into(),
         });
@@ -1347,7 +1365,7 @@ mod tests {
         let err = inspect(&svc, "ghost", crate::output::Format::Table, &mut out)
             .await
             .unwrap_err();
-        assert!(format!("{err:#}").contains("no such run: ghost"));
+        assert!(format!("{err:#}").contains("no such sandbox: ghost"));
     }
 
     #[tokio::test]
@@ -1373,7 +1391,9 @@ mod tests {
     async fn handshake_rejects_an_unexpected_first_frame() {
         let frame = lns_ipc::encode_wire_frame(&WireFrame::Stdout(b"early".to_vec())).unwrap();
         let mut stream = stream_with(&[frame]).await;
-        let err = expect_run_started(&mut stream).await.unwrap_err();
+        let err = expect_run_started(&mut stream, "start", "7")
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("expected RunStarted"));
     }
 

--- a/crates/lns-cli/src/service.rs
+++ b/crates/lns-cli/src/service.rs
@@ -7,6 +7,7 @@ use lns_ipc::{SignalKind, StatusInfo};
 pub mod client;
 mod login_agent;
 pub(crate) mod real;
+pub(crate) mod reply;
 
 pub use client::{SandboxService, ServiceClient, TermInfo};
 pub use login_agent::DisableOutcome;

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -338,7 +338,7 @@ async fn await_published_preflight(
         })?;
     match response {
         Some(Response::ImageInspected { inspection }) => published_target(reference, inspection),
-        Some(Response::Error { message }) => anyhow::bail!("daemon error: {message}"),
+        Some(Response::Error { message }) => Err(crate::service::reply::failure(&message)),
         Some(other) => anyhow::bail!("expected sandbox preflight, got {other:?}"),
         None => anyhow::bail!("no response from lns-service during sandbox preflight"),
     }
@@ -578,7 +578,7 @@ pub async fn run_image(
         .context("reading RunStarted frame")?;
     let run_id = match decode_frame(&mut &bytes[..]).context("decoding RunStarted")? {
         Response::RunStarted { run_id } => run_id,
-        Response::Error { message } => anyhow::bail!("daemon error: {message}"),
+        Response::Error { message } => return Err(crate::service::reply::failure(&message)),
         other => anyhow::bail!("expected RunStarted, got {other:?}"),
     };
 
@@ -657,6 +657,7 @@ where
     let tty = args.tty;
     let stdin = args.interactive;
     let detach_chord = args.detach_keys.0.clone();
+    let run = args.run.clone();
 
     let request = Request::ExecImage(build_exec_request(
         args.run,
@@ -674,7 +675,7 @@ where
     let bytes = read_frame_bytes_async(&mut stream)
         .await
         .context("reading ExecStarted frame")?;
-    let target = decode_exec_started(&bytes)?;
+    let target = decode_exec_started(&bytes, &run)?;
     crate::log::debug!(run_id = %target.run_id(), "exec session opened");
 
     drive_targeted_session_with_writers(
@@ -711,12 +712,14 @@ pub fn build_exec_request(
     }
 }
 
-fn decode_exec_started(bytes: &[u8]) -> Result<lns_ipc::SessionTarget> {
+fn decode_exec_started(bytes: &[u8], run: &str) -> Result<lns_ipc::SessionTarget> {
     match decode_frame(&mut &bytes[..]).context("decoding ExecStarted")? {
         Response::ExecStarted { run_id, session_id } => {
             Ok(lns_ipc::SessionTarget::Exec { run_id, session_id })
         }
-        Response::Error { message } => anyhow::bail!("daemon error: {message}"),
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "exec", run, &message,
+        )),
         other => anyhow::bail!("expected ExecStarted, got {other:?}"),
     }
 }
@@ -958,7 +961,7 @@ where
                     WireFrame::Json(Response::RunProgress { .. }) => {}
                     WireFrame::Json(Response::RunExit { code }) => break code,
                     WireFrame::Json(Response::Error { message }) => {
-                        anyhow::bail!("daemon error: {message}")
+                        return Err(crate::service::reply::failure(&message))
                     }
                     other => anyhow::bail!("unexpected response from daemon: {other:?}"),
                 }
@@ -1430,7 +1433,7 @@ where
         }
         WireFrame::Json(Response::RunExit { .. }) => Ok(PrePhaseStep::EarlyExit(PRE_START_FAILURE)),
         WireFrame::Json(Response::Error { message }) => {
-            anyhow::bail!("daemon error: {message}")
+            Err(crate::service::reply::failure(&message))
         }
         other => anyhow::bail!("unexpected frame before SessionReady: {other:?}"),
     }
@@ -1561,7 +1564,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            decode_exec_started(&frame).unwrap(),
+            decode_exec_started(&frame, "7").unwrap(),
             lns_ipc::SessionTarget::Exec {
                 run_id: "run-7".to_string(),
                 session_id: "exec-2".to_string(),

--- a/crates/lns-cli/src/service/reply.rs
+++ b/crates/lns-cli/src/service/reply.rs
@@ -1,0 +1,193 @@
+//! §6: what the service reports reaches the user as one sentence in the product's own words, and §2.4's wrong-kind operand also names the command that takes it.
+
+use anyhow::{Error, anyhow};
+
+const MISSING_RUN: &str = "no such run: ";
+const MISSING_IMAGE: &str = "no such image: ";
+
+pub(crate) fn failure(message: &str) -> Error {
+    anyhow!("{message}")
+}
+
+pub(crate) fn sandbox_failure(verb: &str, run: &str, message: &str) -> Error {
+    match missing_run_detail(message) {
+        Some(detail) => unknown_sandbox(verb, run, detail),
+        None => failure(message),
+    }
+}
+
+pub(crate) fn unknown_sandbox(verb: &str, run: &str, detail: &str) -> Error {
+    if reference_shaped(run) {
+        let (command, effect) = artifact_counterpart(verb);
+        return anyhow!(
+            "no such sandbox: {run}; that looks like an artifact reference — `lns artifact {command}` {effect}"
+        );
+    }
+    if detail.is_empty() {
+        anyhow!("no such sandbox: {run}")
+    } else {
+        anyhow!("no such sandbox: {run}; {detail}")
+    }
+}
+
+pub(crate) fn artifact_failure(message: &str) -> Error {
+    let Some(reference) = message.strip_prefix(MISSING_IMAGE) else {
+        return failure(message);
+    };
+    if could_have_been_a_sandbox_handle(reference) {
+        anyhow!(
+            "no such artifact: {reference}; a sandbox has a name or an id — `lns sandbox ls` lists them"
+        )
+    } else {
+        anyhow!("no such artifact: {reference}")
+    }
+}
+
+/// The service appends what would have helped — the stopped sandboxes a `start` could have named — and that half of its answer survives the rewording.
+fn missing_run_detail(message: &str) -> Option<&str> {
+    message
+        .strip_prefix(MISSING_RUN)
+        .map(|rest| rest.split_once("; ").map_or("", |(_, detail)| detail))
+}
+
+/// A sandbox is named as a DNS label or an id, so this punctuation can only have come from a registry coordinate.
+fn reference_shaped(run: &str) -> bool {
+    run.contains('/') || run.contains(':') || run.contains('@')
+}
+
+fn artifact_counterpart(verb: &str) -> (&'static str, &'static str) {
+    match verb {
+        "rm" => ("rm", "removes one"),
+        _ => ("inspect", "reads one"),
+    }
+}
+
+/// A bare word is what both namespaces answer for, and §2.4 qualifies it into a single untagged segment — a repository path or a chosen tag was always a reference.
+fn could_have_been_a_sandbox_handle(reference: &str) -> bool {
+    let repository = match reference.split_once('/') {
+        Some((host, rest)) if crate::config::is_registry_host(host) => rest,
+        Some(_) => return false,
+        None => reference,
+    };
+    if repository.contains('/') {
+        return false;
+    }
+    match repository.split_once(':') {
+        Some((_, tag)) => tag == "latest",
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_reported_failure_reaches_the_user_without_the_wire_talking() {
+        let err = failure("the cache is locked by another writer");
+        assert_eq!(
+            format!("{err:#}"),
+            "the cache is locked by another writer",
+            "§6 wants one sentence, and `daemon error:` is plumbing the user never asked about"
+        );
+    }
+
+    #[test]
+    fn a_failure_that_is_not_a_miss_passes_through_both_namespaces_untouched() {
+        assert_eq!(
+            format!(
+                "{:#}",
+                sandbox_failure("stop", "reviewer", "the guest is wedged")
+            ),
+            "the guest is wedged"
+        );
+        assert_eq!(
+            format!("{:#}", artifact_failure("the registry refused the digest")),
+            "the registry refused the digest"
+        );
+    }
+
+    #[test]
+    fn a_run_verb_given_a_registry_coordinate_names_the_verb_that_takes_one() {
+        let removal = sandbox_failure(
+            "rm",
+            "ghcr.io/team/x:1.0",
+            "no such run: ghcr.io/team/x:1.0",
+        );
+        assert_eq!(
+            format!("{removal:#}"),
+            "no such sandbox: ghcr.io/team/x:1.0; that looks like an artifact reference — `lns artifact rm` removes one"
+        );
+        let stop = sandbox_failure("stop", "you/agent", "no such run: you/agent");
+        assert!(
+            format!("{stop:#}").contains("`lns artifact inspect` reads one"),
+            "no artifact is stopped, so the reader is the way out: {stop:#}"
+        );
+        let digest = sandbox_failure("logs", "x@sha256:ab", "no such run: x@sha256:ab");
+        assert!(
+            format!("{digest:#}").contains("artifact reference"),
+            "{digest:#}"
+        );
+    }
+
+    #[test]
+    fn a_plausible_sandbox_name_is_not_lectured_about_the_other_namespace() {
+        let err = sandbox_failure("stop", "v1.2-agent", "no such run: v1.2-agent");
+        assert_eq!(format!("{err:#}"), "no such sandbox: v1.2-agent");
+    }
+
+    #[test]
+    fn what_the_service_added_to_a_miss_survives_the_rewording() {
+        let err = sandbox_failure(
+            "start",
+            "ghost",
+            "no such run: ghost; stopped runs: reviewer",
+        );
+        assert_eq!(
+            format!("{err:#}"),
+            "no such sandbox: ghost; stopped runs: reviewer",
+            "the stopped list is the answer to \"what could I have started\", so it must not be dropped"
+        );
+    }
+
+    #[test]
+    fn a_run_the_service_answered_as_unknown_reads_the_same_as_one_it_reported() {
+        assert_eq!(
+            format!("{:#}", unknown_sandbox("inspect", "ghost", "")),
+            "no such sandbox: ghost"
+        );
+    }
+
+    #[test]
+    fn a_ref_verb_given_a_bare_word_names_where_the_sandboxes_are_listed() {
+        let err = artifact_failure("no such image: hub.lns.run/7:latest");
+        assert_eq!(
+            format!("{err:#}"),
+            "no such artifact: hub.lns.run/7:latest; a sandbox has a name or an id — `lns sandbox ls` lists them"
+        );
+    }
+
+    #[test]
+    fn a_ref_verb_given_a_repository_path_says_only_that_nothing_is_cached() {
+        assert_eq!(
+            format!(
+                "{:#}",
+                artifact_failure("no such image: ghcr.io/team/x:1.0")
+            ),
+            "no such artifact: ghcr.io/team/x:1.0",
+            "a path under a registry could never have been a sandbox handle"
+        );
+    }
+
+    #[test]
+    fn only_what_a_bare_word_qualifies_into_could_have_been_a_sandbox_handle() {
+        assert!(could_have_been_a_sandbox_handle("redis"));
+        assert!(could_have_been_a_sandbox_handle("hub.lns.run/redis"));
+        assert!(!could_have_been_a_sandbox_handle("team/x"));
+        assert!(
+            !could_have_been_a_sandbox_handle("registry.example.test/absent:1"),
+            "a chosen tag is something only a reference carries"
+        );
+        assert!(!could_have_been_a_sandbox_handle("hub.lns.run/x@sha256:ab"));
+    }
+}

--- a/crates/lns-cli/src/shortcut.rs
+++ b/crates/lns-cli/src/shortcut.rs
@@ -78,7 +78,7 @@ async fn ask_both(
     {
         Response::RunInspect { .. } => true,
         Response::RunUnknown { .. } => false,
-        Response::Error { message } => bail!("daemon error: {message}"),
+        Response::Error { message } => return Err(crate::service::reply::failure(&message)),
         other => bail!("unexpected response from daemon: {other:?}"),
     };
     let is_an_artifact = match svc.one_shot(Request::ListImages).await? {

--- a/crates/lns-cli/tests/behaviours/interactive_exec.feature
+++ b/crates/lns-cli/tests/behaviours/interactive_exec.feature
@@ -42,5 +42,5 @@ Feature: interactive exec sessions from the CLI
     Given no active run is named "ghost"
     When the user runs "lns exec -it ghost sh"
     Then the command fails with an exit code other than 0
-    And the output contains "no such run: ghost"
+    And the output contains "no such sandbox: ghost"
     And no exec session is started

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -229,6 +229,11 @@ fn names_a_sandbox_only(w: &mut BehaviourWorld, name: String) {
     w.sandbox.cached_references = Vec::new();
 }
 
+#[given(regex = r#"^the service will answer a RemoveRun error "([^"]+)"$"#)]
+fn canned_remove_run_error(w: &mut BehaviourWorld, message: String) {
+    w.sandbox.remove_run_response = Some(Response::Error { message });
+}
+
 #[given(regex = r#"^the service refuses to remove the running sandbox "([^"]+)"$"#)]
 fn service_refuses_a_running_removal(w: &mut BehaviourWorld, name: String) {
     reference_resolves_to_running(w, name.clone());

--- a/crates/lns-cli/tests/behaviours/wrong_kind_operand.feature
+++ b/crates/lns-cli/tests/behaviours/wrong_kind_operand.feature
@@ -1,10 +1,12 @@
-Feature: a RUN verb given a document says which command takes it
+Feature: a wrong-kind operand names the command that takes it
   §2.4: a command takes a REF or a RUN, never either. Given the wrong
   kind, it says which it wanted and which command takes the one you
   typed. A path names a document, and a document is never a RUN, so
   the sandbox verbs redirect to `lns artifact inspect` — the command
   that reads one — instead of asking the service for a run that
-  cannot exist.
+  cannot exist. A registry coordinate is not a path, so the service
+  answers it, and §6 renders that answer as one sentence in the
+  product's own words.
 
   Scenario: inspect redirects a path-shaped operand to the artifact namespace
     When the user runs sandbox command "inspect ./lns.yaml"
@@ -30,3 +32,44 @@ Feature: a RUN verb given a document says which command takes it
     Then the command fails with an exit code other than 0
     And the output contains "no run named v1.2-agent"
     And the output does not contain "takes a RUN"
+
+  Scenario: stop given a registry coordinate names the artifact namespace
+    Given the service will answer an error "no such run: ghcr.io/team/x:1.0"
+    When the user runs sandbox command "stop ghcr.io/team/x:1.0"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such sandbox: ghcr.io/team/x:1.0"
+    And the output contains "that looks like an artifact reference"
+    And the output contains "lns artifact inspect"
+    And the output does not contain "daemon error"
+
+  Scenario: rm given a registry coordinate names the artifact verb that removes one
+    Given the service will answer a RemoveRun error "no such run: ghcr.io/team/x:1.0"
+    When the user runs sandbox command "rm ghcr.io/team/x:1.0"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such sandbox: ghcr.io/team/x:1.0"
+    And the output contains "lns artifact rm"
+    And the output does not contain "daemon error"
+
+  Scenario: a plausible sandbox name gets the miss and nothing else
+    Given the service will answer an error "no such run: reviewer"
+    When the user runs sandbox command "stop reviewer"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such sandbox: reviewer"
+    And the output does not contain "lns artifact"
+    And the output does not contain "daemon error"
+
+  Scenario: an artifact verb given a bare word names the sandbox namespace
+    Given the service will answer an error "no such image: hub.lns.run/7:latest"
+    When the user runs artifact command "rm 7"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such artifact: hub.lns.run/7:latest"
+    And the output contains "lns sandbox ls"
+    And the output does not contain "daemon error"
+
+  Scenario: an artifact verb given a full coordinate says only that it is not cached
+    Given the service will answer an error "no such image: ghcr.io/team/x:1.0"
+    When the user runs artifact command "rm ghcr.io/team/x:1.0"
+    Then the command fails with an exit code other than 0
+    And the output contains "no such artifact: ghcr.io/team/x:1.0"
+    And the output does not contain "lns sandbox"
+    And the output does not contain "daemon error"


### PR DESCRIPTION
## Before

```
$ lns sandbox stop ghcr.io/team/x:1.0
Error: daemon error: no such run: ghcr.io/team/x:1.0

$ lns artifact rm 7
Error: daemon error: no such image: hub.lns.run/7:latest
```

## After

```
$ lns sandbox stop ghcr.io/team/x:1.0
Error: no such sandbox: ghcr.io/team/x:1.0; that looks like an artifact reference — `lns artifact inspect` reads one

$ lns sandbox rm ghcr.io/team/x:1.0
Error: no such sandbox: ghcr.io/team/x:1.0; that looks like an artifact reference — `lns artifact rm` removes one

$ lns sandbox stop reviewer
Error: no such sandbox: reviewer

$ lns artifact rm 7
Error: no such artifact: hub.lns.run/7:latest; a sandbox has a name or an id — `lns sandbox ls` lists them
```

## Problem

`docs/cli-spec.md` §2.4 says:

> A command takes a `REF` or a `RUN`, never either. Given the wrong kind, it
> says which it wanted and which command takes the one you typed.

Two things were wrong:

1. Each error had the `daemon error:` prefix. This is plumbing. §6 says an error
   is one sentence that tells you what stopped `lns` and what to do next.
2. A wrong-kind operand got no help. The command did not name the other
   namespace.

## Solution

A new module, `crates/lns-cli/src/service/reply.rs`, renders every reply the
service reports as an error:

- `failure` gives the message as it is. The `daemon error:` prefix is removed at
  all 24 call sites in `lns-cli`.
- `sandbox_failure` renders a run miss as `no such sandbox: <what you typed>`.
  The operand is echoed as typed, not as the service resolved it.
- `artifact_failure` renders an image miss as `no such artifact: <ref>`.

Classification is local. No more requests go to the service. An operand with
`/`, `:` or `@` is not a sandbox name, so a `RUN` verb given one names the
`artifact` verb that takes it: `rm` for `rm`, `inspect` for the others. In the
other direction, a bare word is a valid `REF` that §2.4 qualifies, so the
`sandbox` namespace is named only when the reference could have been a sandbox
handle — one repository segment, with no tag or `:latest`. A reference with a
repository path or a chosen tag stays a one-sentence miss.

What the service adds to a miss is kept. `lns start ghost` still lists the
stopped sandboxes.

The dual-namespace resolution behind `lns rm` and `lns inspect` is unchanged.

## Tests

Red first, in `crates/lns-cli/tests/behaviours/wrong_kind_operand.feature`:

- a `RUN` verb with a registry coordinate gives both sentences;
- a `RUN` verb with a plausible name gives the miss and nothing else;
- an artifact verb with a bare word names `lns sandbox ls`;
- an artifact verb with a full coordinate does not;
- no output holds `daemon error`.

`crates/lns-cli/src/service/reply.rs` carries the Layer 3 tests for the
rendering itself. Existing pins on the old strings are updated: the exec
behaviour, the sandbox and artifact unit tests, and the Layer 1 features.
