### PR TITLE
fix: a -t=false run hands its workload pipes, not a PTY

### DIFF
--- a/crates/e2e-tests/features/microvm_run.feature
+++ b/crates/e2e-tests/features/microvm_run.feature
@@ -43,3 +43,9 @@ Feature: a command runs to completion inside a real microVM
     When the user runs a microVM command "/bin/sh -c 'echo final-$((9*9)); exit 0'"
     Then the exit code is 0
     And the output contains "final-81"
+
+  Scenario: a headless run hands the workload pipes, so no pager can spawn
+    Given the Lens Sandbox service is running
+    When the user runs a microVM command "/bin/sh -c 'if [ -t 1 ]; then echo stdout-is-a-terminal; else echo stdout-is-a-pipe; fi'"
+    Then the exit code is 0
+    And the output contains "stdout-is-a-pipe"

--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -75,7 +75,8 @@ pub struct ToolRuntime {
     pub env: Vec<(String, String)>,
 }
 
-pub const SUPERVISOR_PTY_OPT_IN_TERM: &str = "xterm-256color";
+/// The terminal type a supervised workload is given; PTY-vs-pipes is decided by the run's own `-t` answer in the guest, never by this value.
+pub const WORKLOAD_TERM: &str = "xterm-256color";
 
 /// The vars the supervisor handshake owns; they describe the workload's own session, so replaying them into an exec would tell a piped command it has a colour terminal and hand it the workload's command line.
 fn is_session_only(entry: &str) -> bool {
@@ -83,7 +84,7 @@ fn is_session_only(entry: &str) -> bool {
     match key {
         "AGENT_COMMAND" | "WORKSPACE_PATH" => true,
         // Only the value we injected: a workload that declares its own TERM meant it.
-        "TERM" => value == SUPERVISOR_PTY_OPT_IN_TERM,
+        "TERM" => value == WORKLOAD_TERM,
         _ => key.starts_with("LENS_SANDBOX_"),
     }
 }
@@ -222,15 +223,12 @@ pub fn run_workload_env(
     // The broker's last-wins putenv would otherwise let the image PATH shadow the tool dirs.
     compose_guest_tool_env(&mut composed.env, tools);
     if let Some(agent_command) = agent_command {
-        // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the supervisor PTY opt-in, the command, or the agent cwd.
+        // Internal vars go last: the broker's last-wins putenv means a user `-e TERM=…` can't clobber the terminal type, the command, or the agent cwd.
         composed.env.push(format!("AGENT_COMMAND={agent_command}"));
         if let Some(workdir) = workdir {
             composed.env.push(format!("WORKSPACE_PATH={workdir}"));
         }
-        // nexus-agent-sandbox treats TERM unset or "linux" as "no PTY"; xterm-256color opts it into the PTY path needed for `lns run -it --policy`.
-        composed
-            .env
-            .push(format!("TERM={SUPERVISOR_PTY_OPT_IN_TERM}"));
+        composed.env.push(format!("TERM={WORKLOAD_TERM}"));
         // Only what the author declared: an image's own ENV HOME must not outrank the run-as identity, or an unprivileged workload inherits a home it cannot write.
         for key in ["HOME", "USER"] {
             if let Some(value) = declared(user_env, key) {
@@ -615,7 +613,7 @@ mod tests {
             session_env: vec![
                 "AGENT_COMMAND=agent --serve".into(),
                 "WORKSPACE_PATH=/workspace".into(),
-                format!("TERM={SUPERVISOR_PTY_OPT_IN_TERM}"),
+                format!("TERM={WORKLOAD_TERM}"),
                 "LENS_SANDBOX_TOKEN=a-relay-token".into(),
                 // A malformed entry still names an internal var, so the prefix decides, not the shape.
                 "LENS_SANDBOX_BARE".into(),

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -269,6 +269,21 @@ impl SessionHandler for AgentSession {
     }
 }
 
+/// What the agent process gets for its stdio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentIo {
+    Pty,
+    Pipes,
+}
+
+pub(crate) fn agent_io(_session_has_terminal: bool, devpts_mounted: bool) -> AgentIo {
+    if devpts_mounted {
+        AgentIo::Pty
+    } else {
+        AgentIo::Pipes
+    }
+}
+
 /// Layer the agent env (parent → project → proxy → creds) then scrub internal vars; CA env is applied later at the Command level.
 fn build_agent_env(
     config: &AgentConfig,
@@ -496,6 +511,29 @@ mod tests {
             workspace_path: Some("/tmp".into()),
             scripts: Vec::new(),
         }
+    }
+
+    #[test]
+    fn a_run_that_declined_a_terminal_gets_pipes_even_where_devpts_is_mounted() {
+        assert_eq!(
+            agent_io(false, true),
+            AgentIo::Pipes,
+            "the broker gave us pipes because the run asked for no terminal; a PTY here lets the workload detect one and a pager stalls the run forever"
+        );
+    }
+
+    #[test]
+    fn a_run_that_asked_for_a_terminal_gets_a_pty() {
+        assert_eq!(agent_io(true, true), AgentIo::Pty);
+    }
+
+    #[test]
+    fn a_terminal_run_falls_back_to_pipes_without_devpts() {
+        assert_eq!(
+            agent_io(true, false),
+            AgentIo::Pipes,
+            "openpty cannot allocate a pair without devpts, so the agent must still start"
+        );
     }
 
     #[test]

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -270,14 +270,15 @@ impl SessionHandler for AgentSession {
 }
 
 /// What the agent process gets for its stdio.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum AgentIo {
     Pty,
     Pipes,
 }
 
-pub(crate) fn agent_io(_session_has_terminal: bool, devpts_mounted: bool) -> AgentIo {
-    if devpts_mounted {
+/// The broker hands this supervisor the PTY slave for a run that asked for a terminal and pipes for one that did not, so our own stdio is the run's `-t` answer: a workload that could detect a terminal the run declined stalls the run on the first pager it spawns.
+pub(crate) fn agent_io(session_has_terminal: bool, devpts_mounted: bool) -> AgentIo {
+    if session_has_terminal && devpts_mounted {
         AgentIo::Pty
     } else {
         AgentIo::Pipes
@@ -402,6 +403,21 @@ pub(crate) fn build_agent_command(
     env: &HashMap<String, String>,
 ) -> Command {
     child_spawner::build_command(&agent_child_spec(config, creds, env))
+}
+
+/// Relay a headless workload's stream as it arrives: its bytes are the run's output, so nothing here prefixes, splits, or re-terminates them.
+pub(crate) async fn relay_verbatim(
+    mut reader: impl tokio::io::AsyncRead + Unpin,
+    activity: ActivityStream,
+) {
+    let mut chunk = vec![0u8; 8192];
+    loop {
+        let n = match reader.read(&mut chunk).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => n,
+        };
+        activity.emit(String::from_utf8_lossy(&chunk[..n]).into_owned());
+    }
 }
 
 const MAX_LINE_LEN: usize = 4096;
@@ -987,6 +1003,27 @@ mod tests {
             event.summary.ends_with("\r\n"),
             "activity event must end with CRLF, got: {:?}",
             &event.summary[event.summary.len().saturating_sub(4)..]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_headless_workloads_output_is_relayed_byte_for_byte() {
+        let activity = ActivityStream::new();
+        let (writer, mut reader) = tokio::io::duplex(256);
+        spawn_activity_forwarder(&activity, writer);
+
+        relay_verbatim("commit abc\ndiff --git\n".as_bytes(), activity.clone()).await;
+        drop(activity);
+
+        let mut relayed = Vec::new();
+        reader
+            .read_to_end(&mut relayed)
+            .await
+            .expect("relayed bytes");
+        assert_eq!(
+            String::from_utf8(relayed).expect("utf8"),
+            "commit abc\ndiff --git\n",
+            "a headless run relays the workload's own bytes: no stream prefix, no line rewriting"
         );
     }
 

--- a/crates/lns-supervisor/src/dispatcher/runtime.rs
+++ b/crates/lns-supervisor/src/dispatcher/runtime.rs
@@ -12,7 +12,10 @@ use lens_sandbox_core::child_spawner;
 use lens_sandbox_core::lifecycle::{DEFAULT_GRACE, OrphanReaper, wait_with_signal_forwarding};
 use lens_sandbox_core::privilege::SandboxCredentials;
 
-use super::agent::{AgentRunner, agent_child_spec, build_agent_command, stream_output};
+use super::agent::{
+    AgentIo, AgentRunner, agent_child_spec, agent_io, build_agent_command, relay_verbatim,
+    stream_output,
+};
 use super::{CYAN, DIM, GREEN, RED, RESET};
 use crate::config::AgentConfig;
 use crate::scripts::{Abort, PreparedScript, ScriptFailure, StepRunner};
@@ -71,13 +74,9 @@ impl AgentRunner for RealAgentRunner {
     }
 }
 
-/// Whether the agent opted into PTY mode via `TERM` (`xterm-*` yes; unset, empty, or the `linux` console no).
-fn agent_wants_pty() -> bool {
-    match std::env::var("TERM") {
-        Ok(v) if v.is_empty() || v == "linux" => false,
-        Ok(_) => true,
-        Err(_) => false,
-    }
+/// Our own stdio: the broker gave us the PTY slave when the run asked for a terminal and pipes when it did not.
+fn session_has_terminal() -> bool {
+    std::io::stdout().is_terminal()
 }
 
 /// Whether devpts is mounted so `openpty()` can allocate a pair; the caller falls back to pipe mode otherwise.
@@ -110,10 +109,9 @@ async fn run_agent(
     activity: &ActivityStream,
     reaper: &OrphanReaper,
 ) {
-    if agent_wants_pty() && pty_available() {
-        run_agent_pty(config, creds, env, activity, reaper).await;
-    } else {
-        run_agent_piped(config, creds, env, activity, reaper).await;
+    match agent_io(session_has_terminal(), pty_available()) {
+        AgentIo::Pty => run_agent_pty(config, creds, env, activity, reaper).await,
+        AgentIo::Pipes => run_agent_piped(config, creds, env, activity, reaper).await,
     }
 }
 
@@ -306,7 +304,7 @@ async fn forward_sigwinch(master_fd: std::os::fd::RawFd) {
     }
 }
 
-/// Non-interactive pipe mode: stream stdout/stderr as activity events (current behavior).
+/// Pipe mode: the run declined a terminal, so the workload gets pipes it cannot mistake for one — a pager it would otherwise spawn never starts, and its output is relayed as it comes.
 async fn run_agent_piped(
     config: &AgentConfig,
     creds: Option<SandboxCredentials>,
@@ -318,7 +316,11 @@ async fn run_agent_piped(
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    tracing::info!(command = %config.agent_command, "starting agent process");
+    tracing::info!(
+        command = %config.agent_command,
+        interactive = false,
+        "starting agent process (pipes)"
+    );
     activity.emit(format!(
         "{CYAN}[agent]{RESET} starting: {DIM}{}{RESET}\r\n",
         config.agent_command
@@ -344,14 +346,14 @@ async fn run_agent_piped(
     let stdout_task = stdout.map(|pipe| {
         let activity = activity.clone();
         tokio::spawn(async move {
-            stream_output(pipe, activity, "[stdout]", DIM).await;
+            relay_verbatim(pipe, activity).await;
         })
     });
 
     let stderr_task = stderr.map(|pipe| {
         let activity = activity.clone();
         tokio::spawn(async move {
-            stream_output(pipe, activity, "[stderr]", RED).await;
+            relay_verbatim(pipe, activity).await;
         })
     });
 


### PR DESCRIPTION
## What was wrong

`lns run -t=false` still gave the workload a PTY. The in-guest supervisor logged:

```
starting agent process (PTY) ... interactive=true
```

The workload detected a terminal on stdout. `git log` then colored its output and spawned `/usr/bin/pager`, which waited for input that never arrives. The run hung silently and `lns logs` showed only pager control sequences.

## Where the signal was lost

The `-t` answer already reaches the guest correctly:

1. `lns-cli` sends `tty = !detached && --tty && stdin_is_tty()` in the run request.
2. `lns-service` puts it on the wire as `ClientFrame::OpenSession { tty, .. }`.
3. `lns-session-broker` honours it: `run_tty_session` dups a PTY slave onto the supervisor's fds 0/1/2, `run_pipe_session` dups pipes.

Then the supervisor threw the answer away. It decided PTY-vs-pipes from its own `TERM`:

```rust
fn agent_wants_pty() -> bool {
    match std::env::var("TERM") { Ok(v) if v.is_empty() || v == "linux" => false, Ok(_) => true, Err(_) => false }
}
```

`lns-service` appends `TERM=xterm-256color` to every supervised run's env (last-wins, so `-e TERM=…` cannot clobber it). So `agent_wants_pty()` was always true and every run — headless included — got `openpty()`.

**No protocol change was needed.** The supervisor's own stdio *is* the run's `-t` answer.

## The fix

`crates/lns-supervisor`:

- New host-testable decision in `dispatcher/agent.rs`:

  ```rust
  pub(crate) fn agent_io(session_has_terminal: bool, devpts_mounted: bool) -> AgentIo
  ```

  PTY only when the broker gave us a terminal *and* devpts is mounted; pipes otherwise. The `TERM` sniff is gone.
- `dispatcher/runtime.rs` calls it with `std::io::stdout().is_terminal()` and `pty_available()`.
- The pipe path now relays the workload's bytes **verbatim** (`relay_verbatim`), the way the PTY drain did. Before this change the pipe path was unreachable in production and would have prefixed every line with a dim `[stdout]` / red `[stderr]` tag — that would have been a visible output regression for every headless run, so it is replaced rather than reused. Line-prefixing (`stream_output`) stays where it belongs: `pre-start` script output.

`crates/lns-service` (`workload_env.rs`): the constant that claimed to be a supervisor PTY opt-in no longer is one. Renamed `SUPERVISOR_PTY_OPT_IN_TERM` → `WORKLOAD_TERM` and corrected the comments. The value is unchanged and still exported to a supervised workload — it is a terminal *type*, not a terminal.

## Exec sessions

Not affected. `lns exec` never goes through the supervisor: the broker forks the command itself and already picks `run_pipe_session` for `tty=false`. `exec_session_env` also strips the injected `TERM` before an exec session sees it. Checked, no change needed.

## Before / after

Guest-observable, from `crates/e2e-tests/features/microvm_run.feature`:

```
lns run -q -t=false -- /bin/sh -c 'if [ -t 1 ]; then echo stdout-is-a-terminal; else echo stdout-is-a-pipe; fi'

before:  stdout-is-a-terminal
after:   stdout-is-a-pipe
```

## Tests

Red first, in the layer that owns the decision (Layer 3, `dispatcher/agent.rs` — `dispatcher/runtime.rs` is guest-only and IGNORES-listed):

- `a_run_that_declined_a_terminal_gets_pipes_even_where_devpts_is_mounted` — failed with `left: Pty, right: Pipes` against a seam stubbed with the old rule, which is exactly the reported defect.
- `a_run_that_asked_for_a_terminal_gets_a_pty`, `a_terminal_run_falls_back_to_pipes_without_devpts`.
- `a_headless_workloads_output_is_relayed_byte_for_byte` — failed with `[stdout] commit abc\r\n…` before `relay_verbatim` existed. This pins that the fix does not reformat headless output.

Layer 1: one `@microvm` scenario in `microvm_run.feature` (nightly `e2e-microvm`, not the PR gate).

## Verification

Scoped, as run in this environment (aarch64 Linux):

```
cargo test -p lns-supervisor          75 passed, 0 failed
cargo clippy -p lns-supervisor --all-targets -- -D warnings    clean
cargo clippy -p lns-supervisor -- -D clippy::cognitive_complexity    clean
cargo fmt --all
```

`lns-service` does not build in this sandbox (missing `pango`/`atk` system libraries, and no apt egress), so its rename is unverified locally — CI is the oracle for that crate. The rename is confined to `workload_env.rs`; `grep` confirms no other reference to the old name in the tree.

## Side effect worth knowing

The headless workload's stdin is now the session's stdin pipe instead of an unwritten PTY slave. With `-i=false` the broker has already closed the write end, so a read gets EOF at once. With `-i` (stdin, no tty) host stdin now actually reaches the workload — previously the non-bridged PTY path dropped it. Both match `docker run` semantics.

Closes #359