### PR TITLE
fix(audit): drop the hidden --json alias the spec forbids

### DIFF
--- a/crates/e2e-tests/features/audit_verification.feature
+++ b/crates/e2e-tests/features/audit_verification.feature
@@ -68,10 +68,10 @@ Feature: lns audit shows one unified timeline across all sandboxes
     And the output does not contain "some-provider"
     And the output shows "some-oauth" before "api.example.test"
 
-  Scenario: --json emits raw events and suppresses the table
+  Scenario: --format jsonl emits raw events and suppresses the table
     Given a clean lns cache home
     And a connection ledger with sample events
-    When I run "lns audit --json"
+    When I run "lns audit --format jsonl"
     Then the exit code is 0
     And the output contains "some-oauth"
     And the output contains "class_uid"

--- a/crates/lns-cli/README.md
+++ b/crates/lns-cli/README.md
@@ -184,7 +184,7 @@ lns stop scraper
 
 ```bash
 lns logs claude-code --follow
-lns audit claude-code --follow --json | jq '.event'
+lns audit claude-code --follow --format jsonl | jq '.event'
 lns audit claude-code --denied        # just the blocks
 ```
 

--- a/crates/lns-cli/src/audit/mod.rs
+++ b/crates/lns-cli/src/audit/mod.rs
@@ -17,12 +17,9 @@ pub struct AuditArgs {
     #[arg(
         long,
         value_enum,
-        conflicts_with = "json",
         help = "Output format. jsonl emits one raw JSON event per line; its shape may change before v1.0."
     )]
     pub format: Option<AuditFormat>,
-    #[arg(long, hide = true)]
-    pub json: bool,
 }
 
 /// An audit timeline is an event stream, so its machine-readable form is JSONL rather than a document.
