### PR TITLE
feat: approval cards name the run that is asking

### DIFF
--- a/crates/lns-service/examples/approval_preview.rs
+++ b/crates/lns-service/examples/approval_preview.rs
@@ -151,6 +151,7 @@ fn seed_one() -> Snapshot {
             offer: None,
             token_fallback: None,
             treatment: Treatment::Inspected,
+            run: Some("brave-otter".into()),
         }],
         pending_credentials: vec![],
         sign_ins: vec![],
@@ -170,6 +171,7 @@ fn seed_all() -> Snapshot {
                 offer: None,
                 token_fallback: None,
                 treatment: Treatment::Inspected,
+                run: Some("brave-otter".into()),
             },
             PendingPrompt {
                 id: "net-offer".into(),
@@ -178,6 +180,7 @@ fn seed_all() -> Snapshot {
                 offer: Some("OpenRouter".into()),
                 token_fallback: None,
                 treatment: Treatment::Inspected,
+                run: Some("demo".into()),
             },
         ],
         pending_credentials: vec![
@@ -193,6 +196,7 @@ fn seed_all() -> Snapshot {
                 injection_domains: vec!["api.openai.com".into()],
                 is_project_defined: false,
                 deny_scope: DenyScope::Workload,
+                run: Some("brave-otter".into()),
             },
             CredentialCardPrompt {
                 id: "cred-novalue".into(),
@@ -209,6 +213,7 @@ fn seed_all() -> Snapshot {
                 injection_domains: vec!["api.some-provider.example".into()],
                 is_project_defined: false,
                 deny_scope: DenyScope::Workload,
+                run: Some("demo".into()),
             },
             CredentialCardPrompt {
                 id: "cred-oauth".into(),
@@ -225,6 +230,7 @@ fn seed_all() -> Snapshot {
                 injection_domains: vec!["api.github.com".into(), "github.com".into()],
                 is_project_defined: false,
                 deny_scope: DenyScope::Workload,
+                run: Some("brave-otter".into()),
             },
         ],
         sign_ins: vec![SignInCard {
@@ -239,6 +245,7 @@ fn seed_all() -> Snapshot {
             env_var: None,
             injection_domains: vec!["api.github.com".into(), "github.com".into()],
             is_project_defined: false,
+            run: Some("brave-otter".into()),
         }],
         informs: vec!["sign-in to GitHub failed: device code expired".into()],
         connecting: vec!["OpenRouter".into()],

--- a/crates/lns-service/src/approval_flow/notification.rs
+++ b/crates/lns-service/src/approval_flow/notification.rs
@@ -87,6 +87,7 @@ pub(crate) mod tests {
             offer: None,
             token_fallback: None,
             treatment: Treatment::Inspected,
+            run: None,
         }
     }
 

--- a/crates/lns-service/src/approval_flow/session.rs
+++ b/crates/lns-service/src/approval_flow/session.rs
@@ -71,6 +71,8 @@ pub struct PendingPrompt {
     pub token_fallback: Option<TokenFallback>,
     /// `Raw` when approving splices the connection through unread, which the card has to say out loud.
     pub treatment: Treatment,
+    /// The requesting run's name, attributed by the service from the session channel — never from workload-supplied data.
+    pub run: Option<String>,
 }
 
 impl PendingPrompt {
@@ -152,6 +154,7 @@ pub struct ApprovalSession {
     connecting: Mutex<HashSet<String>>,
     ledger: OnceLock<Arc<dyn LedgerRecorder>>,
     shipped: OnceLock<Policy>,
+    run: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,12 +189,19 @@ impl ApprovalSession {
             connecting: Mutex::new(HashSet::new()),
             ledger: OnceLock::new(),
             shipped: OnceLock::new(),
+            run: None,
         }
     }
 
     /// Captures the run's connectable connectors so a held request to one of their domains offers to connect before the plain allow/deny.
     pub fn with_offers(mut self, offerable: Vec<OfferableConnector>) -> Self {
         self.offerable = offerable;
+        self
+    }
+
+    /// Names the run every card this session raises speaks for; the service attributes it from the channel the request arrived on, never from the workload.
+    pub fn for_run(mut self, run: String) -> Self {
+        self.run = Some(run);
         self
     }
 
@@ -312,6 +322,7 @@ impl ApprovalSession {
             offer,
             token_fallback,
             treatment: req.treatment,
+            run: self.run.clone(),
         });
     }
 
@@ -888,6 +899,29 @@ pub(crate) mod tests {
     fn only_approval(events: &[LedgerEvent]) -> &LedgerEvent {
         assert_eq!(events.len(), 1, "expected exactly one ledger event");
         &events[0]
+    }
+
+    #[test]
+    fn a_network_card_names_the_run_that_raised_it() {
+        let (session, notifier, _s, _rx) = fixture();
+        let session = session.for_run("some-run".into());
+        session.submit_pending(pending("r1", "api.example.test"), Instant::now());
+        assert_eq!(
+            notifier.presented.lock().unwrap()[0].run.as_deref(),
+            Some("some-run"),
+            "two sandboxes asking for the same host raise identical cards unless each names its run"
+        );
+    }
+
+    #[test]
+    fn a_network_card_from_a_session_with_no_run_names_nothing() {
+        let (session, notifier, _s, _rx) = fixture();
+        session.submit_pending(pending("r1", "api.example.test"), Instant::now());
+        assert_eq!(
+            notifier.presented.lock().unwrap()[0].run,
+            None,
+            "a card with no originating run must stay silent rather than name one"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/approval_flow/window.rs
+++ b/crates/lns-service/src/approval_flow/window.rs
@@ -53,6 +53,8 @@ pub struct CredentialCardPrompt {
     pub is_project_defined: bool,
     /// Mirrors [`crate::credential_flow::session::CredentialPendingPrompt::deny_scope`]: how far this card's "Deny" reaches.
     pub deny_scope: DenyScope,
+    /// The requesting run's name, attributed by the service from the session channel — never from workload-supplied data.
+    pub run: Option<String>,
 }
 
 /// An interactive sign-in card: which service, where to sign in, and — for a device flow — the code to type (`None` for a pkce browser redirect). `token_fallback` is `Some` when the connector lets a blocked user pivot to a pasted token.
@@ -66,6 +68,7 @@ pub struct SignInCard {
     pub env_var: Option<String>,
     pub injection_domains: Vec<String>,
     pub is_project_defined: bool,
+    pub run: Option<String>,
 }
 
 pub struct WindowState {
@@ -226,6 +229,7 @@ impl WindowState {
                 injection_domains: prompt.injection_domains,
                 is_project_defined: prompt.is_project_defined,
                 deny_scope: prompt.deny_scope,
+                run: prompt.run,
             },
             decision_tx,
             seq,
@@ -644,6 +648,7 @@ mod tests {
             offer: None,
             token_fallback: None,
             treatment: Treatment::Inspected,
+            run: None,
         }
     }
 
@@ -659,6 +664,7 @@ mod tests {
             is_project_defined: false,
             bound_value_available: false,
             deny_scope: DenyScope::Workload,
+            run: Some("some-run".into()),
         }
     }
 
@@ -670,6 +676,18 @@ mod tests {
         s.insert_pending(prompt("r1", "a.test"), tx.clone());
         s.insert_pending(prompt("r2", "b.test"), tx);
         assert_eq!(s.pending_count(), 2);
+    }
+
+    #[test]
+    fn a_credential_card_keeps_the_run_its_prompt_names() {
+        let s = WindowState::new();
+        let (tx, _rx) = unbounded_channel();
+        s.insert_credential_pending(cred_prompt("c1", "some-provider"), false, tx);
+        assert_eq!(
+            s.snapshot().pending_credentials[0].run.as_deref(),
+            Some("some-run"),
+            "the window must not drop the attribution the service put on the prompt"
+        );
     }
 
     #[test]
@@ -820,6 +838,7 @@ mod tests {
             offer: Some(name.into()),
             token_fallback: None,
             treatment: Treatment::Inspected,
+            run: None,
         }
     }
 
@@ -1142,6 +1161,7 @@ mod tests {
             env_var: None,
             injection_domains: vec![],
             is_project_defined: false,
+            run: None,
         }
     }
 
@@ -1371,6 +1391,7 @@ mod tests {
             is_project_defined: false,
             bound_value_available: false,
             deny_scope: DenyScope::Workload,
+            run: None,
         }
     }
 

