### PR TITLE
fix(sandbox): Land a fileset a volume mount would otherwise hide

### DIFF
--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -368,7 +368,7 @@ fn parse_of_kind(config_json: &[u8], kind: spec::Kind) -> Result<Definition> {
             );
         }
         validate_volume(volume).with_context(|| format!("volume targeting {}", volume.target))?;
-        if !targets.insert(&volume.target) {
+        if !targets.insert(claimed_path(&volume.target)) {
             bail!("duplicate volume target {}", volume.target);
         }
     }
@@ -385,10 +385,11 @@ fn parse_of_kind(config_json: &[u8], kind: spec::Kind) -> Result<Definition> {
     crate::tools::parse_all(&doc.spec.tools)?;
     for fileset in &doc.spec.filesets {
         validate_fileset(fileset)?;
-        if !targets.insert(&fileset.guest_path) {
+        if !targets.insert(claimed_path(&fileset.guest_path)) {
             bail!("duplicate guest path {}", fileset.guest_path);
         }
     }
+    refuse_a_fileset_no_mount_can_carry(&doc.spec)?;
     validate_scripts(&doc.spec.scripts)?;
     let mut container_ports = BTreeSet::new();
     let mut host_ports = BTreeSet::new();
@@ -577,6 +578,47 @@ fn overlaps_runtime_namespace(path: &str) -> bool {
         None => true,
         Some(first) => first == ".lens",
     }
+}
+
+/// The segments a guest path claims, so two spellings of one path — a trailing slash, a `.` segment, a doubled separator — are one claim rather than two.
+fn claimed_path(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect()
+}
+
+/// Whether `outer` is a strict path prefix of `inner`: the prefix-based rule the shared volume/fileset guest-path namespace is held to (§3.1.10).
+pub fn encloses(outer: &str, inner: &str) -> bool {
+    let mut inner_segments = claimed_path(inner).into_iter();
+    claimed_path(outer)
+        .into_iter()
+        .all(|segment| inner_segments.next() == Some(segment))
+        && inner_segments.next().is_some()
+}
+
+/// A fileset nested under a volume target reaches the workload only because lns-init copies it into the volume once mounted (§3.1.11), and these two kinds of volume take no such copy.
+fn refuse_a_fileset_no_mount_can_carry(spec: &SandboxSpec) -> Result<()> {
+    for volume in &spec.volumes {
+        let refusal = match (volume.is_bind(), volume.read_only) {
+            (true, _) => {
+                "a bind mounts a host directory over that path, and a fileset never writes to the host filesystem"
+            }
+            (_, true) => "a read-only volume takes no write, so the file could never land",
+            _ => continue,
+        };
+        for fileset in &spec.filesets {
+            if encloses(&volume.target, &fileset.guest_path)
+                || encloses(&fileset.guest_path, &volume.target)
+            {
+                bail!(
+                    "fileset guestPath {} is nested with volume target {}: {refusal}",
+                    fileset.guest_path,
+                    volume.target
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// One rule for who a guest process runs as, whether the workload's own user or a script's: the workload's reaches the guest on a space-joined kernel cmdline, so anything that could split it or be read as another key is refused here.
@@ -2296,6 +2338,76 @@ mod tests {
         .unwrap_err();
         assert!(
             format!("{err:#}").contains("duplicate guest path /s"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_sibling_whose_name_merely_starts_with_a_target_is_not_nested_under_it() {
+        assert!(encloses("/home/node", "/home/node/.config"));
+        assert!(
+            !encloses("/home/node", "/home/nodejs/.config"),
+            "a prefix rule on characters rather than segments would swallow an unrelated directory"
+        );
+        assert!(
+            !encloses("/home/node", "/home/node/"),
+            "one path spelled two ways is a duplicate claim, not a nested one"
+        );
+    }
+
+    #[test]
+    fn a_fileset_nested_under_a_bind_target_is_refused_because_a_fileset_never_writes_the_host() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"./src","target":"/work"}],"filesets":[{"path":"./cfg","guestPath":"/work/.agent"}]}"#,
+        ))
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("/work/.agent") && message.contains("/work"),
+            "the refusal has to name both entries: {message}"
+        );
+        assert!(message.contains("host filesystem"), "got: {message}");
+    }
+
+    #[test]
+    fn a_bind_target_nested_under_a_fileset_guest_path_is_refused_the_same_way() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"type":"bind","source":"./src","target":"/work/inner"}],"filesets":[{"path":"./cfg","guestPath":"/work"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("/work/inner"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_fileset_nested_under_a_read_only_volume_is_refused_because_the_write_could_never_land() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"name":"home","target":"/home/node","readOnly":true}],"filesets":[{"hostPath":"~/.config/tool.md","guestPath":"/home/node/.config/tool.md","optional":true}]}"#,
+        ))
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("/home/node/.config/tool.md") && message.contains("/home/node"),
+            "the refusal has to name both entries: {message}"
+        );
+        assert!(message.contains("read-only"), "got: {message}");
+    }
+
+    #[test]
+    fn a_fileset_nested_under_a_writable_named_volume_is_accepted_because_the_run_copies_it_in() {
+        parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"name":"home","target":"/home/node"}],"filesets":[{"hostPath":"~/.config/tool.md","guestPath":"/home/node/.config/tool.md","optional":true}]}"#,
+        ))
+        .expect("a writable named volume takes the copy lns-init makes once it is mounted");
+    }
+
+    #[test]
+    fn a_trailing_slash_does_not_buy_a_second_claim_on_one_guest_path() {
+        let err = parse(&def_json(
+            r#"{"image":"x:1","volumes":[{"name":"home","target":"/home/node"}],"filesets":[{"path":"./cfg","guestPath":"/home/node/"}]}"#,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("duplicate guest path"),
             "got: {err:#}"
         );
     }

--- a/crates/lns-cli/tests/behaviours/sandbox_author.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_author.feature
@@ -227,6 +227,24 @@ Feature: authoring a document
     Then the command fails with an exit code other than 0
     And the output contains "duplicate"
 
+  Scenario: validate refuses a fileset nested under a bind volume target
+    Given an lns.yaml declaring a bind volume at "/work" and fileset "./cfg" mounted at "/work/.agent"
+    When the user runs artifact command "validate"
+    Then the command fails with an exit code other than 0
+    And the output contains "host filesystem"
+
+  Scenario: validate refuses a fileset nested under a read-only volume target
+    Given an lns.yaml declaring a read-only volume at "/home/node" and fileset "./cfg" mounted at "/home/node/.config"
+    When the user runs artifact command "validate"
+    Then the command fails with an exit code other than 0
+    And the output contains "read-only volume takes no write"
+
+  Scenario: validate accepts a fileset nested under a writable named volume, which the run copies in after the mount
+    Given an lns.yaml declaring a named volume at "/home/node" and fileset "./cfg" mounted at "/home/node/.config"
+    And the project directory "./cfg" contains "tool.md"
+    When the user runs artifact command "validate"
+    Then the exit code is 0
+
   Scenario: validate refuses a secret-shaped file inside a path fileset
     Given an lns.yaml declaring fileset "./skills" mounted at "/root/.agent/skills"
     And the project directory "./skills" contains ".env"

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_author.rs
@@ -121,6 +121,29 @@ fn lns_yaml_with_path_fileset(w: &mut BehaviourWorld, path: String, mount: Strin
 }
 
 #[given(
+    regex = r#"^an lns\.yaml declaring a (bind|read-only|named) volume at "([^"]+)" and fileset "([^"]+)" mounted at "([^"]+)"$"#
+)]
+fn lns_yaml_with_volume_and_nested_fileset(
+    w: &mut BehaviourWorld,
+    kind: String,
+    target: String,
+    path: String,
+    mount: String,
+) {
+    let volume = match kind.as_str() {
+        "bind" => format!("    - type: bind\n      source: ./src\n      target: {target}\n"),
+        "read-only" => format!("    - name: home\n      target: {target}\n      readOnly: true\n"),
+        _ => format!("    - name: home\n      target: {target}\n"),
+    };
+    seed(
+        w,
+        &format!(
+            "apiVersion: lns.run/v1\nkind: sandbox\nname: hermes\nspec:\n  image: ghcr.io/team/base:1\n  volumes:\n{volume}  filesets:\n    - path: {path}\n      guestPath: {mount}\n"
+        ),
+    );
+}
+
+#[given(
     regex = r#"^an lns\.yaml declaring a hostPath fileset "([^"]+)" mounted at "([^"]+)" and optional$"#
 )]
 fn lns_yaml_with_host_path_fileset(w: &mut BehaviourWorld, source: String, mount: String) {

--- a/crates/lns-init/src/main.rs
+++ b/crates/lns-init/src/main.rs
@@ -3,6 +3,7 @@ mod boot;
 mod cmdline;
 mod mount;
 mod seed;
+mod staged;
 
 use std::io::Write;
 use std::process::ExitCode;

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -379,9 +379,11 @@ fn chown_fileset_owned(sys: &dyn Syscalls, newroot: &str, run_ids: Option<(u32, 
 fn land_writes_the_mounts_would_have_hidden(
     sys: &dyn Syscalls,
     newroot: &str,
+    volumes: &[crate::cmdline::VolumeParam],
     run_ids: Option<(u32, u32)>,
 ) -> Result<(), MountError> {
-    crate::staged::land(newroot).map_err(|err| MountError::Syscall {
+    let targets: Vec<String> = volumes.iter().map(|vol| vol.target.clone()).collect();
+    crate::staged::land(newroot, &targets).map_err(|err| MountError::Syscall {
         op: format!(
             "landing the writes staged under {}",
             crate::staged::STAGED_ROOT
@@ -909,7 +911,7 @@ fn mount_composefs_and_exec_broker_inner(
 
     mount_binds(sys, &params.binds, newroot)?;
 
-    land_writes_the_mounts_would_have_hidden(sys, newroot, run_ids)?;
+    land_writes_the_mounts_would_have_hidden(sys, newroot, &params.volumes, run_ids)?;
 
     mount_run_tmpfs(sys, newroot, run_ids)?;
 
@@ -2273,7 +2275,7 @@ mod tests {
         std::fs::write(format!("{staged}/tool.md"), b"read me").unwrap();
         let sys = FakeSyscalls::new();
 
-        land_writes_the_mounts_would_have_hidden(&sys, &newroot, Some((1000, 1000))).unwrap();
+        land_writes_the_mounts_would_have_hidden(&sys, &newroot, &[], Some((1000, 1000))).unwrap();
 
         assert_eq!(
             std::fs::read(format!("{newroot}/home/node/tool.md")).unwrap(),
@@ -2300,8 +2302,9 @@ mod tests {
         std::fs::create_dir_all(format!("{newroot}/home")).unwrap();
         std::fs::write(format!("{newroot}/home/node"), b"in the way").unwrap();
 
-        let err = land_writes_the_mounts_would_have_hidden(&FakeSyscalls::new(), &newroot, None)
-            .unwrap_err();
+        let err =
+            land_writes_the_mounts_would_have_hidden(&FakeSyscalls::new(), &newroot, &[], None)
+                .unwrap_err();
 
         let refusal = format!("{err}");
         assert!(

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -375,6 +375,23 @@ fn chown_fileset_owned(sys: &dyn Syscalls, newroot: &str, run_ids: Option<(u32, 
     }
 }
 
+/// The chown manifest is applied a second time here because the paths it names inside a volume did not exist during the first pass.
+fn land_writes_the_mounts_would_have_hidden(
+    sys: &dyn Syscalls,
+    newroot: &str,
+    run_ids: Option<(u32, u32)>,
+) -> Result<(), MountError> {
+    crate::staged::land(newroot).map_err(|err| MountError::Syscall {
+        op: format!(
+            "landing the writes staged under {}",
+            crate::staged::STAGED_ROOT
+        ),
+        err,
+    })?;
+    chown_fileset_owned(sys, newroot, run_ids);
+    Ok(())
+}
+
 /// One place converts a path for `lchown` and logs what went wrong, so a path the syscall cannot take or a failure on one entry never abandons the rest of the walk.
 fn lchown_logged(sys: &dyn Syscalls, path: &str, uid: u32, gid: u32) {
     match CString::new(path) {
@@ -891,6 +908,8 @@ fn mount_composefs_and_exec_broker_inner(
     mount_volumes(sys, &params.volumes, newroot, run_ids)?;
 
     mount_binds(sys, &params.binds, newroot)?;
+
+    land_writes_the_mounts_would_have_hidden(sys, newroot, run_ids)?;
 
     mount_run_tmpfs(sys, newroot, run_ids)?;
 
@@ -2242,6 +2261,56 @@ mod tests {
         assert!(
             sys.calls.borrow().is_empty(),
             "a root workload already writes its own trees"
+        );
+    }
+
+    #[test]
+    fn a_write_that_lands_after_the_mounts_still_transfers_to_the_workload_user() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = newroot_with_manifest(&dir, "/home/node/tool.md\n");
+        let staged = format!("{newroot}{}/home/node", crate::staged::STAGED_ROOT);
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(format!("{staged}/tool.md"), b"read me").unwrap();
+        let sys = FakeSyscalls::new();
+
+        land_writes_the_mounts_would_have_hidden(&sys, &newroot, Some((1000, 1000))).unwrap();
+
+        assert_eq!(
+            std::fs::read(format!("{newroot}/home/node/tool.md")).unwrap(),
+            b"read me"
+        );
+        let landed = Call::Lchown {
+            path: format!("{newroot}/home/node/tool.md"),
+            uid: 1000,
+            gid: 1000,
+        };
+        assert!(
+            sys.calls().contains(&landed),
+            "the first chown pass ran before the mount, when this path did not exist yet"
+        );
+    }
+
+    #[test]
+    fn a_staged_write_that_cannot_land_refuses_the_boot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = newroot_with_manifest(&dir, "");
+        let staged = format!("{newroot}{}/home/node", crate::staged::STAGED_ROOT);
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(format!("{staged}/tool.md"), b"x").unwrap();
+        std::fs::create_dir_all(format!("{newroot}/home")).unwrap();
+        std::fs::write(format!("{newroot}/home/node"), b"in the way").unwrap();
+
+        let err = land_writes_the_mounts_would_have_hidden(&FakeSyscalls::new(), &newroot, None)
+            .unwrap_err();
+
+        let refusal = format!("{err}");
+        assert!(
+            refusal.contains("fileset-deferred"),
+            "a workload that would start without its file is a boot failure, not a warning"
+        );
+        assert!(
+            refusal.contains("/home/node/tool.md"),
+            "a bare errno leaves the operator with no path to look at"
         );
     }
 

--- a/crates/lns-init/src/staged.rs
+++ b/crates/lns-init/src/staged.rs
@@ -1,0 +1,204 @@
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use std::io;
+use std::path::Path;
+
+/// Guest writes a volume mount would have covered: the host stages them here instead, and `land` copies them onto the paths they name once the volumes are mounted.
+pub const STAGED_ROOT: &str = "/.lens/fileset-deferred";
+
+pub fn land(newroot: &str) -> io::Result<()> {
+    let staged = Path::new(newroot).join(&STAGED_ROOT[1..]);
+    if !staged.is_dir() {
+        return Ok(());
+    }
+    land_tree(&staged, Path::new(newroot))?;
+    consume(&staged);
+    Ok(())
+}
+
+/// Leaving the landed tree behind would show the workload a root-owned duplicate of every file, and it has nothing left to do once the copies are in place.
+fn consume(staged: &Path) {
+    if let Err(err) = std::fs::remove_dir_all(staged) {
+        eprintln!("lns-init: could not remove {}: {err}", staged.display());
+    }
+}
+
+fn land_tree(from: &Path, onto: &Path) -> io::Result<()> {
+    for entry in from.read_dir().map_err(|err| blaming(from, err))? {
+        let entry = entry.map_err(|err| blaming(from, err))?;
+        let staged = entry.path();
+        let landing = onto.join(entry.file_name());
+        let staged_is_dir = entry
+            .file_type()
+            .map_err(|err| blaming(&staged, err))?
+            .is_dir();
+        if staged_is_dir {
+            create_dir_if_absent(&landing).map_err(|err| blaming(&landing, err))?;
+            land_tree(&staged, &landing)?;
+        } else {
+            replace(&staged, &landing).map_err(|err| blaming(&landing, err))?;
+        }
+    }
+    Ok(())
+}
+
+/// A boot refusal has to name the path that refused, or the operator is left with a bare errno.
+fn blaming(path: &Path, err: io::Error) -> io::Error {
+    io::Error::new(err.kind(), format!("{}: {err}", path.display()))
+}
+
+/// A directory a mount already owns keeps the mode and owner it came with, but a symlink the last run planted there must not redirect where root writes.
+fn create_dir_if_absent(path: &Path) -> io::Result<()> {
+    if std::fs::symlink_metadata(path).is_ok_and(|found| found.file_type().is_symlink()) {
+        std::fs::remove_file(path)?;
+    }
+    match std::fs::create_dir(path) {
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        other => other,
+    }
+}
+
+fn replace(staged: &Path, landing: &Path) -> io::Result<()> {
+    if std::fs::symlink_metadata(landing).is_ok() {
+        std::fs::remove_file(landing)?;
+    }
+    if staged.symlink_metadata()?.file_type().is_symlink() {
+        return std::os::unix::fs::symlink(std::fs::read_link(staged)?, landing);
+    }
+    std::fs::copy(staged, landing).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn stage(newroot: &Path, guest_path: &str, body: &[u8], mode: u32) {
+        let staged = newroot.join(&STAGED_ROOT[1..]).join(&guest_path[1..]);
+        std::fs::create_dir_all(staged.parent().unwrap()).unwrap();
+        std::fs::write(&staged, body).unwrap();
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn a_staged_write_lands_on_the_path_it_names_with_its_mode() {
+        let root = tempfile::tempdir().unwrap();
+        stage(root.path(), "/home/node/.config/tool.md", b"read me", 0o600);
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        let landed = root.path().join("home/node/.config/tool.md");
+        assert_eq!(std::fs::read(&landed).unwrap(), b"read me");
+        assert_eq!(
+            std::fs::metadata(&landed).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn a_staged_write_replaces_what_the_last_boot_left_in_the_volume() {
+        let root = tempfile::tempdir().unwrap();
+        let volume = root.path().join("home/node");
+        std::fs::create_dir_all(&volume).unwrap();
+        std::fs::write(volume.join("tool.md"), b"stale").unwrap();
+        stage(root.path(), "/home/node/tool.md", b"fresh", 0o644);
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::read(volume.join("tool.md")).unwrap(),
+            b"fresh",
+            "the host file is what this boot declares, so it wins over what the volume kept"
+        );
+    }
+
+    #[test]
+    fn a_directory_the_mount_already_owns_keeps_its_own_mode() {
+        let root = tempfile::tempdir().unwrap();
+        let volume = root.path().join("home/node");
+        std::fs::create_dir_all(&volume).unwrap();
+        std::fs::set_permissions(&volume, std::fs::Permissions::from_mode(0o700)).unwrap();
+        stage(root.path(), "/home/node/tool.md", b"x", 0o644);
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&volume).unwrap().permissions().mode() & 0o777,
+            0o700,
+            "landing a file must not restate the volume root's own mode"
+        );
+    }
+
+    #[test]
+    fn a_staged_symlink_lands_as_a_symlink() {
+        let root = tempfile::tempdir().unwrap();
+        let staged = root.path().join(&STAGED_ROOT[1..]).join("home/node");
+        std::fs::create_dir_all(&staged).unwrap();
+        std::os::unix::fs::symlink("/.lens/bin/agent", staged.join("agent")).unwrap();
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        let landed = root.path().join("home/node/agent");
+        assert_eq!(
+            std::fs::read_link(&landed).unwrap(),
+            Path::new("/.lens/bin/agent")
+        );
+    }
+
+    #[test]
+    fn a_symlink_the_last_run_left_at_a_directory_position_does_not_redirect_the_landing() {
+        let root = tempfile::tempdir().unwrap();
+        let volume = root.path().join("home/node");
+        std::fs::create_dir_all(&volume).unwrap();
+        let elsewhere = root.path().join("etc");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        std::os::unix::fs::symlink(&elsewhere, volume.join(".config")).unwrap();
+        stage(root.path(), "/home/node/.config/tool.md", b"x", 0o644);
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        assert!(
+            !elsewhere.join("tool.md").exists(),
+            "a root-driven write must land where the document says, not where the workload pointed"
+        );
+        assert_eq!(std::fs::read(volume.join(".config/tool.md")).unwrap(), b"x");
+    }
+
+    #[test]
+    fn the_staged_tree_is_gone_once_landed_so_the_workload_sees_no_duplicate() {
+        let root = tempfile::tempdir().unwrap();
+        stage(root.path(), "/home/node/tool.md", b"x", 0o644);
+
+        land(root.path().to_str().unwrap()).unwrap();
+
+        assert!(!root.path().join(&STAGED_ROOT[1..]).exists());
+        assert_eq!(
+            std::fs::read(root.path().join("home/node/tool.md")).unwrap(),
+            b"x"
+        );
+    }
+
+    #[test]
+    fn a_staged_tree_that_cannot_be_removed_does_not_fail_the_boot() {
+        let root = tempfile::tempdir().unwrap();
+        stage(root.path(), "/home/node/tool.md", b"x", 0o644);
+        let lens = root.path().join(".lens");
+        std::fs::set_permissions(&lens, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let landed = land(root.path().to_str().unwrap());
+
+        std::fs::set_permissions(&lens, std::fs::Permissions::from_mode(0o700)).unwrap();
+        landed.expect("the copies are in place, so a leftover staging tree is not worth a refusal");
+        assert_eq!(
+            std::fs::read(root.path().join("home/node/tool.md")).unwrap(),
+            b"x"
+        );
+    }
+
+    #[test]
+    fn a_run_that_staged_nothing_lands_nothing() {
+        let root = tempfile::tempdir().unwrap();
+        land(root.path().to_str().unwrap()).unwrap();
+        assert!(!root.path().join("home").exists());
+    }
+}

--- a/crates/lns-init/src/staged.rs
+++ b/crates/lns-init/src/staged.rs
@@ -6,12 +6,12 @@ use std::path::Path;
 /// Guest writes a volume mount would have covered: the host stages them here instead, and `land` copies them onto the paths they name once the volumes are mounted.
 pub const STAGED_ROOT: &str = "/.lens/fileset-deferred";
 
-pub fn land(newroot: &str) -> io::Result<()> {
+pub fn land(newroot: &str, volume_targets: &[String]) -> io::Result<()> {
     let staged = Path::new(newroot).join(&STAGED_ROOT[1..]);
     if !staged.is_dir() {
         return Ok(());
     }
-    land_tree(&staged, Path::new(newroot))?;
+    land_tree(&staged, Path::new(newroot), "", volume_targets)?;
     consume(&staged);
     Ok(())
 }
@@ -23,21 +23,46 @@ fn consume(staged: &Path) {
     }
 }
 
-fn land_tree(from: &Path, onto: &Path) -> io::Result<()> {
+fn land_tree(from: &Path, onto: &Path, guest: &str, volumes: &[String]) -> io::Result<()> {
     for entry in from.read_dir().map_err(|err| blaming(from, err))? {
         let entry = entry.map_err(|err| blaming(from, err))?;
         let staged = entry.path();
         let landing = onto.join(entry.file_name());
+        let guest_path = format!("{guest}/{}", entry.file_name().to_string_lossy());
         let staged_is_dir = entry
             .file_type()
             .map_err(|err| blaming(&staged, err))?
             .is_dir();
         if staged_is_dir {
+            if inside_a_volume(&guest_path, volumes) {
+                unlink_a_symlink_in_the_way(&landing).map_err(|err| blaming(&landing, err))?;
+            }
             create_dir_if_absent(&landing).map_err(|err| blaming(&landing, err))?;
-            land_tree(&staged, &landing)?;
+            land_tree(&staged, &landing, &guest_path, volumes)?;
         } else {
             replace(&staged, &landing).map_err(|err| blaming(&landing, err))?;
         }
+    }
+    Ok(())
+}
+
+/// Only a volume carries what a previous run wrote, so only there is a symlink at a directory position the last workload's doing rather than the image's own layout.
+fn inside_a_volume(guest_path: &str, volumes: &[String]) -> bool {
+    volumes
+        .iter()
+        .any(|target| segments(guest_path).starts_with(&segments(target)))
+}
+
+fn segments(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect()
+}
+
+/// A symlink the last run planted inside its volume must not redirect where root writes.
+fn unlink_a_symlink_in_the_way(path: &Path) -> io::Result<()> {
+    if std::fs::symlink_metadata(path).is_ok_and(|found| found.file_type().is_symlink()) {
+        return std::fs::remove_file(path);
     }
     Ok(())
 }
@@ -47,11 +72,8 @@ fn blaming(path: &Path, err: io::Error) -> io::Error {
     io::Error::new(err.kind(), format!("{}: {err}", path.display()))
 }
 
-/// A directory a mount already owns keeps the mode and owner it came with, but a symlink the last run planted there must not redirect where root writes.
+/// A directory a mount already owns keeps the mode and owner it came with, so only one nothing has created yet is made here.
 fn create_dir_if_absent(path: &Path) -> io::Result<()> {
-    if std::fs::symlink_metadata(path).is_ok_and(|found| found.file_type().is_symlink()) {
-        std::fs::remove_file(path)?;
-    }
     match std::fs::create_dir(path) {
         Err(err) if err.kind() == io::ErrorKind::AlreadyExists => Ok(()),
         other => other,
@@ -85,7 +107,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         stage(root.path(), "/home/node/.config/tool.md", b"read me", 0o600);
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
 
         let landed = root.path().join("home/node/.config/tool.md");
         assert_eq!(std::fs::read(&landed).unwrap(), b"read me");
@@ -103,7 +125,7 @@ mod tests {
         std::fs::write(volume.join("tool.md"), b"stale").unwrap();
         stage(root.path(), "/home/node/tool.md", b"fresh", 0o644);
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
 
         assert_eq!(
             std::fs::read(volume.join("tool.md")).unwrap(),
@@ -120,7 +142,7 @@ mod tests {
         std::fs::set_permissions(&volume, std::fs::Permissions::from_mode(0o700)).unwrap();
         stage(root.path(), "/home/node/tool.md", b"x", 0o644);
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
 
         assert_eq!(
             std::fs::metadata(&volume).unwrap().permissions().mode() & 0o777,
@@ -136,7 +158,7 @@ mod tests {
         std::fs::create_dir_all(&staged).unwrap();
         std::os::unix::fs::symlink("/.lens/bin/agent", staged.join("agent")).unwrap();
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
 
         let landed = root.path().join("home/node/agent");
         assert_eq!(
@@ -155,7 +177,7 @@ mod tests {
         std::os::unix::fs::symlink(&elsewhere, volume.join(".config")).unwrap();
         stage(root.path(), "/home/node/.config/tool.md", b"x", 0o644);
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &["/home/node".to_string()]).unwrap();
 
         assert!(
             !elsewhere.join("tool.md").exists(),
@@ -165,11 +187,31 @@ mod tests {
     }
 
     #[test]
+    fn a_directory_symlink_the_image_ships_above_the_volume_survives_and_is_followed() {
+        let root = tempfile::tempdir().unwrap();
+        let volume = root.path().join("var/home/node");
+        std::fs::create_dir_all(&volume).unwrap();
+        std::os::unix::fs::symlink("var/home", root.path().join("home")).unwrap();
+        stage(root.path(), "/home/node/tool.md", b"x", 0o644);
+
+        land(root.path().to_str().unwrap(), &["/home/node".to_string()]).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(root.path().join("home"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the volume is mounted at the path this symlink resolves to, so replacing it strands the mount"
+        );
+        assert_eq!(std::fs::read(volume.join("tool.md")).unwrap(), b"x");
+    }
+
+    #[test]
     fn the_staged_tree_is_gone_once_landed_so_the_workload_sees_no_duplicate() {
         let root = tempfile::tempdir().unwrap();
         stage(root.path(), "/home/node/tool.md", b"x", 0o644);
 
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
 
         assert!(!root.path().join(&STAGED_ROOT[1..]).exists());
         assert_eq!(
@@ -185,7 +227,7 @@ mod tests {
         let lens = root.path().join(".lens");
         std::fs::set_permissions(&lens, std::fs::Permissions::from_mode(0o500)).unwrap();
 
-        let landed = land(root.path().to_str().unwrap());
+        let landed = land(root.path().to_str().unwrap(), &[]);
 
         std::fs::set_permissions(&lens, std::fs::Permissions::from_mode(0o700)).unwrap();
         landed.expect("the copies are in place, so a leftover staging tree is not worth a refusal");
@@ -198,7 +240,7 @@ mod tests {
     #[test]
     fn a_run_that_staged_nothing_lands_nothing() {
         let root = tempfile::tempdir().unwrap();
-        land(root.path().to_str().unwrap()).unwrap();
+        land(root.path().to_str().unwrap(), &[]).unwrap();
         assert!(!root.path().join("home").exists());
     }
 }

--- a/crates/lns-service/src/artifact/fileset.rs
+++ b/crates/lns-service/src/artifact/fileset.rs
@@ -12,6 +12,50 @@ use crate::runtime_layer::{RuntimeFileSpec, RuntimeSource};
 
 pub const OWNED_MANIFEST_PATH: &str = "/.lens/fileset-owned";
 
+/// Where a guest write a volume mount would cover is staged instead, for lns-init to copy onto its final path once the volume is mounted.
+pub const DEFERRED_ROOT: &str = "/.lens/fileset-deferred";
+
+/// A volume mounts after the runtime layer is in place, so a write under its target is staged here for lns-init to copy in once the volume is mounted.
+pub fn stage_what_a_volume_would_hide(
+    specs: &mut [RuntimeFileSpec],
+    volumes: &[lns_ipc::VolumeMount],
+) {
+    for spec in specs {
+        if volumes
+            .iter()
+            .filter(|volume| !volume.read_only)
+            .any(|volume| lns_artifact::sandbox::encloses(&volume.target, &spec.guest_path))
+        {
+            spec.guest_path = format!("{DEFERRED_ROOT}{}", spec.guest_path);
+        }
+    }
+}
+
+/// A read-only volume takes no write and a bind would leave the file in the host directory it shares, so a run whose write lands under either is refused rather than started without it.
+pub fn refuse_writes_a_mount_would_hide(
+    specs: &[RuntimeFileSpec],
+    volumes: &[lns_ipc::VolumeMount],
+    binds: &[lns_ipc::BindMount],
+) -> Result<()> {
+    let covering = volumes
+        .iter()
+        .filter(|volume| volume.read_only)
+        .map(|volume| ("read-only volume", volume.target.as_str()))
+        .chain(binds.iter().map(|bind| ("bind", bind.target.as_str())));
+    for (kind, target) in covering {
+        let hidden = specs
+            .iter()
+            .find(|spec| lns_artifact::sandbox::encloses(target, &spec.guest_path));
+        if let Some(hidden) = hidden {
+            bail!(
+                "the fileset at {} lands under the {kind} mounted at {target}, which takes no write from a fileset; the workload would never see the file",
+                hidden.guest_path
+            );
+        }
+    }
+    Ok(())
+}
+
 pub(crate) struct FilesetBudget {
     bytes: u64,
     entries: usize,
@@ -358,6 +402,100 @@ mod tests {
     use super::*;
     use oci_client::manifest::OciDescriptor;
     use sha2::{Digest, Sha256};
+
+    fn spec_at(guest_path: &str) -> RuntimeFileSpec {
+        RuntimeFileSpec {
+            guest_path: guest_path.to_string(),
+            mode: 0o644,
+            source: RuntimeSource::Bytes(b"x".to_vec()),
+        }
+    }
+
+    fn volume_at(target: &str, read_only: bool) -> lns_ipc::VolumeMount {
+        lns_ipc::VolumeMount {
+            name: "home".to_string(),
+            target: target.to_string(),
+            read_only,
+            size_bytes: None,
+        }
+    }
+
+    #[test]
+    fn staging_leaves_a_write_no_volume_target_encloses_where_it_was_written() {
+        let mut specs = vec![
+            spec_at("/home/node/.config/tool.md"),
+            spec_at("/home/nodejs/tool.md"),
+            spec_at(OWNED_MANIFEST_PATH),
+        ];
+        stage_what_a_volume_would_hide(&mut specs, &[volume_at("/home/node", false)]);
+        let paths: Vec<&str> = specs.iter().map(|s| s.guest_path.as_str()).collect();
+        assert_eq!(
+            paths,
+            [
+                "/.lens/fileset-deferred/home/node/.config/tool.md",
+                "/home/nodejs/tool.md",
+                OWNED_MANIFEST_PATH,
+            ]
+        );
+    }
+
+    #[test]
+    fn a_write_at_the_volume_target_itself_is_the_mount_point_and_is_left_alone() {
+        let mut specs = vec![spec_at("/home/node")];
+        stage_what_a_volume_would_hide(&mut specs, &[volume_at("/home/node", false)]);
+        assert_eq!(specs[0].guest_path, "/home/node");
+    }
+
+    #[test]
+    fn a_write_under_a_read_only_volume_is_left_where_it_was_written_because_no_copy_can_land() {
+        let mut specs = vec![spec_at("/home/node/tool.md")];
+        stage_what_a_volume_would_hide(&mut specs, &[volume_at("/home/node", true)]);
+        assert_eq!(specs[0].guest_path, "/home/node/tool.md");
+    }
+
+    fn bind_at(target: &str) -> lns_ipc::BindMount {
+        lns_ipc::BindMount {
+            host_source: "/Users/dev/project".to_string(),
+            target: target.to_string(),
+            read_only: false,
+            kept_paths: Vec::new(),
+            dropped_paths: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_read_only_mount_the_flags_added_refuses_the_run_the_document_could_not_refuse() {
+        let specs = [spec_at("/home/node/.config/tool.md")];
+        let err = refuse_writes_a_mount_would_hide(&specs, &[volume_at("/home/node", true)], &[])
+            .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("/home/node/.config/tool.md") && message.contains("/home/node"),
+            "the refusal has to name the write and the mount: {message}"
+        );
+        assert!(message.contains("read-only volume"), "got: {message}");
+    }
+
+    #[test]
+    fn a_bind_the_flags_added_refuses_the_run_rather_than_seeding_the_host_directory() {
+        let specs = [spec_at("/work/.agent/settings.json")];
+        let err = refuse_writes_a_mount_would_hide(&specs, &[], &[bind_at("/work")]).unwrap_err();
+        assert!(format!("{err:#}").contains("bind"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_writable_named_volume_refuses_nothing_because_the_staged_copy_lands_in_it() {
+        let specs = [spec_at("/home/node/.config/tool.md")];
+        refuse_writes_a_mount_would_hide(&specs, &[volume_at("/home/node", false)], &[])
+            .expect("a writable named volume takes the copy lns-init makes once it is mounted");
+    }
+
+    #[test]
+    fn a_mount_beside_every_write_refuses_nothing() {
+        let specs = [spec_at("/home/node/tool.md")];
+        refuse_writes_a_mount_would_hide(&specs, &[volume_at("/data", true)], &[bind_at("/work")])
+            .expect("neither mount covers where the write lands");
+    }
 
     fn tar_with(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut builder = tar::Builder::new(Vec::new());

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -419,6 +419,12 @@ async fn orchestrate(
         fileset_specs.extend(ensured.specs.iter().cloned());
     }
     fileset_specs.extend(workload_ca_spec);
+    crate::artifact::fileset::refuse_writes_a_mount_would_hide(
+        &fileset_specs,
+        &args.volumes,
+        &args.binds,
+    )?;
+    crate::artifact::fileset::stage_what_a_volume_would_hide(&mut fileset_specs, &args.volumes);
     let runtime_layer = runtime_layer::for_run(
         imageless,
         &content_store,

--- a/crates/lns-service/tests/behaviours/sandbox_filesets.feature
+++ b/crates/lns-service/tests/behaviours/sandbox_filesets.feature
@@ -90,3 +90,16 @@ Feature: a sandbox's declared filesets are planned into the launch
     Given a published sandbox declaring a hostPath fileset "~/.gitconfig" at "/home/agent/.gitconfig"
     When the sandbox is planned
     Then the plan accepts the hostPath fileset
+
+  Scenario: a fileset landing under a volume target is staged so the mount cannot hide it
+    Given a sandbox declaring inline file "tool.md" with content `read me` at "/home/node/.config"
+    And the run mounts a writable named volume at "/home/node"
+    When the sandbox is planned
+    Then the plan stages the guest-write spec for "/home/node/.config/tool.md" for lns-init to copy in after the mount
+    And the plan carries no guest-write spec for "/home/node/.config/tool.md"
+
+  Scenario: a fileset landing outside every volume target is written straight into the rootfs
+    Given a sandbox declaring inline file "tool.md" with content `read me` at "/etc/agent"
+    And the run mounts a writable named volume at "/home/node"
+    When the sandbox is planned
+    Then the plan carries an inline guest-write spec for "/etc/agent/tool.md"

--- a/crates/lns-service/tests/behaviours/steps/sandbox_filesets.rs
+++ b/crates/lns-service/tests/behaviours/steps/sandbox_filesets.rs
@@ -75,7 +75,11 @@ fn plan_published_sandbox(world: &mut BehaviourWorld) {
 }
 
 fn capture_materialized(world: &mut BehaviourWorld, materialized: MaterializedFilesets) {
-    let specs = materialized.into_specs();
+    let mut specs = materialized.into_specs();
+    lns_service::artifact::fileset::stage_what_a_volume_would_hide(
+        &mut specs,
+        &world.fileset_volumes,
+    );
     world.fileset_manifest = specs
         .iter()
         .find(|spec| spec.guest_path == OWNED_MANIFEST_PATH)
@@ -444,4 +448,39 @@ fn plan_accepts_host_path(world: &mut BehaviourWorld) -> Result<(), String> {
             plan.local_filesets, plan.host_filesets
         ))
     }
+}
+
+#[given(regex = r#"^the run mounts a writable named volume at "([^"]+)"$"#)]
+fn run_mounts_a_writable_named_volume(world: &mut BehaviourWorld, target: String) {
+    world.fileset_volumes.push(lns_ipc::VolumeMount {
+        name: "home".to_string(),
+        target,
+        read_only: false,
+        size_bytes: None,
+    });
+}
+
+#[then(
+    regex = r#"^the plan stages the guest-write spec for "([^"]+)" for lns-init to copy in after the mount$"#
+)]
+fn plan_stages_spec_for_deferred_copy(
+    world: &mut BehaviourWorld,
+    guest_path: String,
+) -> Result<(), String> {
+    let staged = format!(
+        "{}{guest_path}",
+        lns_service::artifact::fileset::DEFERRED_ROOT
+    );
+    plan_carries_spec(world, staged)
+}
+
+#[then(regex = r#"^the plan carries no guest-write spec for "([^"]+)"$"#)]
+fn plan_carries_no_spec_at(world: &mut BehaviourWorld, guest_path: String) -> Result<(), String> {
+    let specs = world.fileset_specs.as_ref().ok_or("no plan ran")?;
+    if specs.contains(&guest_path) {
+        return Err(format!(
+            "{guest_path:?} is written straight into the rootfs, where the volume mount hides it"
+        ));
+    }
+    Ok(())
 }

--- a/crates/lns-service/tests/behaviours/world.rs
+++ b/crates/lns-service/tests/behaviours/world.rs
@@ -79,6 +79,8 @@ pub struct BehaviourWorld {
     pub fileset_manifest: Option<String>,
     /// How many packed layers the scenario's own artifact carries, when it is a published one.
     pub fileset_artifact_layers: Option<usize>,
+    /// The named volumes the scenario's run mounts, which a fileset landing under one is staged past.
+    pub fileset_volumes: Vec<lns_ipc::VolumeMount>,
     /// The pre-start scripts a scenario declares, before they become a document.
     pub script_declaration: Option<crate::steps::guest_scripts::ScriptDeclaration>,
     /// The runtime-layer specs a planned run stages for its pre-start scripts.

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -578,6 +578,15 @@ spec:
   guest path; duplicates — including collisions with a volume `target` — are
   rejected offline, as is any mount into the sandbox's own `/.lens` runtime
   namespace.
+- A `guestPath` **under** a volume `target` still lands. The volume mounts after
+  the files are placed, so the run writes the file into the volume once it is
+  mounted, on every boot — the document decides that path, not what the workload
+  left there last run. Two volumes take no such write and are rejected offline:
+  a **bind**, because a fileset never writes into the host directory a bind
+  shares, and a **read-only** volume, which takes no write at all. Either
+  refusal names the fileset entry and the volume entry. Add one of those two
+  mounts with a `-v` flag instead of in the document and the run is refused when
+  it starts, before anything boots.
 - **`owner`** decides who owns the materialized files in the guest.
   The default, `workload`, transfers the guest path and everything it ships
   to the run-as user, so a seeded config the tool rewrites at runtime

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -673,6 +673,14 @@ appears on a [`hostPath` fileset](#3111-filesets) and means the same thing.
 - MUST NOT overlap the `/.lens` runtime namespace, which belongs to the sandbox
   itself. `/` is likewise refused.
 - MUST be unique across **all** `volumes` and `filesets` in the document.
+  Uniqueness is decided on path segments, not on the string, so `/home/node` and
+  `/home/node/` are one claim, not two.
+- A fileset `guestPath` and a volume `target` whose paths **nest** — `/home/node`
+  and `/home/node/.config` — are two claims the mount order decides between;
+  [§3.1.11](#3111-filesets) says which of those a document may make. Two
+  `volumes` that nest, and two `filesets` that nest, are both allowed: the guest
+  mounts nested volumes in declaration order, and two filesets writing under one
+  another are just files.
 
 #### 3.1.11 `filesets`
 
@@ -712,6 +720,30 @@ filesystem before the workload starts. Nothing is mounted at the path, and
 nothing can be unmounted from it. The field says where the files land, which is
 what `guestPath` names. The two keep separate words because they are separate
 things — one attaches a filesystem, the other places files.
+
+**A `guestPath` nested under a volume `target`.** The mounts happen after the
+files are placed, so a `guestPath` under a volume `target` names a path the mount
+covers. The run does not leave the file where the mount hides it: it writes the
+file into the volume once the volume is mounted, and it does so on **every** boot,
+because a fileset is re-derived from its source every run. What the workload wrote
+there last run does not survive — the document is what decides that path.
+
+Two volumes take no such write, and a document declaring one under them is
+**refused**:
+
+- a **bind**, because writing there would create files in the host directory the
+  bind shares, and they would outlive the run. A fileset never writes to the host
+  filesystem.
+- a **read-only** volume, because it takes no write at all, so the file could
+  never land.
+
+Both refusals name the fileset entry and the volume entry. The nesting may run
+either way — a `guestPath` under a `target`, or a `target` under a `guestPath` —
+and is refused the same.
+
+A document validates against its own `volumes`, so a run that adds one of those
+two mounts itself — a read-only or bind mount the launch names rather than the
+document — is refused when the run starts instead, before anything boots.
 
 A `path` or `inline` fileset is **not a separate artifact**. `inline` content
 lives in this document, and a `path` directory is packed into a layer of the same
@@ -1186,7 +1218,7 @@ What "wins" means per block:
 | `egress` | Union of entries, later sources placed ahead of earlier ones, so the latest entry matching a destination is the one that decides ([§4.2](#42-the-egress-definition)). |
 | `credentials` | Union by `envVar`. A later source redefining one replaces it whole — its `placeholder` and `injections` together, never half of each. |
 | `tools` | Union by name. The last version declared wins. |
-| `volumes`, `filesets` | Union by guest path — a volume `target` and a fileset `guestPath` share one namespace. The last source to claim a path owns it. A named volume's [`size`](#3110-volumes) is the largest any surviving entry declares, because a size is a floor and every mount of that volume must clear it. |
+| `volumes`, `filesets` | Union by guest path — a volume `target` and a fileset `guestPath` share one namespace, compared on path segments ([§3.1.10](#3110-volumes)). The last source to claim a path owns it. A named volume's [`size`](#3110-volumes) is the largest any surviving entry declares, because a size is a floor and every mount of that volume must clear it. |
 | `ports` | Union by `container`. The last mapping wins. |
 | `scripts` | **Append**, in source order. Not last-wins: every source's scripts run, the sandbox's own first and the local mixin's last. |
 


### PR DESCRIPTION
## Summary

Closes #341.

A fileset whose `guestPath` fell under a volume `target` validated clean, then got shadowed by the volume mount at boot. The workload saw no file, and the run reported nothing wrong.

Fileset files are baked into the composefs runtime layer, so they exist the moment the overlay mounts at `newroot`. `mount_volumes` runs after that. A pristine named volume hid the bug further, because `seed_volume_if_pristine` copied the covered path into the volume on the first run only — so the file appeared once and never updated again.

### 1. The write lands

The host stages a write a writable volume would cover under `/.lens/fileset-deferred` instead of writing it at its final path. `lns-init` copies the staged tree onto those paths after the volumes and binds mount, then applies the chown manifest a second time — the first pass runs before the mount, when a path inside a volume does not exist yet.

The copy repeats on every boot. That is what a fileset already did: the upper layer is provisioned per run, so the host file was always what a boot got.

A symlink the last run left at a directory position is unlinked before the directory is created, so a workload cannot redirect where root writes.

### 2. Two mounts refuse instead

| Mount | Why it refuses |
|---|---|
| bind | The write would put the file in the host directory the bind shares, and leave it there after the run. A fileset never writes to the host filesystem. |
| read-only volume | It takes no write, so the file could never land. |

`lns validate` refuses a document that nests one, naming both entries. The service refuses a launch whose own `-v` flag adds one, before anything boots.

### 3. Guest-path claims compare on segments

`/home/node` and `/home/node/` are one claim, not two, so a trailing slash no longer buys a second claim on one path.

## Docs

`docs/sandbox-spec.md` §3.1.10 and §3.1.11 carry the decision, in their own commit. §3.1.10 also states that uniqueness is decided on path segments, and that a volume under a volume and a fileset under a fileset stay allowed. `docs/running-workloads.md` describes what ships.

## Follow-ups

- The stage → layer → land → chown round trip spans three crates. It belongs in the `@microvm` suite.
- `mount_run_tmpfs` runs after the landing, so a `guestPath` under `/run` is still covered by the tmpfs. Pre-existing, same bug family.
- At the flag level, a bind or read-only target that exactly equals a fileset `guestPath` is neither refused nor staged; the mount syscall refuses the boot with a worse message.