### PR TITLE
feat(connectors): github reaches the npm and maven package registries

### DIFF
--- a/crates/lns-policy/src/connectors.rs
+++ b/crates/lns-policy/src/connectors.rs
@@ -987,6 +987,35 @@ mod tests {
     }
 
     #[test]
+    fn bundled_github_reaches_the_npm_and_maven_package_registries() {
+        let gh = bundled_connectors()
+            .iter()
+            .find(|i| i.id == "github")
+            .expect("github is bundled");
+        let oauth = gh.oauth.as_ref().expect("oauth block present");
+        assert!(
+            oauth.scopes.iter().any(|s| s == "read:packages"),
+            "the package registries reject a token without read:packages, got: {:?}",
+            oauth.scopes
+        );
+        for domain in ["npm.pkg.github.com", "maven.pkg.github.com"] {
+            assert!(
+                gh.routes.iter().any(|r| r.match_pattern == domain),
+                "the workload cannot reach {domain} without a route, got: {:?}",
+                gh.routes
+            );
+            assert!(
+                oauth
+                    .injections
+                    .iter()
+                    .any(|i| i.kind == InjectionKind::BearerHeader && i.domain == domain),
+                "{domain} authenticates with Authorization: Bearer, got: {:?}",
+                oauth.injections
+            );
+        }
+    }
+
+    #[test]
     fn bundled_catalog_ships_openrouter_as_a_pkce_connector() {
         let or = bundled_connectors()
             .iter()

--- a/crates/lns-policy/src/connectors.yaml
+++ b/crates/lns-policy/src/connectors.yaml
@@ -29,11 +29,14 @@ connectors:
     routes:
       - match: api.github.com
       - match: github.com
+      - match: npm.pkg.github.com
+      - match: maven.pkg.github.com
     oauth:
       clientId: "${LNS_OAUTH_CLIENT_ID_GITHUB}"
       scopes:
         - repo
         - read:org
+        - read:packages
       deviceAuthorizationEndpoint: https://github.com/login/device/code
       tokenEndpoint: https://github.com/login/oauth/access_token
       userinfoEndpoint: https://api.github.com/user
@@ -45,6 +48,10 @@ connectors:
           domain: api.github.com
         - kind: basic_x_access_token
           domain: github.com
+        - kind: bearer_header
+          domain: npm.pkg.github.com
+        - kind: bearer_header
+          domain: maven.pkg.github.com
     tokenFallback:
       help: https://github.com/settings/personal-access-tokens/new
   - id: google


### PR DESCRIPTION
The github connector asked only for `repo` and `read:org`, and routed only `api.github.com` and `github.com`. A workload could not install a private package from GitHub Packages.

This adds:

- the `read:packages` scope
- routes for `npm.pkg.github.com` and `maven.pkg.github.com`
- a `bearer_header` injection for each of those two hosts

An existing connection gets the new scope only when the user connects again. That is inherent to OAuth scoping.

`ghcr.io` is out of scope here: a private image pull goes through `lns login`, which is a separate, per-machine store.