### PR TITLE
fix: exclude loopback from the guest proxy variables

### DIFF
--- a/crates/lns-service/src/workload_env.rs
+++ b/crates/lns-service/src/workload_env.rs
@@ -199,12 +199,14 @@ fn ca_bundle_env() -> [(&'static str, &'static str); 5] {
 }
 
 /// The proxy vars the supervisor hands its workload, so an HTTP client in an exec takes the route the agent's does rather than one the gate never sees.
-fn proxy_env() -> [(&'static str, &'static str); 4] {
+fn proxy_env() -> [(&'static str, &'static str); 6] {
     [
         ("HTTPS_PROXY", lns_session::GUEST_PROXY_URL),
         ("https_proxy", lns_session::GUEST_PROXY_URL),
         ("HTTP_PROXY", lns_session::GUEST_PROXY_URL),
         ("http_proxy", lns_session::GUEST_PROXY_URL),
+        ("NO_PROXY", lns_session::GUEST_NO_PROXY),
+        ("no_proxy", lns_session::GUEST_NO_PROXY),
     ]
 }
 
@@ -961,6 +963,18 @@ mod tests {
             assert!(
                 env.contains(&format!("{key}={}", lns_session::GUEST_PROXY_URL)),
                 "a curl in an exec would take a different route than the workload without {key}, so a probe would report on a path the agent never uses: {env:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_loopback_request_in_an_exec_session_stays_in_the_guest() {
+        let env = exec_session_env(&Default::default(), &[], &Default::default()).env;
+
+        for key in ["NO_PROXY", "no_proxy"] {
+            assert!(
+                env.contains(&format!("{key}={}", lns_session::GUEST_NO_PROXY)),
+                "without {key} a curl in an exec sends a request for a server the run itself started to the egress proxy, which cannot connect back into the guest: {env:?}"
             );
         }
     }

--- a/crates/lns-session/src/lib.rs
+++ b/crates/lns-session/src/lib.rs
@@ -15,6 +15,9 @@ pub const SYSTEM_CA_BUNDLE_PATH: &str = "/etc/ssl/certs/ca-certificates.crt";
 /// The proxy the supervisor runs and points its workload at, so the service can point an exec session at the same one; one spelling, or an exec takes a route the workload never takes.
 pub const GUEST_PROXY_URL: &str = "http://127.0.0.1:3128";
 
+/// What the proxy variables exclude, so a workload reaching a server it started itself is not sent to a proxy that cannot connect back into the guest; one spelling, or an exec fails a request the workload can make.
+pub const GUEST_NO_PROXY: &str = "localhost,127.0.0.1,::1";
+
 /// Where the service stages each `pre-start` script and the supervisor reads them from; one spelling, or the guest runs nothing and reports success.
 pub const SCRIPTS_DIR: &str = "/.lens/scripts";
 

--- a/crates/lns-supervisor/src/dispatcher/agent.rs
+++ b/crates/lns-supervisor/src/dispatcher/agent.rs
@@ -284,6 +284,8 @@ fn build_agent_env(
         full_env.insert("https_proxy".into(), local_proxy.clone());
         full_env.insert("HTTP_PROXY".into(), local_proxy.clone());
         full_env.insert("http_proxy".into(), local_proxy);
+        full_env.insert("NO_PROXY".into(), lns_session::GUEST_NO_PROXY.into());
+        full_env.insert("no_proxy".into(), lns_session::GUEST_NO_PROXY.into());
     }
 
     if let Some(home) = effective_home(env, creds) {
@@ -844,6 +846,36 @@ mod tests {
             env.get("HTTPS_PROXY").map(String::as_str),
             Some(lns_session::GUEST_PROXY_URL),
             "the service points an exec session at this spelling without asking the guest, so a change here that leaves the constant behind sends an exec around the gate"
+        );
+    }
+
+    #[test]
+    fn a_loopback_request_stays_in_the_guest_instead_of_going_to_the_proxy() {
+        let mut config = make_agent_config();
+        config.core.is_root = true;
+
+        let env = build_agent_env(&config, None, &HashMap::new());
+
+        for key in ["NO_PROXY", "no_proxy"] {
+            assert_eq!(
+                env.get(key).map(String::as_str),
+                Some("localhost,127.0.0.1,::1"),
+                "without {key} a curl or reqwest sends a request for a server the workload itself started to the egress proxy, which cannot connect back into the guest"
+            );
+        }
+    }
+
+    #[test]
+    fn the_loopback_exclusions_the_workload_gets_are_the_ones_an_exec_session_gets() {
+        let mut config = make_agent_config();
+        config.core.is_root = true;
+
+        let env = build_agent_env(&config, None, &HashMap::new());
+
+        assert_eq!(
+            env.get("NO_PROXY").map(String::as_str),
+            Some(lns_session::GUEST_NO_PROXY),
+            "the service points an exec session at this spelling without asking the guest, so a change here that leaves the constant behind makes an exec fail on a loopback request the workload can make"
         );
     }
 


### PR DESCRIPTION
## What a workload can do now

A workload can talk to a server that it started itself. Before this fix
the request went to the egress proxy and failed.

Before:

```
$ node -e 'require("http").createServer((q,r)=>r.end("ok")).listen(33355,"127.0.0.1")' &
$ curl http://127.0.0.1:33355/
curl: (52) Empty reply from server
```

After:

```
$ curl http://127.0.0.1:33355/
ok
```

The same is true in an `lns sandbox exec` session. A test suite that
starts a mock server on `127.0.0.1:<port>` now passes inside a sandbox.

## Mechanism

The guest exports `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy` and
`https_proxy` = `http://127.0.0.1:3128`. It exported no exclusion list.
Every client that honours these variables (curl, reqwest, Python
requests, Go net/http) sent loopback requests to the proxy.

This branch adds `NO_PROXY` and `no_proxy` = `localhost,127.0.0.1,::1`
at both injection sites:

- `crates/lns-supervisor/src/dispatcher/agent.rs` — the workload
  environment, and the `pre-start` scripts that layer on it.
- `crates/lns-service/src/workload_env.rs` — `proxy_env()` for exec
  sessions.

One shared constant holds the list: `lns_session::GUEST_NO_PROXY`, next
to the existing `GUEST_PROXY_URL`. Both crates depend on `lns-session`,
so the two sites cannot drift apart.

This does not weaken the sandbox. Loopback traffic never leaves the
guest. nftables still forces all egress through the proxy, whatever the
environment says.

## Tests

Three new unit tests, written red first:

- `a_loopback_request_stays_in_the_guest_instead_of_going_to_the_proxy`
  pins the list on the workload environment.
- `the_loopback_exclusions_the_workload_gets_are_the_ones_an_exec_session_gets`
  pins the workload site to the shared constant.
- `a_loopback_request_in_an_exec_session_stays_in_the_guest` pins the
  list on the exec session environment.

## What CI covers that I could not run

I ran `cargo test -p lns-supervisor` (72 pass) and
`cargo check -p lns-session --all-targets` locally. Both are green.
`cargo fmt --check` and `cargo clippy` on these two crates are clean.

I could not build `lns-service` in my environment: its GUI dependencies
(pango, atk) are not installable there. Please read the CI result for
the `lns-service` test and the coverage gate.

Closes #367
