### PR TITLE
fix(lns-init): mount a tmpfs at /dev/shm so POSIX shared memory works

### DIFF
--- a/crates/lns-init/src/mount.rs
+++ b/crates/lns-init/src/mount.rs
@@ -19,6 +19,8 @@ const DEV: &str = "/dev";
 const DEV_NULL: &str = "/dev/null";
 const DEV_PTS: &str = "/dev/pts";
 const DEV_PTMX: &str = "/dev/ptmx";
+const DEV_SHM: &str = "/dev/shm";
+const DEV_SHM_TMPFS_OPTS: &str = "mode=1777";
 const CONTENT: &str = "/content";
 const COMPOSEFS_META: &str = "/composefs-meta";
 const UPPER_MOUNTPOINT: &str = "/mnt/upper";
@@ -786,6 +788,19 @@ fn ensure_dev_ptmx(sys: &dyn Syscalls) -> Result<(), MountError> {
     }
 }
 
+/// No `size=`: the kernel's tmpfs default is half of guest RAM, which the run already bounds — Docker's 64M cap is the footgun `--disable-dev-shm-usage` exists for.
+fn mount_dev_shm(sys: &dyn Syscalls) -> Result<(), MountError> {
+    do_mkdir(sys, DEV_SHM, 0o1777)?;
+    do_mount(
+        sys,
+        "tmpfs",
+        DEV_SHM,
+        "tmpfs",
+        MountFlags::none().nosuid().nodev().noexec(),
+        Some(DEV_SHM_TMPFS_OPTS),
+    )
+}
+
 fn do_chdir(sys: &dyn Syscalls, path: &str) -> Result<(), MountError> {
     let c = cstring(path, "chdir-path")?;
     sys.chdir(&c).map_err(|err| MountError::Syscall {
@@ -846,6 +861,11 @@ fn mount_composefs_and_exec_broker_inner(
         ensure_dev_ptmx(sys)?;
     }
     ensure_dev_fd_links(sys)?;
+
+    // Shared memory is a convenience, not a boot requirement, so a kernel without it degrades instead of refusing the run.
+    if let Err(err) = mount_dev_shm(sys) {
+        eprintln!("lns-init: {DEV_SHM} unavailable, POSIX shared memory will fail: {err}");
+    }
 
     let content_tag = params.content_tag.as_deref().unwrap();
     do_mount(
@@ -2956,6 +2976,89 @@ mod tests {
             .unwrap();
         assert!(overlay < vol_mount, "volume mounts after the overlay root");
         assert!(vol_mount < chroot, "volume mounts before the pivot/chroot");
+    }
+
+    #[test]
+    fn boot_mounts_dev_shm_as_a_world_writable_tmpfs() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        assert!(
+            calls.iter().any(
+                |c| matches!(c, Call::Mkdir { path, mode } if path == DEV_SHM && *mode == 0o1777)
+            ),
+            "devtmpfs ships no shm directory, so the mountpoint has to be created 1777"
+        );
+        let (flags, data) = calls
+            .into_iter()
+            .find_map(|c| match c {
+                Call::Mount {
+                    target,
+                    fstype,
+                    flags,
+                    data,
+                    ..
+                } if target == DEV_SHM && fstype == "tmpfs" => Some((flags, data)),
+                _ => None,
+            })
+            .expect("/dev/shm is a tmpfs so shm_open and sem_open work");
+        assert_eq!(flags, MountFlags::none().nosuid().nodev().noexec());
+        assert_eq!(
+            data.as_deref(),
+            Some("mode=1777"),
+            "mode 1777 lets any uid create shm files, and no size= means the kernel default \
+             (half of guest RAM) instead of Docker's 64M footgun"
+        );
+    }
+
+    #[test]
+    fn boot_mounts_dev_shm_before_moving_dev_into_the_new_root() {
+        let sys = FakeSyscalls::new();
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        let calls = sys.calls();
+        let shm = calls
+            .iter()
+            .position(|c| matches!(c, Call::Mount { target, .. } if target == DEV_SHM))
+            .expect("/dev/shm is mounted");
+        let dev_move = calls
+            .iter()
+            .position(|c| matches!(c, Call::MoveMount { from, .. } if from == DEV))
+            .expect("/dev is moved into the new root");
+        assert!(
+            shm < dev_move,
+            "/dev/shm rides into the new root as a child of the moved /dev subtree, like /dev/pts"
+        );
+    }
+
+    #[test]
+    fn boot_survives_a_dev_shm_mount_failure() {
+        let sys = FakeSyscalls::new().fail_when(|c| match c {
+            Call::Mount { target, .. } if target == DEV_SHM => Some(ErrorKind::InvalidInput),
+            _ => None,
+        });
+        let _ = mount_composefs_and_exec_broker_inner(
+            &full_params(),
+            None,
+            "/newroot",
+            FULL_CMDLINE,
+            &sys,
+        );
+        assert!(
+            sys.calls().iter().any(|c| matches!(c, Call::Fexecve(_))),
+            "shared memory is a convenience, not a boot requirement: the run still starts"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #351.

## What

`lns-init` creates `/dev/shm` (devtmpfs ships no shm directory) and mounts a tmpfs there during rootfs assembly, in the same block as the existing `/dev/pts` pseudo-mount and before the `/dev` subtree is move-mounted into the new root — the mount rides into the workload's root exactly the way `/dev/pts` already does.

- Flags `nosuid,nodev,noexec`, mode `1777` (Docker parity for permissions).
- **No `size=` option** — the kernel tmpfs default (half of guest RAM) instead of Docker's 64 MB cap, per the decision recorded in #351: the guest's RAM is already bounded per run, and the 64 MB cap is the footgun `--disable-dev-shm-usage` exists for. The test pins the mount data exactly so a size option can't sneak in.
- A failed shm mount degrades with a stderr warning instead of refusing the boot, matching the crate's policy for non-essential steps (`lchown_logged`, fileset chown skips): a guest that boots today keeps booting.

## Out of scope

`/dev/mqueue`: the pinned guest kernel is a prebuilt binary with no config in the tree, so `CONFIG_POSIX_MQUEUE` can't be verified from here; shipping an unverifiable mount means either a boot refusal or a second degrade path with no reported victim. Separate issue if wanted.

## Tests

Layer 3 against `FakeSyscalls`, red-first: mountpoint mkdir at 1777 + tmpfs with exactly `nosuid+nodev+noexec` and data exactly `mode=1777`; a call-order assertion that the shm mount precedes the `/dev` move-mount; and a scripted mount failure that still reaches the broker `fexecve` (green-on-arrival, mutation-proved by swapping the tolerate for `?`). `make lint`, `make complexity`, `make coverage-affected` (`mount.rs` 100%) all green. Live-guest confirmation (`df -h /dev/shm`, Postgres start) is `e2e-microvm` territory.

Sibling of #350 — both are the same shape: privileged rootfs assembly belongs in PID-1, before capability confinement makes it impossible anywhere else.