### PR TITLE
fix: exec sessions get the workload's proxy environment

### DIFF
--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -99,7 +99,17 @@ fn ca_bundle_env() -> [(&'static str, &'static str); 5] {
     ]
 }
 
-/// What an `lns exec` into a live run joins: the run's own resolved environment, then the caller's additions, its declared tools, the CA bundle the workload trusts, and last the credential placeholders — which override, because the workload's real env carries the placeholder for those vars too.
+/// The proxy vars the supervisor hands its workload, so an HTTP client in an exec takes the route the agent's does rather than one the gate never sees.
+fn proxy_env() -> [(&'static str, &'static str); 4] {
+    [
+        ("HTTPS_PROXY", lns_session::GUEST_PROXY_URL),
+        ("https_proxy", lns_session::GUEST_PROXY_URL),
+        ("HTTP_PROXY", lns_session::GUEST_PROXY_URL),
+        ("http_proxy", lns_session::GUEST_PROXY_URL),
+    ]
+}
+
+/// What an `lns exec` into a live run joins: the run's own resolved environment, then the caller's additions, its declared tools, the proxy and CA bundle the workload is given, and last the credential placeholders — which override, because the workload's real env carries the placeholder for those vars too.
 pub fn exec_session_env(
     exec_environment: &crate::run_registry::ExecEnvironment,
     exec_env: &[String],
@@ -118,7 +128,7 @@ pub fn exec_session_env(
         .collect();
     let mut env = compose_workload_env(Some(&joined), &caller, &[]).env;
     compose_guest_tool_env(&mut env, &exec_environment.tools);
-    for (key, value) in ca_bundle_env() {
+    for (key, value) in proxy_env().into_iter().chain(ca_bundle_env()) {
         overwrite(&mut env, key, value);
     }
     for (key, value) in &exec_environment.placeholders {
@@ -673,6 +683,37 @@ mod tests {
                 "a python or node command in an exec fails TLS without {key}: {env:?}"
             );
         }
+    }
+
+    #[test]
+    fn an_exec_session_reaches_the_network_through_the_same_proxy_the_workload_does() {
+        let env = exec_session_env(&Default::default(), &[]);
+
+        for key in ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] {
+            assert!(
+                env.contains(&format!("{key}={}", lns_session::GUEST_PROXY_URL)),
+                "a curl in an exec would take a different route than the workload without {key}, so a probe would report on a path the agent never uses: {env:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_runs_proxy_outranks_a_proxy_the_exec_caller_names() {
+        let run = crate::run_registry::ExecEnvironment {
+            session_env: vec!["HTTPS_PROXY=http://an-image-baked-proxy".into()],
+            ..Default::default()
+        };
+
+        let env = exec_session_env(
+            &run,
+            &["http_proxy=http://a-caller-named-proxy".to_string()],
+        );
+
+        assert!(
+            env.contains(&format!("HTTPS_PROXY={}", lns_session::GUEST_PROXY_URL))
+                && env.contains(&format!("http_proxy={}", lns_session::GUEST_PROXY_URL)),
+            "the supervisor overrides a workload-set proxy for the same reason: a route around the gate is not the caller's to choose: {env:?}"
+        );
     }
 
     #[test]

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -12,6 +12,9 @@ pub const STAGED_CA_BUNDLE_PATH: &str = "/.lens/ca-certificates.crt";
 /// The store every workload env var names, the broker seeds, and the supervisor appends the proxy CA to; one spelling, or TLS falls back to no roots with no error.
 pub const SYSTEM_CA_BUNDLE_PATH: &str = "/etc/ssl/certs/ca-certificates.crt";
 
+/// The proxy the supervisor runs and points its workload at, so the service can point an exec session at the same one; one spelling, or an exec takes a route the workload never takes.
+pub const GUEST_PROXY_URL: &str = "http://127.0.0.1:3128";
+
 /// Where the service stages each `pre-start` script and the supervisor reads them from; one spelling, or the guest runs nothing and reports success.
 pub const SCRIPTS_DIR: &str = "/.lens/scripts";
 

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -834,6 +834,20 @@ mod tests {
     }
 
     #[test]
+    fn the_proxy_the_workload_is_pointed_at_is_the_one_an_exec_session_is_pointed_at() {
+        let mut config = make_agent_config();
+        config.core.is_root = true;
+
+        let env = build_agent_env(&config, None, &HashMap::new());
+
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some(lns_session::GUEST_PROXY_URL),
+            "the service points an exec session at this spelling without asking the guest, so a change here that leaves the constant behind sends an exec around the gate"
+        );
+    }
+
+    #[test]
     fn build_agent_command_ca_env_overrides_project_env() {
         let config = make_agent_config();
         let mut env = HashMap::new();


### PR DESCRIPTION
## The probe

In a booted sandbox, ask an exec session what proxy it uses.

Before:

```
$ lns sandbox exec t -- env | grep -i proxy
$
```

Nothing. The workload in the same sandbox carries four proxy variables.

After:

```
$ lns sandbox exec t -- env | grep -i proxy
HTTPS_PROXY=http://127.0.0.1:3128
https_proxy=http://127.0.0.1:3128
HTTP_PROXY=http://127.0.0.1:3128
http_proxy=http://127.0.0.1:3128
```

## The problem

The supervisor gives its workload these four variables when it runs the proxy. An exec session is composed on the host and never received them. A proxy-aware client (`curl`, most HTTP libraries) thus took a different route in an exec than in the workload. A probe reported on a path the agent never uses.

This restores the contract: **an exec runs in the workload's environment.**

## The change

- `lns-session` gets `GUEST_PROXY_URL` — one spelling of the proxy the supervisor listens on, next to `SYSTEM_CA_BUNDLE_PATH`, which crosses the same boundary for the same reason.
- `lns-service` `exec_session_env` writes the four proxy variables the way it already writes the CA bundle: they override what the image or the caller set, because a route around the gate is not the caller's to choose. This matches the supervisor, where the injected proxy also overrides a workload-set `HTTPS_PROXY`.
- `lns-supervisor` gets a test that pins its injected proxy to the same constant, so the two sides cannot drift apart in silence.

## Tests

Red first, in the layer that assembles the environment:

- `an_exec_session_reaches_the_network_through_the_same_proxy_the_workload_does`
- `the_runs_proxy_outranks_a_proxy_the_exec_caller_names`
- `the_proxy_the_workload_is_pointed_at_is_the_one_an_exec_session_is_pointed_at` (drift guard, lns-supervisor)