### PR TITLE
fix(lns-init): seed /etc/hosts so localhost resolves in the guest

### DIFF
--- a/crates/lns-init/src/hosts.rs
+++ b/crates/lns-init/src/hosts.rs
@@ -1,0 +1,102 @@
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+const LOOPBACK_NAMES: &str = "127.0.0.1\tlocalhost\n::1\tlocalhost\n";
+const HOSTS_MODE: u32 = 0o644;
+
+pub fn seed_if_absent(newroot: &str) -> io::Result<()> {
+    let etc = Path::new(newroot).join("etc");
+    let hosts = etc.join("hosts");
+    if hosts.symlink_metadata().is_ok() {
+        return Ok(());
+    }
+    write_loopback_names(&etc, &hosts)
+        .map_err(|err| io::Error::new(err.kind(), format!("{}: {err}", hosts.display())))
+}
+
+fn write_loopback_names(etc: &Path, hosts: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(etc)?;
+    std::fs::write(hosts, LOOPBACK_NAMES)?;
+    std::fs::set_permissions(hosts, std::fs::Permissions::from_mode(HOSTS_MODE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn newroot() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn an_image_that_ships_no_hosts_file_still_resolves_localhost() {
+        let root = newroot();
+
+        seed_if_absent(root.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("etc/hosts")).unwrap(),
+            "127.0.0.1\tlocalhost\n::1\tlocalhost\n"
+        );
+    }
+
+    #[test]
+    fn the_seeded_file_is_readable_by_the_confined_workload() {
+        let root = newroot();
+
+        seed_if_absent(root.path().to_str().unwrap()).unwrap();
+
+        let mode = std::fs::metadata(root.path().join("etc/hosts"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o644);
+    }
+
+    #[test]
+    fn a_hosts_file_the_image_ships_survives_byte_for_byte() {
+        let root = newroot();
+        std::fs::create_dir(root.path().join("etc")).unwrap();
+        let shipped = "10.0.0.1\tregistry.internal\n";
+        std::fs::write(root.path().join("etc/hosts"), shipped).unwrap();
+
+        seed_if_absent(root.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("etc/hosts")).unwrap(),
+            shipped
+        );
+    }
+
+    #[test]
+    fn a_hosts_symlink_the_image_ships_is_left_where_it_points() {
+        let root = newroot();
+        std::fs::create_dir(root.path().join("etc")).unwrap();
+        std::os::unix::fs::symlink("/run/hosts", root.path().join("etc/hosts")).unwrap();
+
+        seed_if_absent(root.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::read_link(root.path().join("etc/hosts")).unwrap(),
+            Path::new("/run/hosts"),
+            "the image decides where its hosts file lives, dangling or not"
+        );
+    }
+
+    #[test]
+    fn a_rootfs_that_refuses_the_write_names_the_path_it_refused() {
+        let root = newroot();
+        std::fs::write(root.path().join("etc"), b"not a directory").unwrap();
+
+        let err = seed_if_absent(root.path().to_str().unwrap()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("etc/hosts"),
+            "an operator needs the path that refused, not a bare errno: {err}"
+        );
+    }
+}

--- a/crates/lns-init/src/main.rs
+++ b/crates/lns-init/src/main.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 mod boot;
 mod cmdline;
+mod hosts;
 mod mount;
 mod seed;
 mod staged;

--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -394,6 +394,13 @@ fn land_writes_the_mounts_would_have_hidden(
     Ok(())
 }
 
+/// Runs on the assembled rootfs — after every mount and after the staged writes land — so image, volume, bind, and fileset all keep their own hosts file, and every session reads the one this boot leaves behind.
+fn seed_loopback_names(newroot: &str) {
+    if let Err(err) = crate::hosts::seed_if_absent(newroot) {
+        eprintln!("lns-init: could not seed the guest hosts file: {err}");
+    }
+}
+
 /// One place converts a path for `lchown` and logs what went wrong, so a path the syscall cannot take or a failure on one entry never abandons the rest of the walk.
 fn lchown_logged(sys: &dyn Syscalls, path: &str, uid: u32, gid: u32) {
     match CString::new(path) {
@@ -912,6 +919,8 @@ fn mount_composefs_and_exec_broker_inner(
     mount_binds(sys, &params.binds, newroot)?;
 
     land_writes_the_mounts_would_have_hidden(sys, newroot, &params.volumes, run_ids)?;
+
+    seed_loopback_names(newroot);
 
     mount_run_tmpfs(sys, newroot, run_ids)?;
 
@@ -2110,6 +2119,44 @@ mod tests {
             sys.calls()
                 .iter()
                 .any(|c| matches!(c, Call::Lchown { uid: 4242, .. }))
+        );
+    }
+
+    #[test]
+    fn boot_leaves_a_hosts_file_in_the_rootfs_every_session_shares() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap();
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{newroot}/etc/hosts")).unwrap(),
+            "127.0.0.1\tlocalhost\n::1\tlocalhost\n"
+        );
+    }
+
+    #[test]
+    fn a_rootfs_that_refuses_the_hosts_file_still_reaches_the_broker() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let newroot = dir.path().to_str().unwrap();
+        std::fs::write(dir.path().join("etc"), b"not a directory").unwrap();
+        let sys = FakeSyscalls::new();
+        let err = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            newroot,
+            FULL_CMDLINE,
+            &sys,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&err, MountError::Syscall { op, .. } if op.contains("fexecve")),
+            "a name the guest can still reach by address is not worth refusing the boot: {err:?}"
         );
     }
 


### PR DESCRIPTION
Closes #268.

## What

`lns-init` writes a minimal `/etc/hosts` into the assembled rootfs when — and only when — nothing exists at that path:

```
127.0.0.1	localhost
::1	localhost
```

The write happens after every mount (overlay, volumes, binds) and after the staged fileset writes land, immediately before the broker `fexecve` — so an `/etc/hosts` supplied by the image, a volume, a bind, or a fileset is left byte-for-byte untouched (a symlink, dangling or not, counts as image-supplied), and every session the broker forks reads the same file. A failed seed logs to stderr and does not refuse the boot: a guest that can still dial 127.0.0.1 beats no guest.

## Why alpine looked fine and prism did not

alpine ships its own `/etc/hosts`, so the issue's alpine repro depends on the lns version's session wiring; glibc images that ship none (`rust:*-bookworm`, the prism image) had no `localhost` at all — confirmed by running a full Postgres-backed test suite in a `rust:1.97.1-bookworm` guest, where every DB test failed on `could not translate host name "localhost"`.

## Out of scope

The issue also proposes adding the guest hostname to the seeded lines. lns-init cannot know it: no hostname reaches the kernel cmdline; it arrives per session in `OpenSession` and is applied inside `unshare(CLONE_NEWUTS)` precisely so the name cannot leak across sessions. A boot-global hosts line would contradict that isolation, so the hostname line is a separate decision if wanted.

## Tests

Layer 3, red-first: exact seeded bytes; 0644 for the confined workload; image-supplied file untouched (mutation-checked: removing the existence guard fails it); image symlink preserved; write-refusal error names the path; boot wiring leaves the file in the rootfs; a refused seed still reaches the broker exec. `make lint`, `make complexity`, `make coverage-affected` (lns-init at 100%) all green. Live-guest confirmation is nightly `e2e-microvm` territory per the repo's test policy.