--- a/crates/lns-service/src/credential_flow/bind.rs
+++ b/crates/lns-service/src/credential_flow/bind.rs
@@ -27,6 +27,8 @@ pub fn bind_prompt(integ: &Connector) -> Option<CredentialPendingPrompt> {
         bound_value_available: false,
         // The bind card holds no request and speaks for the machine, so its deny is the standing one.
         deny_scope: DenyScope::Machine,
+        // A bind is the developer's own `lns connect`, so there is no run to name.
+        run: None,
     })
 }
 
@@ -129,6 +131,16 @@ mod tests {
             vec!["api.example.test".to_string()]
         );
         assert!(prompt.oauth_display_name.is_none());
+    }
+
+    #[test]
+    fn bind_prompt_names_no_run() {
+        let prompt = bind_prompt(&credential_connector("some-provider", "SOME_TOKEN"))
+            .expect("a credential connector is bindable");
+        assert_eq!(
+            prompt.run, None,
+            "a bind is the developer's own connect, so naming a run would attribute it to a sandbox that never asked"
+        );
     }
 
     #[test]

--- a/crates/lns-service/src/credential_flow/notification.rs
+++ b/crates/lns-service/src/credential_flow/notification.rs
@@ -102,6 +102,7 @@ impl CredentialNotifier for WindowCredentialNotifier {
                 env_var: prompt.env_var.clone(),
                 injection_domains: prompt.injection_domains.clone(),
                 is_project_defined: prompt.is_project_defined,
+                run: prompt.run.clone(),
             },
             cancel,
         );
