### PR TITLE
feat!: a run's decisions live with the run, not in the working directory

### DIFF
--- a/.claude/skills/problem-first/SKILL.md
+++ b/.claude/skills/problem-first/SKILL.md
@@ -40,7 +40,7 @@ This is a monorepo with multiple crates. When the user describes a problem, dete
 | `lns-cli` | The `lns` developer CLI — clap-driven IPC client that drives the service. The shipping artifact. |
 | `lns-service` | Tray-resident background service — microVM lifecycle, OCI ingest, content/layer caches, supervisor relay, audit-chain writer. |
 | `lns-ipc` | Shared `Request`/`Response` types and wire codec for the lns-cli ↔ lns-service contract. |
-| `lns-policy` | Network rules and credential-provider policy (`lns-local-mixin.yaml`) plus per-machine credential decisions. |
+| `lns-policy` | Network rules and credential-provider policy (the run's `decisions.yaml`) plus per-machine credential decisions. |
 | `lns-init` | Static-musl PID-1 for the guest microVM. |
 | `lns-session` | Wire-protocol types (postcard) for the host ↔ guest session channel. |
 | `lns-session-broker` | Guest-side session host — PTY allocation, per-session workload forks, vsock framing. |

--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,6 @@ coverage
 # Per-package build artifacts
 bin/
 
-# Auto-created when running `lns`; a runtime artifact, not source. The e2e
-# harness boots real runs with the crate dir as cwd (make e2e-microvm), and
-# example recipes boot with their own dir as cwd (docs/examples/*).
-/lns-local-mixin.yaml
-/crates/e2e-tests/lns-local-mixin.yaml
-/docs/examples/**/lns-local-mixin.yaml
-
 # Claude Code local settings
 .claude/settings.local.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,17 @@ LNS is a local desktop app for running AI agents, commands, OCI images, and othe
 
 - **Start here:** `docs/README.md` — the first-party user documentation index.
 - **Product language:** the Product Vision above and `docs/` are the source of truth for terminology and framing; keep naming consistent with them. `docs/` is user-facing documentation only — no internal sales/marketing material lives in this repo.
-- **Concepts:** approvals drive policy authoring; a per-directory decisions file (`lns-local-mixin.yaml`, a `kind: mixin` document auto-created empty; a destination no rule decides is asked about) holds the network rules; `Vz` on macOS / `KVM` on Linux is the only runtime; real secrets stay outside the workload.
+- **Concepts:** approvals drive policy authoring; a per-run decisions file (`~/.lns/runs/<RUN>/decisions.yaml`, a `kind: mixin` document created empty with the run; a destination no rule decides is asked about) holds the network rules, and `lns sandbox save` writes a run out as a document to keep; `Vz` on macOS / `KVM` on Linux is the only runtime; real secrets stay outside the workload.
 - **Target format:** `docs/sandbox-spec.md` is the normative specification for the `lns.run/v1` document format and the decisions behind it. **The code does not implement all of it** — see [Transitional mode](#transitional-mode) before you touch a document-format surface.
 - **Sibling product:** Lens Agents is the centrally managed counterpart for IT teams. Same policy model.
 
-Before proposing new features or architecture, consider whether they preserve the core principles: **a sandbox you don't turn off**, **disposable, never leaky** (a run's state never escapes the sandbox; stopped runs persist until removed, and one `prune` sweeps them all away), **no system dependencies** (the user runs one binary; no apt/brew preflight, no privileged installer), **policy you run into, not write**, **one directory = one project**, **real secrets stay outside the workload**. A small user-launched background service (the tray-resident `lns-service`, started by `lns service start` and stoppable via the tray Quit menu or `lns service stop`) is part of "a sandbox you don't turn off" — not a daemon in the apt/launchd sense.
+Before proposing new features or architecture, consider whether they preserve the core principles: **a sandbox you don't turn off**, **disposable, never leaky** (a run's state never escapes the sandbox; stopped runs persist until removed, and one `prune` sweeps them all away), **no system dependencies** (the user runs one binary; no apt/brew preflight, no privileged installer), **policy you run into, not write**, **the working directory only roots relative paths**, **real secrets stay outside the workload**. A small user-launched background service (the tray-resident `lns-service`, started by `lns service start` and stoppable via the tray Quit menu or `lns service stop`) is part of "a sandbox you don't turn off" — not a daemon in the apt/launchd sense.
 
 ## Transitional mode
 
 **The document format has an agreed target that the code has not reached.** `docs/sandbox-spec.md` states that target and states it as settled. This section is the contributor rule for the gap between them. It is temporary and shrinks as the gap closes.
 
-Read this before changing anything that parses, validates, publishes, resolves, or merges an `lns.yaml` or the per-directory decisions file.
+Read this before changing anything that parses, validates, publishes, resolves, or merges an `lns.yaml` or a run's decisions file.
 
 ### Which document wins
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,10 @@ lns run
   Resources: 1 vCPU · 512 MiB
   Flags:     -i -t
   Ports:     127.0.0.1:8642 -> 8642, 127.0.0.1:9119 -> 9119