@@ -35,11 +32,7 @@ pub enum AuditFormat {
 
 impl AuditArgs {
     pub(super) fn format(&self) -> AuditFormat {
-        self.format.unwrap_or(if self.json {
-            AuditFormat::Jsonl
-        } else {
-            AuditFormat::Table
-        })
+        self.format.unwrap_or(AuditFormat::Table)
     }
 }
 
@@ -248,12 +241,12 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(env)]
-    async fn the_json_flag_emits_one_raw_event_per_line() {
+    async fn the_jsonl_format_emits_one_raw_event_per_line() {
         let home = tempfile::TempDir::new().unwrap();
         write_ledger(home.path());
         let _env = home_env(home.path());
         let mut out = Vec::new();
-        let code = dispatch_argv(&["lns", "audit", "--json"], &mut out)
+        let code = dispatch_argv(&["lns", "audit", "--format", "jsonl"], &mut out)
             .await
             .unwrap();
         assert_eq!(code, 0);
@@ -315,40 +308,26 @@ mod tests {
         assert_eq!(text.trim(), "No audit events for sandbox nope.");
     }
 
-    #[tokio::test]
-    #[serial_test::serial(env)]
-    async fn the_jsonl_format_emits_exactly_what_the_deprecated_json_flag_emitted() {
-        let home = tempfile::TempDir::new().unwrap();
-        write_ledger(home.path());
-        let _env = home_env(home.path());
-        let mut legacy = Vec::new();
-        dispatch_argv(&["lns", "audit", "--json"], &mut legacy)
-            .await
-            .unwrap();
-        let mut current = Vec::new();
-        dispatch_argv(&["lns", "audit", "--format", "jsonl"], &mut current)
-            .await
-            .unwrap();
-        assert_eq!(
-            String::from_utf8(current).unwrap(),
-            String::from_utf8(legacy).unwrap(),
-            "the alias must not change a single byte for existing scripts"
-        );
+    #[test]
+    fn omitting_the_format_flag_selects_the_table() {
+        let matches = crate::command::build_cli()
+            .try_get_matches_from(["lns", "audit"])
+            .expect("audit takes no required argument");
+        let (_, sub) = matches.subcommand().expect("audit is the subcommand");
+        let args = AuditArgs::from_arg_matches(sub).expect("audit args parse");
+        assert_eq!(args.format(), AuditFormat::Table);
     }
 
     #[test]
-    fn asking_for_both_the_alias_and_a_conflicting_format_is_rejected() {
+    fn there_is_no_separate_json_switch() {
         let err = crate::command::build_cli()
-            .try_get_matches_from(["lns", "audit", "--json", "--format", "table"])
-            .expect_err("--json means jsonl, so --format table contradicts it");
-        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+            .try_get_matches_from(["lns", "audit", "--json"])
+            .expect_err("--format jsonl is the only machine output spelling");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
-    fn the_deprecated_json_flag_still_parses_but_is_hidden_from_help() {
-        crate::command::build_cli()
-            .try_get_matches_from(["lns", "audit", "--json"])
-            .expect("existing scripts keep working");
+    fn the_format_flag_is_the_advertised_output_switch() {
         let help = crate::command::build_cli()
             .find_subcommand_mut("audit")
             .expect("audit is registered")
@@ -360,18 +339,18 @@ mod tests {
         );
         assert!(
             !help.contains("--json"),
-            "the deprecated alias is not advertised: {help}"
+            "no separate json switch is advertised: {help}"
         );
     }
 
     #[tokio::test]
     #[serial_test::serial(env)]
-    async fn the_json_flag_labels_a_sandbox_run() {
+    async fn the_jsonl_format_labels_a_sandbox_run() {
         let home = tempfile::TempDir::new().unwrap();
         write_sandbox_run_chain(home.path(), "5a5a5a");
         let _env = home_env(home.path());
         let mut out = Vec::new();
-        let code = dispatch_argv(&["lns", "audit", "--json"], &mut out)
+        let code = dispatch_argv(&["lns", "audit", "--format", "jsonl"], &mut out)
             .await
             .unwrap();
         assert_eq!(code, 0);

--- a/crates/lns-cli/src/audit/timeline.rs
+++ b/crates/lns-cli/src/audit/timeline.rs
@@ -282,7 +282,6 @@ mod tests {
             connector: None,
             kind: None,
             format: None,
-            json: false,
         }
     }
 
@@ -565,15 +564,15 @@ mod tests {
     }
 
     #[test]
-    fn json_emits_one_ocsf_object_per_event_in_sorted_order() {
+    fn jsonl_emits_one_ocsf_object_per_event_in_sorted_order() {
         let fix = Fixture::new();
         fix.write_run(RUN, &[run_env(RUN, "2026-06-29T13:00:00Z", &["FOO"])]);
         fix.write_ledger(&[connection(RUN, "2026-06-29T14:00:00Z")]);
-        let json = AuditArgs {
-            json: true,
+        let jsonl = AuditArgs {
+            format: Some(AuditFormat::Jsonl),
             ..args()
         };
-        let text = fix.render(&json);
+        let text = fix.render(&jsonl);
         let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 2);
         let newest: Value = serde_json::from_str(lines[0]).unwrap();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -79,8 +79,7 @@ takes it, passes it through when the target settles as a sandbox, and refuses it
 saying why — when the target is a document or a cached artifact.
 
 `lns audit` takes `--format <table|jsonl>` instead — a timeline is an event stream, so
-its machine-readable form is one JSON event per line. The older `--json` spelling still
-works as an alias for `--format jsonl`.
+its machine-readable form is one JSON event per line.
 
 What the JSON gives you:
 
@@ -360,8 +359,7 @@ Filters compose:
   events carry no connector, so this narrows the stream to ledger events.
 - `--kind <kind>` — one of `launch`, `egress`, `env`, `volume`, `bind`, `approval`,
   `connection`, `credential`, `tool`.
-- `--format jsonl` — one raw JSON event per line instead of the table. (`--json` is the
-  older spelling of the same thing and still works.)
+- `--format jsonl` — one raw JSON event per line instead of the table.
 
 Integrity is checked automatically as the log is read: if a hash chain has been altered,
 truncated, or can't be verified against its anchor, `lns audit` prints an inline


### PR DESCRIPTION
## Problem

`docs/cli-spec.md` §4.3 says: "there is no separate `--json` switch." The code still had one. `lns audit` carried a hidden `--json` flag that aliased `--format jsonl`.

## Change

This commit deletes the flag. `--format <table|jsonl>` is the only output switch.

## Before

`--json` worked, but no help text showed it:

```
$ lns audit --json
{"class_uid":3002,"unmapped":{"lns_kind":"connection"}, ...}
```

## After

Clap rejects the argument:

```
$ lns audit --json
error: unexpected argument '--json' found

  tip: to pass '--json' as a value, use '-- --json'

Usage: lns audit [OPTIONS] [SANDBOX]

For more information, try '--help'.
```

## Unchanged

`--format jsonl` emits the same bytes as before:

```
$ lns audit --format jsonl
{"class_uid":3002,"unmapped":{"lns_kind":"connection"}, ...}
```

`--format` still defaults to `table`.

## Tests

Layer 3, inline in `crates/lns-cli/src/audit/`:

- Added `there_is_no_separate_json_switch` — pins the clap `UnknownArgument` error. It failed red before the flag was deleted.
- Added `omitting_the_format_flag_selects_the_table` — pins the default.
- Renamed `the_json_flag_emits_one_raw_event_per_line` to `the_jsonl_format_...`; it now drives `--format jsonl`.
- Renamed `the_json_flag_labels_a_sandbox_run` and `json_emits_one_ocsf_object_per_event_in_sorted_order` the same way.
- Replaced the hidden-flag help test with `the_format_flag_is_the_advertised_output_switch`.
- Deleted the alias-equivalence test and the `--json`/`--format table` conflict test. Both described a flag that no longer exists.

Layer 1: `crates/e2e-tests/features/audit_verification.feature` now runs `lns audit --format jsonl`.

## Docs

- `docs/cli-reference.md` — removed both statements that `--json` still works.
- `crates/lns-cli/README.md` — the example now pipes `--format jsonl` into `jq`.

`docs/cli-spec.md` is not touched. The spec already states the target.
