### PR TITLE
test: pin that a document's resources outrank the machine config upward

### DIFF
--- a/crates/lns-cli/tests/behaviours/run_config_defaults.feature
+++ b/crates/lns-cli/tests/behaviours/run_config_defaults.feature
@@ -43,6 +43,13 @@ Feature: lns run falls back to configured defaults
     When the local run summary is composed against the configured defaults
     Then the run summary shows "3 vCPU · 6144 MiB"
 
+  Scenario: A document asking for more than the machine configured gets what it declared
+    Given the default "run.cpus" is "4"
+    And the default "run.mem" is "2048"
+    And an lns.yaml declaring 6 vCPU and 8Gi of memory
+    When the local run summary is composed against the configured defaults
+    Then the run summary shows "6 vCPU · 8192 MiB"
+
   Scenario: A per-run flag outranks both the document and a configured default
     Given the default "run.cpus" is "4"
     And an lns.yaml declaring 3 vCPU and 6Gi of memory

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -104,6 +104,11 @@ fn declares_resources(world: &mut BehaviourWorld) {
     install_definition(world, "  resources:\n    cpu: 3\n    memory: 6Gi\n");
 }
 
+#[given(regex = r"^an lns.yaml declaring 6 vCPU and 8Gi of memory$")]
+fn declares_resources_above_the_machine_defaults(world: &mut BehaviourWorld) {
+    install_definition(world, "  resources:\n    cpu: 6\n    memory: 8Gi\n");
+}
+
 #[given(regex = r"^an lns.yaml declaring a volume sized 40Gi$")]
 fn declares_a_sized_volume(world: &mut BehaviourWorld) {
     install_definition(

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -398,6 +398,23 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_vm_size_grants_a_sandbox_that_asks_for_more_than_the_machine_configured() {
+        let res = resources(6, 8192);
+        assert_eq!(
+            {
+                let s = sandbox_vm_size(
+                    Some(&res),
+                    &configured(Some(4), Some(2048)),
+                    Some(TEST_HOST),
+                );
+                (s.cpus, s.mem_mib)
+            },
+            (6, 8192),
+            "the config is a gap-filler, so it neither raises nor lowers a size the document declared"
+        );
+    }
+
+    #[test]
     fn sandbox_vm_size_lets_a_flag_outrank_both_the_sandbox_and_a_config_default() {
         let res = resources(2, 1024);
         let request = RequestedSize {


### PR DESCRIPTION
## What this PR does

It adds the regression guards for the resource precedence in issue #357. It does not change production code.

## The defect #357 reports is already fixed at HEAD

Commit `d30aa843` ("fix: a config default no longer outranks the resources a document declares") fixed it. That commit is in `lns-v0.22.0` and `lns-v0.23.0`. It is not in `0.21.0`, the version the issue observes and re-confirms. The report therefore reproduces only on the installed 0.21 binary.

The precedence at HEAD is the documented one, flag > document > machine config > default, at every layer:

| Layer | Where |
|---|---|
| Machine defaults travel in their own slots, never folded into the flags | `crates/lns-cli/src/config/mod.rs:377` |
| The launch banner resolves the size | `crates/lns-cli/src/run/summary.rs:41` |
| The wire carries flag, explicit-flag signal, and config apart | `crates/lns-cli/src/service/orchestrator.rs:526` |
| The size the VM boots with | `crates/lns-service/src/run/mod.rs:186` |

Memory (`mem_config`) travels the same separate path as `cpus_config`.

## Why this PR still exists

The guards only covered a document asking for **less** than the machine configured:

```gherkin
Given the default "run.cpus" is "4"
And an lns.yaml declaring 3 vCPU and 6Gi of memory
Then the run summary shows "3 vCPU · 6144 MiB"
```

An implementation that clamped a declared size down to `run.cpus` passes that. The direction #357 names — a document asking for **more** than the machine configured — was unpinned. This PR pins it:

```gherkin
Scenario: A document asking for more than the machine configured gets what it declared
  Given the default "run.cpus" is "4"
  And the default "run.mem" is "2048"
  And an lns.yaml declaring 6 vCPU and 8Gi of memory
  When the local run summary is composed against the configured defaults
  Then the run summary shows "6 vCPU · 8192 MiB"
```

- **Layer 2** (`crates/lns-cli/tests/behaviours/run_config_defaults.feature`) — what the launch banner reports.
- **Layer 3** (`crates/lns-service/src/run/mod.rs`) — what the VM boots with.

## Mutation proof

Both tests are green on arrival, so they were proven to bite. Clamping the declared size to the configured default in `resolve_declared`:

```rust
cpus: overrides.cpus.or(declared.cpus.map(|c| c.min(defaults.cpus))).unwrap_or(defaults.cpus),
```

turns the new scenario red:

```
✘  Then the run summary shows "6 vCPU · 8192 MiB"
517 scenarios (513 passed, 4 failed)
```

Reverting the mutation returns 517/517.

## Verification

`cargo test -p lns-cli --test behaviours` — 46 features, 517 scenarios, 517 passed.

`lns-service` does not build in this environment (`pango` / `atk` are absent), so its Layer 3 test is verified by CI only.

## Adjacent defect found, not fixed here

`crates/lns-service/src/run_registry.rs:535` reports a **stopped** run's size from `RunConfig::from_run_args(&record.args)` — the pre-resolution request, so the flag or the built-in `1`, never what the run resolved to. A live run is corrected by `set_resolved_size`; a stopped one is not. A stopped run of a document declaring 6 vCPU inspects as 1 vCPU. That is stale reporting, not precedence, so it is out of scope here and deserves its own issue.

Closes #357