-  Policy:
-    file: /Users/you/dev/my-app/lns-local-mixin.yaml
-    default verdict: ask
-    rules: none defined; anything else asks
-    source: auto-created (no policy in this directory)
+  Decisions: recorded in this run, and removed with it
 ```
 
-When the workload opens a connection no rule covers, the background service raises an approval prompt showing the host and action (e.g. `CONNECT api.linear.app:443`). You choose allow/deny — once, or always. "Always" writes a matching rule to `lns-local-mixin.yaml`, so future runs load the decision automatically.
+When the workload opens a connection no rule covers, the background service raises an approval prompt showing the host and action (e.g. `CONNECT api.linear.app:443`). You choose allow/deny — once, or always. "Always" writes a matching rule into this run's own decisions, so the same question is not asked again for that run. `lns sandbox save --kind mixin -f <FILE>` keeps those answers past the run, as a mixin you commit and name in `spec.mixins`.
 
 ## What it does
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ Security-sensitive areas include:
 
 - Guest/host isolation — the microVM boundary (Vz on macOS, KVM on Linux) and the host-side service that owns its lifecycle
 - Policy enforcement — whether a workload can reach a network gate, port, or credential-backed action that policy did not approve
-- The approval flow — decisions written to `lns-local-mixin.yaml`, and whether a denied request can be silently turned into an allowed one
+- The approval flow — decisions written to the run's own `decisions.yaml`, and whether a denied request can be silently turned into an allowed one
 - Credential handling — placeholder substitution and boundary credential exchange, and whether any real secret can reach the guest VM
 - The audit chain — tamper-evidence of the recorded run history, and the `lns audit` verifier
 - The host IPC surface — the local Unix socket between `lns` and `lns-service`

--- a/crates/e2e-tests/features/sandbox_save.feature
+++ b/crates/e2e-tests/features/sandbox_save.feature
@@ -1,0 +1,26 @@
+Feature: the working directory is read, never written
+
+  `sandbox-spec.md` §8.5: the working directory roots the paths the user types
+  and nothing else. `lns` creates no file there that the user did not name, and
+  `save` — the one verb that writes one — never destroys a file already there.
+
+  Scenario: a run creates no file in the directory it was started from
+    Given a clean lns cache home
+    And a working directory holding "lns.yaml"
+    When I run "lns run" in that directory
+    Then the command fails with an exit code other than 0
+    And the working directory holds only "lns.yaml"
+
+
+  Scenario: save with no file to write to is refused by name
+    Given a clean lns cache home
+    When I run "lns sandbox save some-run"
+    Then the exit code is 2
+    And the output contains "--file"
+
+  Scenario: a save that cannot complete leaves the named file as it was
+    Given a clean lns cache home
+    And a working directory holding "keep.yaml"
+    When I run "lns sandbox save some-run -f keep.yaml" in that directory
+    Then the command fails with an exit code other than 0
+    And "keep.yaml" still holds what it held

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -175,7 +175,7 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
         }
     }
     let definition = format!(
-        "apiVersion: lns.run/v1\nkind: sandbox\nname: e2e-microvm\nspec:\n  image: {}{spec_tail}\n",
+        "apiVersion: lns.run/v1\nkind: sandbox\nname: e2e-microvm\nspec:\n  mixins:\n    - ./{PROJECT_MIXIN}\n  image: {}{spec_tail}\n",
         world
             .project_image
             .clone()
@@ -183,10 +183,10 @@ fn microvm_project(world: &mut E2eWorld) -> std::path::PathBuf {
     );
     std::fs::write(root.join("lns.yaml"), definition).expect("write project lns.yaml");
     std::fs::write(
-        root.join("lns-local-mixin.yaml"),
-        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n",
+        root.join(PROJECT_MIXIN),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: project-egress\nspec:\n  egress:\n    http: []\n",
     )
-    .expect("write the project policy");
+    .expect("write the project mixin");
     root
 }
 
@@ -243,10 +243,10 @@ fn last_run(world: &E2eWorld) -> Result<String, String> {
         .ok_or_else(|| "no run id was captured from the run output".to_string())
 }
 
-/// The project's own mixin is the only decisions file a run reads, so a scenario that wants rules in force writes them beside the document.
+/// A rule applies because a document names it (`sandbox-spec.md` §8.5), so a scenario that wants rules in force writes them into the mixin the project's `lns.yaml` declares.
 fn write_policy(world: &mut E2eWorld, yaml: &str) {
-    let path = microvm_project(world).join("lns-local-mixin.yaml");
-    std::fs::write(&path, yaml).expect("write policy file");
+    let path = microvm_project(world).join(PROJECT_MIXIN);
+    std::fs::write(&path, yaml).expect("write the project mixin");
 }
 
 fn track_volume(world: &mut E2eWorld, name: &str) {
@@ -709,8 +709,8 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
     std::fs::write(consumer.join("consumer-marker"), "consumer project\n")
         .expect("write consumer marker");
     std::fs::write(
-        consumer.join("lns-local-mixin.yaml"),
-        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        consumer.join(PROJECT_MIXIN),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: project-egress\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     )
     .expect("write consumer policy");
     track_volume(world, &volume);
@@ -724,6 +724,8 @@ async fn run_published_declarative_sandbox_offline(world: &mut E2eWorld) {
     let mut args = vec![
         "run".to_string(),
         "--yes".to_string(),
+        "--mixin".to_string(),
+        consumer.join(PROJECT_MIXIN).to_string_lossy().into_owned(),
         reference,
         "--".to_string(),
     ];
@@ -1087,13 +1089,15 @@ fn run_pulled_sandbox_offline(world: &mut E2eWorld, cmd_line: &str) {
         .path()
         .to_path_buf();
     std::fs::write(
-        consumer.join("lns-local-mixin.yaml"),
-        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        consumer.join(PROJECT_MIXIN),
+        "apiVersion: lns.run/v1\nkind: mixin\nname: project-egress\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     )
     .expect("write consumer policy");
     let mut args = vec![
         "run".to_string(),
         "--yes".to_string(),
+        "--mixin".to_string(),
+        consumer.join(PROJECT_MIXIN).to_string_lossy().into_owned(),
         reference,
         "--".to_string(),
     ];
@@ -1633,7 +1637,7 @@ fn output_lists_that_run(world: &mut E2eWorld) -> Result<(), String> {
 fn policy_ask_with_direct_route(world: &mut E2eWorld) {
     write_policy(
         world,
-        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n        transport: direct\n",
+        "apiVersion: lns.run/v1\nkind: mixin\nname: project-egress\nspec:\n  egress:\n    http:\n      - match: api.example.test\n        verdict: allow\n        transport: direct\n",
     );
 }
 
@@ -1641,9 +1645,12 @@ fn policy_ask_with_direct_route(world: &mut E2eWorld) {
 fn policy_deny_all(world: &mut E2eWorld) {
     write_policy(
         world,
-        "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
+        "apiVersion: lns.run/v1\nkind: mixin\nname: project-egress\nspec:\n  egress:\n    http:\n      - match: \"*\"\n        verdict: deny\n",
     );
 }
+
+/// The mixin every e2e project declares, since §8.5 makes a rule apply only where a document names it.
+const PROJECT_MIXIN: &str = "project-egress.yaml";
 
 const SUPERBLOCK_OFFSET: u64 = 1024;
 

--- a/crates/e2e-tests/tests/steps/mod.rs
+++ b/crates/e2e-tests/tests/steps/mod.rs
@@ -4,4 +4,5 @@ pub mod gui_stubs;
 pub mod microvm;
 pub mod producer;
 pub mod sandbox;
+pub mod save;
 pub mod service;

--- a/crates/e2e-tests/tests/steps/save.rs
+++ b/crates/e2e-tests/tests/steps/save.rs
@@ -1,0 +1,83 @@
+use crate::E2eWorld;
+use crate::specutil::{arg_parser::split_args, assert_contains, run_cli_in_dir};
+use cucumber::{given, then, when};
+
+const KEPT: &str =
+    "apiVersion: lns.run/v1\nkind: sandbox\nname: kept\nspec:\n  image: alpine:3.20\n";
+
+#[given(regex = r#"^a working directory holding "([^"]+)"$"#)]
+fn a_working_directory_holding(world: &mut E2eWorld, file: String) {
+    let dir = world
+        .project
+        .get_or_insert_with(|| tempfile::TempDir::new().expect("project tempdir"));
+    std::fs::write(dir.path().join(file), KEPT).expect("seed the file the save must not destroy");
+}
+
+#[when(regex = r#"^I run "([^"]*)" in that directory$"#)]
+fn i_run_in_that_directory(world: &mut E2eWorld, cmd_line: String) {
+    let dir = world
+        .project
+        .as_ref()
+        .expect("Given a working directory first")
+        .path()
+        .to_path_buf();
+    let mut envs: Vec<(&str, std::ffi::OsString)> = Vec::new();
+    if let Some(home) = &world.home {
+        envs.push(("HOME", home.path().into()));
+        envs.push(("LNS_HOME", home.path().join(".lns").into()));
+    }
+    world.result = Some(run_cli_in_dir(&dir, split_args(&cmd_line), envs));
+}
+
+#[then(regex = r#"^the command fails with an exit code other than 0$"#)]
+fn the_command_fails(world: &mut E2eWorld) -> Result<(), String> {
+    let result = world.result.as_ref().ok_or("no CLI run captured")?;
+    if result.exit_code == 0 {
+        return Err(format!(
+            "expected a refusal, got exit 0 with:\n{}\n{}",
+            result.stdout, result.stderr
+        ));
+    }
+    Ok(())
+}
+
+/// §8.5 has `lns` create no file the user did not name, and the old design created a decisions file here on the first run.
+#[then(regex = r#"^the working directory holds only "([^"]+)"$"#)]
+fn the_working_directory_holds_only(world: &mut E2eWorld, file: String) -> Result<(), String> {
+    let dir = world
+        .project
+        .as_ref()
+        .ok_or("Given a working directory first")?
+        .path();
+    let mut found: Vec<String> = std::fs::read_dir(dir)
+        .map_err(|e| e.to_string())?
+        .map(|entry| {
+            entry
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .map_err(|e| e.to_string())
+        })
+        .collect::<Result<_, _>>()?;
+    found.sort();
+    if found == [file.clone()] {
+        Ok(())
+    } else {
+        Err(format!(
+            "a run that writes into the project puts state where the user keeps their own files; expected only {file:?}, found {found:?}"
+        ))
+    }
+}
+
+#[then(regex = r#"^"([^"]+)" still holds what it held$"#)]
+fn the_file_is_untouched(world: &mut E2eWorld, file: String) -> Result<(), String> {
+    let dir = world
+        .project
+        .as_ref()
+        .ok_or("Given a working directory first")?
+        .path();
+    let found = std::fs::read_to_string(dir.join(file)).map_err(|e| e.to_string())?;
+    assert_contains(
+        &found,
+        KEPT.trim(),
+        "the file the save refused to overwrite",
+    )
+}

--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -66,7 +66,7 @@ pub struct Merged {
 /// The graph is walked this deep and refused beyond, so a chain nobody can read cannot stall a launch.
 pub const MAX_DEPTH: usize = 5;
 
-/// Flatten a sandbox and its mixins into the one ordered source list §3.3.2 merges: the sandbox first, then each of its `mixins` in order with that mixin's own `mixins` expanded right after it, then each extra reference in the order the user gave it, then the directory's own decisions last.
+/// Flatten a sandbox and its mixins into the one ordered source list §3.3.2 merges: the sandbox first, then each of its `mixins` in order with that mixin's own `mixins` expanded right after it, then each extra reference in the order the user gave it, then the run's own decisions last.
 ///
 /// A mixin's own mixins come after it, so they beat it — a mixin that pulls in another is asking for that other's version of a shared setting. The local source is the exception: §8.1 puts it after every other source outright, so what it pulled merges before it.
 /// A source many documents name appears once, at the last place it was named: an earlier appearance can decide nothing a later one does not, since either a source after it sets a key or the source itself sets it again.

--- a/crates/lns-artifact/src/merge.rs
+++ b/crates/lns-artifact/src/merge.rs
@@ -680,7 +680,7 @@ mod tests {
             &root,
             &extra,
             Some(Source {
-                label: "lns-local-mixin.yaml",
+                label: "decisions.yaml",
                 spec: &local,
             }),
             &graph,
@@ -688,7 +688,7 @@ mod tests {
         .expect("every reference resolves");
         assert_eq!(
             labels(&sources),
-            [ROOT_LABEL, "own", "flag", "lns-local-mixin.yaml"],
+            [ROOT_LABEL, "own", "flag", "decisions.yaml"],
             "the developer's own decisions are last, so nothing they pulled can overrule them (docs/sandbox-spec.md §8.1)"
         );
     }
@@ -702,7 +702,7 @@ mod tests {
             &root,
             &[],
             Some(Source {
-                label: "lns-local-mixin.yaml",
+                label: "decisions.yaml",
                 spec: &local,
             }),
             &graph,
@@ -710,7 +710,7 @@ mod tests {
         .expect("every reference resolves");
         assert_eq!(
             labels(&sources),
-            [ROOT_LABEL, "locals-own", "lns-local-mixin.yaml"],
+            [ROOT_LABEL, "locals-own", "decisions.yaml"],
             "§3.3.2 puts a mixin's own mixins after it, but §8.1 says the local one is last outright, and what it pulled is still something pulled"
         );
     }
@@ -972,7 +972,7 @@ mod tests {
             &root,
             &[],
             Some(Source {
-                label: "lns-local-mixin.yaml",
+                label: "decisions.yaml",
                 spec: &local,
             }),
             &graph,

--- a/crates/lns-artifact/src/spec.rs
+++ b/crates/lns-artifact/src/spec.rs
@@ -158,7 +158,8 @@ pub fn read_kind(config_json: &[u8]) -> Result<Kind> {
     Kind::from_kind_str(&kind).ok_or_else(|| anyhow::anyhow!("unknown artifact kind {kind:?}"))
 }
 
-pub(crate) fn is_valid_name(name: &str) -> bool {
+/// The `sandbox-spec.md` §2 `name` grammar, which every document must satisfy before anything writes or loads it.
+pub fn is_valid_name(name: &str) -> bool {
     let bytes = name.as_bytes();
     if bytes.is_empty() || bytes.len() > 63 {
         return false;

--- a/crates/lns-cli/src/artifact/mixin_plan.rs
+++ b/crates/lns-cli/src/artifact/mixin_plan.rs
@@ -6,8 +6,16 @@ use anyhow::{Context, Result, bail};
 use super::author::Fs;
 use super::fileset::local_mixin_document;
 
-/// The decisions file holds one machine's answers, so §6.1 refuses an entry naming it rather than publishing it.
-const LOCAL_MIXIN_FILENAME: &str = "lns-local-mixin.yaml";
+/// `sandbox-spec.md` §8.1: a run's decisions hold one machine's answers about one run, so an entry resolving into the run store is refused rather than published.
+const RUN_STORE_DIR: &str = "runs";
+
+/// True for a document inside `~/.lns/runs/`, whatever it is called there.
+fn is_a_runs_own_decisions(document: &Path, lns_home: Option<&Path>) -> bool {
+    let Some(home) = lns_home else {
+        return false;
+    };
+    document.starts_with(home.join(RUN_STORE_DIR))
+}
 
 /// One local mixin a push publishes, with the repository the parent reference and its own name earn it.
 #[derive(Debug, PartialEq, Eq)]
@@ -65,6 +73,7 @@ pub fn plan_local_mixins<F: Fs + ?Sized>(
     let mut walk = Walk {
         fs,
         parent_reference,
+        lns_home: lns_ipc::lns_home().ok(),
         nodes: Vec::new(),
         trail: Vec::new(),
         children: std::collections::BTreeMap::new(),
@@ -78,6 +87,7 @@ pub fn plan_local_mixins<F: Fs + ?Sized>(
 struct Walk<'a, F: Fs + ?Sized> {
     fs: &'a F,
     parent_reference: &'a str,
+    lns_home: Option<PathBuf>,
     nodes: Vec<PlannedMixin>,
     trail: Vec<PathBuf>,
     children: std::collections::BTreeMap<PathBuf, Vec<PathBuf>>,
@@ -104,9 +114,9 @@ impl<F: Fs + ?Sized> Walk<'_, F> {
 
     fn plan_one(&mut self, declared: &str, root: &Path) -> Result<PathBuf> {
         let document = local_mixin_document(self.fs, root, declared);
-        if document.file_name() == Some(LOCAL_MIXIN_FILENAME.as_ref()) {
+        if is_a_runs_own_decisions(&document, self.lns_home.as_deref()) {
             bail!(
-                "mixin {declared} names {LOCAL_MIXIN_FILENAME}, which holds this machine's own decisions and is never published"
+                "mixin {declared} names a run's own decisions, which are that run's answers on this machine and are never published; `lns sandbox save --kind mixin` writes a copy you can name"
             );
         }
         if let Some(position) = self.trail.iter().position(|seen| seen == &document) {
@@ -504,18 +514,56 @@ mod tests {
     }
 
     #[test]
-    fn a_local_entry_naming_the_decisions_file_is_refused() {
-        let fs = MapFs::with(&[("/work/lns-local-mixin.yaml", &mixin_yaml("lns-local-mixin"))]);
+    #[serial_test::serial(env)]
+    fn planning_an_entry_that_resolves_into_the_run_store_refuses_and_names_the_way_out() {
+        let _home = crate::test_env::EnvScope::set("LNS_HOME", "/home/dev/.lns");
+        let decisions = "/home/dev/.lns/runs/aa01/decisions.yaml";
+        let fs = MapFs::with(&[(decisions, &mixin_yaml("decisions"))]);
         let err = plan_local_mixins(
             &fs,
             Path::new("/work"),
-            &sandbox_naming(r#"["./lns-local-mixin.yaml"]"#),
+            &sandbox_naming(&format!(r#"["{decisions}"]"#)),
             PARENT,
         )
         .unwrap_err();
+        let message = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("never published"),
-            "§8.1 keeps one machine's answers off every registry; got: {err:#}"
+            message.contains("never published"),
+            "§8.1 keeps one run's answers off every registry; got: {message}"
+        );
+        assert!(
+            message.contains("lns sandbox save"),
+            "a refusal that does not name the supported way out leaves the author stuck; got: {message}"
+        );
+    }
+
+    #[test]
+    fn a_path_inside_the_run_store_is_recognised_as_a_runs_own_decisions() {
+        assert!(
+            is_a_runs_own_decisions(
+                Path::new("/home/dev/.lns/runs/aa01/decisions.yaml"),
+                Some(Path::new("/home/dev/.lns"))
+            ),
+            "§8.1 keeps one run's answers off every registry, and the path is what identifies them"
+        );
+    }
+
+    #[test]
+    fn a_document_named_decisions_outside_the_run_store_publishes_like_any_other() {
+        assert!(
+            !is_a_runs_own_decisions(
+                Path::new("/work/decisions.yaml"),
+                Some(Path::new("/home/dev/.lns"))
+            ),
+            "§8.4 makes a saved copy an ordinary document, so refusing it by name would refuse what save exists to produce"
+        );
+    }
+
+    #[test]
+    fn a_machine_with_no_resolvable_home_refuses_nothing_on_that_ground() {
+        assert!(
+            !is_a_runs_own_decisions(Path::new("/work/decisions.yaml"), None),
+            "a home nobody can resolve is not evidence that a path is a run's own"
         );
     }
 

--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -349,7 +349,6 @@ where
         .one_shot(Request::InspectImage {
             image: args.reference.clone(),
             mixins: Vec::new(),
-            decisions: None,
         })
         .await?;
     // A mixin pull installs nothing: it caches documents, so there is no effect to consent to and its tools are disclosed where they are installed.
@@ -627,7 +626,6 @@ pub(crate) async fn inspect_cached<W: std::io::Write>(
         .one_shot(Request::InspectImage {
             image: reference.to_string(),
             mixins: mixins.to_vec(),
-            decisions: None,
         })
         .await?
     {

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -1,41 +1,9 @@
 use std::fmt::Write as _;
 use std::io;
-use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
-use lns_policy::{Policy, Verdict};
+use anyhow::Result;
 
 use crate::cli::RunArgs;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PolicySource {
-    Found,
-    AutoCreated,
-}
-
-pub const DEFAULT_POLICY_FILENAME: &str = "lns-local-mixin.yaml";
-
-/// The project's own mixin is found beside the document and never named, so a definition run from another directory is governed by that directory's decisions rather than the one you typed in.
-pub fn policy_path(project: &Path) -> PathBuf {
-    project.join(DEFAULT_POLICY_FILENAME)
-}
-
-pub fn resolve_policy(project: &Path) -> Result<(PathBuf, PolicySource)> {
-    let path = policy_path(project);
-    match std::fs::metadata(&path) {
-        Ok(md) if md.is_file() => Ok((path, PolicySource::Found)),
-        Ok(_) => anyhow::bail!(
-            "{} exists but is not a regular file; remove it so the run can record what you decide",
-            path.display()
-        ),
-        Err(_) => {
-            lns_policy::Policy::default()
-                .save_atomic(&path)
-                .with_context(|| format!("creating default policy at {}", path.display()))?;
-            Ok((path, PolicySource::AutoCreated))
-        }
-    }
-}
 
 /// The size the run will boot with: an explicit flag outranks what the definition declared, which outranks this machine's config defaults, which outrank the built-in size.
 pub fn resolved_size(
@@ -94,15 +62,10 @@ pub fn drop_overridden_mounts(args: &mut RunArgs, overridden: &[String]) {
 pub fn print_run_summary(
     args: &RunArgs,
     size: lns_artifact::resources::VmSize,
-    project: &Path,
     writer: &mut impl io::Write,
-) -> Result<PathBuf> {
-    let (path, source) = resolve_policy(project)?;
-    let policy = Policy::load_or_default(&path)
-        .with_context(|| format!("loading policy from {}", path.display()))?;
-    let body = format_summary(args, size, &policy, &path, &source);
-    writer.write_all(body.as_bytes())?;
-    Ok(path)
+) -> Result<()> {
+    writer.write_all(format_summary(args, size).as_bytes())?;
+    Ok(())
 }
 
 /// How an entry names the source that decided it, empty for a run that resolved no mixin; only for a block whose keys are unique, never for egress, where two sources may key alike.
@@ -326,13 +289,7 @@ fn entry_line(entry: &lns_ipc::SourceContribution, attributed: bool) -> String {
     format!("{}{attribution}{note}", entry.key)
 }
 
-pub fn format_summary(
-    args: &RunArgs,
-    size: lns_artifact::resources::VmSize,
-    policy: &Policy,
-    policy_path: &Path,
-    source: &PolicySource,
-) -> String {
+pub fn format_summary(args: &RunArgs, size: lns_artifact::resources::VmSize) -> String {
     let mut s = String::with_capacity(512);
     s.push_str("lns run\n");
     writeln!(s, "  Image:     {}", image_line(args)).unwrap();
@@ -392,11 +349,7 @@ pub fn format_summary(
     .unwrap();
     writeln!(s, "  Flags:     {}", flags_line(args)).unwrap();
     writeln!(s, "  Ports:     {}", ports_line(args)).unwrap();
-    s.push_str("  Policy:\n");
-    writeln!(s, "    file: {}", policy_path.display()).unwrap();
-    writeln!(s, "    unmatched destinations: {}", unmatched_line(policy)).unwrap();
-    writeln!(s, "    rules: {}", rules_line(policy)).unwrap();
-    writeln!(s, "    source: {}", source_line(source)).unwrap();
+    writeln!(s, "  Decisions: {DECISIONS_LINE}").unwrap();
     s.push('\n');
     s
 }
@@ -584,68 +537,17 @@ fn ports_line(args: &RunArgs) -> String {
         .join(", ")
 }
 
-fn unmatched_line(policy: &Policy) -> &'static str {
-    if policy.network.is_closed() {
-        "denied by the catch-all rule"
-    } else {
-        "ask"
-    }
-}
-
-fn rules_line(policy: &Policy) -> String {
-    let egress = &policy.network.egress;
-    if egress.http.is_empty() && egress.tcp.is_empty() {
-        return "none defined; anything else asks".to_string();
-    }
-    let (allows, denies) = tally(egress.http.iter().map(|r| r.verdict));
-    let raw = raw_counts(&egress.tcp);
-    let tail = if policy.network.is_closed() {
-        "anything else denied"
-    } else {
-        "anything else asks"
-    };
-    format!("{allows} allow, {denies} deny{raw}, {tail}")
-}
-
-/// Raw splices counted apart from the routes, since nothing inspects one and folded into the route count a splice would read as one more gated host. Empty when the table is, so a policy with no raw rules carries no zeros.
-fn raw_counts(tcp: &[lns_policy::TcpEgressRule]) -> String {
-    if tcp.is_empty() {
-        return String::new();
-    }
-    let (allows, denies) = tally(tcp.iter().map(|r| r.verdict));
-    format!(", {allows} raw allow, {denies} raw deny")
-}
-
-fn tally(verdicts: impl Iterator<Item = Verdict>) -> (u32, u32) {
-    verdicts.fold((0u32, 0u32), |(a, d), verdict| match verdict {
-        Verdict::Allow => (a + 1, d),
-        Verdict::Deny => (a, d + 1),
-    })
-}
-
-fn source_line(source: &PolicySource) -> String {
-    match source {
-        PolicySource::Found => "found in the project directory".to_string(),
-        PolicySource::AutoCreated => {
-            "auto-created (no policy in the project directory)".to_string()
-        }
-    }
-}
+/// `docs/sandbox-spec.md` §8.1: a fresh run starts with an empty decisions file, so the disclosure says where an answer goes rather than reporting rules nobody has made yet.
+const DECISIONS_LINE: &str = "recorded in this run, and removed with it";
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use lns_artifact::resources::{DEFAULT_VM_SIZE, VmSize};
-    use lns_policy::{RouteRule, TcpEgressRule};
 
     /// Most lines are indifferent to the size, so they read the built-in default; the resources line has its own tests.
-    fn summary_of(
-        args: &RunArgs,
-        policy: &Policy,
-        policy_path: &Path,
-        source: &PolicySource,
-    ) -> String {
-        format_summary(args, DEFAULT_VM_SIZE, policy, policy_path, source)
+    fn summary_of(args: &RunArgs) -> String {
+        format_summary(args, DEFAULT_VM_SIZE)
     }
 
     fn spec_with_scripts(entries: &str) -> lns_artifact::sandbox::SandboxSpec {
@@ -856,12 +758,7 @@ mod tests {
     fn summary_with_publish(ports: Vec<lns_ipc::PortPublish>) -> String {
         let mut args = run_args(Some("prism"));
         args.publish = ports;
-        summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        )
+        summary_of(&args)
     }
 
     fn fileset_entry(path: Option<&str>) -> lns_artifact::sandbox::FilesetEntry {
@@ -1049,22 +946,12 @@ mod tests {
     fn the_mixins_line_names_what_a_composed_sandbox_resolved_into() {
         let mut args = run_args(Some("prism"));
         args.resolved_mixins = vec!["ghcr.io/acme/postgres-tools@sha256:c41e8b7d".into()];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Mixins:    ghcr.io/acme/postgres-tools@sha256:c41e8b7d"),
             "the resolved document declares no mixins of its own, so without this line a composed sandbox reads as an authored one and a tool the user did not expect has nowhere to be traced to; got: {s}"
         );
-        let authored = summary_of(
-            &run_args(Some("prism")),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let authored = summary_of(&run_args(Some("prism")));
         assert!(!authored.contains("Mixins:"), "got: {authored}");
     }
 
@@ -1200,12 +1087,7 @@ mod tests {
                 &[("the sandbox", "node@20")],
             )],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("node@22  [from ghcr.io/acme/obs@sha256:cccccccccccc…, replaced node@20 from the sandbox]"),
             "a developer reading `node@22` has to be able to see that a mixin put it there over the version their own document asked for; got: {s}"
@@ -1226,12 +1108,7 @@ mod tests {
                 &[],
             )],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Credentials: SOME_TOKEN  [from ghcr.io/acme/obs@sha256:cccccccccccc…]"),
             "got: {s}"
@@ -1259,12 +1136,7 @@ mod tests {
                 ),
             ],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         let first = s
             .lines()
             .find(|l| l.contains("SOME_TOKEN"))
@@ -1301,12 +1173,7 @@ mod tests {
                 ),
             ],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("\n             proxy.vendor.example  [from the sandbox]\n"),
             "a merged table is read as a table, so the second entry has to sit under the first rather than restate the label; got: {s}"
@@ -1323,12 +1190,7 @@ mod tests {
             size_bytes: None,
         })];
         composed(&mut args, Vec::new());
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Volume:    scratch \u{2192} /scratch\n"),
             "the user typed this one, so naming a source for it would invent an author; got: {s}"
@@ -1355,12 +1217,7 @@ mod tests {
             )],
         );
         drop_overridden_mounts(&mut args, &["/scratch".to_string()]);
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Volume:    mine \u{2192} /scratch\n"),
             "the mixin's mount is not what boots, so naming it as the author of the user's own mount inverts who decided this; got: {s}"
@@ -1388,12 +1245,7 @@ mod tests {
                 ),
             ],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains(
                 "Rules:     allow api.vendor.example  [from ghcr.io/acme/obs@sha256:cccccccccccc…]"
@@ -1425,12 +1277,7 @@ mod tests {
                 &[],
             )],
         );
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("[from ghcr.io/acme/obs@sha256:cccccccccccc…]"),
             "a mixin opening a host socket is a thing the developer is approving, so it has to name who asked; got: {s}"
@@ -1450,12 +1297,7 @@ mod tests {
             )],
         );
         args.tools = vec!["node@22".into()];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("some/dir@sha256:a\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{2026}"),
             "a directory the user named is theirs to spell, so shortening it by bytes would panic on a run that is otherwise fine; got: {s}"
@@ -1466,12 +1308,7 @@ mod tests {
     fn an_uncomposed_run_prints_exactly_what_it_printed_before_attribution_existed() {
         let mut args = run_args(Some("prism"));
         args.tools = vec!["node@22".into()];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Tools:     node@22\n"), "got: {s}");
         assert!(
             !s.contains("[from") && !s.contains("Rules:") && !s.contains("Credentials:"),
@@ -1492,15 +1329,7 @@ mod tests {
                 displaced: Vec::new(),
             })
             .collect();
-        let mut closed = Policy::default();
-        closed.add_rule(RouteRule::deny_host("*"));
-
-        let s = summary_of(
-            &args,
-            &closed,
-            Path::new("./lns-policy.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
 
         assert!(
             s.contains("Rules:")
@@ -1518,12 +1347,7 @@ mod tests {
     fn tools_line_lists_declared_tools_and_is_absent_without_them() {
         let mut args = run_args(Some("prism"));
         args.tools = vec!["node@22.11.0".into(), "python@3.12.6".into()];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Tools:     node@22.11.0, python@3.12.6"),
             "got: {s}"
@@ -1572,18 +1396,16 @@ mod tests {
     }
 
     #[test]
-    fn summary_lists_image_resources_flags_and_policy_block() {
+    fn summary_lists_image_resources_flags_and_the_decisions_line() {
         let args = run_args(Some("ubuntu"));
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/home/dev/my-app/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Image:"), "missing Image line: {s}");
         assert!(s.contains("Resources:"), "missing Resources line: {s}");
         assert!(s.contains("Flags:"), "missing Flags line: {s}");
-        assert!(s.contains("Policy:"), "missing Policy block: {s}");
+        assert!(
+            s.contains("Decisions: recorded in this run, and removed with it"),
+            "§8.1 puts a run's answers in the run, so the disclosure has to say that before the first prompt: {s}"
+        );
     }
 
     #[test]
@@ -1603,12 +1425,7 @@ mod tests {
                 size_bytes: None,
             }),
         ];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Volume:    prism-data → /data"),
             "missing volume line: {s}"
@@ -1629,12 +1446,7 @@ mod tests {
             exclude: Vec::new(),
             optional: false,
         })];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Bind:      /Users/me/proj → /work (read-write)"),
             "missing bind line: {s}"
@@ -1651,12 +1463,7 @@ mod tests {
             exclude: Vec::new(),
             optional: false,
         })];
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(
             s.contains("Bind:      /Users/me/cfg → /cfg (read-only)"),
             "missing read-only bind line: {s}"
@@ -1693,58 +1500,33 @@ mod tests {
     fn summary_lists_the_requested_workdir() {
         let mut args = run_args(Some("ubuntu"));
         args.workdir = Some("/app".into());
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Workdir:   /app"), "missing workdir line: {s}");
     }
 
     #[test]
     fn summary_omits_workdir_line_when_unset() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&run_args(Some("ubuntu")));
         assert!(!s.contains("Workdir:"), "no workdir line expected: {s}");
     }
 
     #[test]
     fn summary_omits_volume_line_when_none_attached() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&run_args(Some("ubuntu")));
         assert!(!s.contains("Volume:"), "no volume line expected: {s}");
     }
 
     #[test]
     fn image_field_shows_resolving_placeholder_until_service_confirms_digest() {
         let args = run_args(Some("ubuntu"));
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("ubuntu (resolving…)"), "no placeholder: {s}");
     }
 
     #[test]
     fn no_reference_run_shows_the_local_definition_as_the_image() {
         let args = run_args(None);
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("./lns.yaml (resolving…)"), "got: {s}");
         assert!(
             !s.contains("imageless"),
@@ -1756,24 +1538,14 @@ mod tests {
     fn a_file_selector_run_shows_the_selected_definition_as_the_image() {
         let mut args = run_args(None);
         args.file = Some(std::path::PathBuf::from("lns.dev.yaml"));
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("lns.dev.yaml (resolving…)"), "got: {s}");
         assert!(!s.contains("./lns.yaml"), "got: {s}");
     }
 
     #[test]
     fn resources_line_renders_the_size_the_run_will_boot_with() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&run_args(Some("ubuntu")));
         assert!(s.contains("1 vCPU · 512 MiB"), "resources line wrong: {s}");
     }
 
@@ -1791,9 +1563,6 @@ mod tests {
                 mem_mib: 6144,
                 disk_bytes: 40 << 30,
             },
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
         );
         assert!(s.contains("3 vCPU · 6144 MiB"), "resources line wrong: {s}");
     }
@@ -1839,9 +1608,6 @@ mod tests {
                 mem_mib: 512,
                 disk_bytes: 40 << 30,
             },
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
         );
         assert!(s.contains("40 GiB disk"), "resources line wrong: {s}");
     }
@@ -1852,12 +1618,7 @@ mod tests {
         args.interactive = true;
         args.tty = true;
         args.detach = false;
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Flags:     -i -t"), "flags line wrong: {s}");
     }
 
@@ -1867,12 +1628,7 @@ mod tests {
         args.interactive = false;
         args.tty = false;
         args.detach = true;
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Flags:     -d"), "flags line wrong: {s}");
     }
 
@@ -1880,12 +1636,7 @@ mod tests {
     fn flags_line_includes_auto_remove_when_set() {
         let mut args = run_args(Some("ubuntu"));
         args.auto_remove = true;
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Flags:     -i -t --rm"), "flags line wrong: {s}");
     }
 
@@ -1895,206 +1646,7 @@ mod tests {
         args.interactive = false;
         args.tty = false;
         args.detach = false;
-        let s = summary_of(
-            &args,
-            &Policy::default(),
-            Path::new("/x/lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
+        let s = summary_of(&args);
         assert!(s.contains("Flags:     (none)"), "flags line wrong: {s}");
-    }
-
-    #[test]
-    fn a_closed_policy_does_not_claim_anything_still_asks() {
-        // The catch-all answers for whatever the named rules leave, so nothing is
-        // unmatched — telling the developer it asks would be false, not vague.
-        let mut policy = Policy::default();
-        policy.add_rule(RouteRule::allow_host("api.example.test"));
-        policy.add_rule(RouteRule::deny_host("*"));
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &policy,
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(
-            s.contains("unmatched destinations: denied by the catch-all rule"),
-            "got: {s}"
-        );
-        assert!(s.contains("anything else denied"), "got: {s}");
-    }
-
-    #[test]
-    fn policy_block_shows_the_file_path_and_a_rule_summary() {
-        let mut policy = Policy::default();
-        policy.add_rule(RouteRule::allow_host("api.linear.app"));
-        policy.add_rule(RouteRule::allow_host("api.example.com"));
-        policy.add_rule(RouteRule::allow_host("registry.npmjs.org"));
-        policy.add_rule(RouteRule::deny_host("evil.example"));
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &policy,
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(s.contains("file: ./lns-local-mixin.yaml"));
-        assert!(
-            s.contains("unmatched destinations: ask"),
-            "the default is no longer a field the file varies, so the summary states the rule: {s}"
-        );
-        assert!(s.contains("3 allow, 1 deny, anything else asks"));
-    }
-
-    #[test]
-    fn the_rules_line_counts_the_raw_splices_apart_from_the_inspected_routes() {
-        // The launch summary is the only surface that discloses this directory's own
-        // policy, and a raw splice is the widest grant it can express — folded into
-        // the route count it would read as one more inspected host.
-        let mut policy = Policy::default();
-        policy.add_rule(RouteRule::allow_host("api.example.test"));
-        policy
-            .network
-            .egress
-            .tcp
-            .push(TcpEgressRule::allow_destination("0.0.0.0/0:5432"));
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &policy,
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(
-            s.contains("1 allow, 0 deny, 1 raw allow, 0 raw deny, anything else asks"),
-            "got: {s}"
-        );
-    }
-
-    #[test]
-    fn the_rules_line_reports_a_raw_only_policy_rather_than_none_defined() {
-        let mut policy = Policy::default();
-        policy
-            .network
-            .egress
-            .tcp
-            .push(TcpEgressRule::allow_destination("db.internal:5432"));
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &policy,
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(
-            s.contains("0 allow, 0 deny, 1 raw allow, 0 raw deny, anything else asks"),
-            "a file holding only raw rules is not a file holding none: {s}"
-        );
-    }
-
-    #[test]
-    fn rules_line_says_none_defined_for_an_empty_route_list() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(
-            s.contains("rules: none defined; anything else asks"),
-            "rules line wrong: {s}"
-        );
-    }
-
-    #[test]
-    fn rules_line_uses_singular_counts_at_one() {
-        let mut policy = Policy::default();
-        policy.add_rule(RouteRule::allow_host("api.linear.app"));
-        policy.add_rule(RouteRule::deny_host("evil.example"));
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &policy,
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(s.contains("1 allow, 1 deny, anything else asks"));
-    }
-
-    #[test]
-    fn source_line_for_a_found_file_names_the_project_directory() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
-        );
-        assert!(s.contains("source: found in the project directory"));
-    }
-
-    #[test]
-    fn source_line_for_auto_created_calls_out_no_policy_in_the_project_directory() {
-        let s = summary_of(
-            &run_args(Some("ubuntu")),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::AutoCreated,
-        );
-        assert!(s.contains("source: auto-created (no policy in the project directory)"));
-    }
-
-    #[test]
-    fn resolve_policy_finds_the_default_file_of_the_project_rather_than_of_the_cwd() {
-        // One directory is one project, so the run reads the decisions beside the definition it runs, wherever the developer started it.
-        let cwd = tempfile::TempDir::new().unwrap();
-        let project = tempfile::TempDir::new().unwrap();
-        let preexisting = project.path().join(DEFAULT_POLICY_FILENAME);
-        Policy::default().save_atomic(&preexisting).unwrap();
-        let (resolved, source) = resolve_policy(project.path()).unwrap();
-        assert_eq!(resolved, preexisting);
-        assert_eq!(source, PolicySource::Found);
-        assert!(!cwd.path().join(DEFAULT_POLICY_FILENAME).exists());
-    }
-
-    #[test]
-    fn resolve_policy_auto_creates_default_file_when_missing() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let (resolved, source) = resolve_policy(dir.path()).unwrap();
-        assert_eq!(resolved, dir.path().join(DEFAULT_POLICY_FILENAME));
-        assert_eq!(source, PolicySource::AutoCreated);
-        let body = std::fs::read_to_string(&resolved).unwrap();
-        assert!(
-            !body.contains("defaultVerdict"),
-            "a file born with the key would be born with the one value the loader tells you to delete: {body}"
-        );
-        assert!(
-            body.contains("egress:") && body.contains("http: []"),
-            "the scaffold must name the table the guest reads, not the deprecated one:\n{body}"
-        );
-        assert!(!body.contains("allowedRoutes"), "got:\n{body}");
-        assert!(!body.contains("defaultTransport"), "got:\n{body}");
-        assert!(!body.contains("transport:"), "got:\n{body}");
-    }
-
-    #[test]
-    fn resolve_policy_errors_when_default_path_is_a_directory() {
-        let dir = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir(dir.path().join(DEFAULT_POLICY_FILENAME)).unwrap();
-        let err = resolve_policy(dir.path()).expect_err("must reject non-file");
-        assert!(format!("{err:#}").contains("not a regular file"));
-    }
-
-    #[test]
-    fn print_run_summary_writes_to_provided_writer_and_returns_resolved_path() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let args = run_args(Some("ubuntu"));
-        let mut buf = Vec::<u8>::new();
-        let path = print_run_summary(
-            &args,
-            resolved_size(Default::default(), &args),
-            dir.path(),
-            &mut buf,
-        )
-        .unwrap();
-        assert_eq!(path, dir.path().join(DEFAULT_POLICY_FILENAME));
-        let text = String::from_utf8(buf).unwrap();
-        assert!(text.contains("lns run"));
-        assert!(text.contains("Policy:"));
     }
 }

--- a/crates/lns-cli/src/run/summary.rs
+++ b/crates/lns-cli/src/run/summary.rs
@@ -1020,7 +1020,7 @@ mod tests {
         let contributions = vec![contributed(
             lns_ipc::ContributionBlock::Mount,
             "/home/agent/.gitconfig",
-            "lns-local-mixin.yaml",
+            "decisions.yaml",
             &[],
         )];
         assert_eq!(

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -377,9 +377,6 @@ async fn save<W: std::io::Write>(
     args: &SandboxSaveArgs,
     out: &mut W,
 ) -> Result<i32> {
-    if svc.document_exists(&args.file) {
-        bail!("{} already exists; not overwriting it", args.file.display());
-    }
     let name = document_name(&args.file)?;
     match svc
         .one_shot(Request::SaveRun {
@@ -390,8 +387,7 @@ async fn save<W: std::io::Write>(
         .await?
     {
         Response::RunSaved { document } => {
-            svc.write_document(&args.file, &document)
-                .with_context(|| format!("writing {}", args.file.display()))?;
+            write_saved_document(svc, &args.file, &document)?;
             writeln!(out, "saved sandbox {} to {}", args.run, args.file.display())?;
             Ok(0)
         }
@@ -399,6 +395,21 @@ async fn save<W: std::io::Write>(
             "save", &args.run, &message,
         )),
         other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+/// Creating the file is the refusal: a check before the write is a window in which the file appears, and a path that is already there would be truncated in it.
+fn write_saved_document(
+    svc: &impl SandboxService,
+    file: &std::path::Path,
+    document: &str,
+) -> Result<()> {
+    match svc.write_document(file, document) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            bail!("{} already exists; not overwriting it", file.display())
+        }
+        Err(e) => Err(e).with_context(|| format!("writing {}", file.display())),
     }
 }
 

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -38,6 +38,8 @@ pub enum SandboxCommand {
     Ls(SandboxLsArgs),
     #[command(about = "Print one sandbox's live state and launch configuration.")]
     Inspect(SandboxInspectArgs),
+    #[command(about = "Write a sandbox out as a document you keep.")]
+    Save(SandboxSaveArgs),
     #[command(about = "Remove a sandbox: its record and its writable layer.")]
     Rm(SandboxRmArgs),
     #[command(about = "Remove every stopped sandbox, writable layers included.")]
@@ -177,6 +179,48 @@ pub struct SandboxRmArgs {
         help = "Stop a running sandbox first, then remove it."
     )]
     pub force: bool,
+}
+
+/// `docs/cli-spec.md` §3.2.3: `-f` is required, because `lns` never picks a path in the user's directory for them.
+#[derive(clap::Args)]
+pub struct SandboxSaveArgs {
+    #[arg(
+        value_name = "RUN",
+        help = "Sandbox id or name to write out; running or stopped."
+    )]
+    pub run: String,
+
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        required = true,
+        help = "Where to write the document. Refuses to overwrite an existing file."
+    )]
+    pub file: std::path::PathBuf,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = SaveDocumentKind::Sandbox,
+        help = "What to write: the run as it resolved, or only what it decided."
+    )]
+    pub kind: SaveDocumentKind,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SaveDocumentKind {
+    Sandbox,
+    Mixin,
+}
+
+impl From<SaveDocumentKind> for lns_ipc::SaveKind {
+    fn from(kind: SaveDocumentKind) -> Self {
+        match kind {
+            SaveDocumentKind::Sandbox => lns_ipc::SaveKind::Sandbox,
+            SaveDocumentKind::Mixin => lns_ipc::SaveKind::Mixin,
+        }
+    }
 }
 
 pub fn augment(app: clap::Command) -> clap::Command {
@@ -323,7 +367,59 @@ where
         SandboxCommand::Logs(args) => logs(svc, args, stdout, stderr).await,
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
+        SandboxCommand::Save(args) => save(svc, args, out).await,
     }
+}
+
+/// §8.4 has the service render what ran and this machine write where the user said, so a document nobody named is never created.
+async fn save<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &SandboxSaveArgs,
+    out: &mut W,
+) -> Result<i32> {
+    if svc.document_exists(&args.file) {
+        bail!("{} already exists; not overwriting it", args.file.display());
+    }
+    let name = document_name(&args.file)?;
+    match svc
+        .one_shot(Request::SaveRun {
+            run: args.run.clone(),
+            kind: args.kind.into(),
+            name,
+        })
+        .await?
+    {
+        Response::RunSaved { document } => {
+            svc.write_document(&args.file, &document)
+                .with_context(|| format!("writing {}", args.file.display()))?;
+            writeln!(out, "saved sandbox {} to {}", args.run, args.file.display())?;
+            Ok(0)
+        }
+        Response::Error { message } => Err(crate::service::reply::sandbox_failure(
+            "save", &args.run, &message,
+        )),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+/// §8.4 names the saved document for the file it lands in, so a stem that is not a legal §2 `name` is refused before the service renders anything.
+fn document_name(file: &std::path::Path) -> Result<String> {
+    let stem = file
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} has no filename to name the document after",
+                file.display()
+            )
+        })?;
+    if !lns_artifact::spec::is_valid_name(stem) {
+        bail!(
+            "{stem} cannot name a document, so saving there would write one `lns artifact validate` refuses; a name is lowercase letters, digits and dashes, starts and ends with a letter or digit, and is at most 63 characters"
+        );
+    }
+    Ok(stem.to_string())
 }
 
 fn run_operand(cmd: &SandboxCommand) -> Option<(&'static str, &str)> {
@@ -336,6 +432,7 @@ fn run_operand(cmd: &SandboxCommand) -> Option<(&'static str, &str)> {
         SandboxCommand::Logs(args) => Some(("logs", args.run.as_str())),
         SandboxCommand::Attach(args) => Some(("attach", args.run.as_str())),
         SandboxCommand::Rm(args) => Some(("rm", args.run.as_str())),
+        SandboxCommand::Save(args) => Some(("save", args.run.as_str())),
         _ => None,
     }
 }
@@ -977,6 +1074,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn save_writes_the_rendered_document_through_the_service_it_was_given() {
+        let svc = CannedService::new(Response::RunSaved {
+            document: "apiVersion: lns.run/v1\nkind: mixin\nname: agreed\n".into(),
+        });
+        let cmd = SandboxCommand::Save(SandboxSaveArgs {
+            run: "reviewer".into(),
+            file: std::path::PathBuf::from("./agreed.yaml"),
+            kind: SaveDocumentKind::Mixin,
+        });
+        let mut out = Vec::new();
+        let code = run_with_writers(
+            &cmd,
+            &svc,
+            TermInfo::default(),
+            &mut ScriptedTerminal::absent(),
+            &mut out,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await
+        .expect("a rendered document lands where the user named");
+        assert_eq!(code, 0);
+        assert!(
+            String::from_utf8(out)
+                .expect("utf-8")
+                .contains("saved sandbox reviewer to ./agreed.yaml"),
+            "the user has to be told which file now holds the run"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_naming_a_run_the_service_does_not_know_says_which_verb_and_which_run() {
+        let svc = CannedService::new(Response::Error {
+            message: "no such run: ghost".into(),
+        });
+        let cmd = SandboxCommand::Save(SandboxSaveArgs {
+            run: "ghost".into(),
+            file: std::path::PathBuf::from("./out.yaml"),
+            kind: SaveDocumentKind::Sandbox,
+        });
+        let err = run_with_writers(
+            &cmd,
+            &svc,
+            TermInfo::default(),
+            &mut ScriptedTerminal::absent(),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("ghost"),
+            "a refusal has to name the run the user typed; got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_given_an_answer_that_is_not_a_document_refuses_rather_than_writing_it() {
+        let svc = CannedService::new(Response::Pong);
+        let cmd = SandboxCommand::Save(SandboxSaveArgs {
+            run: "reviewer".into(),
+            file: std::path::PathBuf::from("./out.yaml"),
+            kind: SaveDocumentKind::Sandbox,
+        });
+        let err = run_with_writers(
+            &cmd,
+            &svc,
+            TermInfo::default(),
+            &mut ScriptedTerminal::absent(),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("unexpected response"),
+            "writing whatever came back would put something other than a document in the user's directory; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_file_whose_stem_is_not_a_legal_name_refuses_before_anything_is_written() {
+        let err = document_name(std::path::Path::new("./Team_Rules.yaml")).expect_err(
+            "§8.4 names the document for its file, so an illegal stem would write one §5 rejects",
+        );
+        assert!(
+            format!("{err:#}").contains("lowercase"),
+            "the refusal has to say what a name takes, or the user guesses again; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_path_with_no_filename_cannot_name_the_document_it_would_write() {
+        let err = document_name(std::path::Path::new("/")).expect_err(
+            "§8.4 names the saved document for its file, so a path with no stem names nothing",
+        );
+        assert!(format!("{err:#}").contains("no filename"), "got: {err:#}");
+    }
+
+    #[tokio::test]
     async fn run_with_writers_refuses_the_interactive_exec_verb() {
         let svc = CannedService::new(Response::Pong);
         let cmd = SandboxCommand::Exec(crate::cli::ExecArgs {
@@ -1498,7 +1697,7 @@ mod tests {
                     started: "2026-01-01T00:00:00Z".into(),
                 },
                 config: lns_ipc::RunConfig {
-                    policy_path: Some("/work/lns-local-mixin.yaml".into()),
+                    policy_path: Some("/home/dev/.lns/runs/aa01/decisions.yaml".into()),
                     ..Default::default()
                 },
             }),
@@ -1517,15 +1716,15 @@ mod tests {
 
     #[test]
     fn policy_doc_marks_an_unreadable_file() {
-        let doc = policy_doc("/work/lns-local-mixin.yaml", None);
-        assert_eq!(doc["path"], "/work/lns-local-mixin.yaml");
+        let doc = policy_doc("/home/dev/.lns/runs/aa01/decisions.yaml", None);
+        assert_eq!(doc["path"], "/home/dev/.lns/runs/aa01/decisions.yaml");
         assert!(doc["error"].as_str().unwrap().contains("could not be read"));
     }
 
     #[test]
     fn policy_doc_embeds_a_parsed_policy() {
         let doc = policy_doc(
-            "/work/lns-local-mixin.yaml",
+            "/home/dev/.lns/runs/aa01/decisions.yaml",
             Some(serde_json::json!({"network": {"egress": {"http": []}}})),
         );
         assert_eq!(

--- a/crates/lns-cli/src/service/client.rs
+++ b/crates/lns-cli/src/service/client.rs
@@ -25,8 +25,7 @@ pub trait SandboxService: Send + Sync {
     fn open_stream(&self, request: Request) -> BoxFuture<'_, Result<Self::Stream>>;
     fn aux_socket(&self) -> Option<PathBuf>;
     fn load_policy(&self, path: &str) -> Option<serde_json::Value>;
-    /// Where a rendered document lands. The service renders it and this machine writes it, so `lns sandbox save` never has the service reach into the user's directory.
-    fn document_exists(&self, path: &std::path::Path) -> bool;
+    /// Where a rendered document lands, created rather than opened, so a path that is already there answers `AlreadyExists` instead of being replaced.
     fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()>;
 }
 

--- a/crates/lns-cli/src/service/client.rs
+++ b/crates/lns-cli/src/service/client.rs
@@ -25,6 +25,9 @@ pub trait SandboxService: Send + Sync {
     fn open_stream(&self, request: Request) -> BoxFuture<'_, Result<Self::Stream>>;
     fn aux_socket(&self) -> Option<PathBuf>;
     fn load_policy(&self, path: &str) -> Option<serde_json::Value>;
+    /// Where a rendered document lands. The service renders it and this machine writes it, so `lns sandbox save` never has the service reach into the user's directory.
+    fn document_exists(&self, path: &std::path::Path) -> bool;
+    fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/lns-cli/src/service/orchestrator.rs
+++ b/crates/lns-cli/src/service/orchestrator.rs
@@ -257,13 +257,11 @@ async fn preflight_local(
     definition: &str,
     project_dir: &Path,
     mixins: &[String],
-    decisions: &Path,
 ) -> Result<ResolvedDefinition> {
     let request = Request::ResolveDefinition {
         definition: definition.to_string(),
         project_dir: project_dir.display().to_string(),
         mixins: mixins.to_vec(),
-        decisions: Some(decisions.display().to_string()),
     };
     match timeout(
         PUBLISHED_PREFLIGHT_TIMEOUT,
@@ -303,12 +301,10 @@ async fn preflight_published(
     socket: &Path,
     reference: &str,
     mixins: &[String],
-    decisions: &Path,
 ) -> Result<PublishedTarget> {
     let request = Request::InspectImage {
         image: reference.to_string(),
         mixins: mixins.to_vec(),
-        decisions: Some(decisions.display().to_string()),
     };
     await_published_preflight(reference, real::send_request(socket, &request)).await
 }
@@ -342,9 +338,6 @@ pub async fn run_image(
 ) -> Result<i32> {
     let client = real_client()?;
     args.mixins = crate::run::target::root_named_directories(&args.mixins, &cwd)?;
-    let project_dir = target.project_dir().unwrap_or(&cwd).to_path_buf();
-    // §8.1 has every run in a directory resolve its decisions, so a directory that decided something needs the preflight even when nothing declared a mixin.
-    let decisions = crate::run::summary::policy_path(&project_dir);
     let mut authored_egress = None;
     // A mixin the preflight pulled brings its filesets packed in its own artifact, and the merged document alone cannot say which.
     let mut packed_filesets = Vec::new();
@@ -353,10 +346,9 @@ pub async fn run_image(
         json,
         project_dir,
     } = &mut target
-        && (!def.spec.mixins.is_empty() || !args.mixins.is_empty() || decisions.is_file())
+        && (!def.spec.mixins.is_empty() || !args.mixins.is_empty())
     {
-        let resolved =
-            preflight_local(client.socket(), json, project_dir, &args.mixins, &decisions).await?;
+        let resolved = preflight_local(client.socket(), json, project_dir, &args.mixins).await?;
         **def = read_resolved_definition(&resolved.definition)?;
         *json = resolved.definition;
         authored_egress = Some(resolved.authored_egress);
@@ -370,7 +362,7 @@ pub async fn run_image(
     }
     let published = match &target {
         crate::run::target::RunTarget::Reference(reference) => {
-            Some(preflight_published(client.socket(), reference, &args.mixins, &decisions).await?)
+            Some(preflight_published(client.socket(), reference, &args.mixins).await?)
         }
         crate::run::target::RunTarget::Local { .. } => {
             // A path-shaped REF resolved to a definition; the summary names its image, not the path.
@@ -451,12 +443,9 @@ pub async fn run_image(
     // The size travels as its own value: writing it back into args.cpus/args.mem would tell the service the user asked for it explicitly.
     let size = crate::run::summary::resolved_size(defaults.size, &args);
     let quiet = args.quiet;
-    let resolved_policy = if quiet {
-        let (path, _source) = crate::run::summary::resolve_policy(&project_dir)?;
-        path
-    } else {
-        print_run_summary(&args, size, &project_dir, &mut std::io::stderr())?
-    };
+    if !quiet {
+        print_run_summary(&args, size, &mut std::io::stderr())?;
+    }
 
     let (volumes, bind_specs) = crate::cli::split_mounts(&args.mounts);
     let reference = target.image();
@@ -536,7 +525,6 @@ pub async fn run_image(
         mixins: run_mixins.to_merge,
         composed_mixins: run_mixins.composed,
         name: args.name,
-        policy_path: Some(resolved_policy.to_string_lossy().into_owned()),
         sandbox_user,
         sandbox_uid,
         entrypoint: args.entrypoint,

--- a/crates/lns-cli/src/service/real.rs
+++ b/crates/lns-cli/src/service/real.rs
@@ -286,6 +286,14 @@ impl SandboxService for RealSandboxService {
         let policy = lns_policy::Policy::load_or_default(path).ok()?;
         serde_json::to_value(&policy).ok()
     }
+
+    fn document_exists(&self, path: &std::path::Path) -> bool {
+        path.exists()
+    }
+
+    fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+        std::fs::write(path, contents)
+    }
 }
 
 #[cfg(test)]

--- a/crates/lns-cli/src/service/real.rs
+++ b/crates/lns-cli/src/service/real.rs
@@ -287,12 +287,13 @@ impl SandboxService for RealSandboxService {
         serde_json::to_value(&policy).ok()
     }
 
-    fn document_exists(&self, path: &std::path::Path) -> bool {
-        path.exists()
-    }
-
     fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()> {
-        std::fs::write(path, contents)
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)?
+            .write_all(contents.as_bytes())
     }
 }
 

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -179,10 +179,6 @@ impl SandboxService for CannedService {
         None
     }
 
-    fn document_exists(&self, _path: &std::path::Path) -> bool {
-        false
-    }
-
     fn write_document(&self, _path: &std::path::Path, _contents: &str) -> std::io::Result<()> {
         Ok(())
     }

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -178,6 +178,14 @@ impl SandboxService for CannedService {
     fn load_policy(&self, _path: &str) -> Option<serde_json::Value> {
         None
     }
+
+    fn document_exists(&self, _path: &std::path::Path) -> bool {
+        false
+    }
+
+    fn write_document(&self, _path: &std::path::Path, _contents: &str) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 pub(crate) async fn stream_with(frames: &[Vec<u8>]) -> tokio::io::DuplexStream {

--- a/crates/lns-cli/tests/behaviours/definition_selection.feature
+++ b/crates/lns-cli/tests/behaviours/definition_selection.feature
@@ -3,8 +3,8 @@ Feature: selecting the sandbox definition file
   reference naming a `.yaml` file, or the explicit `-f/--file` selector, is
   the override that operates on a different definition file: the file's
   directory is the project, so it roots the relative binds and filesets,
-  compose-style, and holds the decisions the run resolves. Nothing names the
-  decisions file: it is always the one beside the definition.
+  compose-style. That is all the directory decides: a run's own decisions live
+  with the run, and no file in a directory governs what starts there.
 
   Scenario: a path-shaped reference naming a yaml file runs that file's definition
     Given a sandbox definition file "lns.dev.yaml" in the current directory
@@ -57,12 +57,6 @@ Feature: selecting the sandbox definition file
     Then the command fails with an exit code other than 0
     And the output contains "no sandbox definition at"
     And the output contains "lns.dev.yaml"
-
-  Scenario: a definition in another directory is governed by that directory's decisions
-    Given a sandbox definition file "/other/lns.dev.yaml" declaring a relative bind and fileset
-    When the user runs "lns run /other/lns.dev.yaml"
-    Then the exit code is 0
-    And the run reads its decisions from "/other/lns-local-mixin.yaml"
 
   Scenario: no flag can point the run at another decisions file
     Given a sandbox definition file "/other/lns.dev.yaml" declaring a relative bind and fileset

--- a/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
+++ b/crates/lns-cli/tests/behaviours/local_decisions_disclosure.feature
@@ -1,34 +1,39 @@
-Feature: the disclosure names what this directory decided
-  A run in a directory that has decided something resolves those decisions as the
-  last source of its document, so the summary printed before boot lists their
-  rules the way it lists every other source's: each entry named by the source that
-  decided it, the developer's own ahead of what it overruled. An override nobody
-  intended is visible while the run can still be refused.
+Feature: the disclosure names the source that decided each rule
+  A mixin the user layers on resolves after the sandbox that declares it, so the
+  summary printed before boot lists its rules the way it lists every other
+  source's: each entry named by the source that decided it, the later one ahead
+  of what it overruled. An override nobody intended is visible while the run can
+  still be refused.
 
-  Scenario: a rule this directory decided is listed with the file that decided it
-    Given the sandbox denies "docs.some-vendor.example" and this directory allows it
+  Scenario: a rule a layered mixin decided is listed with the source that decided it
+    Given the sandbox denies "docs.some-vendor.example" and a layered mixin allows it
     When the run summary is composed before boot
-    Then the run summary attributes "allow docs.some-vendor.example" to "lns-local-mixin.yaml"
+    Then the run summary attributes "allow docs.some-vendor.example" to "team-egress.yaml"
     And the run summary attributes "deny docs.some-vendor.example" to "the sandbox"
 
-  Scenario: the decisions file is named among the sources the run resolved
-    Given the sandbox denies "docs.some-vendor.example" and this directory allows it
+  Scenario: the layered mixin is named among the sources the run resolved
+    Given the sandbox denies "docs.some-vendor.example" and a layered mixin allows it
     When the run summary is composed before boot
-    Then the run summary lists "Mixins:    lns-local-mixin.yaml"
+    Then the run summary lists "Mixins:    team-egress.yaml"
 
-  Scenario: a directory that decided nothing has no second author to name
-    Given the sandbox denies "docs.some-vendor.example" and this directory decided nothing
+  Scenario: a run that layered nothing has no second author to name
+    Given the sandbox denies "docs.some-vendor.example" and nothing is layered on it
     When the run summary is composed before boot
     Then the run summary lists "Rules:     deny docs.some-vendor.example"
     And the run summary does not contain "[from"
 
   Scenario: a rule that says why it is in the file says so before boot too
-    Given the sandbox denies "docs.some-vendor.example" and this directory allowed it during a run
+    Given the sandbox denies "docs.some-vendor.example" and a layered mixin allowed it during a run
     When the run summary is composed before boot
-    Then the run summary lists "allow docs.some-vendor.example  [from lns-local-mixin.yaml]  approved during a run"
+    Then the run summary lists "allow docs.some-vendor.example  [from team-egress.yaml]  approved during a run"
 
   Scenario: a rule the sandbox explains says so even where there is no source to name
-    Given the sandbox denies "docs.some-vendor.example" with a note and this directory decided nothing
+    Given the sandbox denies "docs.some-vendor.example" with a note and nothing is layered on it
     When the run summary is composed before boot
     Then the run summary lists "deny docs.some-vendor.example  the vendor mirrors the API here"
     And the run summary does not contain "[from"
+
+  Scenario: the disclosure says where an answer given at a prompt will go
+    Given the sandbox denies "docs.some-vendor.example" and nothing is layered on it
+    When the run summary is composed before boot
+    Then the run summary lists "Decisions: recorded in this run, and removed with it"

--- a/crates/lns-cli/tests/behaviours/run_visibility.feature
+++ b/crates/lns-cli/tests/behaviours/run_visibility.feature
@@ -14,23 +14,12 @@ Feature: users see what `lns run` is doing from the moment they hit Enter
   Scenario: Summary block appears immediately on invocation
     When the command starts
     Then a run summary is printed before any service round-trip
-    And the summary lists Image, Resources, Flags, and a Policy block
+    And the summary lists Image, Resources, Flags, and a Decisions line
     And fields not yet known to the CLI are shown as "(resolving…)"
 
-  Scenario: Policy block answers what and why
-    Given the working directory contains `./lns-local-mixin.yaml`
-    And that policy has 3 allow rules, and 1 deny rule
+  Scenario: the Decisions line says where an answer goes
     When the summary is printed
-    Then the Policy block shows the file path
-    And what happens to a destination no rule names
-    And a one-line rule summary: "3 allow, 1 deny, anything else asks"
-    And the provenance line: "source: found in the project directory"
-
-  Scenario: Auto-created policy is called out in the source line
-    Given no `lns-local-mixin.yaml` exists in the working directory
-    When the run starts
-    Then the Policy block source line reads "auto-created (no policy in the project directory)"
-    And a destination no rule names is "ask"ed
+    Then the Decisions line reads "recorded in this run, and removed with it"
 
   Scenario: Phase lines fill in fields the summary left as placeholders (cold cache)
     Given the image is not in the local cache

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -147,10 +147,19 @@ Feature: managing running sandboxes from the CLI
     And the service received a SaveRun request for run 3 naming the document "agreed"
 
   Scenario: save refuses to overwrite a file that is already there
-    Given "./out.yaml" already exists
+    Given the service renders run 3 as "apiVersion: lns.run/v1\nkind: sandbox\nname: out\n"
+    And "./out.yaml" already exists
     When the user runs sandbox command "save 3 -f ./out.yaml"
     Then the command fails with an exit code other than 0
-    And the output contains "already exists"
+    And the output contains "already exists; not overwriting it"
+    And no document was written
+
+  Scenario: save that cannot write names the file the user has to fix
+    Given the service renders run 3 as "apiVersion: lns.run/v1\nkind: sandbox\nname: out\n"
+    And "./locked/out.yaml" cannot be written
+    When the user runs sandbox command "save 3 -f ./locked/out.yaml"
+    Then the command fails with an exit code other than 0
+    And the output contains "writing ./locked/out.yaml"
     And no document was written
 
   Scenario: save without a file to write to is refused by the grammar

--- a/crates/lns-cli/tests/behaviours/sandbox_cli.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_cli.feature
@@ -93,16 +93,16 @@ Feature: managing running sandboxes from the CLI
     And the output contains "running"
     And the output contains "memMib"
 
-  Scenario: inspect embeds the policy file when it is readable
-    Given the service reports run 3 with policy path "/work/lns-local-mixin.yaml"
+  Scenario: inspect embeds the run's decisions file when it is readable
+    Given the service reports run 3 with policy path "/home/dev/.lns/runs/aa01/decisions.yaml"
     And the policy file parses with one allow rule
     When the user runs sandbox command "inspect 3 --format json"
     Then the exit code is 0
     And the output contains "egress"
-    And the output contains "/work/lns-local-mixin.yaml"
+    And the output contains "/home/dev/.lns/runs/aa01/decisions.yaml"
 
-  Scenario: inspect marks an unreadable policy file instead of failing
-    Given the service reports run 3 with policy path "/work/lns-local-mixin.yaml"
+  Scenario: inspect marks an unreadable decisions file instead of failing
+    Given the service reports run 3 with policy path "/home/dev/.lns/runs/aa01/decisions.yaml"
     When the user runs sandbox command "inspect 3 --format json"
     Then the exit code is 0
     And the output contains "policy file could not be read"
@@ -132,3 +132,34 @@ Feature: managing running sandboxes from the CLI
     Then the exit code is 5
     And the workload stdout contains "live output"
     And the service received an AttachRun request for run 3
+
+  Scenario: save writes the run out as a document at the path the user named
+    Given the service renders run 3 as "apiVersion: lns.run/v1\nkind: sandbox\nname: out\n"
+    When the user runs sandbox command "save 3 -f ./out.yaml"
+    Then the exit code is 0
+    And the document written to "./out.yaml" contains "kind: sandbox"
+    And the output contains "saved sandbox 3"
+
+  Scenario: save names the document after the file it lands in
+    Given the service renders run 3 as "apiVersion: lns.run/v1\nkind: mixin\nname: agreed\n"
+    When the user runs sandbox command "save 3 -f ./agreed.yaml --kind mixin"
+    Then the exit code is 0
+    And the service received a SaveRun request for run 3 naming the document "agreed"
+
+  Scenario: save refuses to overwrite a file that is already there
+    Given "./out.yaml" already exists
+    When the user runs sandbox command "save 3 -f ./out.yaml"
+    Then the command fails with an exit code other than 0
+    And the output contains "already exists"
+    And no document was written
+
+  Scenario: save without a file to write to is refused by the grammar
+    When the grammar is given sandbox command "save 3"
+    Then the exit code is 2
+    And the output contains "--file"
+
+  Scenario: save into a file whose name a document cannot carry is refused
+    When the user runs sandbox command "save 3 -f ./Team_Rules.yaml"
+    Then the command fails with an exit code other than 0
+    And the output contains "lowercase"
+    And no document was written

--- a/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_filesets.rs
@@ -87,12 +87,10 @@ fn local_run_prepared(world: &mut BehaviourWorld) {
     if world.cwd.is_none() {
         world.cwd = Some(tempfile::TempDir::new().expect("create tempdir"));
     }
-    let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut buf,
     )
     .expect("print_run_summary");
@@ -176,12 +174,10 @@ fn pulled_run_prepared(world: &mut BehaviourWorld) {
     if world.cwd.is_none() {
         world.cwd = Some(tempfile::TempDir::new().expect("create tempdir"));
     }
-    let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut buf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_ports.rs
@@ -81,12 +81,10 @@ fn summarize(world: &mut BehaviourWorld, defaults: &Defaults, flags: &str, local
     if world.cwd.is_none() {
         world.cwd = Some(tempfile::TempDir::new().expect("create tempdir"));
     }
-    let cwd = world.cwd.as_ref().expect("cwd").path().to_path_buf();
     let mut buf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut buf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declarative_run.rs
@@ -160,13 +160,7 @@ fn compose_summary(world: &mut BehaviourWorld, defaults: Defaults, flags: &str) 
     let args: RunArgs = parse_args(&argv).expect("override flags must parse");
     let size = lns_cli::run::summary::resolved_size(defaults.size, &args);
     world.resolved_run = Some(ResolvedRunView {
-        summary: lns_cli::run::summary::format_summary(
-            &args,
-            size,
-            &lns_policy::Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &lns_cli::run::summary::PolicySource::Found,
-        ),
+        summary: lns_cli::run::summary::format_summary(&args, size),
         ..Default::default()
     });
 }

--- a/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-cli/tests/behaviours/steps/declared_tools.rs
@@ -143,12 +143,10 @@ fn run_summary_discloses_tools(w: &mut BehaviourWorld) -> Result<(), String> {
     if w.cwd.is_none() {
         w.cwd = Some(tempfile::TempDir::new().map_err(|e| e.to_string())?);
     }
-    let cwd = w.cwd.as_ref().ok_or("cwd")?.path().to_path_buf();
     let mut buf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut buf,
     )
     .map_err(|e| format!("{e:#}"))?;

--- a/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
+++ b/crates/lns-cli/tests/behaviours/steps/definition_selection.rs
@@ -70,22 +70,6 @@ fn request_carries_variant_definition(w: &mut BehaviourWorld, _name: String) -> 
     Ok(())
 }
 
-#[then(regex = r#"^the run reads its decisions from "([^"]+)"$"#)]
-fn run_reads_decisions_from(w: &mut BehaviourWorld, path: String) -> Result<(), String> {
-    let found = w
-        .sandbox_run
-        .decisions
-        .as_ref()
-        .ok_or("the run resolved no decisions file")?;
-    if found != &PathBuf::from(&path) {
-        return Err(format!(
-            "one directory is one project, so a definition somewhere else is governed by the decisions beside it; expected {path}, got {}",
-            found.display()
-        ));
-    }
-    Ok(())
-}
-
 #[then(regex = r#"^the service request roots the bind and fileset at "([^"]+)"$"#)]
 fn request_roots_sources_at(w: &mut BehaviourWorld, dir: String) -> Result<(), String> {
     let value = wire_definition(w)?;

--- a/crates/lns-cli/tests/behaviours/steps/host_bind.rs
+++ b/crates/lns-cli/tests/behaviours/steps/host_bind.rs
@@ -3,8 +3,7 @@ use cucumber::{given, then, when};
 use lns_cli::cli::{RunArgs, split_mounts};
 use lns_cli::command::parse_args;
 use lns_cli::run::host_bind::{DirScan, ResolvedBind, resolve_binds};
-use lns_cli::run::summary::{PolicySource, format_bind_dispositions, format_summary};
-use lns_policy::Policy;
+use lns_cli::run::summary::{format_bind_dispositions, format_summary};
 use lns_policy::decision_store::DecisionStore;
 use lns_policy::host_bind_decisions::{HostBindDecisionFile, SecretDisposition};
 use std::path::Path;
@@ -142,9 +141,6 @@ fn run_resolve(world: &mut BehaviourWorld, flags: &str, interactive: bool) {
             let mut text = format_summary(
                 &args,
                 lns_cli::run::summary::resolved_size(Default::default(), &args),
-                &Policy::default(),
-                Path::new("./lns-local-mixin.yaml"),
-                &PolicySource::Found,
             );
             text.push_str(&format_bind_dispositions(resolved));
             text

--- a/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
+++ b/crates/lns-cli/tests/behaviours/steps/local_decisions.rs
@@ -1,14 +1,11 @@
-use std::path::Path;
-
 use cucumber::{given, then, when};
 use lns_cli::cli::RunArgs;
 use lns_cli::command::parse_args;
-use lns_cli::run::summary::{PolicySource, adopt_pinned_mixins, format_summary, resolved_size};
-use lns_policy::Policy;
+use lns_cli::run::summary::{adopt_pinned_mixins, format_summary, resolved_size};
 
 use crate::world::BehaviourWorld;
 
-/// What the service answers for a directory whose decisions the resolution reached: every egress entry of the merged document, in the order a first-match gate reads them.
+/// What the service answers for a run whose resolution reached a layered mixin: every egress entry of the merged document, in the order a first-match gate reads them.
 fn resolution(w: &mut BehaviourWorld, sources: &[&str], entries: &[(&str, &str)]) {
     w.decisions.sources = sources.iter().map(|s| (*s).to_string()).collect();
     w.decisions.contributions = entries
@@ -23,21 +20,21 @@ fn resolution(w: &mut BehaviourWorld, sources: &[&str], entries: &[(&str, &str)]
         .collect();
 }
 
-#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory allows it$"#)]
-fn the_directory_allows_what_the_sandbox_denies(w: &mut BehaviourWorld, host: String) {
+#[given(regex = r#"^the sandbox denies "([^"]+)" and a layered mixin allows it$"#)]
+fn a_layered_mixin_allows_what_the_sandbox_denies(w: &mut BehaviourWorld, host: String) {
     resolution(
         w,
-        &["lns-local-mixin.yaml"],
+        &["team-egress.yaml"],
         &[
-            (&format!("allow {host}"), "lns-local-mixin.yaml"),
+            (&format!("allow {host}"), "team-egress.yaml"),
             (&format!("deny {host}"), "the sandbox"),
         ],
     );
 }
 
-#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory allowed it during a run$"#)]
-fn the_directory_allowed_it_during_a_run(w: &mut BehaviourWorld, host: String) {
-    the_directory_allows_what_the_sandbox_denies(w, host.clone());
+#[given(regex = r#"^the sandbox denies "([^"]+)" and a layered mixin allowed it during a run$"#)]
+fn a_layered_mixin_allowed_it_during_a_run(w: &mut BehaviourWorld, host: String) {
+    a_layered_mixin_allows_what_the_sandbox_denies(w, host.clone());
     let approved = format!("allow {host}");
     for entry in w
         .decisions
@@ -49,14 +46,14 @@ fn the_directory_allowed_it_during_a_run(w: &mut BehaviourWorld, host: String) {
     }
 }
 
-#[given(regex = r#"^the sandbox denies "([^"]+)" and this directory decided nothing$"#)]
-fn the_directory_decided_nothing(w: &mut BehaviourWorld, host: String) {
+#[given(regex = r#"^the sandbox denies "([^"]+)" and nothing is layered on it$"#)]
+fn nothing_is_layered_on_it(w: &mut BehaviourWorld, host: String) {
     resolution(w, &[], &[(&format!("deny {host}"), "the sandbox")]);
 }
 
-#[given(regex = r#"^the sandbox denies "([^"]+)" with a note and this directory decided nothing$"#)]
+#[given(regex = r#"^the sandbox denies "([^"]+)" with a note and nothing is layered on it$"#)]
 fn the_sandbox_explains_what_it_denies(w: &mut BehaviourWorld, host: String) {
-    the_directory_decided_nothing(w, host);
+    nothing_is_layered_on_it(w, host);
     for entry in w.decisions.contributions.iter_mut() {
         entry.note = Some("the vendor mirrors the API here".to_string());
     }
@@ -73,13 +70,7 @@ fn compose_the_summary(w: &mut BehaviourWorld) {
     let sources = std::mem::take(&mut w.decisions.sources);
     let contributions = std::mem::take(&mut w.decisions.contributions);
     adopt_pinned_mixins(&mut args, &sources, &[], &contributions);
-    w.summary_output = format_summary(
-        &args,
-        resolved_size(Default::default(), &args),
-        &Policy::default(),
-        Path::new("./lns-local-mixin.yaml"),
-        &PolicySource::Found,
-    );
+    w.summary_output = format_summary(&args, resolved_size(Default::default(), &args));
 }
 
 #[then(regex = r#"^the run summary lists "([^"]+)"$"#)]
@@ -98,7 +89,7 @@ fn summary_attributes(w: &mut BehaviourWorld, entry: String, source: String) -> 
         Ok(())
     } else {
         Err(format!(
-            "a rule this directory decided that the disclosure cannot attribute leaves an override nobody intended invisible; expected {needle:?} in:\n{}",
+            "a rule a layered mixin decided that the disclosure cannot attribute leaves an override nobody intended invisible; expected {needle:?} in:\n{}",
             w.summary_output
         ))
     }

--- a/crates/lns-cli/tests/behaviours/steps/run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run.rs
@@ -10,7 +10,6 @@ use lns_cli::service::{
 use lns_ipc::{
     LogLevel, Response, WireFrame, encode_frame, encode_wire_frame, read_frame_bytes_async,
 };
-use lns_policy::{Policy, RouteRule};
 use std::io::Write as _;
 use tokio::io::AsyncWriteExt;
 
@@ -130,14 +129,6 @@ fn emit_started_run_42(world: &mut BehaviourWorld) {
     }
 }
 
-fn require_cwd(world: &BehaviourWorld) -> &std::path::Path {
-    world
-        .cwd
-        .as_ref()
-        .expect("Background did not initialise a working directory")
-        .path()
-}
-
 fn parse_argv(argv: &[String]) -> RunArgs {
     let mut full = vec!["lns".to_string()];
     full.extend(argv.iter().cloned());
@@ -154,29 +145,6 @@ fn user_invokes_lns_run(world: &mut BehaviourWorld, image_and_flags: String) {
 
 #[given(regex = r"^the working directory is `[^`]+`$")]
 fn working_directory_is(_world: &mut BehaviourWorld) {}
-
-#[given(regex = r"^the working directory contains `\./lns-local-mixin\.yaml`$")]
-fn cwd_contains_policy_file(world: &mut BehaviourWorld) {
-    let _ = require_cwd(world);
-}
-
-#[given(regex = r#"^that policy has (\d+) allow rules?, and (\d+) deny rules?$"#)]
-fn that_policy_has(world: &mut BehaviourWorld, allows: usize, denies: usize) {
-    let cwd = require_cwd(world).to_path_buf();
-    let mut policy = Policy::default();
-    for i in 0..allows {
-        policy.add_rule(RouteRule::allow_host(format!("allow-{i}.example")));
-    }
-    for i in 0..denies {
-        policy.add_rule(RouteRule::deny_host(format!("deny-{i}.example")));
-    }
-    policy
-        .save_atomic(&cwd.join("lns-local-mixin.yaml"))
-        .expect("save_atomic");
-}
-
-#[given(regex = r"^no `lns-local-mixin\.yaml` exists in the working directory$")]
-fn no_policy_in_cwd(_world: &mut BehaviourWorld) {}
 
 #[given(regex = r"^the command is `lns run ([^`]+)`$")]
 fn the_command_is(world: &mut BehaviourWorld, args_after_run: String) {
@@ -198,13 +166,11 @@ fn the_command_is(world: &mut BehaviourWorld, args_after_run: String) {
 
 #[when(regex = r"^(?:the command starts|the summary is printed|the run starts)$")]
 async fn the_run_starts(world: &mut BehaviourWorld) {
-    let cwd = require_cwd(world).to_path_buf();
     let args = parse_argv(&world.argv);
     let mut buf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut buf,
     )
     .expect("print_run_summary");
@@ -259,9 +225,9 @@ fn summary_is_printed(world: &mut BehaviourWorld) -> Result<(), String> {
     }
 }
 
-#[then(regex = r"^the summary lists Image, Resources, Flags, and a Policy block$")]
+#[then(regex = r"^the summary lists Image, Resources, Flags, and a Decisions line$")]
 fn summary_lists_all_fields(world: &mut BehaviourWorld) -> Result<(), String> {
-    for label in ["Image:", "Resources:", "Flags:", "Policy:"] {
+    for label in ["Image:", "Resources:", "Flags:", "Decisions:"] {
         if !world.summary_output.contains(label) {
             return Err(format!("missing {label} in:\n{}", world.summary_output));
         }
@@ -281,69 +247,9 @@ fn resolving_placeholder_present(world: &mut BehaviourWorld) -> Result<(), Strin
     }
 }
 
-#[then(regex = r"^the Policy block shows the file path$")]
-fn policy_block_shows_file_path(world: &mut BehaviourWorld) -> Result<(), String> {
-    let cwd = require_cwd(world);
-    let expected = cwd.join("lns-local-mixin.yaml");
-    let needle = format!("file: {}", expected.display());
-    if world.summary_output.contains(&needle) {
-        Ok(())
-    } else {
-        Err(format!("missing {needle:?} in:\n{}", world.summary_output))
-    }
-}
-
-#[then(regex = r"^what happens to a destination no rule names$")]
-fn unmatched_line_present(world: &mut BehaviourWorld) -> Result<(), String> {
-    if world.summary_output.contains("unmatched destinations: ask") {
-        Ok(())
-    } else {
-        Err(format!(
-            "missing `unmatched destinations:` line in:\n{}",
-            world.summary_output
-        ))
-    }
-}
-
-#[then(regex = r#"^a one-line rule summary: "([^"]+)"$"#)]
-fn rule_summary_is(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
-    if world.summary_output.contains(&expected) {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected rule summary {expected:?} in:\n{}",
-            world.summary_output
-        ))
-    }
-}
-
-#[then(regex = r#"^the provenance line: "([^"]+)"$"#)]
-fn provenance_line_is(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
-    if world.summary_output.contains(&expected) {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected provenance {expected:?} in:\n{}",
-            world.summary_output
-        ))
-    }
-}
-
-#[then(regex = r#"^the Policy block source line reads "([^"]+)"$"#)]
-fn source_line_reads(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
-    if world.summary_output.contains(&expected) {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected source line {expected:?} in:\n{}",
-            world.summary_output
-        ))
-    }
-}
-
-#[then(regex = r#"^a destination no rule names is "([^"]+)"ed$"#)]
-fn unmatched_destination_is(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
-    let needle = format!("unmatched destinations: {expected}");
+#[then(regex = r#"^the Decisions line reads "([^"]+)"$"#)]
+fn decisions_line_reads(world: &mut BehaviourWorld, expected: String) -> Result<(), String> {
+    let needle = format!("Decisions: {expected}");
     if world.summary_output.contains(&needle) {
         Ok(())
     } else {
@@ -494,13 +400,11 @@ fn image_cannot_be_resolved(_world: &mut BehaviourWorld) {}
 
 #[when(regex = r"^resolution fails$")]
 async fn resolution_fails(world: &mut BehaviourWorld) {
-    let cwd = require_cwd(world).to_path_buf();
     let args = parse_argv(&world.argv);
     let mut sbuf = Vec::<u8>::new();
     print_run_summary(
         &args,
         lns_cli::run::summary::resolved_size(Default::default(), &args),
-        &cwd,
         &mut sbuf,
     )
     .expect("print_run_summary");

--- a/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
+++ b/crates/lns-cli/tests/behaviours/steps/run_config_defaults.rs
@@ -3,9 +3,7 @@ use cucumber::{then, when};
 use lns_cli::cli::RunArgs;
 use lns_cli::command::parse_args;
 use lns_cli::config;
-use lns_cli::run::summary::{PolicySource, format_summary};
-use lns_policy::Policy;
-use std::path::Path;
+use lns_cli::run::summary::format_summary;
 
 fn config_path(world: &mut BehaviourWorld) -> std::path::PathBuf {
     if world.cwd.is_none() {
@@ -26,9 +24,6 @@ fn resolve_run_against_defaults(world: &mut BehaviourWorld, image_and_flags: Str
         summary: format_summary(
             &resolved,
             lns_cli::run::summary::resolved_size(Default::default(), &resolved),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
         ),
         mixins: resolved.mixins.clone(),
         ..Default::default()
@@ -79,9 +74,6 @@ fn compose_declared_summary_against_defaults(world: &mut BehaviourWorld, flags: 
         summary: format_summary(
             &resolved,
             lns_cli::run::summary::resolved_size(declared.size, &resolved),
-            &Policy::default(),
-            Path::new("./lns-local-mixin.yaml"),
-            &PolicySource::Found,
         ),
         ..Default::default()
     });

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -33,6 +33,7 @@ pub(crate) struct FakeSandboxService {
     requests: Arc<Mutex<Vec<Request>>>,
     /// Layer 2 writes no files, so a saved document lands here for the scenario to read.
     existing_documents: Vec<PathBuf>,
+    unwritable_documents: Vec<PathBuf>,
     written_documents: Arc<Mutex<Vec<(PathBuf, String)>>>,
 }
 
@@ -125,11 +126,13 @@ impl SandboxService for FakeSandboxService {
         self.policy.clone()
     }
 
-    fn document_exists(&self, path: &Path) -> bool {
-        self.existing_documents.iter().any(|p| p == path)
-    }
-
     fn write_document(&self, path: &Path, contents: &str) -> std::io::Result<()> {
+        if self.existing_documents.iter().any(|p| p == path) {
+            return Err(std::io::Error::from(std::io::ErrorKind::AlreadyExists));
+        }
+        if self.unwritable_documents.iter().any(|p| p == path) {
+            return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        }
         self.written_documents
             .lock()
             .expect("lock")
@@ -553,6 +556,7 @@ pub(crate) fn fake_sandbox_service(w: &BehaviourWorld) -> FakeSandboxService {
         policy: w.sandbox.policy.clone(),
         requests: w.sandbox.requests.clone(),
         existing_documents: w.sandbox.existing_documents.clone(),
+        unwritable_documents: w.sandbox.unwritable_documents.clone(),
         written_documents: w.sandbox.written_documents.clone(),
     }
 }
@@ -802,6 +806,11 @@ fn canned_saved_document(w: &mut BehaviourWorld, _run_id: u32, document: String)
 #[given(regex = r#"^"([^"]+)" already exists$"#)]
 fn document_already_exists(w: &mut BehaviourWorld, path: String) {
     w.sandbox.existing_documents.push(PathBuf::from(path));
+}
+
+#[given(regex = r#"^"([^"]+)" cannot be written$"#)]
+fn document_cannot_be_written(w: &mut BehaviourWorld, path: String) {
+    w.sandbox.unwritable_documents.push(PathBuf::from(path));
 }
 
 #[then(regex = r#"^the document written to "([^"]+)" contains "([^"]+)"$"#)]

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -31,6 +31,9 @@ pub(crate) struct FakeSandboxService {
     unreachable: bool,
     policy: Option<serde_json::Value>,
     requests: Arc<Mutex<Vec<Request>>>,
+    /// Layer 2 writes no files, so a saved document lands here for the scenario to read.
+    existing_documents: Vec<PathBuf>,
+    written_documents: Arc<Mutex<Vec<(PathBuf, String)>>>,
 }
 
 impl SandboxService for FakeSandboxService {
@@ -120,6 +123,18 @@ impl SandboxService for FakeSandboxService {
 
     fn load_policy(&self, _path: &str) -> Option<serde_json::Value> {
         self.policy.clone()
+    }
+
+    fn document_exists(&self, path: &Path) -> bool {
+        self.existing_documents.iter().any(|p| p == path)
+    }
+
+    fn write_document(&self, path: &Path, contents: &str) -> std::io::Result<()> {
+        self.written_documents
+            .lock()
+            .expect("lock")
+            .push((path.to_path_buf(), contents.to_string()));
+        Ok(())
     }
 }
 
@@ -537,12 +552,32 @@ pub(crate) fn fake_sandbox_service(w: &BehaviourWorld) -> FakeSandboxService {
         unreachable: w.sandbox.unreachable,
         policy: w.sandbox.policy.clone(),
         requests: w.sandbox.requests.clone(),
+        existing_documents: w.sandbox.existing_documents.clone(),
+        written_documents: w.sandbox.written_documents.clone(),
     }
 }
 
 #[when(regex = r#"^the user runs sandbox command "([^"]+)"$"#)]
 async fn run_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
     drive_sandbox_command(w, &cmd).await;
+}
+
+/// A verb the grammar turns away never reaches the service, so the scenario reads the parse refusal rather than a response.
+#[when(regex = r#"^the grammar is given sandbox command "([^"]+)"$"#)]
+fn parse_sandbox_command(w: &mut BehaviourWorld, cmd: String) {
+    let mut argv: Vec<&str> = vec!["lns", "sandbox"];
+    argv.extend(cmd.split_whitespace());
+    let parsed: Result<SandboxArgs, _> = parse_args(&argv);
+    w.result = Some(match parsed {
+        Ok(_) => CliRun {
+            exit_code: 0,
+            output: String::new(),
+        },
+        Err(e) => CliRun {
+            exit_code: 2,
+            output: e.to_string(),
+        },
+    });
 }
 
 pub(crate) async fn drive_sandbox_command(w: &mut BehaviourWorld, cmd: &str) {
@@ -754,6 +789,62 @@ fn then_logs_request(w: &mut BehaviourWorld, run_id: u32, mode: String) -> Resul
         Ok(())
     } else {
         Err(format!("expected {expected:?} among {requests:?}"))
+    }
+}
+
+#[given(regex = r#"^the service renders run (\d+) as "([^"]*)"$"#)]
+fn canned_saved_document(w: &mut BehaviourWorld, _run_id: u32, document: String) {
+    w.sandbox.response = Some(Response::RunSaved {
+        document: document.replace("\\n", "\n"),
+    });
+}
+
+#[given(regex = r#"^"([^"]+)" already exists$"#)]
+fn document_already_exists(w: &mut BehaviourWorld, path: String) {
+    w.sandbox.existing_documents.push(PathBuf::from(path));
+}
+
+#[then(regex = r#"^the document written to "([^"]+)" contains "([^"]+)"$"#)]
+fn then_document_written(
+    w: &mut BehaviourWorld,
+    path: String,
+    needle: String,
+) -> Result<(), String> {
+    let written = w.sandbox.written_documents.lock().expect("lock");
+    let target = PathBuf::from(&path);
+    match written.iter().find(|(p, _)| *p == target) {
+        Some((_, contents)) if contents.contains(&needle) => Ok(()),
+        Some((_, contents)) => Err(format!("expected {needle:?} in:\n{contents}")),
+        None => Err(format!("nothing was written to {path}; got {written:?}")),
+    }
+}
+
+#[then("no document was written")]
+fn then_no_document_written(w: &mut BehaviourWorld) -> Result<(), String> {
+    let written = w.sandbox.written_documents.lock().expect("lock");
+    if written.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "a refused save that still wrote would destroy the file it refused to overwrite; got {written:?}"
+        ))
+    }
+}
+
+#[then(
+    regex = r#"^the service received a SaveRun request for run (\d+) naming the document "([^"]+)"$"#
+)]
+fn then_save_request(w: &mut BehaviourWorld, run_id: u32, name: String) -> Result<(), String> {
+    let requests = w.sandbox.requests.lock().expect("lock");
+    let matched = requests.iter().any(|r| {
+        matches!(r, Request::SaveRun { run, name: n, .. } if run == &run_id.to_string() && n == &name)
+    });
+    if matched {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected a SaveRun naming {name:?} among {requests:?}"
+        ))
     }
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_run.rs
@@ -199,11 +199,11 @@ fn drive_run(w: &mut BehaviourWorld, argv: &[String]) {
                 output: format!("{e:#}"),
             });
         }