@@ -140,6 +141,7 @@ mod tests {
             injection_domains: vec![],
             is_project_defined: false,
             deny_scope: crate::credential_flow::session::DenyScope::Workload,
+            run: Some("some-run".into()),
         }
     }
 
@@ -261,6 +263,7 @@ mod tests {
             env_var: None,
             injection_domains: vec![],
             is_project_defined: false,
+            run: Some("some-run".into()),
         }
     }
 
@@ -280,6 +283,29 @@ mod tests {
                 command: None,
             }),
             "the card carries the prompt's token fallback so the UI can offer the pivot"
+        );
+    }
+
+    #[test]
+    fn a_sign_in_card_carries_the_run_the_prompt_names() {
+        let (n, state, _rx) = fixture(false, false);
+        let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
+        n.present_sign_in(&sign_in_prompt(), cancel_tx);
+        assert_eq!(
+            state.snapshot().sign_ins[0].run.as_deref(),
+            Some("some-run"),
+            "the run the service attributed to the prompt must reach the card the developer reads"
+        );
+    }
+
+    #[test]
+    fn a_credential_card_carries_the_run_the_prompt_names() {
+        let (n, state, _rx) = fixture(false, false);
+        n.present(&prompt("c1", "some-provider"));
+        assert_eq!(
+            state.snapshot().pending_credentials[0].run.as_deref(),
+            Some("some-run"),
+            "the run the service attributed to the prompt must reach the card the developer reads"
         );
     }
 

--- a/crates/lns-service/src/credential_flow/session.rs
+++ b/crates/lns-service/src/credential_flow/session.rs
@@ -57,6 +57,8 @@ pub struct CredentialPendingPrompt {
     pub bound_value_available: bool,
     /// What this card's "Deny" is allowed to mean, so the durability of a refusal is fixed by the card that asked rather than by which flow happens to receive the answer.
     pub deny_scope: DenyScope,
+    /// The requesting run's name, attributed by the service from the session channel — never from workload-supplied data.
+    pub run: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -71,6 +73,8 @@ pub struct SignInPrompt {
     pub env_var: Option<String>,
     pub injection_domains: Vec<String>,
     pub is_project_defined: bool,
+    /// The requesting run's name, attributed by the service from the session channel — never from workload-supplied data.
+    pub run: Option<String>,
 }
 
 /// Abstracts the desktop notification surface so tests can drive prompts without the real system.
@@ -200,6 +204,7 @@ pub struct CredentialSession {
     pkce_challenge_gen: ChallengeGen,
     pkce_timeout: Duration,
     ledger: OnceLock<Arc<dyn LedgerRecorder>>,
+    run: Option<String>,
 }
 
 impl CredentialSession {
@@ -250,7 +255,14 @@ impl CredentialSession {
             pkce_challenge_gen: Box::new(crate::oauth::PkceChallenge::generate),
             pkce_timeout: PKCE_SIGN_IN_TIMEOUT,
             ledger: OnceLock::new(),
+            run: None,
         }
+    }
+
+    /// Names the run every card this session raises speaks for; the service attributes it from the channel the request arrived on, never from the workload.
+    pub fn for_run(mut self, run: String) -> Self {
+        self.run = Some(run);
+        self
     }
 
     pub fn set_ledger_recorder(&self, recorder: Arc<dyn LedgerRecorder>) {
@@ -580,6 +592,7 @@ impl CredentialSession {
             is_project_defined,
             bound_value_available,
             deny_scope: DenyScope::Workload,
+            run: self.run.clone(),
         });
     }
 