-        Ok(target) => run_resolved(w, &target, cwd),
+        Ok(target) => run_resolved(w, &target),
     }
 }
 
-fn run_resolved(w: &mut BehaviourWorld, target: &RunTarget, cwd: &Path) {
+fn run_resolved(w: &mut BehaviourWorld, target: &RunTarget) {
     if let Some(refusal) = w.sandbox_run.refusal.clone() {
         w.result = Some(surface_service_refusal(&refusal));
         return;
@@ -212,9 +212,6 @@ fn run_resolved(w: &mut BehaviourWorld, target: &RunTarget, cwd: &Path) {
     w.sandbox_run.verify_sandbox = Some(target.verify_sandbox());
     w.sandbox_run.definition = target.definition_json();
     w.sandbox_run.project_dir = target.project_dir().map(Path::to_path_buf);
-    w.sandbox_run.decisions = Some(lns_cli::run::summary::policy_path(
-        target.project_dir().unwrap_or(cwd),
-    ));
     w.result = Some(CliRun {
         exit_code: 0,
         output: String::new(),

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -244,6 +244,7 @@ pub struct SandboxCliRig {
     pub policy: Option<serde_json::Value>,
     pub requests: std::sync::Arc<std::sync::Mutex<Vec<lns_ipc::Request>>>,
     pub existing_documents: Vec<std::path::PathBuf>,
+    pub unwritable_documents: Vec<std::path::PathBuf>,
     pub written_documents: std::sync::Arc<std::sync::Mutex<Vec<(std::path::PathBuf, String)>>>,
     pub workload_stdout: Vec<u8>,
     pub prompt_answer: Option<String>,

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -219,7 +219,6 @@ pub struct SandboxRunRig {
     pub verify_sandbox: Option<bool>,
     pub definition: Option<String>,
     pub project_dir: Option<std::path::PathBuf>,
-    pub decisions: Option<std::path::PathBuf>,
     pub refusal: Option<String>,
 }
 
@@ -244,6 +243,8 @@ pub struct SandboxCliRig {
     pub unreachable: bool,
     pub policy: Option<serde_json::Value>,
     pub requests: std::sync::Arc<std::sync::Mutex<Vec<lns_ipc::Request>>>,
+    pub existing_documents: Vec<std::path::PathBuf>,
+    pub written_documents: std::sync::Arc<std::sync::Mutex<Vec<(std::path::PathBuf, String)>>>,
     pub workload_stdout: Vec<u8>,
     pub prompt_answer: Option<String>,
     pub terminal_available: bool,

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -27,10 +27,10 @@ pub use protocol::{
     ImageInfo, ImageView, LogLevel, MixinView, MountSpec, PackedFilesetSource, PortPublish,
     Protocol, RegistryLoginSummary, Request, Response, RunConfig, RunDetails, RunImageArgs,
     RunStatsInfo, RunStatus, RunSummary, SandboxFileset, SandboxFilesetOwner, SandboxMount,
-    SandboxMountKind, SandboxPort, SandboxScript, SandboxView, SecretValues, SessionTarget,
-    SignalKind, SourceContribution, StatusInfo, VolumeInfo, VolumeMount, VolumePruneFailure,
-    cmdline_unsafe_char, validate_bind_source, validate_run_name, validate_volume_name,
-    validate_volume_target,
+    SandboxMountKind, SandboxPort, SandboxScript, SandboxView, SaveKind, SecretValues,
+    SessionTarget, SignalKind, SourceContribution, StatusInfo, VolumeInfo, VolumeMount,
+    VolumePruneFailure, cmdline_unsafe_char, validate_bind_source, validate_run_name,
+    validate_volume_name, validate_volume_target,
 };
 pub use socket::{SocketPathError, default_socket_path};
 pub use update::{NO_UPDATE_CHECK_ENV, UpdateStatus};

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -70,6 +70,13 @@ pub enum Request {
         run: String,
         new_name: String,
     },
+    /// Render one run as a document the user keeps; the service owns the run's state, and the caller owns the file it lands in.
+    SaveRun {
+        run: String,
+        kind: SaveKind,
+        /// The `name` the rendered document carries, which the caller takes from the file it will write.
+        name: String,
+    },
     PruneRuns,
     ListVolumes,
     CreateVolume {
@@ -99,18 +106,12 @@ pub enum Request {
         project_dir: String,
         #[serde(default)]
         mixins: Vec<String>,
-        /// The decisions file this run reads, so what the preflight resolves is what the boot resolves.
-        #[serde(default)]
-        decisions: Option<String>,
     },
     InspectImage {
         image: String,
         /// The mixin references the user named on the command line, in flag order, so the preflight describes the document that will boot.
         #[serde(default)]
         mixins: Vec<String>,
-        /// The decisions file this run reads, absent when the question is about the artifact rather than about a run in some directory.
-        #[serde(default)]
-        decisions: Option<String>,
     },
     TagImage {
         from: String,
@@ -226,6 +227,9 @@ pub enum Response {
     RunStats {
         stats: RunStatsInfo,
     },
+    RunSaved {
+        document: String,
+    },
     RunsPruned {
         removed: Vec<String>,
     },
@@ -285,7 +289,7 @@ pub enum Response {
         /// Which source decided each entry of the merged document, so the disclosure can attribute every line it shows.
         #[serde(default)]
         contributions: Vec<SourceContribution>,
-        /// The egress every source but this directory's own decided, as JSON: the run folds the live decisions file over it rather than over the copy the merged document carries, so a rule deleted mid-run retracts.
+        /// The egress every document source decided, as JSON: the run folds the live decisions file over it rather than over the copy the merged document carries, so a rule deleted mid-run retracts.
         #[serde(default)]
         authored_egress: String,
         /// Which artifact carries each packed fileset the merge reached; the merged document alone cannot say, since a mixin's entry is a layer of the mixin's own artifact.
@@ -692,6 +696,7 @@ pub struct RunDetails {
 pub struct RunConfig {
     pub cpus: u8,
     pub mem_mib: usize,
+    /// The run's own decisions file, filled in by the service from the run's directory; a caller never names it.
     pub policy_path: Option<String>,
     pub sandbox_user: Option<String>,
     pub sandbox_uid: Option<u32>,
@@ -716,7 +721,7 @@ impl RunConfig {
         Self {
             cpus: args.cpus,
             mem_mib: args.mem,
-            policy_path: args.policy_path.clone(),
+            policy_path: None,
             sandbox_user: args.sandbox_user.clone(),
             sandbox_uid: args.sandbox_uid,
             entrypoint: args.entrypoint.clone(),
@@ -779,7 +784,6 @@ pub struct RunImageArgs {
     pub cpus_config: Option<u8>,
     #[serde(default)]
     pub mem_config: Option<usize>,
-    pub policy_path: Option<String>,
     #[serde(default)]
     pub sandbox_user: Option<String>,
     #[serde(default)]
@@ -819,7 +823,7 @@ pub struct RunImageArgs {
     /// The local definition's absolute directory; absent for a published reference, which the service resolves by repo@digest instead.
     #[serde(default)]
     pub definition_dir: Option<String>,
-    /// What the preflight resolved from every source but this directory's own, as JSON egress: the gate folds the live decisions file over it, so a rule deleted mid-run retracts. Absent when the definition is the only source there was, and unread for a published reference (which the service resolves itself).
+    /// What the preflight resolved from every document source, as JSON egress: the gate folds the run's live decisions file over it, so a rule deleted mid-run retracts. Absent when the definition is the only source there was, and unread for a published reference (which the service resolves itself).
     #[serde(default)]
     pub authored_egress: Option<String>,
     /// Which artifact carries each of the merged definition's packed filesets, as the resolve answered; a published reference is peeked at boot and needs none of this.
@@ -1062,6 +1066,14 @@ pub struct ExecImageArgs {
     pub stdin: bool,
     #[serde(default)]
     pub initial_winsize: Option<(u16, u16)>,
+}
+
+/// Which document `SaveRun` renders: the run as a whole, or only what it decided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SaveKind {
+    Sandbox,
+    Mixin,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1374,7 +1386,6 @@ mod tests {
             mem_explicit: false,
             cpus_config: None,
             mem_config: None,
-            policy_path: None,
             sandbox_user: Some("sandbox".into()),
             sandbox_uid: Some(65534),
             entrypoint: None,
@@ -1417,7 +1428,6 @@ mod tests {
             mem_explicit: false,
             cpus_config: None,
             mem_config: None,
-            policy_path: None,
             sandbox_user: None,
             sandbox_uid: None,
             entrypoint: None,
@@ -1562,7 +1572,6 @@ mod tests {
             mem_explicit: true,
             cpus_config: None,
             mem_config: None,
-            policy_path: Some("/work/lns-local-mixin.yaml".into()),
             sandbox_user: Some("sandbox".into()),
             sandbox_uid: Some(65534),
             entrypoint: Some("/bin/sh".into()),
@@ -1611,8 +1620,8 @@ mod tests {
         assert_eq!(config.cpus, 2);
         assert_eq!(config.mem_mib, 1024);
         assert_eq!(
-            config.policy_path.as_deref(),
-            Some("/work/lns-local-mixin.yaml")
+            config.policy_path, None,
+            "a run's decisions file is the service's to name from the run's own directory, so a caller's launch args must not carry one"
         );
         assert_eq!(config.sandbox_user.as_deref(), Some("sandbox"));
         assert_eq!(config.entrypoint.as_deref(), Some("/bin/sh"));
@@ -1899,7 +1908,6 @@ mod tests {
         let req = Request::InspectImage {
             image: "registry.example.test/team/sandbox:1".into(),
             mixins: vec!["ghcr.io/acme/obs-tools:2".into()],
-            decisions: Some("/work/lns-local-mixin.yaml".into()),
         };
         let frame = crate::encode_frame(&req).unwrap();
         let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -434,7 +434,8 @@ impl Policy {
         Ok(policy)
     }
 
-    pub fn save_atomic(&self, path: &Path) -> io::Result<()> {
+    /// The `mixin` document this policy is, named for the file it will be read from when it carries no name of its own.
+    pub fn document_bytes(&self, path: &Path) -> io::Result<Vec<u8>> {
         let document = LocalMixinDocument {
             api_version: API_VERSION.to_string(),
             kind: KIND.to_string(),
@@ -444,9 +445,13 @@ impl Policy {
                 rest: self.rest.clone(),
             },
         };
-        let yaml = serde_yaml::to_string(&document)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        crate::secure_file::write_yaml_document_atomic(path, yaml.as_bytes())
+        serde_yaml::to_string(&document)
+            .map(String::into_bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    pub fn save_atomic(&self, path: &Path) -> io::Result<()> {
+        crate::secure_file::write_yaml_document_atomic(path, &self.document_bytes(path)?)
     }
 
     pub fn add_rule(&mut self, rule: RouteRule) {

--- a/crates/lns-policy/src/lib.rs
+++ b/crates/lns-policy/src/lib.rs
@@ -35,7 +35,7 @@ pub struct NetworkPolicy {
     pub egress: Egress,
 }
 
-/// The document format every artifact is written in (`docs/sandbox-spec.md` §2), which the directory's own decisions are written in too.
+/// The document format every artifact is written in (`docs/sandbox-spec.md` §2), which a run's own decisions are written in too.
 pub const API_VERSION: &str = "lns.run/v1";
 
 /// The kind §8.1 records a decision as, so it merges under the same rules as anything the developer pulled.
@@ -660,13 +660,11 @@ mod tests {
 
     /// Write a decisions file whose spec holds the given blocks, so a fixture states the one thing it is about.
     fn decisions_file(dir: &TempDir, spec: &str) -> PathBuf {
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let body: String = spec.lines().map(|line| format!("  {line}\n")).collect();
         fs::write(
             &path,
-            format!(
-                "apiVersion: {API_VERSION}\nkind: {KIND}\nname: lns-local-mixin\nspec:\n{body}"
-            ),
+            format!("apiVersion: {API_VERSION}\nkind: {KIND}\nname: decisions\nspec:\n{body}"),
         )
         .unwrap();
         path
@@ -1547,7 +1545,7 @@ egress:
     #[test]
     fn save_atomic_writes_file_readable_by_load_or_default() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("api.linear.app"));
 
@@ -1559,7 +1557,7 @@ egress:
     #[test]
     fn save_atomic_creates_parent_directory() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("nested/dir/lns-local-mixin.yaml");
+        let path = dir.path().join("nested/dir/decisions.yaml");
         Policy::default().save_atomic(&path).unwrap();
         assert!(path.exists());
     }
@@ -1567,7 +1565,7 @@ egress:
     #[test]
     fn save_atomic_leaves_no_tmp_file_on_success() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         Policy::default().save_atomic(&path).unwrap();
         let tmp = path.with_extension("yaml.tmp");
         assert!(!tmp.exists(), "tmp file should be renamed away");
@@ -1618,7 +1616,7 @@ egress:
         let victim = dir.path().join("victim");
         let victim_contents = b"victim-data-must-survive";
         fs::write(&victim, victim_contents).unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         std::os::unix::fs::symlink(&victim, path.with_extension("yaml.tmp")).unwrap();
 
         let _ = Policy::default().save_atomic(&path);
@@ -1636,7 +1634,7 @@ egress:
         let dir = TempDir::new().unwrap();
         let reference = dir.path().join("reference");
         fs::write(&reference, b"").unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
 
         Policy::default().save_atomic(&path).unwrap();
 
@@ -1653,7 +1651,7 @@ egress:
     #[test]
     fn file_policy_store_save_writes_yaml_readable_by_load_or_default() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let store = FilePolicyStore::new(path.clone());
 
         let mut p = Policy::default();
@@ -1669,7 +1667,7 @@ egress:
         let dir = TempDir::new().unwrap();
         let unwritable = dir.path().join("file-not-a-dir");
         fs::write(&unwritable, b"").unwrap();
-        let path = unwritable.join("nested/lns-local-mixin.yaml");
+        let path = unwritable.join("nested/decisions.yaml");
         let store = FilePolicyStore::new(path);
 
         let err = store.save(&Policy::default()).unwrap_err();
@@ -1722,7 +1720,7 @@ egress:
     #[test]
     fn the_decisions_file_is_the_mixin_the_specification_says_it_is() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let mut p = Policy::default();
         p.add_rule(RouteRule::allow_host("docs.some-vendor.example"));
         p.save_atomic(&path).unwrap();
@@ -1746,12 +1744,12 @@ egress:
     #[test]
     fn the_document_is_named_for_the_file_it_is_written_to() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         Policy::default().save_atomic(&path).unwrap();
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("name: lns-local-mixin"),
+                .contains("name: decisions"),
             "§2 requires a name on every document, and nobody is here to choose one"
         );
     }
@@ -1800,10 +1798,10 @@ egress:
     #[test]
     fn a_block_the_run_never_writes_survives_the_run_writing_one_it_does() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         fs::write(
             &path,
-            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  mixins:\n    - ghcr.io/team/base@sha256:abc\n  egress:\n    http: []\n",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  mixins:\n    - ghcr.io/team/base@sha256:abc\n  egress:\n    http: []\n",
         )
         .unwrap();
 
@@ -1822,7 +1820,7 @@ egress:
     #[test]
     fn a_document_of_another_kind_is_refused_rather_than_read_as_decisions() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         fs::write(
             &path,
             "apiVersion: lns.run/v1\nkind: sandbox\nname: something-else\nspec:\n  egress:\n    http: []\n",
@@ -1839,7 +1837,7 @@ egress:
     #[test]
     fn a_document_named_what_no_document_may_be_named_is_refused() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         fs::write(
             &path,
             "apiVersion: lns.run/v1\nkind: mixin\nname: Not_A_Label!\nspec:\n  egress:\n    http: []\n",
@@ -1855,7 +1853,7 @@ egress:
 
     #[test]
     fn a_name_is_a_label_or_it_is_not_a_name() {
-        for valid in ["a", "9", "lns-local-mixin", &"a".repeat(63)] {
+        for valid in ["a", "9", "team-egress", &"a".repeat(63)] {
             assert!(is_dns_label(valid), "{valid} is a label");
         }
         for invalid in ["", "-a", "a-", "aBc", "a_b", "a.b", &"a".repeat(64)] {
@@ -1866,7 +1864,7 @@ egress:
     #[test]
     fn a_document_of_another_api_version_is_refused() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         fs::write(
             &path,
             "apiVersion: lns.run/v2\nkind: mixin\nname: local\nspec:\n  egress:\n    http: []\n",
@@ -1880,7 +1878,7 @@ egress:
     #[test]
     fn an_empty_file_is_the_mixin_nobody_wrote() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         fs::write(&path, "  \n").unwrap();
         assert_eq!(
             Policy::load_or_default(&path).unwrap().network,

--- a/crates/lns-policy/src/registry_auth.rs
+++ b/crates/lns-policy/src/registry_auth.rs
@@ -1,4 +1,4 @@
-//! Registry logins live in `~/.lns/registry-auth.json`, not `lns-local-mixin.yaml`, to keep the shareable policy file free of per-machine secrets.
+//! Registry logins live in `~/.lns/registry-auth.json`, not a run's `decisions.yaml`, to keep a document that can be saved and shared free of per-machine secrets.
 
 use std::collections::HashMap;
 use std::fs;

--- a/crates/lns-service/Cargo.toml
+++ b/crates/lns-service/Cargo.toml
@@ -75,7 +75,7 @@ tracing            = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "ansi"] }
 anstyle = "1"
 
-# Approval-flow deps. serde_yaml: lns-local-mixin.yaml load/save. notify:
+# Approval-flow deps. serde_yaml: decisions.yaml load/save. notify:
 # filesystem watcher for hot-swap on manual policy edits. The
 # approval UI itself is rendered by the eframe/egui setup above —
 # no HTTP stack is involved.

--- a/crates/lns-service/src/approval_flow/protocol.rs
+++ b/crates/lns-service/src/approval_flow/protocol.rs
@@ -21,7 +21,7 @@ pub enum GuestFrame {
     Other,
 }
 
-/// The verdict the guest gate accepts. `ask` is one no document may write — `lns_policy::Verdict` stays two-valued so it cannot reach `lns-local-mixin.yaml` — but the gate has always taken it, and it is how a served destination is held (sandbox-spec §3.2.1).
+/// The verdict the guest gate accepts. `ask` is one no document may write — `lns_policy::Verdict` stays two-valued so it cannot reach a run's `decisions.yaml` — but the gate has always taken it, and it is how a served destination is held (sandbox-spec §3.2.1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WireVerdict {

--- a/crates/lns-service/src/approval_flow/watcher.rs
+++ b/crates/lns-service/src/approval_flow/watcher.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_modify_on_target_path() {
-        let target = Path::new("/tmp/lns-local-mixin.yaml");
+        let target = Path::new("/tmp/runs/aa01/decisions.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Modify(ModifyKind::Any), target),
             target
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_create_on_target_path() {
-        let target = Path::new("/tmp/lns-local-mixin.yaml");
+        let target = Path::new("/tmp/runs/aa01/decisions.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Create(CreateKind::Any), target),
             target
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_accepts_remove_on_target_path() {
-        let target = Path::new("/tmp/lns-local-mixin.yaml");
+        let target = Path::new("/tmp/runs/aa01/decisions.yaml");
         assert!(is_policy_change(
             &evt(EventKind::Remove(RemoveKind::Any), target),
             target
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_rejects_event_on_sibling_path() {
-        let target = Path::new("/tmp/lns-local-mixin.yaml");
+        let target = Path::new("/tmp/runs/aa01/decisions.yaml");
         let sibling = Path::new("/tmp/something-else.yaml");
         assert!(!is_policy_change(
             &evt(EventKind::Modify(ModifyKind::Any), sibling),
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn is_policy_change_rejects_uninteresting_event_kinds() {
-        let target = Path::new("/tmp/lns-local-mixin.yaml");
+        let target = Path::new("/tmp/runs/aa01/decisions.yaml");
         assert!(!is_policy_change(
             &evt(EventKind::Access(notify::event::AccessKind::Any), target),
             target
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn spawn_returns_ok_for_existing_parent_dir() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         Policy::default().save_atomic(&path).unwrap();
 
         let notifier = Arc::new(crate::approval_flow::session::tests::RecordingNotifier::default());
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn spawn_with_path_that_has_no_parent_uses_cwd() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         Policy::default().save_atomic(&path).unwrap();
 
         let notifier = Arc::new(crate::approval_flow::session::tests::RecordingNotifier::default());
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn event_handler_closure_reloads_policy_on_matching_event() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let mut updated = Policy::default();
         updated.add_rule(RouteRule::allow_host("api.linear.app"));
         updated.save_atomic(&path).unwrap();
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn handle_event_for_matching_modify_reloads_and_applies_policy() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let mut updated = Policy::default();
         updated.add_rule(RouteRule::allow_host("api.linear.app"));
         updated.save_atomic(&path).unwrap();
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn handle_event_for_unrelated_path_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let target = dir.path().join("lns-local-mixin.yaml");
+        let target = dir.path().join("decisions.yaml");
         let sibling = dir.path().join("other.yaml");
         Policy::default().save_atomic(&target).unwrap();
 
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn handle_event_with_notify_error_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         let (session, mut rx) = make_session();
 
         handle_event(
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn handle_event_with_malformed_policy_file_is_a_noop() {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("lns-local-mixin.yaml");
+        let path = dir.path().join("decisions.yaml");
         std::fs::write(&path, "this is: not\n  - a: valid\npolicy: [").unwrap();
         let (session, mut rx) = make_session();
 

--- a/crates/lns-service/src/artifact/mixin.rs
+++ b/crates/lns-service/src/artifact/mixin.rs
@@ -1361,7 +1361,7 @@ mod tests {
     fn a_decisions_file_that_is_no_mixin_refuses_the_run_naming_the_file() {
         let err = LocalSource::read(
             Some(FetchedMixin {
-                pinned: "lns-local-mixin.yaml".to_string(),
+                pinned: "decisions.yaml".to_string(),
                 document: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"x","spec":{"image":"x:1"}}"#.to_string(),
                 layers: Vec::new(),
             }),
@@ -1369,7 +1369,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            format!("{err:#}").contains("lns-local-mixin.yaml"),
+            format!("{err:#}").contains("decisions.yaml"),
             "a run that dropped a decisions file it could not read would boot without what the developer decided; got: {err:#}"
         );
     }
@@ -1378,8 +1378,8 @@ mod tests {
     fn a_directory_that_decided_only_destinations_is_still_a_source_of_the_merge() {
         let local = LocalSource::read(
             Some(FetchedMixin {
-                pinned: "lns-local-mixin.yaml".to_string(),
-                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#.to_string(),
+                pinned: "decisions.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{"egress":{"http":[{"match":"api.example.test","verdict":"allow"}]}}}"#.to_string(),
                 layers: Vec::new(),
             }),
             decided_in("/work/lns.yaml"),
@@ -1396,9 +1396,9 @@ mod tests {
     fn decided(spec: &str) -> Option<LocalSource> {
         LocalSource::read(
             Some(FetchedMixin {
-                pinned: "lns-local-mixin.yaml".to_string(),
+                pinned: "decisions.yaml".to_string(),
                 document: format!(
-                    r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{spec}}}"#
+                    r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{spec}}}"#
                 ),
                 layers: Vec::new(),
             }),
@@ -1442,7 +1442,7 @@ mod tests {
                 .map(|c| (c.key.as_str(), c.source.as_str()))
                 .collect::<Vec<_>>(),
             [
-                ("allow docs.some-vendor.example", "lns-local-mixin.yaml"),
+                ("allow docs.some-vendor.example", "decisions.yaml"),
                 (
                     "deny docs.some-vendor.example",
                     lns_artifact::merge::ROOT_LABEL
@@ -1452,7 +1452,7 @@ mod tests {
         );
         assert_eq!(
             out.mixins,
-            ["lns-local-mixin.yaml"],
+            ["decisions.yaml"],
             "a source the run merged is one the disclosure names"
         );
     }
@@ -1533,11 +1533,11 @@ mod tests {
         let source = Fake::new(&[("/decisions/tools", r#"{"tools":["ripgrep@14"]}"#)]);
         let local = LocalSource::read(
             Some(FetchedMixin {
-                pinned: "lns-local-mixin.yaml".to_string(),
-                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{"mixins":["./tools"]}}"#.to_string(),
+                pinned: "decisions.yaml".to_string(),
+                document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{"mixins":["./tools"]}}"#.to_string(),
                 layers: Vec::new(),
             }),
-            decided_in("/decisions/lns-local-mixin.yaml"),
+            decided_in("/decisions/decisions.yaml"),
         )
         .expect("a written file reads")
         .expect("a written file contributes");
@@ -1567,7 +1567,7 @@ mod tests {
                 document: r#"{"apiVersion":"lns.run/v1","kind":"mixin","name":"dev","spec":{"mixins":["./tools"]}}"#.to_string(),
                 layers: Vec::new(),
             }),
-            decided_in("/decisions/lns-local-mixin.yaml"),
+            decided_in("/decisions/decisions.yaml"),
         )
         .expect("a written file reads")
         .expect("a written file contributes");

--- a/crates/lns-service/src/artifact/mixin_dir.rs
+++ b/crates/lns-service/src/artifact/mixin_dir.rs
@@ -28,7 +28,7 @@ pub fn read_path_mixin<D: MixinDir>(dir: &D, path: &Path) -> Result<FetchedMixin
     parse_document(&yaml, &document, &root, document.display().to_string())
 }
 
-/// Read the directory's own decisions, which every run there resolves without being named (`docs/sandbox-spec.md` §8.1); a directory nobody has decided anything in has none to read.
+/// Read a run's own decisions, which that run resolves without being named (`docs/sandbox-spec.md` §8.1); a run that has been asked nothing has none to read.
 pub fn read_local_mixin<D: MixinDir>(dir: &D, file: &Path) -> Result<Option<FetchedMixin>> {
     let yaml = match dir.read(file) {
         Ok(yaml) => yaml,
@@ -279,7 +279,7 @@ mod tests {
         assert!(
             read_local_mixin(
                 &Fake::new(BTreeMap::new()),
-                Path::new("/work/lns-local-mixin.yaml")
+                Path::new("/work/decisions.yaml")
             )
             .unwrap()
             .is_none(),
@@ -289,9 +289,9 @@ mod tests {
 
     #[test]
     fn a_decisions_file_an_editor_has_truncated_contributes_nothing() {
-        let dir = holding("/work/lns-local-mixin.yaml", "  \n");
+        let dir = holding("/work/decisions.yaml", "  \n");
         assert!(
-            read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+            read_local_mixin(&dir, Path::new("/work/decisions.yaml"))
                 .unwrap()
                 .is_none(),
             "an editor truncates a file before it writes one, and a run that caught it mid-write must not refuse"
@@ -301,14 +301,14 @@ mod tests {
     #[test]
     fn the_decisions_file_is_named_by_the_file_it_is() {
         let dir = holding(
-            "/work/lns-local-mixin.yaml",
-            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  tools:\n    - ripgrep@14\n",
+            "/work/decisions.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  tools:\n    - ripgrep@14\n",
         );
-        let fetched = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+        let fetched = read_local_mixin(&dir, Path::new("/work/decisions.yaml"))
             .unwrap()
             .expect("a written file contributes");
         assert_eq!(
-            fetched.pinned, "lns-local-mixin.yaml",
+            fetched.pinned, "decisions.yaml",
             "nothing names this source, so a disclosure attributes it by the file it is"
         );
         assert!(
@@ -321,10 +321,10 @@ mod tests {
     #[test]
     fn a_path_the_decisions_file_writes_is_rooted_in_its_own_directory() {
         let dir = holding(
-            "/work/lns-local-mixin.yaml",
-            "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  filesets:\n    - path: ./notes\n      guestPath: /home/agent/notes\n",
+            "/work/decisions.yaml",
+            "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  filesets:\n    - path: ./notes\n      guestPath: /home/agent/notes\n",
         );
-        let fetched = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml"))
+        let fetched = read_local_mixin(&dir, Path::new("/work/decisions.yaml"))
             .unwrap()
             .expect("a written file contributes");
         assert!(
@@ -354,19 +354,19 @@ mod tests {
             format!("{refused:#}").contains("/work/mixins/pg"),
             "a path this machine cannot read is not a path that decided nothing; got: {refused:#}"
         );
-        let err = read_local_mixin(&Denied, Path::new("/work/lns-local-mixin.yaml")).unwrap_err();
+        let err = read_local_mixin(&Denied, Path::new("/work/decisions.yaml")).unwrap_err();
         assert!(
-            format!("{err:#}").contains("/work/lns-local-mixin.yaml"),
+            format!("{err:#}").contains("/work/decisions.yaml"),
             "a file that exists and cannot be read is not a directory that decided nothing; got: {err:#}"
         );
     }
 
     #[test]
     fn a_decisions_file_that_is_not_yaml_names_the_file_it_could_not_parse() {
-        let dir = holding("/work/lns-local-mixin.yaml", "\tnot: [valid");
-        let err = read_local_mixin(&dir, Path::new("/work/lns-local-mixin.yaml")).unwrap_err();
+        let dir = holding("/work/decisions.yaml", "\tnot: [valid");
+        let err = read_local_mixin(&dir, Path::new("/work/decisions.yaml")).unwrap_err();
         assert!(
-            format!("{err:#}").contains("parsing /work/lns-local-mixin.yaml"),
+            format!("{err:#}").contains("parsing /work/decisions.yaml"),
             "got: {err:#}"
         );
     }

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -344,7 +344,7 @@ fn record_sandbox_run(
     }
 }
 
-/// Disclose the sandbox's shipped network policy at boot: name it as the source your own decisions layer over, warning if it is over-broad.
+/// Disclose the sandbox's shipped network policy at boot: name it as the source the run's own decisions layer over, warning if it is over-broad.
 fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     let Some(policy) = policy else {
         return;
@@ -352,7 +352,7 @@ fn disclose_effective_policy(policy: Option<&lns_policy::Policy>) {
     if policy.network != lns_policy::NetworkPolicy::default() {
         crate::log::info!(
             "policy",
-            "this sandbox ships a network policy; it governs the run except where your own lns-local-mixin.yaml decides otherwise"
+            "this sandbox ships a network policy; it governs the run except where this run's own decisions decide otherwise"
         );
         let summary =
             crate::artifact::policy::run_summary(&crate::artifact::policy::guardrail_flags(policy));

--- a/crates/lns-service/src/artifact/real.rs
+++ b/crates/lns-service/src/artifact/real.rs
@@ -18,6 +18,8 @@ pub(crate) struct ResolvedForRun {
     reference: String,
     pub(crate) digest: String,
     resolved: crate::artifact::assembly::ResolvedSandbox,
+    /// The merged sandbox document, kept so the run can be written back out as one document (`docs/sandbox-spec.md` §8.4).
+    pub(crate) document: Vec<u8>,
 }
 
 /// Peek a run reference's manifest and, when it is a published sandbox, resolve it; a plain image returns `None` so the caller runs it directly (a bare `verify_sandbox` reference that resolves to a plain image is refused as "not a sandbox").
@@ -68,6 +70,7 @@ pub(crate) async fn resolve_for_run(
                 reference: image_ref.to_string(),
                 digest,
                 resolved,
+                document: resolution.document,
             }))
         }
     }
@@ -84,6 +87,7 @@ pub(crate) async fn plan_resolved(
         reference,
         digest,
         resolved,
+        document: _,
     } = resolved;
     record_sandbox_run(run_id, microvm, &reference, &digest, &resolved);
     crate::image_store::record_artifact_run(&reference, &digest, &resolved.base_image)
@@ -224,7 +228,7 @@ impl crate::artifact::fileset::HostFileProbe for RealSnapshotDir {
     }
 }
 
-/// The directory's own decisions as a merge source, read off this machine; a run that named no decisions file resolves without one.
+/// The run's own decisions as a merge source, read off this machine; a boot that names no decisions file resolves without one.
 fn local_source(
     decisions: Option<&std::path::Path>,
 ) -> Result<Option<crate::artifact::mixin::LocalSource>> {
@@ -363,7 +367,6 @@ pub(crate) async fn resolve_definition(
     definition: &str,
     project_dir: &str,
     mixins: &[String],
-    decisions: Option<&std::path::Path>,
 ) -> Result<lns_ipc::Response> {
     let project_dir = std::path::Path::new(project_dir);
     crate::artifact::mixin::require_a_rooted_project_dir(project_dir)?;
@@ -373,7 +376,7 @@ pub(crate) async fn resolve_definition(
         mixins,
         &home,
         &RegistryMixins,
-        local_source(decisions)?,
+        None,
     )
     .await
     .with_context(|| format!("resolving the definition in {}", project_dir.display()))?;
@@ -399,11 +402,7 @@ pub(crate) async fn resolve_definition(
     })
 }
 
-pub(crate) async fn inspect(
-    image_ref: &str,
-    mixins: &[String],
-    decisions: Option<&std::path::Path>,
-) -> Result<ArtifactInspection> {
+pub(crate) async fn inspect(image_ref: &str, mixins: &[String]) -> Result<ArtifactInspection> {
     let reference: Reference = image_ref
         .parse()
         .with_context(|| format!("invalid image reference {image_ref}"))?;
@@ -421,7 +420,7 @@ pub(crate) async fn inspect(
         mixins,
         &crate::artifact::mixin::Locator::Reference(image_ref.to_string()),
         &RegistryMixins,
-        local_source(decisions)?,
+        None,
     )
     .await
     .with_context(|| format!("resolving {image_ref}"))?;

--- a/crates/lns-service/src/cache.rs
+++ b/crates/lns-service/src/cache.rs
@@ -8,3 +8,10 @@ pub fn root() -> Result<PathBuf> {
 pub fn run_dir(root: &Path, run_id: &str) -> PathBuf {
     root.join("runs").join(run_id)
 }
+
+/// `sandbox-spec.md` §8.3 keeps a run's decisions in the run's own directory, so removing the run removes what it decided.
+pub fn decisions_path(root: &Path, run_id: &str) -> PathBuf {
+    run_dir(root, run_id).join(DECISIONS_FILENAME)
+}
+
+pub const DECISIONS_FILENAME: &str = "decisions.yaml";

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -2439,9 +2439,20 @@ mod tests {
         );
     }
 
+    /// Deregisters what a test registered, so a later `prune` does not sweep a run the suite left behind.
+    struct RegisteredRun(&'static str);
+
+    impl Drop for RegisteredRun {
+        fn drop(&mut self) {
+            crate::run_registry::deregister(self.0);
+        }
+    }
+
     /// A stopped run with a record on disk, which is what `save` reads: the record is written for every run before its session begins.
-    #[cfg(test)]
-    fn stopped_run_with_a_record(home: &std::path::Path, run_id: &str) -> String {
+    fn stopped_run_with_a_record(
+        home: &std::path::Path,
+        run_id: &'static str,
+    ) -> (String, RegisteredRun) {
         let record = crate::run_record::test_record(run_id);
         let name = record.name.clone();
         std::fs::create_dir_all(crate::cache::run_dir(home, run_id)).expect("run dir");
@@ -2451,7 +2462,7 @@ mod tests {
         )
         .expect("record");
         crate::run_registry::register_stopped(crate::run_registry::StoppedRun { record });
-        name
+        (name, RegisteredRun(run_id))
     }
 
     #[tokio::test]
@@ -2460,7 +2471,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
         let run_id = "aa0000000000000000000000000000fb";
-        let name = stopped_run_with_a_record(home.path(), run_id);
+        let (name, _registered) = stopped_run_with_a_record(home.path(), run_id);
         match handle_request(&Request::InspectRun { run: name }, Instant::now()).await {
             Response::RunInspect { details } => assert_eq!(
                 details.config.policy_path,
@@ -2480,7 +2491,8 @@ mod tests {
     async fn saving_a_run_renders_the_document_and_writes_no_file() {
         let home = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
-        let name = stopped_run_with_a_record(home.path(), "aa0000000000000000000000000000ff");
+        let (name, _registered) =
+            stopped_run_with_a_record(home.path(), "aa0000000000000000000000000000ff");
         match handle_request(
             &Request::SaveRun {
                 run: name,
@@ -2507,7 +2519,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
         let run_id = "aa0000000000000000000000000000fe";
-        let name = stopped_run_with_a_record(home.path(), run_id);
+        let (name, _registered) = stopped_run_with_a_record(home.path(), run_id);
         std::fs::write(
             crate::cache::decisions_path(home.path(), run_id),
             "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  egress:\n    http:\n      - match: git.example.test\n        verdict: allow\n",
@@ -2541,6 +2553,7 @@ mod tests {
         let record = crate::run_record::test_record("aa0000000000000000000000000000fd");
         let name = record.name.clone();
         crate::run_registry::register_stopped(crate::run_registry::StoppedRun { record });
+        let _registered = RegisteredRun("aa0000000000000000000000000000fd");
         match handle_request(
             &Request::SaveRun {
                 run: name.clone(),
@@ -2552,8 +2565,8 @@ mod tests {
         .await
         {
             Response::Error { message } => assert!(
-                message.contains(&name),
-                "a run whose record is unreadable must name itself rather than fail anonymously; got: {message}"
+                message.contains(&format!("no run record for {name}")),
+                "a run whose record is unreadable must say the record is missing, not that the run is; got: {message}"
             ),
             other => unreachable!("expected Error, got {other:?}"),
         }
@@ -2587,7 +2600,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
         let run_id = "aa0000000000000000000000000000fc";
-        let name = stopped_run_with_a_record(home.path(), run_id);
+        let (name, _registered) = stopped_run_with_a_record(home.path(), run_id);
         std::fs::write(crate::run_record::record_path(home.path(), run_id), b"{").expect("damage");
         match handle_request(
             &Request::SaveRun {

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use std::time::Instant;
 
 use crate::log;
@@ -564,28 +565,13 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             definition,
             project_dir,
             mixins,
-            decisions,
         } => image_response(
-            crate::artifact::real::resolve_definition(
-                definition,
-                project_dir,
-                mixins,
-                decisions.as_deref().map(std::path::Path::new),
-            )
-            .await,
+            crate::artifact::real::resolve_definition(definition, project_dir, mixins).await,
         ),
-        Request::InspectImage {
-            image,
-            mixins,
-            decisions,
-        } => image_response(
-            crate::artifact::real::inspect(
-                image,
-                mixins,
-                decisions.as_deref().map(std::path::Path::new),
-            )
-            .await
-            .map(|inspection| Response::ImageInspected { inspection }),
+        Request::InspectImage { image, mixins } => image_response(
+            crate::artifact::real::inspect(image, mixins)
+                .await
+                .map(|inspection| Response::ImageInspected { inspection }),
         ),
         Request::TagImage { from, to } => {
             image_response(crate::image_store::tag(from, to).await.map(|()| {
@@ -615,10 +601,30 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
             Err(message) => Response::Error { message },
         },
         Request::PruneRuns => image_response(prune_runs_request().await),
+        Request::SaveRun { run, kind, name } => image_response(save_run_request(run, *kind, name)),
         Request::Unknown { method } => Response::Error {
             message: format!("unknown method: {method}"),
         },
     }
+}
+
+/// `docs/cli-spec.md` §3.2.3: the service renders the document, and the caller writes the file it named.
+fn save_run_request(run: &str, kind: lns_ipc::SaveKind, name: &str) -> anyhow::Result<Response> {
+    let run_id = crate::run_registry::resolve(run).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let cache_dir = crate::cache::root()?;
+    let bytes = std::fs::read(crate::run_record::record_path(&cache_dir, &run_id))
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("no run record for {run}"))?;
+    let record: crate::run_record::RunRecord = serde_json::from_slice(&bytes)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("parsing the run record for {run}"))?;
+    let decisions_path = crate::cache::decisions_path(&cache_dir, &run_id);
+    let decisions = lns_policy::Policy::load_or_default(&decisions_path)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("reading what {run} decided"))?;
+    Ok(Response::RunSaved {
+        document: crate::run::render_saved(&record, &decisions, kind, name)?,
+    })
 }
 
 async fn kill_request(run: &str, signal: lns_ipc::SignalKind) -> Response {
@@ -1242,7 +1248,6 @@ mod tests {
                 mem_explicit: false,
                 cpus_config: None,
                 mem_config: None,
-                policy_path: None,
                 sandbox_user: None,
                 sandbox_uid: None,
                 entrypoint: None,
@@ -2432,6 +2437,173 @@ mod tests {
             Response::Acknowledged,
             "killing an exited run is already satisfied and must not forward to a dead session"
         );
+    }
+
+    /// A stopped run with a record on disk, which is what `save` reads: the record is written for every run before its session begins.
+    #[cfg(test)]
+    fn stopped_run_with_a_record(home: &std::path::Path, run_id: &str) -> String {
+        let record = crate::run_record::test_record(run_id);
+        let name = record.name.clone();
+        std::fs::create_dir_all(crate::cache::run_dir(home, run_id)).expect("run dir");
+        std::fs::write(
+            crate::run_record::record_path(home, run_id),
+            serde_json::to_vec(&record).expect("serialize"),
+        )
+        .expect("record");
+        crate::run_registry::register_stopped(crate::run_registry::StoppedRun { record });
+        name
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn inspecting_a_run_names_the_decisions_file_in_that_run_s_own_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        let run_id = "aa0000000000000000000000000000fb";
+        let name = stopped_run_with_a_record(home.path(), run_id);
+        match handle_request(&Request::InspectRun { run: name }, Instant::now()).await {
+            Response::RunInspect { details } => assert_eq!(
+                details.config.policy_path,
+                Some(
+                    crate::cache::decisions_path(home.path(), run_id)
+                        .display()
+                        .to_string()
+                ),
+                "§8.3 puts a run's decisions in its own directory, and inspect is where the user reads what that run decided"
+            ),
+            other => unreachable!("expected RunInspect, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn saving_a_run_renders_the_document_and_writes_no_file() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        let name = stopped_run_with_a_record(home.path(), "aa0000000000000000000000000000ff");
+        match handle_request(
+            &Request::SaveRun {
+                run: name,
+                kind: lns_ipc::SaveKind::Sandbox,
+                name: "kept".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::RunSaved { document } => {
+                assert!(
+                    document.contains("kind: sandbox") && document.contains("name: kept"),
+                    "§8.4 renders the run under the name the caller took from its file; got: {document}"
+                );
+            }
+            other => unreachable!("expected RunSaved, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn saving_a_run_reads_what_that_run_decided() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        let run_id = "aa0000000000000000000000000000fe";
+        let name = stopped_run_with_a_record(home.path(), run_id);
+        std::fs::write(
+            crate::cache::decisions_path(home.path(), run_id),
+            "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  egress:\n    http:\n      - match: git.example.test\n        verdict: allow\n",
+        )
+        .expect("decisions");
+        match handle_request(
+            &Request::SaveRun {
+                run: name,
+                kind: lns_ipc::SaveKind::Mixin,
+                name: "agreed".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::RunSaved { document } => {
+                assert!(
+                    document.contains("git.example.test"),
+                    "saving what a run decided is the point of the verb; got: {document}"
+                );
+            }
+            other => unreachable!("expected RunSaved, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn saving_a_run_whose_record_is_gone_says_which_run() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        let record = crate::run_record::test_record("aa0000000000000000000000000000fd");
+        let name = record.name.clone();
+        crate::run_registry::register_stopped(crate::run_registry::StoppedRun { record });
+        match handle_request(
+            &Request::SaveRun {
+                run: name.clone(),
+                kind: lns_ipc::SaveKind::Sandbox,
+                name: "kept".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::Error { message } => assert!(
+                message.contains(&name),
+                "a run whose record is unreadable must name itself rather than fail anonymously; got: {message}"
+            ),
+            other => unreachable!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn saving_an_unknown_run_reports_no_such_run() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        match handle_request(
+            &Request::SaveRun {
+                run: "ghost".into(),
+                kind: lns_ipc::SaveKind::Sandbox,
+                name: "kept".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::Error { message } => {
+                assert!(message.contains("no such run: ghost"), "got: {message}")
+            }
+            other => unreachable!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn saving_a_run_whose_record_does_not_parse_says_so() {
+        let home = tempfile::tempdir().unwrap();
+        let _h = crate::test_env::EnvVarGuard::set("LNS_HOME", home.path());
+        let run_id = "aa0000000000000000000000000000fc";
+        let name = stopped_run_with_a_record(home.path(), run_id);
+        std::fs::write(crate::run_record::record_path(home.path(), run_id), b"{").expect("damage");
+        match handle_request(
+            &Request::SaveRun {
+                run: name,
+                kind: lns_ipc::SaveKind::Sandbox,
+                name: "kept".into(),
+            },
+            Instant::now(),
+        )
+        .await
+        {
+            Response::Error { message } => {
+                assert!(message.contains("parsing the run record"), "got: {message}")
+            }
+            other => unreachable!("expected Error, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -4075,7 +4247,6 @@ mod tests {
                     definition: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1"}}"#.into(),
                     project_dir: "/work".into(),
                     mixins: Vec::new(),
-                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -4104,7 +4275,6 @@ mod tests {
                     definition: r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"hermes","spec":{"image":"ghcr.io/team/base:1","mixins":["./mixins/pg"]}}"#.into(),
                     project_dir: "work".into(),
                     mixins: Vec::new(),
-                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -4128,7 +4298,6 @@ mod tests {
                     definition: "{}".into(),
                     project_dir: "/work".into(),
                     mixins: Vec::new(),
-                    decisions: None,
                 },
                 Instant::now(),
             )
@@ -4151,7 +4320,6 @@ mod tests {
                 &Request::InspectImage {
                     image: "###".into(),
                     mixins: Vec::new(),
-                    decisions: None,
                 },
                 Instant::now(),
             )

--- a/crates/lns-service/src/run/decisions.rs
+++ b/crates/lns-service/src/run/decisions.rs
@@ -1,0 +1,178 @@
+use std::io;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use lns_policy::Policy;
+
+pub(crate) trait Fs: Send + Sync {
+    fn is_file(&self, p: &Path) -> bool;
+    fn create_dir_all(&self, p: &Path) -> io::Result<()>;
+    fn write(&self, p: &Path, bytes: &[u8]) -> io::Result<()>;
+}
+
+pub(crate) struct RealFs;
+
+impl Fs for RealFs {
+    fn is_file(&self, p: &Path) -> bool {
+        p.is_file()
+    }
+    fn create_dir_all(&self, p: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(p)
+    }
+    /// The same atomic write every later decision goes through, so an interrupted first boot never leaves a half-written document the next start has to parse.
+    fn write(&self, p: &Path, bytes: &[u8]) -> io::Result<()> {
+        lns_policy::secure_file::write_yaml_document_atomic(p, bytes)
+    }
+}
+
+pub(crate) fn ensure(path: &Path) -> Result<()> {
+    ensure_with(&RealFs, path)
+}
+
+/// A restart rejoins the run that already answered, so an existing file is left exactly as the developer left it.
+pub(crate) fn ensure_with<F: Fs + ?Sized>(fs: &F, path: &Path) -> Result<()> {
+    if fs.is_file(path) {
+        return Ok(());
+    }
+    let parent = path.parent().unwrap_or(Path::new("."));
+    fs.create_dir_all(parent)
+        .with_context(|| format!("creating the run directory {}", parent.display()))?;
+    let bytes = Policy::default()
+        .document_bytes(path)
+        .context("rendering the empty decisions document")?;
+    fs.write(path, &bytes)
+        .with_context(|| format!("creating the decisions file {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeFs {
+        files: Mutex<HashMap<PathBuf, Vec<u8>>>,
+        dirs: Mutex<Vec<PathBuf>>,
+        mkdir_fails: bool,
+        write_fails: bool,
+    }
+
+    impl Fs for FakeFs {
+        fn is_file(&self, p: &Path) -> bool {
+            self.files.lock().expect("lock").contains_key(p)
+        }
+        fn create_dir_all(&self, p: &Path) -> io::Result<()> {
+            if self.mkdir_fails {
+                return Err(io::Error::other("no space"));
+            }
+            self.dirs.lock().expect("lock").push(p.to_path_buf());
+            Ok(())
+        }
+        fn write(&self, p: &Path, bytes: &[u8]) -> io::Result<()> {
+            if self.write_fails {
+                return Err(io::Error::other("read-only"));
+            }
+            self.files
+                .lock()
+                .expect("lock")
+                .insert(p.to_path_buf(), bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn path() -> PathBuf {
+        PathBuf::from("/h/runs/aa01/decisions.yaml")
+    }
+
+    #[test]
+    fn a_run_without_a_decisions_file_gets_an_empty_one_named_for_its_stem() {
+        let fs = FakeFs::default();
+        ensure_with(&fs, &path())
+            .expect("§8.1 has the file exist whether or not anything was asked");
+        let files = fs.files.lock().expect("lock");
+        let text = String::from_utf8(files[&path()].clone()).expect("utf-8");
+        assert!(
+            text.contains("kind: mixin"),
+            "§8.1 records a decision in mixin grammar; got: {text}"
+        );
+        assert!(
+            text.contains("name: decisions"),
+            "§8.3 names the document for the file's own stem; got: {text}"
+        );
+        assert!(
+            !text.contains("match:"),
+            "a run that has been asked nothing has decided nothing; got: {text}"
+        );
+    }
+
+    /// The production entry, against a real filesystem: the fake above proves the decision, and this proves the wiring that carries it out.
+    #[test]
+    fn the_production_entry_lands_an_empty_decisions_file_in_a_fresh_run_directory() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let path = crate::cache::decisions_path(home.path(), "aa01");
+        ensure(&path).expect("a first run has neither the directory nor the file");
+        let text = std::fs::read_to_string(&path).expect("the run can read back what it wrote");
+        assert!(
+            text.contains("kind: mixin") && text.contains("name: decisions"),
+            "§8.3 puts a run's decisions in its own directory, in mixin grammar; got: {text}"
+        );
+        ensure(&path).expect("a restart is not an error");
+    }
+
+    #[test]
+    fn the_run_directory_is_created_before_the_file_lands_in_it() {
+        let fs = FakeFs::default();
+        ensure_with(&fs, &path()).expect("a first run has no directory yet");
+        assert_eq!(
+            fs.dirs.lock().expect("lock").as_slice(),
+            [PathBuf::from("/h/runs/aa01")],
+            "the decisions file is the first thing written into a fresh run's directory"
+        );
+    }
+
+    #[test]
+    fn a_restart_keeps_what_the_run_already_decided() {
+        let fs = FakeFs::default();
+        fs.files
+            .lock()
+            .expect("lock")
+            .insert(path(), b"apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  egress:\n    http:\n      - match: git.example.test\n        verdict: allow\n".to_vec());
+        ensure_with(&fs, &path()).expect("an existing file is not an error");
+        let files = fs.files.lock().expect("lock");
+        let text = String::from_utf8(files[&path()].clone()).expect("utf-8");
+        assert!(
+            text.contains("git.example.test"),
+            "a start rejoins the run that answered, so overwriting the file would drop its answers; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_run_directory_that_cannot_be_created_names_itself_in_the_error() {
+        let fs = FakeFs {
+            mkdir_fails: true,
+            ..FakeFs::default()
+        };
+        let err = ensure_with(&fs, &path())
+            .expect_err("a run with nowhere to record decisions must not boot");
+        assert!(
+            format!("{err:#}").contains("/h/runs/aa01"),
+            "the directory that failed is what the operator has to fix; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_decisions_file_that_cannot_be_written_names_itself_in_the_error() {
+        let fs = FakeFs {
+            write_fails: true,
+            ..FakeFs::default()
+        };
+        let err = ensure_with(&fs, &path())
+            .expect_err("a run whose answers cannot be recorded must not boot");
+        assert!(
+            format!("{err:#}").contains("decisions.yaml"),
+            "the file that failed is what the operator has to fix; got: {err:#}"
+        );
+    }
+}

--- a/crates/lns-service/src/run/mod.rs
+++ b/crates/lns-service/src/run/mod.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use lns_ipc::{Response, WireFrame};
 use tokio::sync::mpsc::Sender;
 
+mod decisions;
 mod orchestrator;
+mod save;
+pub(crate) use save::render as render_saved;
 mod scratch;
 mod shutdown;
 pub use orchestrator::{PreparedRun, handle, prepare};

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -48,7 +48,7 @@ pub async fn prepare(run_id: &str, args: &RunImageArgs) -> Result<PreparedRun> {
                 image_ref,
                 args.verify_sandbox,
                 &args.mixins,
-                args.policy_path.as_deref().map(Path::new),
+                Some(cache::decisions_path(&cache::root()?, run_id).as_path()),
             )
             .await?
             {
@@ -160,29 +160,38 @@ async fn orchestrate(
     if matches!(mode, super::LaunchMode::Restart { .. }) {
         run_scratch.keep();
     }
-    let policy: Option<PathBuf> = args.policy_path.as_deref().map(PathBuf::from);
+    let decisions = cache::decisions_path(&cache_dir, &run_id);
+    super::decisions::ensure(&decisions)?;
+    let policy = Some(decisions);
 
     // A local definition plans directly; a published sandbox reference boots what it resolved to; a plain image passes through unchanged.
     let resolved_image = args.resolved_image.as_deref().or(args.image.as_deref());
+    let mut resolved_document: Option<String> = None;
     let sandbox_plan = match document {
-        PreparedDocument::Local(definition) => Some(
-            crate::artifact::real::plan_local(
-                &definition,
-                args.authored_egress.as_deref(),
-                &crate::artifact::packed_from_the_wire(&args.packed_filesets),
-                &args.denied_host_paths,
+        PreparedDocument::Local(definition) => {
+            resolved_document = Some(definition.clone());
+            Some(
+                crate::artifact::real::plan_local(
+                    &definition,
+                    args.authored_egress.as_deref(),
+                    &crate::artifact::packed_from_the_wire(&args.packed_filesets),
+                    &args.denied_host_paths,
+                )
+                .await?,
             )
-            .await?,
-        ),
-        PreparedDocument::Published(resolved) => Some(
-            crate::artifact::real::plan_resolved(
-                *resolved,
-                &run_id,
-                &microvm,
-                &args.denied_host_paths,
+        }
+        PreparedDocument::Published(resolved) => {
+            resolved_document = String::from_utf8(resolved.document.clone()).ok();
+            Some(
+                crate::artifact::real::plan_resolved(
+                    *resolved,
+                    &run_id,
+                    &microvm,
+                    &args.denied_host_paths,
+                )
+                .await?,
             )
-            .await?,
-        ),
+        }
         PreparedDocument::Imageless => None,
     };
     let tool_requests = match &sandbox_plan {
@@ -625,6 +634,7 @@ async fn orchestrate(
         run_id: run_id.clone(),
         name: microvm.clone(),
         args: record_args,
+        resolved_document,
         descriptor_sha256: recorded_descriptor_sha,
         layer_digests: recorded_layer_digests,
         image: image_label,

--- a/crates/lns-service/src/run/save.rs
+++ b/crates/lns-service/src/run/save.rs
@@ -1,0 +1,650 @@
+use anyhow::{Context, Result};
+use lns_ipc::SaveKind;
+use lns_policy::Policy;
+use serde_json::{Value, json};
+
+use crate::run_record::RunRecord;
+
+/// `docs/sandbox-spec.md` §8.4: a run written out as a document the developer keeps, named for the file it lands in.
+pub(crate) fn render(
+    record: &RunRecord,
+    decisions: &Policy,
+    kind: SaveKind,
+    name: &str,
+) -> Result<String> {
+    match kind {
+        SaveKind::Mixin => render_mixin(decisions, name),
+        SaveKind::Sandbox => render_sandbox(record, decisions, name),
+    }
+}
+
+fn render_mixin(decisions: &Policy, name: &str) -> Result<String> {
+    let mut named = decisions.clone();
+    named.name = Some(name.to_string());
+    let bytes = named
+        .document_bytes(std::path::Path::new(name))
+        .context("rendering what this run decided")?;
+    String::from_utf8(bytes).context("the rendered mixin is not utf-8")
+}
+
+fn render_sandbox(record: &RunRecord, decisions: &Policy, name: &str) -> Result<String> {
+    let mut document = base_document(record)?;
+    document["name"] = json!(name);
+    let spec = document
+        .get_mut("spec")
+        .and_then(Value::as_object_mut)
+        .context("the document this run booted has no spec")?;
+    // Every source is already folded in, so a reference left here would resolve a second time on the next run.
+    spec.remove("mixins");
+    overlay_launch(spec, &record.args);
+    root_declared_paths(spec, record.args.definition_dir.as_deref());
+    spec.insert("egress".to_string(), effective_egress(spec, decisions)?);
+    serde_yaml::to_string(&document).context("rendering this run as a document")
+}
+
+/// §8.4: a relative `source` means the directory of the document that declared it, and a saved document lands somewhere else, so every path it carries is written absolute.
+fn root_declared_paths(spec: &mut serde_json::Map<String, Value>, project_dir: Option<&str>) {
+    let Some(project_dir) = project_dir else {
+        return;
+    };
+    let root = std::path::Path::new(project_dir);
+    for (block, field) in [("volumes", "source"), ("filesets", "path")] {
+        let Some(entries) = spec.get_mut(block).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for entry in entries {
+            let Some(declared) = entry.get(field).and_then(Value::as_str) else {
+                continue;
+            };
+            let path = std::path::Path::new(declared);
+            if path.is_absolute() {
+                continue;
+            }
+            let absolute = lns_artifact::sandbox::fold_path(&root.join(path));
+            entry[field] = json!(absolute.display().to_string());
+        }
+    }
+}
+
+/// The document the run booted, or the envelope a run with no document of its own needs before its launch is written into it.
+fn base_document(record: &RunRecord) -> Result<Value> {
+    match record.resolved_document.as_deref() {
+        Some(json) => serde_json::from_str(json).context("parsing the document this run booted"),
+        None => Ok(json!({
+            "apiVersion": "lns.run/v1",
+            "kind": "sandbox",
+            "name": record.name,
+            "spec": { "image": record.image },
+        })),
+    }
+}
+
+fn overlay_launch(spec: &mut serde_json::Map<String, Value>, args: &lns_ipc::RunImageArgs) {
+    if !args.cmd.is_empty() {
+        spec.insert("command".to_string(), json!(args.cmd.join(" ")));
+    }
+    set_if_declared(spec, "workdir", args.workdir.as_deref());
+    set_if_declared(spec, "user", args.sandbox_user.as_deref());
+    set_if_declared(spec, "entrypoint", args.entrypoint.as_deref());
+    overlay_env(spec, &args.env);
+    overlay_mounts(spec, args);
+    if !args.published_ports.is_empty() {
+        spec.insert("ports".to_string(), ports_of(&args.published_ports));
+    }
+    spec.insert(
+        "resources".to_string(),
+        json!({ "cpu": args.cpus, "memory": format!("{}Mi", args.mem) }),
+    );
+}
+
+/// The run's mounts reach the service already merged with the document's, in a shape that carries less — no `exclude`, no `size`. So a guest path the document declares keeps the document's entry, and only one it does not declare is added from the run.
+fn overlay_mounts(spec: &mut serde_json::Map<String, Value>, args: &lns_ipc::RunImageArgs) {
+    let mut mounts: Vec<Value> = spec
+        .get("volumes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let declared: Vec<String> = mounts
+        .iter()
+        .filter_map(|entry| entry.get("target").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    let from_the_run = args
+        .binds
+        .iter()
+        .map(|bind| {
+            (
+                bind.target.clone(),
+                json!({
+                    "type": "bind",
+                    "source": bind.host_source,
+                    "target": bind.target,
+                    "readOnly": bind.read_only,
+                }),
+            )
+        })
+        .chain(args.volumes.iter().map(|volume| {
+            (
+                volume.target.clone(),
+                json!({
+                    "name": volume.name,
+                    "target": volume.target,
+                    "readOnly": volume.read_only,
+                }),
+            )
+        }))
+        .filter(|(target, _)| !declared.contains(target))
+        .map(|(_, entry)| entry);
+    mounts.extend(from_the_run);
+    if !mounts.is_empty() {
+        spec.insert("volumes".to_string(), Value::Array(mounts));
+    }
+}
+
+/// A field the run did not set stays as the document wrote it, since writing `null` would override the image's own value.
+fn set_if_declared(spec: &mut serde_json::Map<String, Value>, field: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        spec.insert(field.to_string(), json!(value));
+    }
+}
+
+/// A per-run `-e` outranks what the document declared, so it lands over the declared map rather than beside it.
+fn overlay_env(spec: &mut serde_json::Map<String, Value>, env: &[String]) {
+    let mut declared = spec
+        .get("env")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for entry in env {
+        if let Some((key, value)) = entry.split_once('=') {
+            declared.insert(key.to_string(), json!(value));
+        }
+    }
+    if !declared.is_empty() {
+        spec.insert("env".to_string(), Value::Object(declared));
+    }
+}
+
+fn ports_of(published: &[lns_ipc::PortPublish]) -> Value {
+    Value::Array(
+        published
+            .iter()
+            .map(|p| json!({ "host": p.host_port, "container": p.container_port }))
+            .collect(),
+    )
+}
+
+/// §8.1 puts the run's decisions after every document, so what it decided leads the table the saved document carries.
+fn effective_egress(spec: &serde_json::Map<String, Value>, decisions: &Policy) -> Result<Value> {
+    let authored: lns_policy::Egress = match spec.get("egress") {
+        Some(value) => {
+            serde_json::from_value(value.clone()).context("reading the egress this run resolved")?
+        }
+        None => lns_policy::Egress::default(),
+    };
+    let baseline = Policy {
+        network: lns_policy::NetworkPolicy { egress: authored },
+        name: None,
+        rest: Default::default(),
+    };
+    let effective = crate::artifact::policy::merge_effective(Some(&baseline), None, decisions);
+    serde_json::to_value(effective.network.egress).context("rendering the egress this run enforced")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record_with(document: Option<&str>) -> RunRecord {
+        let mut record = crate::run_record::test_record("aa01");
+        record.name = "brave_lion".to_string();
+        record.image = "docker.io/library/alpine:3.20".to_string();
+        record.resolved_document = document.map(str::to_string);
+        record
+    }
+
+    fn decided(matches: &str) -> Policy {
+        let mut policy = Policy::default();
+        policy.add_rule(lns_policy::RouteRule {
+            match_pattern: matches.to_string(),
+            verdict: lns_policy::Verdict::Allow,
+            transport: lns_policy::Transport::default(),
+            scheme: None,
+            description: None,
+            tls_terminate: false,
+            rules: Vec::new(),
+            binaries: None,
+        });
+        policy
+    }
+
+    fn yaml(text: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(text).expect("a document the user can validate")
+    }
+
+    #[test]
+    fn a_saved_mixin_holds_what_the_run_decided_and_nothing_else() {
+        let text = render(
+            &record_with(None),
+            &decided("git.example.test"),
+            SaveKind::Mixin,
+            "agreed-egress",
+        )
+        .expect("a run that decided something can be written out");
+        let doc = yaml(&text);
+        assert_eq!(
+            doc["kind"], "mixin",
+            "§8.4 writes what the run decided as a mixin; got: {text}"
+        );
+        assert_eq!(
+            doc["name"], "agreed-egress",
+            "§8.4 names the document for the file it lands in; got: {text}"
+        );
+        assert_eq!(
+            doc["spec"]["egress"]["http"][0]["match"], "git.example.test",
+            "the decision is the whole point of saving it; got: {text}"
+        );
+        assert!(
+            doc["spec"].get("image").is_none(),
+            "a mixin that carried the run's image would relaunch it; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_carries_the_egress_the_run_enforced() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","egress":{"http":[{"match":"docs.example.test","verdict":"allow"}],"tcp":[]}}}"#;
+        let text = render(
+            &record_with(Some(document)),
+            &decided("git.example.test"),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect("a run with a document can be written out");
+        let doc = yaml(&text);
+        let http = doc["spec"]["egress"]["http"]
+            .as_sequence()
+            .expect("an http table")
+            .iter()
+            .map(|e| e["match"].as_str().unwrap_or_default().to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            http.contains(&"docs.example.test".to_string())
+                && http.contains(&"git.example.test".to_string()),
+            "§8.4 saves the whole egress the run enforced, its own decisions included; got: {http:?}"
+        );
+        assert_eq!(
+            http.first().map(String::as_str),
+            Some("git.example.test"),
+            "§8.1 puts the run's decisions last in the merge, so §4.2 places them ahead in the table; got: {http:?}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_writes_a_relative_source_as_the_path_the_run_resolved() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","volumes":[{"type":"bind","source":"./src","target":"/work"},{"type":"bind","source":"/etc/ssl","target":"/ssl"}],"filesets":[{"path":"./skills","guestPath":"/skills"}]}}"#;
+        let mut record = record_with(Some(document));
+        record.args.definition_dir = Some("/home/dev/my-app".into());
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run with relative sources can be written out");
+        let doc = yaml(&text);
+        assert_eq!(
+            doc["spec"]["volumes"][0]["source"], "/home/dev/my-app/src",
+            "§8.4 saves the path the run resolved, or the saved document binds whatever sits beside it; got: {text}"
+        );
+        assert_eq!(
+            doc["spec"]["volumes"][1]["source"], "/etc/ssl",
+            "an absolute source already means one thing everywhere; got: {text}"
+        );
+        assert_eq!(
+            doc["spec"]["filesets"][0]["path"], "/home/dev/my-app/skills",
+            "a fileset roots the same way a bind does; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_named_volume_keeps_its_name_and_a_document_with_no_filesets_is_left_alone() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","volumes":[{"name":"cache","target":"/cache"}]}}"#;
+        let mut record = record_with(Some(document));
+        record.args.definition_dir = Some("/home/dev/my-app".into());
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run mounting a named volume can be written out");
+        let doc = yaml(&text);
+        assert_eq!(
+            doc["spec"]["volumes"][0]["name"], "cache",
+            "a named volume's source is its name, and rooting it would ask for a volume nobody created; got: {text}"
+        );
+        assert!(
+            doc["spec"]["volumes"][0].get("source").is_none(),
+            "rooting must not invent a source the document never declared; got: {text}"
+        );
+        assert!(
+            doc["spec"].get("filesets").is_none(),
+            "a document declaring no filesets gains none by being saved; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_run_from_a_published_reference_has_no_project_directory_to_root_against() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","volumes":[{"name":"cache","target":"/cache"}]}}"#;
+        let mut record = record_with(Some(document));
+        record.args.definition_dir = None;
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a pulled run can be written out");
+        assert_eq!(
+            yaml(&text)["spec"]["volumes"][0]["name"],
+            "cache",
+            "a named volume has no path to root, and inventing one would ask for a volume nobody created; got: {text}"
+        );
+    }
+
+    /// §8.4 keeps a grant out of a saved `sandbox`, so the saved egress is exactly the documents' plus this run's own answers.
+    #[test]
+    fn a_saved_egress_is_the_documents_plus_this_runs_answers_and_nothing_else() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","egress":{"http":[{"match":"docs.example.test","verdict":"allow"}],"tcp":[]}}}"#;
+        let text = render(
+            &record_with(Some(document)),
+            &decided("git.example.test"),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect("a run that granted a connector can still be written out");
+        let doc = yaml(&text);
+        let http: Vec<String> = doc["spec"]["egress"]["http"]
+            .as_sequence()
+            .expect("an http table")
+            .iter()
+            .map(|e| e["match"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(
+            http,
+            ["git.example.test", "docs.example.test"],
+            "the saved egress is the documents' plus this run's own answers, and nothing a connector opened; got: {text}"
+        );
+        assert!(
+            doc["spec"].get("credentials").is_none(),
+            "a granted method's credentials are consent too, and carrying them would leak the grant a different way; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_drops_the_mixins_it_already_merged() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","mixins":["ghcr.io/team/tools@sha256:aa"]}}"#;
+        let text = render(
+            &record_with(Some(document)),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect("a run that merged a mixin can be written out");
+        assert!(
+            yaml(&text)["spec"].get("mixins").is_none(),
+            "the mixin is folded in already, and resolving it again could bring different bytes; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_run_from_a_plain_image_saves_as_a_document_naming_that_image() {
+        let text = render(
+            &record_with(None),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "scratch",
+        )
+        .expect("a run with no document of its own still ran something");
+        let doc = yaml(&text);
+        assert_eq!(doc["kind"], "sandbox");
+        assert_eq!(
+            doc["spec"]["image"], "docker.io/library/alpine:3.20",
+            "the image it booted is what makes the saved document runnable; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_records_the_size_the_run_booted_with() {
+        let mut record = record_with(None);
+        record.args.cpus = 4;
+        record.args.mem = 2048;
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "big")
+            .expect("a resized run can be written out");
+        let doc = yaml(&text);
+        assert_eq!(doc["spec"]["resources"]["cpu"], 4);
+        assert_eq!(
+            doc["spec"]["resources"]["memory"], "2048Mi",
+            "a size saved without its unit would read as bytes; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_per_run_variable_outranks_the_one_the_document_declared() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","env":{"MODE":"dev","KEEP":"yes"}}}"#;
+        let mut record = record_with(Some(document));
+        record.args.env = vec!["MODE=prod".to_string()];
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run with an overridden variable can be written out");
+        let doc = yaml(&text);
+        assert_eq!(
+            doc["spec"]["env"]["MODE"], "prod",
+            "the run booted with the flag's value, so saving the declared one would not reproduce it; got: {text}"
+        );
+        assert_eq!(
+            doc["spec"]["env"]["KEEP"], "yes",
+            "a flag replaces one variable, not the whole map; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_carries_the_mounts_the_run_was_started_with() {
+        let mut record = record_with(None);
+        record.args.binds = vec![lns_ipc::BindMount {
+            host_source: "/home/dev/my-app/src".into(),
+            target: "/work".into(),
+            read_only: false,
+            dropped_paths: Vec::new(),
+            kept_paths: Vec::new(),
+        }];
+        record.args.volumes = vec![lns_ipc::VolumeMount {
+            name: "cache".into(),
+            target: "/cache".into(),
+            read_only: true,
+            size_bytes: None,
+        }];
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run with mounts can be written out");
+        let doc = yaml(&text);
+        let mounts = doc["spec"]["volumes"]
+            .as_sequence()
+            .expect("a volumes list");
+        assert_eq!(
+            mounts[0]["source"], "/home/dev/my-app/src",
+            "a saved document with no bind does not reproduce the run it claims to be; got: {text}"
+        );
+        assert_eq!(mounts[0]["target"], "/work");
+        assert_eq!(
+            mounts[1]["name"], "cache",
+            "a named volume is named, not sourced; got: {text}"
+        );
+        assert_eq!(mounts[1]["readOnly"], true);
+    }
+
+    /// The wire shape carries no `exclude` and no `size`, so a declared target that took it would lose an isolation control and a capacity floor with nothing in the file to say a rule was ever there.
+    #[test]
+    fn a_declared_mount_is_saved_as_the_document_wrote_it() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","volumes":[{"type":"bind","source":"./","target":"/work","exclude":[".cargo","node_modules"]},{"name":"cache","target":"/cache","size":"100Gi"}]}}"#;
+        let mut record = record_with(Some(document));
+        record.args.definition_dir = Some("/home/dev/my-app".into());
+        record.args.binds = vec![lns_ipc::BindMount {
+            host_source: "/home/dev/my-app".into(),
+            target: "/work".into(),
+            read_only: false,
+            dropped_paths: Vec::new(),
+            kept_paths: Vec::new(),
+        }];
+        record.args.volumes = vec![lns_ipc::VolumeMount {
+            name: "cache".into(),
+            target: "/cache".into(),
+            read_only: false,
+            size_bytes: None,
+        }];
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run whose mounts the document declared can be written out");
+        let doc = yaml(&text);
+        let mounts = doc["spec"]["volumes"]
+            .as_sequence()
+            .expect("a volumes list");
+        assert_eq!(
+            mounts.len(),
+            2,
+            "the run's copy of a declared mount is the same mount, not a second one; got: {text}"
+        );
+        assert_eq!(
+            mounts[0]["exclude"][0], ".cargo",
+            "§3.1.10 keeps an excluded subpath out of the guest, and a saved document that drops it mounts what the author hid; got: {text}"
+        );
+        assert_eq!(
+            mounts[0]["source"], "/home/dev/my-app",
+            "a relative source still roots, so the saved document means the same thing anywhere; got: {text}"
+        );
+        assert_eq!(
+            mounts[1]["size"], "100Gi",
+            "a size is a floor, and dropping it silently resizes the volume to the default; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_mount_the_run_added_that_no_document_declared_is_saved_with_it() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","volumes":[{"name":"kept","target":"/other"}]}}"#;
+        let mut record = record_with(Some(document));
+        record.args.definition_dir = Some("/home/dev/my-app".into());
+        record.args.binds = vec![lns_ipc::BindMount {
+            host_source: "/home/dev/my-app/src".into(),
+            target: "/work".into(),
+            read_only: false,
+            dropped_paths: Vec::new(),
+            kept_paths: Vec::new(),
+        }];
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run with an extra -v can be written out");
+        let doc = yaml(&text);
+        let mounts = doc["spec"]["volumes"]
+            .as_sequence()
+            .expect("a volumes list");
+        assert_eq!(mounts.len(), 2, "got: {text}");
+        assert_eq!(
+            mounts[0]["name"], "kept",
+            "a declared mount the run did not touch survives; got: {text}"
+        );
+        assert_eq!(
+            mounts[1]["source"], "/home/dev/my-app/src",
+            "a `-v` no document declared is part of what the run was; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_publishes_the_ports_the_run_published() {
+        let mut record = record_with(None);
+        record.args.published_ports = vec![lns_ipc::PortPublish {
+            host_ip: std::net::IpAddr::from([127, 0, 0, 1]),
+            host_port: 8080,
+            container_port: 80,
+            protocol: lns_ipc::Protocol::Tcp,
+        }];
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "web")
+            .expect("a run publishing a port can be written out");
+        let doc = yaml(&text);
+        assert_eq!(doc["spec"]["ports"][0]["host"], 8080);
+        assert_eq!(doc["spec"]["ports"][0]["container"], 80);
+    }
+
+    #[test]
+    fn a_document_that_does_not_parse_names_itself_rather_than_writing_half_a_file() {
+        let err = render(
+            &record_with(Some("not a document")),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect_err("a damaged record must not produce a document the user trusts");
+        assert!(
+            format!("{err:#}").contains("the document this run booted"),
+            "the message has to say which of the two inputs failed; got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_document_with_no_spec_is_refused() {
+        let err = render(
+            &record_with(Some(
+                r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"x"}"#,
+            )),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect_err("a document with no spec describes no sandbox");
+        assert!(format!("{err:#}").contains("no spec"), "got: {err:#}");
+    }
+
+    #[test]
+    fn an_egress_block_that_does_not_parse_names_itself() {
+        let err = render(
+            &record_with(Some(
+                r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"x","spec":{"image":"a:1","egress":7}}"#,
+            )),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect_err("an egress block that is not a table decides nothing");
+        assert!(
+            format!("{err:#}").contains("the egress this run resolved"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_saved_sandbox_records_the_identity_and_entrypoint_the_run_booted_with() {
+        let mut record = record_with(None);
+        record.args.workdir = Some("/workspace".into());
+        record.args.sandbox_user = Some("agent".into());
+        record.args.entrypoint = Some("/bin/sh".into());
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "reviewer")
+            .expect("a run with per-run overrides can be written out");
+        let doc = yaml(&text);
+        assert_eq!(doc["spec"]["workdir"], "/workspace");
+        assert_eq!(doc["spec"]["user"], "agent");
+        assert_eq!(
+            doc["spec"]["entrypoint"], "/bin/sh",
+            "a saved document that dropped the entrypoint would run something else; got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_run_that_overrode_nothing_leaves_those_fields_as_the_document_wrote_them() {
+        let document = r#"{"apiVersion":"lns.run/v1","kind":"sandbox","name":"upstream","spec":{"image":"alpine:3.20","workdir":"/srv"}}"#;
+        let text = render(
+            &record_with(Some(document)),
+            &Policy::default(),
+            SaveKind::Sandbox,
+            "reviewer",
+        )
+        .expect("a run with no overrides can be written out");
+        let doc = yaml(&text);
+        assert_eq!(
+            doc["spec"]["workdir"], "/srv",
+            "an unset flag is not an instruction to clear what the document declared; got: {text}"
+        );
+        assert!(doc["spec"].get("user").is_none(), "got: {text}");
+    }
+
+    #[test]
+    fn a_run_that_kept_the_images_command_saves_no_command_of_its_own() {
+        let mut record = record_with(None);
+        record.args.cmd = Vec::new();
+        let text = render(&record, &Policy::default(), SaveKind::Sandbox, "scratch")
+            .expect("a run with no command can be written out");
+        assert!(
+            yaml(&text)["spec"].get("command").is_none(),
+            "an empty command written down would override the image's own; got: {text}"
+        );
+    }
+}

--- a/crates/lns-service/src/run_record.rs
+++ b/crates/lns-service/src/run_record.rs
@@ -11,6 +11,9 @@ pub struct RunRecord {
     pub run_id: String,
     pub name: String,
     pub args: lns_ipc::RunImageArgs,
+    /// The merged sandbox document this run booted, so `lns sandbox save` writes what ran rather than what was typed.
+    #[serde(default)]
+    pub resolved_document: Option<String>,
     pub descriptor_sha256: String,
     pub layer_digests: Vec<String>,
     pub image: String,
@@ -217,7 +220,6 @@ mod tests {
             mem_explicit: false,
             cpus_config: None,
             mem_config: None,
-            policy_path: None,
             denied_host_paths: Vec::new(),
             sandbox_user: None,
             sandbox_uid: None,
@@ -245,6 +247,7 @@ mod tests {
 
     pub(crate) fn sample_record(run_id: &str) -> RunRecord {
         RunRecord {
+            resolved_document: None,
             version: CURRENT_VERSION,
             run_id: run_id.to_string(),
             name: format!("name-{run_id}"),

--- a/crates/lns-service/src/run_registry.rs
+++ b/crates/lns-service/src/run_registry.rs
@@ -551,11 +551,24 @@ pub fn inspect(run_id: &str) -> Option<lns_ipc::RunDetails> {
         .and_then(|m| m.get(run_id))
         .map(|e| lns_ipc::RunDetails {
             summary: summary_of(run_id, e),
-            config: match e {
-                RunEntry::Live(h) => h.config.clone(),
-                RunEntry::Stopped(s) => lns_ipc::RunConfig::from_run_args(&s.record.args),
-            },
+            config: with_its_decisions_file(
+                match e {
+                    RunEntry::Live(h) => h.config.clone(),
+                    RunEntry::Stopped(s) => lns_ipc::RunConfig::from_run_args(&s.record.args),
+                },
+                run_id,
+            ),
         })
+}
+
+/// A run's decisions file is the service's to name from the run's own directory (`docs/sandbox-spec.md` §8.3), so `inspect` fills it in here rather than reading it off what a caller sent.
+fn with_its_decisions_file(mut config: lns_ipc::RunConfig, run_id: &str) -> lns_ipc::RunConfig {
+    config.policy_path = crate::cache::root().ok().map(|root| {
+        crate::cache::decisions_path(&root, run_id)
+            .display()
+            .to_string()
+    });
+    config
 }
 
 pub fn cancel(run_id: &str) -> bool {

--- a/crates/lns-service/src/supervisor/mod.rs
+++ b/crates/lns-service/src/supervisor/mod.rs
@@ -531,8 +531,8 @@ mod tests {
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);
-        let policy_path = d.path().join("lns-local-mixin.yaml");
-        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n").expect("policy");
+        let policy_path = d.path().join("decisions.yaml");
+        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  egress:\n    http: []\n").expect("policy");
 
         let result = SupervisorSession::start(
             "deadbeef00000000000000000000aa99".to_string(),
@@ -561,8 +561,8 @@ mod tests {
         let supervisor_bin = d.path().join("supervisor.real");
         std::fs::write(&supervisor_bin, b"fake supervisor").expect("write");
         let _sb = EnvVarGuard::set("LNS_SUPERVISOR_BIN", &supervisor_bin);
-        let policy_path = d.path().join("lns-local-mixin.yaml");
-        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: lns-local-mixin\nspec:\n  egress:\n    http: []\n").expect("policy");
+        let policy_path = d.path().join("decisions.yaml");
+        std::fs::write(&policy_path, "apiVersion: lns.run/v1\nkind: mixin\nname: decisions\nspec:\n  egress:\n    http: []\n").expect("policy");
         let mut sandbox_policy = lns_policy::Policy::default();
         sandbox_policy.add_rule(lns_policy::RouteRule::deny_host("api.example.test"));
 

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -189,7 +189,7 @@ pub fn run_headless(
     ipc_handle: JoinHandle<anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
     crate::log::warn!(
-        "no display detected — running headless without the tray; interactive approval prompts can't be shown, so pre-authorize access in lns-local-mixin.yaml"
+        "no display detected — running headless without the tray; interactive approval prompts can't be shown, so pre-authorize access in a mixin the run names"
     );
     shutdown.wait_sync();
     match ipc_handle.join() {

--- a/crates/lns-service/tests/behaviours/approval_flow.feature
+++ b/crates/lns-service/tests/behaviours/approval_flow.feature
@@ -28,11 +28,11 @@ Feature: lns-service approval flow
     And a future request to "api.linear.app" prompts again
 
   Scenario: Always allow writes a rule to the policy file and hot-swaps the running policy
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And the policy has no rule for "api.linear.app"
     And an approval entry is visible for a request to "api.linear.app"
     When the developer picks "always allow"
-    Then "lns-local-mixin.yaml" contains a new allow rule for "api.linear.app"
+    Then "decisions.yaml" contains a new allow rule for "api.linear.app"
     And the running policy contains the same rule
     And the workload's request proceeds
     And a future request to "api.linear.app" is allowed without prompting
@@ -55,11 +55,11 @@ Feature: lns-service approval flow
     And a future request to "api.linear.app" prompts again
 
   Scenario: Always deny writes a deny rule to the policy file and hot-swaps the running policy
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And the policy has no rule for "api.linear.app"
     And an approval entry is visible for a request to "api.linear.app"
     When the developer picks "always deny"
-    Then "lns-local-mixin.yaml" contains a new deny rule for "api.linear.app"
+    Then "decisions.yaml" contains a new deny rule for "api.linear.app"
     And the running policy contains the same rule
     And the workload's request is denied always
     And a future request to "api.linear.app" is denied without prompting
@@ -93,8 +93,8 @@ Feature: lns-service approval flow
     And no restart of the workload is required
 
   Scenario: A manual edit to the policy file hot-swaps the running policy
-    Given a workload is running with "lns-local-mixin.yaml" loaded
-    When the developer edits "lns-local-mixin.yaml" to add an allow rule for "api.linear.app"
+    Given a workload is running with "decisions.yaml" loaded
+    When the developer edits "decisions.yaml" to add an allow rule for "api.linear.app"
     Then a subsequent request from the workload to "api.linear.app" is allowed without prompting
     And no restart of the workload is required
 
@@ -103,29 +103,29 @@ Feature: lns-service approval flow
   # match, so writing the second answer behind it would be a line that never fires —
   # and silence would leave the developer believing their deny stuck.
   Scenario: A second, contradicting always-decision is not written behind the rule the first one wrote
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And an approval entry is visible for a request to "api.example.test"
     When the developer picks "always allow"
     And the workload makes a request to "api.example.test"
     And the developer picks "always deny"
-    Then "lns-local-mixin.yaml" contains a new allow rule for "api.example.test"
-    And "lns-local-mixin.yaml" holds no deny rule for "api.example.test"
+    Then "decisions.yaml" contains a new allow rule for "api.example.test"
+    And "decisions.yaml" holds no deny rule for "api.example.test"
     And the approval window informs the developer that a rule already decides the destination
 
   # A raw splice is passed through untouched, so the rule has to name the port the
   # developer was shown; the bare host would grant every other port on that host too.
   Scenario: Always allow on a raw splice writes the port-scoped destination to the raw table
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always allow"
-    Then "lns-local-mixin.yaml" contains a new raw allow rule for "db.internal:5432"
+    Then "decisions.yaml" contains a new raw allow rule for "db.internal:5432"
     And the workload's request proceeds
 
   Scenario: Always deny on a raw splice writes a raw deny rule
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always deny"
-    Then "lns-local-mixin.yaml" contains a new raw deny rule for "db.internal:5432"
+    Then "decisions.yaml" contains a new raw deny rule for "db.internal:5432"
     And the workload's request is denied always
 
   # The developer's own file can already hold the answer they just gave, stranded behind
@@ -133,7 +133,7 @@ Feature: lns-service approval flow
   # bigger surprise, so the card keeps coming back — but they have to be told why, or
   # "always allow" reads as remembered while nothing changed.
   Scenario: An always-decision the file already holds behind another rule is reported, not silently dropped
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And the policy denies "*.example.test" and holds an allow rule for "api.example.test" behind that
     And an approval entry is visible for a request to "api.example.test"
     When the developer picks "always allow"
@@ -143,21 +143,21 @@ Feature: lns-service approval flow
   # The raw table is the pre-filter, so an approved splice takes the destination over
   # from the HTTP rules naming that host — silently, unless the card says so.
   Scenario: Approving a raw splice says which HTTP rule stops applying to it
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And the policy allows "db.internal"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always allow"
-    Then "lns-local-mixin.yaml" contains a new raw allow rule for "db.internal:5432"
+    Then "decisions.yaml" contains a new raw allow rule for "db.internal:5432"
     And the approval window informs the developer that the HTTP rule for "db.internal" no longer applies
 
   # One unparseable rule force-denies the whole policy inside the guest, so a
   # destination we cannot express has to leave the file alone and say so.
   Scenario: A raw destination that cannot be expressed as a rule is not written to the policy file
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And an approval entry is visible for a raw splice to "db.internal"
     When the developer picks "always allow"
     Then the workload's request proceeds
-    And the raw table in "lns-local-mixin.yaml" stays empty
+    And the raw table in "decisions.yaml" stays empty
     And the approval window informs the developer that the destination could not be turned into a rule
 
   Scenario: A failed policy-file write keeps the rule in memory and notifies the developer
@@ -173,14 +173,14 @@ Feature: lns-service approval flow
   # decided on purpose. §4.2 gives an entry a description for saying otherwise, and the
   # entry nobody typed is the one that needs it.
   Scenario: An entry an always-decision writes says how it got there
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And the policy has no rule for "docs.some-vendor.example"
     And an approval entry is visible for a request to "docs.some-vendor.example"
     When the developer picks "always allow"
-    Then the rule for "docs.some-vendor.example" in "lns-local-mixin.yaml" is noted as approved during a run
+    Then the rule for "docs.some-vendor.example" in "decisions.yaml" is noted as approved during a run
 
   Scenario: A raw entry an always-decision writes says how it got there
-    Given the sandbox was launched with --policy "lns-local-mixin.yaml"
+    Given the run records what it decides in "decisions.yaml"
     And an approval entry is visible for a raw splice to "db.internal:5432"
     When the developer picks "always allow"
-    Then the raw rule for "db.internal:5432" in "lns-local-mixin.yaml" is noted as approved during a run
+    Then the raw rule for "db.internal:5432" in "decisions.yaml" is noted as approved during a run

--- a/crates/lns-service/tests/behaviours/approval_rig.rs
+++ b/crates/lns-service/tests/behaviours/approval_rig.rs
@@ -93,7 +93,7 @@ pub struct ApprovalRig {
 impl ApprovalRig {
     pub fn new() -> Self {
         let dir = TempDir::new().expect("create tempdir");
-        let policy_path = dir.path().join("lns-local-mixin.yaml");
+        let policy_path = dir.path().join("decisions.yaml");
         let notifier = Arc::new(TestNotifier::default());
         let store = Arc::new(FlakyStore::new(policy_path.clone()));
         let (tx, rx) = mpsc::unbounded_channel();

--- a/crates/lns-service/tests/behaviours/declared_rig.rs
+++ b/crates/lns-service/tests/behaviours/declared_rig.rs
@@ -9,7 +9,7 @@ pub struct DeclaredRig {
     pub error: Option<String>,
     /// Mixin documents this machine can resolve, keyed by reference.
     pub mixins: std::collections::BTreeMap<String, String>,
-    /// The document the directory's own decisions file holds, for a scenario about the source §3.3.2 puts last.
+    /// The document a run's own decisions file holds, for a scenario about the source §3.3.2 puts last.
     pub local_mixin: Option<String>,
     /// The document the resolution produced, so a scenario can see what did and did not get merged into it.
     pub resolved_document: Option<String>,

--- a/crates/lns-service/tests/behaviours/mixin_resolution.feature
+++ b/crates/lns-service/tests/behaviours/mixin_resolution.feature
@@ -12,7 +12,7 @@ Feature: a run resolves the mixins its document declares
   an entry never went through it and is refused rather than booted without what
   it contributes.
 
-  The directory's own decisions are the last source in that list, so they merge
+  The run's own decisions are the last source in that list, so they merge
   into the document like any other and the disclosure attributes them to the
   file. What the guest enforces is folded from that file live, so a rule the
   developer deletes mid-run stops applying.
@@ -29,45 +29,45 @@ Feature: a run resolves the mixins its document declares
     When the published sandbox is resolved and launched
     Then the run installs "node@22"
 
-  Scenario: what the directory decided reaches the run, after everything it pulled
+  Scenario: what the run decided reaches the run, after everything it pulled
     Given a mixin declaring the tool "python@3.11"
     And the sandbox definition declares that mixin
-    And the directory's own decisions declare the tool "python@3.12"
+    And the run's own decisions declare the tool "python@3.12"
     When the published sandbox is resolved and launched
     Then the run installs "python@3.12"
 
-  Scenario: what the directory decided merges into the document that boots
+  Scenario: what the run decided merges into the document that boots
     Given the sandbox definition declares nothing but its image
-    And the directory's own decisions allow "api.some-provider.example"
+    And the run's own decisions allow "api.some-provider.example"
     When the published sandbox is resolved and launched
     Then the run installs "curl@8"
     And the resolved document allows "api.some-provider.example"
-    And the disclosure attributes "allow api.some-provider.example" to "lns-local-mixin.yaml"
+    And the disclosure attributes "allow api.some-provider.example" to "decisions.yaml"
 
-  Scenario: a directory that decided only destinations is a source the disclosure names
+  Scenario: a run that decided only destinations is a source the disclosure names
     Given the sandbox definition declares nothing but its image
-    And the directory's own decisions allow "api.some-provider.example" and nothing else
+    And the run's own decisions allow "api.some-provider.example" and nothing else
     When the published sandbox is resolved and launched
-    Then the run resolved the directory's own decisions as a source
+    Then the run resolved its own decisions as a source
 
-  Scenario: what the directory decided outranks a destination the sandbox denies
+  Scenario: what the run decided outranks a destination the sandbox denies
     Given the sandbox definition denies "docs.some-vendor.example"
-    And the directory's own decisions allow "docs.some-vendor.example" and nothing else
+    And the run's own decisions allow "docs.some-vendor.example" and nothing else
     When the published sandbox is resolved and launched
     Then a workload request to "docs.some-vendor.example" is allowed by policy
-    And the disclosure attributes "allow docs.some-vendor.example" to "lns-local-mixin.yaml"
+    And the disclosure attributes "allow docs.some-vendor.example" to "decisions.yaml"
     And the disclosure attributes "deny docs.some-vendor.example" to "the sandbox"
 
   Scenario: a destination the developer never decided stays the sandbox's to deny
     Given the sandbox definition denies "docs.some-vendor.example"
-    And the directory's own decisions allow "api.some-provider.example" and nothing else
+    And the run's own decisions allow "api.some-provider.example" and nothing else
     When the published sandbox is resolved and launched
     Then a workload request to "docs.some-vendor.example" is denied by policy
 
-  Scenario: a mixin the directory's decisions name merges before them
+  Scenario: a mixin the run's decisions name merges before them
     Given a mixin declaring the tools "node@22" and "python@3.11"
     And the sandbox definition declares nothing but its image
-    And the directory's own decisions declare the tool "python@3.12" and that mixin
+    And the run's own decisions declare the tool "python@3.12" and that mixin
     When the published sandbox is resolved and launched
     Then the run installs "node@22"
     And the run installs "python@3.12"
@@ -78,10 +78,10 @@ Feature: a run resolves the mixins its document declares
     When the published sandbox is resolved and launched
     Then a workload request to "api.some-provider.example" is allowed by policy
 
-  Scenario: a mixin cannot open a directory that denies by default
+  Scenario: a mixin cannot open a run that denies by default
     Given a mixin allowing "api.some-provider.example"
     And the sandbox definition declares that mixin
-    And the directory's lns-local-mixin.yaml denies all by default
+    And the run's decisions.yaml denies all by default
     When the published sandbox is resolved and launched
     Then a workload request to "api.some-provider.example" is denied by policy
 

--- a/crates/lns-service/tests/behaviours/steps/approval_flow.rs
+++ b/crates/lns-service/tests/behaviours/steps/approval_flow.rs
@@ -84,7 +84,7 @@ fn given_workload_with_file(world: &mut BehaviourWorld, _filename: String) {
         .expect("save initial policy");
 }
 
-#[given(regex = r#"^the sandbox was launched with --policy "([^"]+)"$"#)]
+#[given(regex = r#"^the run records what it decides in "([^"]+)"$"#)]
 fn given_launched_with_policy(world: &mut BehaviourWorld, _filename: String) {
     let rig = world.approval();
     Policy::default()

--- a/crates/lns-service/tests/behaviours/steps/declared_launch.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_launch.rs
@@ -42,7 +42,7 @@ fn declared_definition(w: &mut BehaviourWorld) -> String {
         .expect("a Given step must declare the definition")
 }
 
-#[given("the directory's lns-local-mixin.yaml denies all by default")]
+#[given("the run's decisions.yaml denies all by default")]
 fn overlay_denies_by_default(w: &mut BehaviourWorld) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.overlay.add_rule(lns_policy::RouteRule::deny_host("*"));

--- a/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
+++ b/crates/lns-service/tests/behaviours/steps/mixin_resolution.rs
@@ -94,11 +94,11 @@ fn mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
     );
 }
 
-#[given(regex = r#"^the directory's own decisions declare the tool "([^"]+)"$"#)]
+#[given(regex = r#"^the run's own decisions declare the tool "([^"]+)"$"#)]
 fn local_mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.local_mixin = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["{tool}"]}}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{{"tools":["{tool}"]}}}}"#
     ));
 }
 
@@ -106,13 +106,13 @@ fn local_mixin_declaring_a_tool(w: &mut BehaviourWorld, tool: String) {
 fn decided(w: &mut BehaviourWorld, spec: &str, allowing: &str) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.local_mixin = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{spec}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{spec}}}"#
     ));
     rig.overlay
         .add_rule(lns_policy::RouteRule::allow_host(allowing));
 }
 
-#[given(regex = r#"^the directory's own decisions allow "([^"]+)"$"#)]
+#[given(regex = r#"^the run's own decisions allow "([^"]+)"$"#)]
 fn local_mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
     decided(
         w,
@@ -123,7 +123,7 @@ fn local_mixin_allowing_a_destination(w: &mut BehaviourWorld, host: String) {
     );
 }
 
-#[given(regex = r#"^the directory's own decisions allow "([^"]+)" and nothing else$"#)]
+#[given(regex = r#"^the run's own decisions allow "([^"]+)" and nothing else$"#)]
 fn local_mixin_allowing_only_a_destination(w: &mut BehaviourWorld, host: String) {
     decided(
         w,
@@ -132,11 +132,11 @@ fn local_mixin_allowing_only_a_destination(w: &mut BehaviourWorld, host: String)
     );
 }
 
-#[given(regex = r#"^the directory's own decisions declare the tool "([^"]+)" and that mixin$"#)]
+#[given(regex = r#"^the run's own decisions declare the tool "([^"]+)" and that mixin$"#)]
 fn local_mixin_declaring_a_tool_and_that_mixin(w: &mut BehaviourWorld, tool: String) {
     let rig = w.declared.get_or_insert_with(Default::default);
     rig.local_mixin = Some(format!(
-        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"lns-local-mixin","spec":{{"tools":["{tool}"],"mixins":["{MIXIN}"]}}}}"#
+        r#"{{"apiVersion":"lns.run/v1","kind":"mixin","name":"decisions","spec":{{"tools":["{tool}"],"mixins":["{MIXIN}"]}}}}"#
     ));
 }
 
@@ -232,13 +232,13 @@ async fn sandbox_is_resolved_and_launched(w: &mut BehaviourWorld) {
     };
     let local = lns_service::artifact::mixin::LocalSource::read(
         local.map(|document| FetchedMixin {
-            pinned: "lns-local-mixin.yaml".to_string(),
+            pinned: "decisions.yaml".to_string(),
             document,
             layers: Vec::new(),
         }),
         Locator::Local(std::path::PathBuf::from("/work")),
     )
-    .expect("the directory's decisions read");
+    .expect("the run's decisions read");
     let planned = match lns_service::artifact::mixin::resolve(
         definition.as_bytes(),
         &[],
@@ -392,13 +392,13 @@ fn disclosure_attributes(
     }
 }
 
-#[then("the run resolved the directory's own decisions as a source")]
-fn run_resolved_the_directorys_decisions(w: &mut BehaviourWorld) -> Result<(), String> {
+#[then("the run resolved its own decisions as a source")]
+fn run_resolved_its_own_decisions(w: &mut BehaviourWorld) -> Result<(), String> {
     let rig = w.declared.as_ref().ok_or("no launch happened")?;
     if rig
         .resolved_mixins
         .iter()
-        .any(|source| source == "lns-local-mixin.yaml")
+        .any(|source| source == "decisions.yaml")
     {
         Ok(())
     } else {

--- a/crates/lns-service/tests/behaviours/steps/run_start_refusal.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_start_refusal.rs
@@ -61,7 +61,6 @@ fn args_named(name: &str) -> RunImageArgs {
         mem_explicit: false,
         cpus_config: None,
         mem_config: None,
-        policy_path: None,
         sandbox_user: None,
         sandbox_uid: None,
         entrypoint: None,

--- a/crates/lns-service/tests/behaviours/steps/run_start_stopped.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_start_stopped.rs
@@ -51,6 +51,7 @@ impl StartHost for ScriptedStartHost {
 
 pub(crate) fn stopped_record(run_id: &str, name: &str) -> RunRecord {
     RunRecord {
+        resolved_document: None,
         version: lns_service::run_record::CURRENT_VERSION,
         run_id: run_id.to_string(),
         name: name.to_string(),
@@ -78,7 +79,6 @@ fn sample_args() -> lns_ipc::RunImageArgs {
         mem_explicit: false,
         cpus_config: None,
         mem_config: None,
-        policy_path: None,
         denied_host_paths: Vec::new(),
         sandbox_user: None,
         sandbox_uid: None,

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ You drive everything through one binary: the `lns` CLI.
   and the stopped-run lifecycle.
 - **[Example: Claude Code](examples/claude-code/)** — a complete agent recipe:
   manifest, seed config, and network allowlist.
-- **[Policy and approvals](policy.md)** — the `lns-local-mixin.yaml` file, being asked
+- **[Policy and approvals](policy.md)** — a run's own `decisions.yaml`, being asked
   about what no rule decides, closing a directory, the approval window, and editing
   the rules by hand.
 - **[Audit](audit.md)** — the per-run audit chain and verifying it with

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,9 +56,10 @@ Everything `lns` keeps for you lives in one directory, `~/.lns/`:
 
 One directory, one thing to back up, one thing `lns uninstall --purge` removes.
 
-The project keeps two files, both in the directory you work in: `./lns.yaml`, the
-sandbox document, and `./lns-local-mixin.yaml`, what you decided here. Secrets are
-never written to the project.
+The project keeps one file in the directory you work in: `./lns.yaml`, the
+sandbox document. What a run decides lives with the run, at
+`~/.lns/runs/<RUN>/decisions.yaml`, and `lns sandbox save` writes it out where you
+name. Secrets are never written to the project.
 
 ## Machine-readable output
 
@@ -161,8 +162,7 @@ a directory holding one, or a path-shaped `.yaml`/`.yml` file naming the
 definition itself (`./lns.dev.yaml`); omit it to run the `./lns.yaml` in the
 current directory, or select another file with `-f`/`--file` (exclusive with
 `REF`). A path-named definition's directory is the project: it roots the relative binds
-and filesets, compose-style, and holds the `lns-local-mixin.yaml` the run
-resolves. A
+and filesets, compose-style. That is all it decides. A
 `COMMAND` after the reference overrides the sandbox base image's default command
 (`lns run ghcr.io/acme/agent:1 echo hi`) while keeping its `ENTRYPOINT`; an explicit `--`
 separator is still accepted. A command with no `REF` (`lns run -- echo hi`) runs
@@ -353,9 +353,9 @@ the document, but nothing sends it to a workload yet. A method whose filesets
 are written inline is offered and applied like any other.
 
 `Never here` on that card is the same standing no `lns connector forget` clears.
-Closing the card answers nothing, so the next run asks again. A `deny` you wrote
-in `lns-local-mixin.yaml` still decides: the connector is source 4 and your own
-file is source 5.
+Closing the card answers nothing, so the next run asks again. A `deny` this run
+already decided still decides: the connector is source 4 and the run's own
+decisions are source 5.
 
 The connector document format is specified in
 [Sandbox specification §3.2](sandbox-spec.md#32-kind-connector).

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -65,9 +65,10 @@ The rest of the surface manages neither a document nor a guest:
 handling — `push`, `pull`, `tag`, `validate`, `inspect`, and `rm` read that from
 the document. There is no `lns connector pull` and no `lns mixin push`.
 
-`lns artifact init` is the exception: it writes a document that does not exist
-yet, so the kind is an argument — `--kind sandbox` (the default), `--kind mixin`,
-or `--kind connector`.
+Two commands write a document that does not exist yet, so each takes the kind as
+an argument. `lns artifact init` takes `--kind sandbox` (the default),
+`--kind mixin`, or `--kind connector`. `lns sandbox save` takes `--kind sandbox`
+(the default) or `--kind mixin`.
 
 ### 1.3 Two names for one command
 
@@ -205,9 +206,10 @@ lns artifact prune [-f]
 | `rm` | `lns rm` | Removes one cached artifact and frees its now-unreferenced layers. Refused while a sandbox holds it — running or stopped — and the message names the holder. |
 | `prune` | | Removes every cached artifact nothing holds, and — when no sandbox is live — the provisioned tool cache, which any running sandbox may still be using. Lists them and asks, unless `-f`/`--force`. |
 
-`-f`/`--file` selects a document other than `./lns.yaml`; its directory is the
-project, so it roots the document's relative binds and filesets and holds the
-project's own mixin ([§3.2.3](#323-the-projects-own-mixin)).
+`-f`/`--file` selects a document other than `./lns.yaml`. The **document's own**
+directory is the project, so it roots that document's relative binds and
+filesets. The working directory and the document's directory decide nothing else
+([§3.2.3](#323-the-runs-decisions-and-saving-them)).
 
 A mixin and a connector are documents you write in an editor. Every artifact verb
 here works on them exactly as it works on a sandbox, because each reads the kind
@@ -227,6 +229,7 @@ lns sandbox logs <RUN> [-f]
 lns sandbox attach <RUN> [--detach-keys <CHORD>]
 lns sandbox ls [-a] [--format <table|json>]
 lns sandbox inspect <RUN> [--format <table|json>]
+lns sandbox save <RUN> -f <FILE> [--kind <sandbox|mixin>]
 lns sandbox rm <RUN> [-f]
 lns sandbox prune [-f]
 ```
@@ -257,7 +260,7 @@ keeping its `ENTRYPOINT`; `--` is accepted but not required.
 | `-t`, `--tty` | `true` | Allocate a PTY; pipe mode is selected automatically when stdin is not a terminal. Turn off with `--tty=false`. |
 | `-d`, `--detach` | `false` | Return once the sandbox is started. Conflicts with `-i` and `-t`. |
 | `--detach-keys <CHORD>` | `ctrl-p,ctrl-q` | Detach chord: single characters or `ctrl-X`, comma-separated. |
-| `--rm` | `false` | Remove the sandbox once the workload exits, writable layer included. |
+| `--rm` | `false` | Remove the sandbox once the workload exits, writable layer included. What the run decided goes with it ([§3.2.3](#323-the-runs-decisions-and-saving-them)). |
 | `-u`, `--user <USER[:GROUP]>` | image `USER`, else `sandbox` | Run-as user or uid inside the sandbox. Outranks `spec.user`, which outranks the image. `HOME` and `USER` follow that user's guest passwd entry unless `env:` or `-e` sets them. |
 | `--entrypoint <COMMAND>` | image `ENTRYPOINT` | Override the image entrypoint; the `COMMAND` after the reference becomes its arguments. `--entrypoint ""` clears it. |
 | `-h`, `--hostname <NAME>` | | Guest hostname for this sandbox. |
@@ -270,9 +273,10 @@ Two things a run does without being asked to:
   statement that the sandbox serves on that port, so it is published on loopback
   — the `host` value when the entry names one, the container number otherwise.
   `-p` adds to that, and overrides an entry for the same container port.
-- **It resolves this project's own mixin.** The `lns-local-mixin.yaml` beside the
-  document is always present and always last in the merge, so the decisions you
-  made here apply without naming a file.
+- **It gives the run its own decisions file.** Every run has one, in the run's
+  own directory, always last in the merge. What you answer at a prompt is written
+  there, so it applies for the rest of that run and never leaks into the next
+  one.
 
 Before anything boots, `lns run` prints what it resolved: the image, the mixins,
 the egress, the credentials, the mounts, the tools, the ports, and the `pre-start`
@@ -291,35 +295,55 @@ contributed it. That summary is the one thing you approve.
 | `attach` | `lns attach` | Re-joins the live session, most useful after `run -d`. The detach chord leaves the sandbox running and returns you to your shell; no signal is sent. Stdin reaches the workload only if the sandbox was started with stdin open. |
 | `ls` | `lns ps` | Lists running sandboxes with their state, CPU, and memory. `-a` includes stopped ones. |
 | `inspect` | `lns inspect` | Prints one sandbox's live state and launch configuration, with its resolved mixin embedded. |
-| `rm` | `lns rm` | Removes a stopped sandbox: its record and its writable layer, the name freed and the artifact released. What it granted and declined goes with it. `-f`/`--force` stops a running one first. |
-| `prune` | | Removes every stopped sandbox, writable layers included, and what each granted and declined. Lists them and asks, unless `-f`/`--force`. |
+| `save` | | Writes one sandbox out as a document you keep ([§3.2.3](#323-the-runs-decisions-and-saving-them)). `-f`/`--file` names the file and is required; `--kind mixin` writes what the run decided instead of the run as it resolved. Works on a running or a stopped sandbox. |
+| `rm` | `lns rm` | Removes a stopped sandbox: its record and its writable layer, the name freed and the artifact released. What it granted, declined, and decided goes with it, so save anything worth keeping first ([§3.2.3](#323-the-runs-decisions-and-saving-them)). `-f`/`--force` stops a running one first. |
+| `prune` | | Removes every stopped sandbox, writable layers included, and what each granted, declined, and decided. Lists them and asks, unless `-f`/`--force`. |
 
 Interrupting `lns` at the terminal (`Ctrl-C`) stops the sandbox. The detach chord
 does not: it returns your terminal, exits `0`, and leaves the workload running.
 
-#### 3.2.3 The project's own mixin
+#### 3.2.3 The run's decisions, and saving them
 
-Every project directory has one mixin nobody publishes: `lns-local-mixin.yaml`,
-beside the document. It holds what you decided here — the destinations you
-approved or refused — and every run in that directory resolves it last, so
-neither what you pulled nor what you connected can overrule it.
+Every run has one mixin nobody publishes: `decisions.yaml`, in the run's own
+directory. It holds what that run decided — the destinations you approved or
+refused — and the run resolves it last, so neither what you pulled nor what you
+connected can overrule it.
 
 - **The run writes it.** A destination no rule decides is asked about at first
   use, and your answer is appended as an `egress` entry. There is no command to
   run: answering the prompt is what records the decision.
-- **You can edit it, and commit it.** It is a `kind: mixin` document, so
-  `lns artifact validate` checks it and `lns artifact inspect` renders it. A
-  project's agreed destinations are reviewable in a pull request instead of
-  rediscovered by every developer.
+- **It belongs to that run.** A second `lns run` is a second run and starts with
+  an empty file, so it asks for itself. `lns start` and `lns exec` rejoin the
+  same run and keep what it decided.
+- **It goes when the run goes.** `lns rm` and `lns prune` take it with the run.
 - **Order is behaviour.** The guest stops at the first entry that matches a
   destination, so an entry placed after a `deny` — or after an entry that
-  restricts which callers or requests it permits — does not apply. When you edit
-  by hand, put the specific entry first.
-- **`deny: '*'` closes the project.** Nothing unlisted gets out, and nothing
-  prompts.
+  restricts which callers or requests it permits — does not apply.
+- **`deny: '*'` closes the run.** Nothing unlisted gets out, and nothing prompts.
 
-`lns run --mixin <PATH>` layers another mixin on top for one run, which is how you
-try a rule set without writing it here.
+`lns sandbox save` is how a decision outlives the run that made it.
+
+```bash
+lns sandbox save <RUN> -f <FILE> [--kind <sandbox|mixin>]
+```
+
+| Option | Default | Meaning |
+|---|---|---|
+| `-f`, `--file <FILE>` | — | Where to write. **Required**: `lns` never picks a path in your directory for you. Refuses to overwrite an existing file. |
+| `--kind <KIND>` | `sandbox` | What to write. `sandbox` writes what the documents resolved to: image, command, `env`, `workdir`, `user`, mounts, ports, resources, tools, filesets, credentials, and the `egress` every document source decided, this run's own decisions included. What a connector granted stays out — a teammate is asked on their own machine ([`sandbox-spec.md` §8.6](sandbox-spec.md#86-where-a-connector-grant-goes)). Every path it carries is written absolute, so the document means the same thing from any directory. `mixin` writes what the run decided and nothing else. |
+
+The document's `name` is the stem of the file you name, in both kinds. A stem
+that is not a legal document name refuses the save and says which characters a
+name takes, rather than writing a document `lns artifact validate` would reject.
+
+What it writes is an ordinary document from that point on: `lns artifact validate`
+checks it, `lns artifact inspect` renders it, and `lns artifact push` publishes
+it. A saved mixin is committable, and the `sandbox` that needs it names it in
+`spec.mixins` — which is how an agreed rule set reaches a teammate. Nothing
+applies because a file sits in a directory.
+
+`lns run --mixin <PATH>` layers a mixin on top for one run, which is how you try a
+rule set before you save one.
 
 ### 3.3 `lns connector`
 
@@ -350,8 +374,8 @@ lns connector forget <ID> --run <RUN>
 Four verbs bound the decision, across two scopes. On the machine: `install`
 makes a connector offerable, and `connect` signs in and stores a connection. On a
 run: `grant` lets it use one method, and `forget` takes that back. The working
-directory is not a scope here — it decides which local mixin resolves, and
-nothing about consent.
+directory is not a scope here — it roots the paths a reference resolves against,
+and nothing about consent.
 
 **`--as` naming a connection that already exists re-authenticates that one in
 place.** Where the authentication comes back with different authority, the grants
@@ -662,7 +686,7 @@ Every value a sandbox runs with is decided by this chain. Earlier wins; later
 fills the gap.
 
 1. **A command-line flag.**
-2. **A resolved mixin**, with this project's own mixin last of all.
+2. **A resolved mixin**, with the run's own decisions last of all.
 3. **The document's `spec`.**
 4. **The base image** — `USER`, `WORKDIR`, `ENTRYPOINT`, `CMD`.
 5. **Your `lns config` default**, for the keys that have one.
@@ -705,15 +729,20 @@ Everything `lns` keeps for you lives in one directory, `~/.lns/`:
 
 One directory, one thing to back up, one thing `lns uninstall --purge` removes.
 
-The project keeps two files, both in the directory you work in:
+A run keeps its own decisions with the run, in `~/.lns/`, and not in your project:
 
 | Path | Holds |
 |---|---|
-| `./lns.yaml` | The sandbox document. |
-| `./lns-local-mixin.yaml` | What you decided here: the egress rules you approved. Committable — which is why a connector grant is not in it. |
+| `~/.lns/runs/<RUN>/decisions.yaml` | What that run decided: the egress rules you approved at its prompts. It goes when the run does; `lns sandbox save --kind mixin` writes it somewhere you keep. |
+
+**`lns` writes no file you did not point it at.** Two commands write into your
+project: `lns artifact init`, to `./lns.yaml` or the `-f` you give it, and
+`lns sandbox save`, to the `-f` it requires. No other command creates a file
+there. The directory is read for the document you point at, and for
+nothing else.
 
 Secrets are never written to the project. A credential value is bound per machine,
-and what a project records is the decision, not the value.
+and what a run records is the decision, not the value.
 
 ---
 
@@ -737,7 +766,7 @@ The product is pre-1.0 and carries no compatibility shims. A rename is a rename.
   runs.
 - [Running workloads](running-workloads.md) — the guide to `run`, `ps`, `exec`,
   and `stop`.
-- [Policy and approvals](policy.md) — the destination grammar, and how the
-  project's own mixin records what you approve.
+- [Policy and approvals](policy.md) — the destination grammar, and how a run's
+  decisions record what you approve.
 - [Audit](audit.md) — the chain `lns audit` reads.
 - [The background service](service.md) — what `lns` is a client of.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,16 +95,12 @@ lns run
   Resources: 1 vCPU · 512 MiB · 10 GiB disk
   Flags:     -i -t
   Ports:     (none)
-  Policy:
-    file: /Users/you/dev/my-app/lns-local-mixin.yaml
-    unmatched destinations: ask
-    rules: none defined; anything else asks
-    source: auto-created (no policy in the project directory)
+  Decisions: recorded in this run, and removed with it
 ```
 
-You run LNS from a project directory — that's where it looks for
-`lns-local-mixin.yaml`, creating an empty one the first time. Run a definition in
-another directory and it reads that project's file instead. To
+You run LNS from a project directory. That directory holds your `lns.yaml` and
+roots the relative paths it spells, and nothing else: `lns` creates no file
+there. What you approve is recorded in the run itself. To
 give the workload your actual project files, bind-mount the directory with
 `-v "$(pwd)":/work` (see [Running workloads](running-workloads.md)); for a
 portable definition use a declarative bind with `source: .`; for scratch
@@ -185,8 +181,9 @@ an approval window appears from the background service showing the host and the
 action (for example `CONNECT api.github.com:443`). You choose:
 
 - **Allow once** / **Deny once** — applies to this request only.
-- **Allow always** / **Deny always** — also writes a matching rule to
-  `lns-local-mixin.yaml`, so the same question isn't asked again.
+- **Allow always** / **Deny always** — also writes a matching rule into this
+  run's own decisions, so the same question isn't asked again for this run.
+  `lns sandbox save --kind mixin -f <FILE>` keeps those answers past the run.
 
 A denied request fails at the boundary the way a real network failure would — a
 refused connection or a failed DNS lookup — never a silent success.
@@ -213,8 +210,8 @@ lns uninstall --purge
 ```
 
 `--purge` deletes the whole data directory and shows the resolved directory in its
-confirmation prompt. Files in your projects, such as each directory's `lns.yaml`
-and `lns-local-mixin.yaml`, are never touched.
+confirmation prompt. Files in your projects, such as each directory's `lns.yaml`,
+are never touched.
 
 ## Where to go next
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -7,31 +7,31 @@ three things: **allow** it, **deny** it at the boundary, or — when no rule mat
 
 ## The policy file
 
-Policy lives in a human-readable YAML file. By default that's
-`lns-local-mixin.yaml` beside the definition being run — the directory you run
-from, unless you name a definition in another one — and the first `lns run` in a
-directory without one creates it:
+Policy lives in a human-readable YAML file. Every run has one of its own, at
+`~/.lns/runs/<RUN>/decisions.yaml`. `lns run` creates it empty and writes your
+answers into it as you give them:
 
 ```yaml
 apiVersion: lns.run/v1
 kind: mixin
-name: lns-local-mixin
+name: decisions
 spec:
   egress:
     http: []
     tcp: []
 ```
 
-`lns run` writes this starter file for you, so you only deal with it by hand if you
-choose to edit the file directly.
+You never name this file, and nothing is created in the directory you work in.
 
 The file is a **mixin** — the same document format a
-[sandbox definition](running-workloads.md#defining-a-sandbox) layers on. Every
-run in the directory resolves it without being named, after every other source,
-so nothing you pulled overrules what you decided. Because it is a source like any
-other, the summary a run prints before booting lists its rules and names the file
-they came from — so a rule of yours that overrules one the sandbox shipped is
-visible while you can still stop the run.
+[sandbox definition](running-workloads.md#defining-a-sandbox) layers on. The run
+resolves it after every other source, so nothing you pulled overrules what you
+decided.
+
+The summary a run prints before booting lists the rules the **documents**
+decided — the sandbox's own and every mixin layered on it — each named by the
+source that decided it. This file is empty at that point, because the run has
+not asked you anything yet. What you answer goes in here as you answer it.
 
 The rules the run enforces are folded from this file as it stands, not from a copy
 taken at launch: a rule an approval appends mid-run applies at once, and one you
@@ -39,23 +39,37 @@ delete mid-run stops applying.
 
 Being a mixin also means the file is not limited to `egress`. Any block a mixin
 can declare, this one can declare too — a tool, a mount, another mixin to layer
-on — and it reaches every run in this directory:
+on.
 
-```yaml
-apiVersion: lns.run/v1
-kind: mixin
-name: lns-local-mixin
-spec:
-  tools:
-    - ripgrep@14
-  egress:
-    http: []
-    tcp: []
+**The file belongs to the run.** A second `lns run` is a second run, and it
+starts with an empty file, so it asks for itself. `lns start` and `lns exec`
+rejoin the same run and keep what it decided. `lns rm` takes the file with the
+run.
+
+## Keeping what a run decided
+
+`lns sandbox save` writes a run out as a document you keep:
+
+```bash
+lns sandbox save reviewer --kind mixin -f ./team-egress.yaml
 ```
 
-One directory, one policy file — it sits next to the project it governs, and
-nothing names it. A definition you run from another directory is governed by
-that directory's file, not by the one where you typed the command.
+That writes what the run decided, and nothing else, as a `kind: mixin` document
+named after the file. `-f` is required — `lns` never picks a path in your
+directory for you — and it refuses to overwrite a file that is already there.
+Drop `--kind mixin` to write the run as a whole instead.
+
+What you save is an ordinary document from that point on. Commit it, and have the
+`lns.yaml` that needs it name it in `spec.mixins`:
+
+```yaml
+spec:
+  mixins:
+    - ./team-egress.yaml
+```
+
+That is how an agreed rule set reaches a teammate. A rule applies because a
+document names it, never because a file sits in a directory.
 
 ### What the file decides, and what it doesn't
 
@@ -216,10 +230,11 @@ section before using it.
 ## Editing the file
 
 No command edits the rules. A decision is recorded one of two ways: you answer the
-card a run raises, or you open `lns-local-mixin.yaml` and write the rule yourself.
+card a run raises, or you write the rule in a mixin of your own and layer it on
+with `--mixin`.
 Both write the same document, and because it is a `kind: mixin` document,
-`lns artifact validate -f lns-local-mixin.yaml` checks what you wrote and
-`lns artifact inspect -f lns-local-mixin.yaml` renders it.
+`lns artifact validate -f <FILE>` checks what you wrote and
+`lns artifact inspect -f <FILE>` renders it.
 
 ### Add an allow or deny rule
 
@@ -378,10 +393,11 @@ If no one responds, the request times out and is treated as a denial.
 
 ## Sharing policy
 
-Because policy is a plain file, it travels. Commit `lns-local-mixin.yaml` to the
-repo so everyone running the project shares the same rules, or hand it to a
-teammate to drop beside their own document. A run loads the file at startup, so
-shared approvals are already in place — no one has to re-approve them.
+Because policy is a plain file, it travels. Save it with `lns sandbox save
+--kind mixin`, then commit the result so everyone running the project shares the
+same rules. Have the `lns.yaml` name it in `spec.mixins`, or pass it per run with
+`--mixin`. Either way the run resolves it at startup, so shared approvals are
+already in place and nobody has to re-approve them.
 
 ## See also
 

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -118,10 +118,9 @@ lns run ghcr.io/acme/agent:latest        # run a published sandbox by reference
 ```
 
 One directory is one project, and the definition you run names which: the
-`lns-local-mixin.yaml` that governs a run sits beside the `lns.yaml` being run, so
-`lns run ../other-project` reads and writes that project's decisions rather than
-yours. A published reference has no directory of its own, so a run of one is
-governed by the directory you start it in.
+directory of the `lns.yaml` being run roots the relative paths that document
+spells. That is all it decides. What a run decides is recorded in the run, not in
+any directory, so `lns run ../other-project` leaves both directories untouched.
 
 To expose your actual host files to the workload, bind-mount a directory with
 `-v /host/path:/guest/path` (see [Host bind mounts](#host-bind-mounts)); for
@@ -639,12 +638,12 @@ lns pull ghcr.io/acme/observability:2      # cache it and the mixins it names
 **The last source to say something about a thing wins.** Sources are ordered:
 the sandbox first, then each entry in `spec.mixins` in order with that mixin's
 own mixins expanded right after it, then each `--mixin` the user passed, and
-last the directory's own
-[`lns-local-mixin.yaml`](policy.md#the-policy-file) — so nothing you pulled
-overrules what you decided here. Every block of that file merges like any other
-source's, including its `egress`, so the summary lists your rules beside the ones
-they overruled. What the running sandbox enforces is folded from the file itself,
-so a rule you add or delete mid-run applies or stops applying at once.
+last the run's own
+[`decisions.yaml`](policy.md#the-policy-file) — so nothing you pulled overrules
+what you decided. Every block of that file merges like any other source's,
+including its `egress`, so the summary lists your rules beside the ones they
+overruled. What the running sandbox enforces is folded from the file itself, so a
+rule you add or delete mid-run applies or stops applying at once.
 
 A local entry is read from this machine, relative to the document that names it.
 It may name the directory — whose `lns.yaml` is read — or the document itself,
@@ -704,10 +703,10 @@ where each line came from — and lists the rules and credentials the merge
 produced, which an uncomposed run has no second author to attribute:
 
 ```
-  Mixins:    /work/mixins/debug-tools, lns-local-mixin.yaml
+  Mixins:    /work/mixins/debug-tools, /work/mixins/team-egress.yaml
   Volume:    cache → /home/agent/.cache  [from /work/mixins/debug-tools]
   Tools:     node@22  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…, replaced node@20 from the sandbox]
-  Rules:     allow docs.vendor.example  [from lns-local-mixin.yaml]  approved during a run
+  Rules:     allow docs.vendor.example  [from /work/mixins/team-egress.yaml]  approved during a run
              allow api.vendor.example  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]
              deny docs.vendor.example  [from the sandbox]
   Credentials: SOME_TOKEN  [from ghcr.io/acme/observability@sha256:c41e8b7d20a9…]

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -10,7 +10,8 @@ connector the user installs to reach a service.
 >
 > For what `lns` accepts today, read the guides:
 > **[Running workloads](running-workloads.md)** for authoring and publishing,
-> and **[Policy and approvals](policy.md)** for the per-directory policy file.
+> and **[Policy and approvals](policy.md)** for the network rule grammar and a
+> run's own decisions.
 >
 > The product is pre-1.0. Every gap between this document and the code closes as
 > a breaking, unversioned change with no compatibility shim.
@@ -677,9 +678,10 @@ what was behind it does not.
 An exclusion travels with the sandbox: a published bind masks what its author
 meant, on whatever machine runs it.
 
-A developer who wants to mask something the author did not name puts a bind with
-their own `exclude` in the [local mixin](#8-the-local-mixin). It is last in the
-merge, so a pulled document cannot undo it.
+A developer who wants to mask something the author did not name writes a mixin of
+their own with that `exclude`, and layers it with `--mixin` or from `spec.mixins`.
+A mixin the user names merges after a pulled document, so the pulled one cannot
+undo it ([§3.3.2](#332-merge-rules)).
 
 **`optional` — a source not every machine has.** A published sandbox names host
 paths that exist on the author's machine and not on every consumer's. `optional:
@@ -853,7 +855,7 @@ collision is caught at launch ([§5](#5-validation-summary)), and the run refuse
 naming both entries and the spelling each used.
 
 [§3.3.2](#332-merge-rules) keys the fileset union on the path **as written**, so a
-local mixin writing `/home/agent/.claude` does not override a connector method's
+mixin writing `/home/agent/.claude` does not override a connector method's
 `~/.claude` — both survive the merge and the run refuses for the collision above.
 To override an entry, match its spelling.
 
@@ -868,8 +870,8 @@ not. A document loaded from the developer's own directory is their own consent
 and is never asked about.
 
 The decision is per machine, so it lives beside the other per-machine state and
-not in the [local mixin](#8-the-local-mixin): the local mixin is a rule the
-directory keeps, and this is a risk accepted by one developer on one computer.
+not in the [run's decisions](#8-the-runs-decisions): that file is one run's
+answers, and this is a risk accepted by one developer on one computer.
 
 #### 3.1.12 `ports`
 
@@ -1278,7 +1280,7 @@ only makes its destinations ask ([§3.2.1](#321-serves)).
 3. **Apply the method.** Its `egress`, `credentials`, and `filesets` reach the
    running guest, and a grant is recorded for this run — the method, and the
    connection behind it where one exists
-   ([§8.4](#84-where-a-connector-grant-goes)).
+   ([§8.6](#86-where-a-connector-grant-goes)).
 
 Authentication that fails or is abandoned grants nothing and leaves the offer
 standing.
@@ -1295,9 +1297,10 @@ held request (`lns connector grant`). The trigger decides when the card
 appears, never whether consent must be informed.
 
 **A grant belongs to one run.** Not to a directory: the working directory
-decides which [local mixin](#8-the-local-mixin) resolves, and nothing about
-consent. A run keeps what it was granted across every stop and start. It loses
-that grant when the run is removed, and not before.
+roots the paths a reference resolves against, and nothing about consent
+([§8.5](#85-what-the-working-directory-decides)). A run keeps what it was granted
+across every stop and start. It loses that grant when the run is removed, and not
+before.
 
 **A grant MAY also be given ahead of the run**, to a name no run holds yet. It
 is then a **reservation**. Exactly one act takes a reservation: **creating a run
@@ -1342,8 +1345,8 @@ before or after it — a connector is source 4, and
 `allow`. The override MUST be named in the pre-boot
 disclosure ([§1.5](#15-one-disclosure)) and on the consent card that introduces
 it. A reservation is no exception: a run takes one as it is created, before the
-disclosure resolves. The [local mixin](#8-the-local-mixin) is unaffected: it is
-source 5, so a `deny` the developer typed still wins.
+disclosure resolves. The [run's decisions](#8-the-runs-decisions) are unaffected:
+they are source 5, so a `deny` the developer answered still wins.
 
 **The held request waits, and applying does not depend on it.** The request that
 triggered the offer stays held while the user chooses a connection and satisfies any
@@ -1362,7 +1365,7 @@ the next start of that run. It does **not** reach a fresh `lns run`: that is a
 different run, and it holds no grant.
 
 **Declining is one run's standing no**, remembered outside every document
-([§8.4](#84-where-a-connector-grant-goes)) and retractable there.
+([§8.6](#86-where-a-connector-grant-goes)) and retractable there.
 
 **A machine MAY hold several connections of one connector**, including several of
 one method. Two tokens for two accounts, or two sign-ins at different scopes, are
@@ -1536,7 +1539,7 @@ document that contributed it and showing the user it asks for
 ([§1.5](#15-one-disclosure)) — so a mixin that wants root gets it by saying so to
 the person running it, which is exactly what `spec.user` would have had to do.
 
-One mixin is never authored: every directory has a [local one](#8-the-local-mixin)
+One mixin is never authored: every run has [its own decisions](#8-the-runs-decisions)
 that the run writes as the developer answers prompts.
 
 #### 3.3.1 How a mixin enters a run
@@ -1600,8 +1603,8 @@ it:
 4. Each granted [connector](#32-kind-connector) — its **granted method** only, in
    grant order. User consent on this machine, so it beats anything a document
    shipped.
-5. The directory's [local mixin](#8-the-local-mixin) — the developer's own
-   decisions, so neither what they pulled nor what they connected can overrule
+5. The run's own [decisions](#8-the-runs-decisions) — the developer's own
+   answers, so neither what they pulled nor what they connected can overrule
    them.
 
 So `lns run claude --mixin first --mixin second` resolves as:
@@ -1614,7 +1617,7 @@ weakest ────────────────────────
 **A connector is the one source no document names**, so it is the one source
 whose position is not a consequence of where it was written down. It sits after
 every document because the user granted it here and now; it sits before the
-local mixin because a `deny` the developer typed by hand is still the last word.
+run's decisions because a `deny` the developer answered is still the last word.
 A connector shadowed that way is reported in the approval window, rather than
 silently taking no effect.
 
@@ -1642,7 +1645,7 @@ What "wins" means per block:
 | `tools` | Union by name. The last version declared wins. |
 | `volumes`, `filesets` | Union by guest path — a volume `target` and a fileset `guestPath` share one namespace, compared on path segments ([§3.1.10](#3110-volumes)). The last source to claim a path owns it. A named volume's [`size`](#3110-volumes) is the largest any surviving entry declares, because a size is a floor and every mount of that volume must clear it. |
 | `ports` | Union by `container`. The last mapping wins. |
-| `scripts` | **Append**, in source order. Not last-wins: every source's scripts run, the sandbox's own first and the local mixin's last. |
+| `scripts` | **Append**, in source order. Not last-wins: every source's scripts run, the sandbox's own first and the run's decisions last. |
 
 **`scripts` is the one block nothing overrides**, and the reason is that it has
 no key. Every other block names what it decides — an `envVar`, a tool, a guest
@@ -1651,7 +1654,7 @@ question. Two scripts state no question. Dropping one because another looked lik
 it would not be an override; it would be a missing dependency, discovered as a
 command not found somewhere inside the workload. So every script survives, and
 order is the only thing resolution decides about them — the source order above,
-which puts the sandbox's own preparation first and the local mixin's last. Later
+which puts the sandbox's own preparation first and the run's decisions last. Later
 still wins, in time rather than in precedence.
 
 Because a source many documents name merges at the last place the order names it,
@@ -1977,6 +1980,8 @@ Offline validation (`lns artifact validate`, and every load path including
   [§3.3.1](#331-how-a-mixin-enters-a-run). Whether a local entry is *publishable*
   is not an offline check on one document: it depends on the document that entry
   names ([§6.1](#61-a-local-mixin-publishes-with-the-document-that-names-it)).
+  A local entry — and a `--mixin` — that resolves to a run's `decisions.yaml` is
+  refused, because that file is one run's own answers ([§8.1](#81-what-it-is)).
 
 Offline validation checks one document in isolation. Six checks cannot run
 there, because they depend on state no document carries — they run at launch:
@@ -2054,7 +2059,7 @@ because a repository is a publishing decision and a directory name is not one.
 | Tag | `sha256-<64 hex>`, where the hex is the child's manifest digest. It is **not a release**; only the tag the author types on `<REF>` is a release. |
 | Source | The author's document is **not** rewritten. Only the published bytes carry the digest, exactly as a resolved `tools[]` entry does. |
 | Cycle | Refused, naming the trail. A document reachable from itself has no digest to pin, because its digest would depend on itself. |
-| The local mixin | Refused. [§8.1](#81-what-it-is) makes `lns-local-mixin.yaml` never published, and an entry naming it cannot be honoured by publishing it. |
+| A run's decisions | Refused. [§8.1](#81-what-it-is) makes a run's `decisions.yaml` never published, and an entry naming it cannot be honoured by publishing it. A saved copy ([§8.4](#84-how-a-decision-leaves-the-run)) is an ordinary document and publishes like one. |
 
 **Why the child carries a tag at all.** The parent resolves it by digest and
 never reads the tag. The tag exists because a registry that prunes untagged
@@ -2187,7 +2192,7 @@ resumes that grant with no fresh consent prompt — the grant was bound to those
 bytes and those bytes came back. This is deliberate: uninstalling is housekeeping
 on the machine, and withdrawing consent is a decision about a run. A run
 retracts its own grant, or its decline, through the store that holds it
-([§8.4](#84-where-a-connector-grant-goes)).
+([§8.6](#86-where-a-connector-grant-goes)).
 
 **Uninstalling does drop every connection**, because they are machine state and the
 machine is what is being cleaned. So a reinstall resumes the grant and **not** the
@@ -2229,20 +2234,19 @@ resolve against nothing; a README SHOULD use absolute URLs.
 
 ---
 
-## 8. The local mixin
+## 8. The run's decisions
 
-Every directory has one mixin nobody wrote. The run fills it in as the developer
-works.
+Every run has one mixin nobody wrote. The run fills it in as the developer works.
 
 A destination no `egress` entry decides is asked about
 ([§1.3](#13-disclosure-before-boot)). The answer is a decision, and an unrecorded
 decision is the same question again tomorrow — so the run writes it down, as an
-`egress` entry, in a `mixin` document, in the directory the work is happening in.
+`egress` entry, in a `mixin` document, in the run's own directory.
 
 ```yaml
 apiVersion: lns.run/v1
 kind: mixin
-name: lns-local-mixin
+name: decisions
 spec:
   egress:
     http:
@@ -2258,17 +2262,23 @@ spec:
 - **A `mixin`.** The same grammar as [§3.3](#33-kind-mixin), so a decision is
   recorded in the shape the rest of the document already defines and stays
   readable by the person who made it.
-- **Always present.** A directory has one whether or not anyone created it, and
-  every run there resolves it without being named.
+- **One run's, and always present.** A run has one whether or not anything was
+  asked, and it resolves without being named. It is created with the run and
+  removed with it, so a run that is gone has no decisions left behind.
+- **Not the directory's.** Two runs started in one directory each answer for
+  themselves, and neither reads the other's file. The working directory decides
+  which paths a reference resolves against and nothing else
+  ([§8.5](#85-what-the-working-directory-decides)).
 - **Written by the run.** An approval appends to it. It holds only what is
   **new** — the decisions the developer made about things nothing had decided.
   Anything a `sandbox` or a `mixin` already declares stays in that document, where
   its author can see it.
 - **Local, and never published.** The one exception to
   [§1.1](#11-one-distribution-mechanism): every other artifact is addressed by
-  digest, and this one is a working file on disk. It holds one machine's answers,
-  so a `mixins` entry that names it is refused rather than published
-  ([§6.1](#61-a-local-mixin-publishes-with-the-document-that-names-it)).
+  digest, and this one is a working file on disk. It holds one machine's answers
+  about one run, so a `mixins` entry or a `--mixin` that resolves to a run's
+  `decisions.yaml` MUST be refused. Saving it is the supported way to reuse it
+  ([§8.4](#84-how-a-decision-leaves-the-run)).
 - **Last in the merge.** It is the developer's own, so it sits after every other
   source in [§3.3.2](#332-merge-rules) — including a `--mixin`. Nothing they pulled
   can overrule what they decided, and that includes what this file itself pulls: a
@@ -2284,25 +2294,76 @@ answer.
 ### 8.2 Why a mixin rather than a format of its own
 
 Because it makes the file worth reading. A decision recorded in mixin grammar is a
-decision a developer can open, correct, and diff — and one they can **commit**, so
-a project's agreed destinations are reviewable in a pull request instead of
-rediscovered by each developer alone. A bespoke policy format would need its own
-parser, its own documentation, and its own answer to every question
-[§3](#3-artifact-kinds) already answers.
+decision a developer can open, correct, and diff — and one they can **keep**, by
+writing the run out as a document of its own
+([§8.4](#84-how-a-decision-leaves-the-run)), so a project's agreed destinations are
+reviewable in a pull request instead of rediscovered by each developer alone. A
+bespoke policy format would need its own parser, its own documentation, and its
+own answer to every question [§3](#3-artifact-kinds) already answers.
 
 It also stops the file being egress-only. If a decision ever needs to record
 something other than a destination, the blocks are already defined.
 
 ### 8.3 The name
 
-The file is `lns-local-mixin.yaml`. The old name described a file that held
-policy; this one holds decisions, in mixin grammar, and may hold more than
-egress — so it says what the file **is** rather than what it once carried, and it
-sorts beside the `lns.yaml` it layers on.
+The file is `decisions.yaml`, in the run's own directory. It holds decisions, in
+mixin grammar, and may hold more than egress — so it says what the file **is**
+rather than where it once sat.
 
 Its `name` is the file's own stem, because nobody is present to choose one.
 
-### 8.4 Where a connector grant goes
+### 8.4 How a decision leaves the run
+
+A decision is worth keeping past the run that made it. The run's directory is
+temporary: it goes when the run does.
+
+So a run can be written out as a document the developer names and puts where they
+want ([`cli-spec.md` §3.2.3](cli-spec.md#323-the-runs-decisions-and-saving-them)).
+
+- Written as a `mixin`, the document holds what the run decided and nothing else.
+- Written as a `sandbox`, it holds what the **documents** resolved to: image,
+  command, `env`, `workdir`, `user`, mounts, ports, resources, tools, filesets,
+  credentials, and the `egress` every document source decided, the run's own
+  decisions included. A mixin the run resolved is folded in, so the saved
+  document names none and resolves nothing; what it came from is in the run's
+  audit record, not in the file.
+- **A grant stays out of it.** What a connector granted is source 4
+  ([§3.3.2](#332-merge-rules)). It is one person's consent on one machine
+  ([§8.6](#86-where-a-connector-grant-goes)), so a saved `sandbox` MUST NOT carry
+  it. A teammate running the saved document is asked on their own machine.
+- **Every path is written absolute.** A relative `source` means the directory of
+  the document that declared it ([§3.3.1](#331-how-a-mixin-enters-a-run)), and a
+  saved document lands somewhere else. So a save MUST write the folded absolute
+  path the run resolved. The document then means the same thing from any
+  directory.
+- Either way the document's `name` is the stem of the file it is written to,
+  because someone is present to choose one — unlike the run's own
+  `decisions.yaml` ([§8.3](#83-the-name)). A stem that is not a legal
+  [`name`](#2-common-top-level-fields) MUST refuse the save rather than write a
+  document [§5](#5-validation-summary) would reject.
+
+From that point it is an ordinary document: validated, rendered, published, and
+named by a `mixins` entry like any other.
+
+**That is how a decision travels.** A rule applies because a document names it,
+never because a file sits in a directory. A team commits the saved mixin and the
+`sandbox` that needs it lists it in `spec.mixins`
+([§3.3.2](#332-merge-rules)) — the same resolution as every other mixin, with no
+path that only works from one directory.
+
+### 8.5 What the working directory decides
+
+The working directory decides nothing about a run's contents. It decides nothing
+about consent.
+
+It roots the relative paths the user types on the command line: a `-f`, a
+`--mixin`, a `-v` source, an `--env-file`. A relative `source` inside a document
+roots at the directory of the document that declared it, not at the working
+directory ([§3.3.1](#331-how-a-mixin-enters-a-run)).
+
+One thing follows: a rule applies because a document names it.
+
+### 8.6 Where a connector grant goes
 
 A connector grant does not live here, and this is the one place where "a
 connector is a mixin" stops short of the obvious. Writing the granted
@@ -2310,7 +2371,8 @@ connector's reference into this file's `mixins` would make every later run
 resolve it by the ordinary rules, with no special path anywhere — which is
 exactly why it is tempting, and exactly why it is wrong.
 
-**This file is committable.** A grant is consent to let a real value reach a real
+**This file can be saved out** ([§8.4](#84-how-a-decision-leaves-the-run)), and a
+saved document is committable. A grant is consent to let a real value reach a real
 destination ([§7.1](#71-connectors)), given by one person on one machine, and
 consent does not travel in a git clone. A teammate is asked on their own machine
 rather than inheriting an answer. Worse, the answer would not even work there:
@@ -2325,7 +2387,8 @@ source.
 
 **The working directory decides nothing about consent**
 ([§3.2.4](#324-installing-connecting-and-applying)). Two runs in one directory
-each answer for themselves.
+each answer for themselves. A run's decisions follow the same rule
+([§8.1](#81-what-it-is)), so one rule governs both.
 
 A decline lives beside it, and both are retractable: a run can forget what it
 decided about one connector, so the next run asks again. Neither is a document,
@@ -2337,6 +2400,6 @@ so neither is committed, and a mis-clicked deny is never permanent.
 
 - [Running workloads](running-workloads.md) — the authoring guide for this format.
 - [Policy and approvals](policy.md) — the `match` pattern grammar and the
-  per-directory `lns-local-mixin.yaml`.
+  run's own `decisions.yaml`.
 - [CLI reference](cli-reference.md) — `lns artifact init`, `validate`, `inspect`,
   `push`.

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -1980,8 +1980,6 @@ Offline validation (`lns artifact validate`, and every load path including
   [§3.3.1](#331-how-a-mixin-enters-a-run). Whether a local entry is *publishable*
   is not an offline check on one document: it depends on the document that entry
   names ([§6.1](#61-a-local-mixin-publishes-with-the-document-that-names-it)).
-  A local entry — and a `--mixin` — that resolves to a run's `decisions.yaml` is
-  refused, because that file is one run's own answers ([§8.1](#81-what-it-is)).
 
 Offline validation checks one document in isolation. Six checks cannot run
 there, because they depend on state no document carries — they run at launch:
@@ -2276,9 +2274,11 @@ spec:
 - **Local, and never published.** The one exception to
   [§1.1](#11-one-distribution-mechanism): every other artifact is addressed by
   digest, and this one is a working file on disk. It holds one machine's answers
-  about one run, so a `mixins` entry or a `--mixin` that resolves to a run's
-  `decisions.yaml` MUST be refused. Saving it is the supported way to reuse it
-  ([§8.4](#84-how-a-decision-leaves-the-run)).
+  about one run, so a `mixins` entry that names it is refused rather than
+  published ([§6.1](#61-a-local-mixin-publishes-with-the-document-that-names-it)).
+  Reading it is not publishing it: a `--mixin` that names one is an ordinary
+  local reference to an ordinary mixin. Saving it is how a decision travels to
+  another machine ([§8.4](#84-how-a-decision-leaves-the-run)).
 - **Last in the merge.** It is the developer's own, so it sits after every other
   source in [§3.3.2](#332-merge-rules) — including a `--mixin`. Nothing they pulled
   can overrule what they decided, and that includes what this file itself pulls: a

--- a/docs/service.md
+++ b/docs/service.md
@@ -37,7 +37,7 @@ Two environment variables override the defaults (mostly useful for development):
 - `LNS_SERVICE_BIN` — use a specific `lns-service` binary.
 - `LNS_HEADLESS=1` — run without the tray or approval window even when a
   display is present. Interactive prompts can't be shown headless, so
-  approvals need pre-authorized rules in `lns-local-mixin.yaml`.
+  approvals need pre-authorized rules in a mixin the run names.
 
 ## Updating
 


### PR DESCRIPTION
The working directory has carried too much meaning. It decided which policy governed a run, and `lns run` created a file there to hold it. This moves that state into the run and leaves the directory alone.

## What changes

**The working directory roots only the relative paths the user types** — a `-f`, a `--mixin`, a `-v` source, an `--env-file`. `lns` creates no file in a project that the user did not name.

**A run's decisions live at `~/.lns/runs/<RUN>/decisions.yaml`.** Same `kind: mixin` document, still last in the merge. The service names it from the run's own directory, creates it empty before the supervisor starts, and removes it with the run. Two runs in one directory each answer for themselves — the rule a connector grant already followed.

**`lns-local-mixin.yaml` is gone.** A rule reaches a run because a document names it in `spec.mixins` or on `--mixin`, never because a file sits in a directory.

**`lns sandbox save <RUN> -f <FILE> [--kind <sandbox|mixin>]`** is how a decision outlives the run that made it.

- `-f` is required — `lns` never picks a path in your directory — and it refuses to overwrite.
- `--kind mixin` writes what the run decided and nothing else.
- The default writes the run as it resolved: mixins folded in, every path absolute, and nothing a connector granted, because that is one person's consent on one machine.
- The file's stem names the document; a stem no document may carry refuses the save.
- The service renders the document and this machine writes it, so the service never reaches into the user's directory.

## Shape of the change

`decisions` leaves the `ResolveDefinition` / `InspectImage` preflight requests and `policy_path` leaves `RunImageArgs`, because a caller never names that file. `lns sandbox inspect` still reports it, filled in by the service from the run id. The launch summary's `Policy:` block becomes a one-line `Decisions:` line, since the merged rules were already disclosed under `Rules:`.

## Commits

`docs/sandbox-spec.md` §8 and `docs/cli-spec.md` §3.2 change first, as the decision. The code and the guides follow in the second commit.

## Testing

- Layer 2: `lns sandbox save` scenarios in `sandbox_cli.feature` — writing, naming the document after the file, refusing an overwrite, refusing an illegal stem, and the grammar refusal without `-f`.
- Layer 3: `run/save.rs` renders both kinds, keeps a declared mount's `exclude` and `size`, roots relative sources, drops folded mixins, and carries no connector grant. `run/decisions.rs` covers first boot, restart, and both failure paths. `ipc/mod.rs` covers the save handler and the inspect path.
- Layer 1: a real `lns run` in a real tempdir leaves the directory holding only its `lns.yaml`, which the old `resolve_policy` write would have failed.

`make lint` and `make complexity` are clean. `make coverage` cannot complete in this environment — six permission-failure tests pass unexpectedly under a root uid and abort the run — so coverage is CI's call; `lns-cli` passes its per-file gate cleanly and `run/save.rs` and `run/decisions.rs` were verified at 100% individually.