@@ -802,6 +815,7 @@ impl CredentialSession {
         let challenge = (self.pkce_challenge_gen)();
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<crate::oauth::SignInPivot>();
         let card_id = credential_id.to_string();
+        let run = self.run.clone();
         let on_authorization_url = move |auth_url: &str| {
             self.notifier.present_sign_in(
                 &SignInPrompt {
@@ -813,6 +827,7 @@ impl CredentialSession {
                     env_var,
                     injection_domains,
                     is_project_defined,
+                    run,
                 },
                 cancel_tx,
             );
@@ -866,6 +881,7 @@ impl CredentialSession {
             self.provider_disclosure(credential_id);
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<crate::oauth::SignInPivot>();
         let card_id = credential_id.to_string();
+        let run = self.run.clone();
         let present = move |code: &crate::oauth::DeviceCode| {
             self.notifier.present_sign_in(
                 &SignInPrompt {
@@ -877,6 +893,7 @@ impl CredentialSession {
                     env_var,
                     injection_domains,
                     is_project_defined,
+                    run,
                 },
                 cancel_tx,
             );
@@ -1958,6 +1975,29 @@ mod tests {
         assert_eq!(p[0].id, "c1");
         assert_eq!(p[0].credential_id, "some-provider");
         assert_eq!(p[0].action, "use of some-provider placeholder");
+    }
+
+    #[test]
+    fn a_credential_card_names_the_run_that_raised_it() {
+        let (s, n, _store, _rx) = fixture();
+        let s = s.for_run("some-run".into());
+        s.submit_pending(pending("c1", "some-provider"), Instant::now());
+        assert_eq!(
+            n.presented.lock().unwrap()[0].run.as_deref(),
+            Some("some-run"),
+            "handing over a secret is a consent decision, so the card must say which run spends it"
+        );
+    }
+
+    #[test]
+    fn a_credential_card_from_a_session_with_no_run_names_nothing() {
+        let (s, n, _store, _rx) = fixture();
+        s.submit_pending(pending("c1", "some-provider"), Instant::now());
+        assert_eq!(
+            n.presented.lock().unwrap()[0].run,
+            None,
+            "a card with no originating run must stay silent rather than name one"
+        );
     }
 
     #[test]
@@ -3235,7 +3275,8 @@ mod tests {
                 help: Some("https://example.com/pat".into()),
                 command: None,
             },
-        )]));
+        )]))
+        .for_run("some-run".into());
         (session, notifier, store, rx, connected)
     }
 
@@ -3362,6 +3403,21 @@ mod tests {
                 command: None,
             }),
             "a sign-in card for a connector with a token fallback offers the pivot"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_device_sign_in_card_names_the_run_that_raised_it() {
+        let (s, n, _store, _rx, _connected) =
+            oauth_fixture(FakeFlow::polling(vec![crate::oauth::PollOutcome::Token(
+                oauth_token(3600),
+            )]));
+        s.submit_pending(pending("c1", "some-oauth"), Instant::now());
+        s.connect_oauth("c1").await;
+        assert_eq!(
+            n.sign_ins.lock().unwrap()[0].run.as_deref(),
+            Some("some-run"),
+            "a sign-in card asks the developer to authorize a run, so it must say which one"
         );
     }
 
@@ -3838,7 +3894,8 @@ mod tests {
             Box::new(move |url| opened_cb.lock().unwrap().push(url.to_string())),
             Box::new(fixed_pkce_challenge),
             Duration::from_secs(30),
-        );
+        )
+        .for_run("some-run".into());
         (session, notifier, store, rx, connected, opened)
     }
 
@@ -3884,6 +3941,18 @@ mod tests {
         assert_eq!(
             n.dismissed_sign_ins.lock().unwrap().as_slice(),
             &["some-pkce".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pkce_sign_in_card_names_the_run_that_raised_it() {
+        let (s, n, _store, _rx, _connected, _opened) = pkce_session(Ok("some-key".into()));
+        s.submit_pending(pending("c1", "some-pkce"), Instant::now());
+        s.connect_oauth("c1").await;
+        assert_eq!(
+            n.sign_ins.lock().unwrap()[0].run.as_deref(),
+            Some("some-run"),
+            "a browser-redirect sign-in names its run the same way a device sign-in does"
         );
     }
 

--- a/crates/lns-service/src/credential_flow/watcher.rs
+++ b/crates/lns-service/src/credential_flow/watcher.rs
@@ -153,6 +153,7 @@ mod tests {
             is_project_defined: false,
             bound_value_available: false,
             deny_scope: crate::credential_flow::session::DenyScope::Workload,
+            run: None,
         });
         let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
         n.present_sign_in(
@@ -165,6 +166,7 @@ mod tests {
                 env_var: None,
                 injection_domains: vec![],
                 is_project_defined: false,
+                run: None,
             },
             cancel_tx,
         );

--- a/crates/lns-service/src/supervisor/adapter.rs
+++ b/crates/lns-service/src/supervisor/adapter.rs
@@ -520,6 +520,7 @@ async fn start_credential_subsystem(
     consent: CredentialConsent,
     connectable_routes: Arc<HashMap<String, Vec<RouteRule>>>,
     oauth: OauthWiring,
+    run_name: String,
 ) -> Result<CredentialSubsystem> {
     // The credentials file is per-machine $HOME state, so its path is independent of `--policy`.
     let credentials_path = lns_ipc::credentials_path()?;
@@ -590,7 +591,8 @@ async fn start_credential_subsystem(
             crate::credential_flow::session::PKCE_SIGN_IN_TIMEOUT,
         )
         .with_oauth_display_names(oauth.display_names)
-        .with_token_fallbacks(oauth.token_fallbacks),
+        .with_token_fallbacks(oauth.token_fallbacks)
+        .for_run(run_name),
     );
 
     tokio::spawn(credential_delivery_loop(
@@ -751,7 +753,8 @@ pub(super) async fn start(
             frame_tx,
             APPROVAL_TIMEOUT,
         )
-        .with_offers(offerable),
+        .with_offers(offerable)
+        .for_run(microvm_name.clone()),
     );
 
     session.set_connector_route_deriver(make_connector_route_deriver(catalog.clone()));
@@ -806,6 +809,7 @@ pub(super) async fn start(
             display_names: oauth_display_names,
             token_fallbacks,
         },
+        microvm_name.clone(),
     )
     .await?;
 

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -1358,6 +1358,19 @@ fn close_button(ui: &mut egui::Ui, id: egui::Id, rect: egui::Rect) -> egui::Resp
     resp
 }
 
+fn run_identity_line(ui: &mut egui::Ui, run: Option<&String>) {
+    use egui::RichText;
+
+    let Some(name) = run else { return };
+    ui.add_space(5.0);
+    ui.label(
+        RichText::new(name)
+            .size(theme::FONT_CAPTION)
+            .strong()
+            .color(window::TEXT_PRIMARY),
+    );
+}
+
 fn render_network_card(
     ui: &mut egui::Ui,
     prompt: &PendingPrompt,
@@ -1372,6 +1385,7 @@ fn render_network_card(
         width,
         |ui| {
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_PUBLIC, "NETWORK");
+            run_identity_line(ui, prompt.run.as_ref());
             ui.add_space(6.0);
             ui.label(
                 RichText::new(format!("Connect to {}?", prompt.host))
@@ -1487,6 +1501,7 @@ fn render_offer_card(
         width,
         |ui| {
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_LINK, "CONNECT");
+            run_identity_line(ui, prompt.run.as_ref());
             ui.add_space(6.0);
             ui.label(
                 RichText::new(format!("Connect to {display_name}?"))
@@ -1550,6 +1565,7 @@ fn render_credential_card(
         width,
         |ui| {
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_KEY, "CREDENTIAL");
+            run_identity_line(ui, prompt.run.as_ref());
             ui.add_space(6.0);
             ui.label(
                 RichText::new(&prompt.credential_id)
@@ -1674,6 +1690,7 @@ fn render_oauth_consent_card(
         width,
         |ui| {
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_LINK, "CONNECT");
+            run_identity_line(ui, prompt.run.as_ref());
             ui.add_space(6.0);
             ui.label(
                 RichText::new(format!("Connect to {display_name}?"))
@@ -1759,6 +1776,7 @@ fn render_sign_in_card(
         width,
         |ui| {
             crate::ui::eyebrow(ui, egui_material_icons::icons::ICON_LINK, "CONNECT");
+            run_identity_line(ui, card.run.as_ref());
             ui.add_space(6.0);
             ui.label(
                 RichText::new(format!("Connect to {}", card.display_name))
@@ -2285,6 +2303,7 @@ mod tests {
                 offer: None,
                 token_fallback: None,
                 treatment: Treatment::Inspected,
+                run: Some("some-run".into()),
             }],
             pending_credentials: Vec::new(),
             sign_ins: Vec::new(),
@@ -2314,6 +2333,7 @@ mod tests {
             is_project_defined: false,
             bound_value_available: false,
             deny_scope: crate::credential_flow::session::DenyScope::Workload,
+            run: Some("some-run".into()),
         }
     }
 
@@ -2403,6 +2423,7 @@ mod tests {
                 offer: None,
                 token_fallback: None,
                 treatment: Treatment::Inspected,
+                run: Some("some-run".into()),
             },
             net_tx,
         );
@@ -2417,6 +2438,7 @@ mod tests {
                 env_var: None,
                 injection_domains: vec![],
                 is_project_defined: false,
+                run: Some("some-run".into()),
             },
             cancel_tx,
         );
@@ -2445,6 +2467,7 @@ mod tests {
             injection_domains: vec![],
             is_project_defined: false,
             deny_scope: DenyScope::Workload,
+            run: Some("some-run".into()),
         }
     }
 
@@ -2488,6 +2511,7 @@ mod tests {
             offer: offer.map(str::to_string),
             token_fallback: None,
             treatment: Treatment::Inspected,
+            run: Some("some-run".into()),
         };
         Snapshot {
             pending: vec![net("n0", "a.test", None), net("n1", "b.test", Some("Svc"))],


### PR DESCRIPTION
Closes #331

## The problem

An approval card says what is asked for. It does not say who asks.
Two sandboxes that want the same credential raise two identical cards.
The user must guess which sandbox gets the secret.

## What changes

Every approval card shows the requesting run's name. The name is on one
line, under the eyebrow. All five card types show it: NETWORK, CONNECT
offer, CREDENTIAL, CONNECT consent, and SIGN IN.

Before:

    NETWORK
    Connect to pypi.org?
    [Deny] [Allow once] [Allow always]

After:

    NETWORK
    brave-otter
    Connect to pypi.org?
    [Deny] [Allow once] [Allow always]

<img width="728" height="486" alt="Screenshot 2026-08-27 at 15 12 29" src="https://github.com/user-attachments/assets/f860f568-5343-4408-b55d-3c36d059ffc9" />

## How the user matches the name

The name is the name `lns ps` prints in the NAME column:

    $ lns ps
    RUN ID        NAME          IMAGE            COMMAND        STATUS    STARTED
    a3f19c2b4d    brave-otter   python:3.12      python app.py  running   2 minutes ago
    7c04e1aa88    demo          alpine:3.20      sh             running   9 minutes ago

The card says `brave-otter`. The user reads the same name in `lns ps`.

## The security rule

The service reads the name from its own run registry. It attributes the
name when it builds the run's approval and credential sessions. The
workload sends no name and cannot set one. A card is a consent surface,
so a sandbox must not name itself.

## No run, no name

A host-initiated bind (`lns connect`) has no originating run. Its card
omits the line. The code never invents a name.

## Tests

New Layer 3 tests pin the behaviour:

- a network card names the run that raised it
- a network card from a session with no run names nothing
- a credential card names the run that raised it
- a credential card from a session with no run names nothing
- a device sign-in card names the run that raised it
- a pkce sign-in card names the run that raised it
- the window keeps the run the prompt names (credential card)
- the sign-in card carries the run the prompt names
- a bind prompt names no run
