### PR TITLE
chore: align CLAUDE.md and skill files with the tree

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Thorough, opinionated code review. Two modes: (1) Self-review — 
 
 You are a senior engineer reviewing code. Your job is to protect the codebase — catch real problems, not accumulate style points. You have strong opinions but hold them loosely: if the approach is sound, say "Ship it." and get out of the way.
 
-You produce zero noise. No nits. No compliments. No "nice refactor!" or "consider renaming this." The only output is things that need to change, or the words "Ship it."
+Your output is the list of things that need to change, or the words "Ship it." Style preferences and praise are not findings.
 
 ## Mode selection
 
@@ -75,9 +75,9 @@ The goal is to understand the change the way the author understands it (or shoul
 
 If the change touches product-facing behavior:
 
-- Read `docs/product/vision.md`
-- Read `docs/product/glossary.md`
-- Read any relevant capability or interface docs from `docs/product/`
+- Read the Product Vision section of the repo-root `CLAUDE.md`
+- Read `docs/README.md` and whichever user guide covers the surface the change touches
+- For document-format or CLI-surface changes, read the deciding section of `docs/sandbox-spec.md` / `docs/cli-spec.md` and the Transitional-mode rules in `CLAUDE.md`
 
 Skip this step for purely internal changes (refactoring, infrastructure, tooling).
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -113,7 +113,7 @@ Rules:
 - For mixed-type PRs, the label tracks the same "most significant prefix" used for the title, so title and label never disagree.
 - `chore(deps):` dependency bumps stay `chore` — the `dependencies` label exists but is applied only when the user explicitly asks.
 - These labels are expected to already exist in the repo. If `gh pr create` rejects a missing label, create it with `gh label create "<name>"` and retry.
-- CI enforces this: the `labels` job in `.github/workflows/ci.yml` (via `scripts/check-pr-labels.sh`) fails the PR unless it carries exactly one type label and no labels outside the sanctioned set. A PR with zero or two type labels is blocked.
+- CI enforces this: `.github/workflows/pr-labels.yml` (via `scripts/check-pr-labels.sh`) fails the PR unless it carries exactly one type label and no labels outside the sanctioned set. A PR with zero or two type labels is blocked.
 
 ### 4. Write PR Body
 

--- a/.claude/skills/problem-first-impl/SKILL.md
+++ b/.claude/skills/problem-first-impl/SKILL.md
@@ -55,8 +55,6 @@ Doc-level alignment was confirmed at intake. This phase is the complementary che
 2. **Approach vs current source.** Open the crate. Does the agreed approach still fit the code as it exists today? Has the crate drifted since `/problem-first` ran? If it has, name the drift and decide: does the approach still hold, or do we go back?
 3. **Re-verify assumptions.** Walk through each load-bearing assumption from `/problem-first` Phase 3. Can you confirm it from the code? An assumption that looked safe at intake may be wrong in practice — if so, the approach may need revisiting. Send the user back to `/problem-first` rather than papering over it.
 
-**Re-check doc alignment only if needed.** In Mode A (same session as `/problem-first`), doc alignment was just confirmed — skip it. In Mode B (picking up a GitHub issue that was filed earlier), the product docs may have moved since the issue was filed. Re-run the doc-level check from `/problem-first` Phase 4 before proceeding.
-
 Then present a summary:
 
 - Problem statement (1-2 sentences)
@@ -85,14 +83,7 @@ If the change has non-obvious unit-test scope (e.g. internal helpers, error-mapp
 
 ## Rules
 
-- **Do not auto-invoke.** Only run when the user explicitly asks or uses `/problem-first-impl`.
-- **Do not re-run Phases 1-3.** That's `/problem-first`'s job. If inputs are missing, send the user back there.
-- **Do not re-run the doc-level alignment check in Mode A.** It just happened. Re-running it is wasted work and second-guesses the intake.
-- **Do re-run it in Mode B.** When picking up an issue filed earlier, docs may have drifted. A quick re-check is cheap insurance.
-- **Do not proceed without an agreed approach.** Scenarios alone aren't enough — without direction, Phase 4 has nothing to compare against and Phase 5 becomes a guessing game.
-- **Do not skip Phase 4.** The code-level check is the last chance to catch spec duplication, stale assumptions, or source drift before code starts.
-- **Do not write the `.feature` file before Phase 4 is explicitly confirmed.**
+- **Phases 1-3 are `/problem-first`'s job.** If inputs are missing, send the user back there rather than re-deriving them here.
 - **Preserve the agreed Gherkin exactly.** Do not rephrase scenarios when writing the file.
 - **Use canonical terminology** from `docs/` and the Product Vision in the repo-root `CLAUDE.md`.
-- **Respect the test pyramid.** Behavioural specs land in Layer 2 (`tests/behaviours/`) unless they genuinely require real I/O (Layer 1, `e2e/`); they never spawn real subprocesses or hit the network at Layer 2.
 - **If scope or direction drifts during Phase 4 or Phase 5**, go back to `/problem-first` rather than papering over it here.

--- a/.claude/skills/problem-first-issue/SKILL.md
+++ b/.claude/skills/problem-first-issue/SKILL.md
@@ -136,8 +136,7 @@ Notes:
 
 - Use one `Feature:` block containing all scenarios. Don't split into multiple fenced blocks unless the scenarios genuinely belong to different feature files.
 - Preserve the exact Gherkin text agreed in `/problem-first`. Do not rephrase.
-- Do NOT describe a solution beyond the agreed direction. The issue is a problem + behavior contract, not a design.
-- Do NOT add labels, milestones, assignees, or projects. The triage team owns those.
+- Describe no solution beyond the agreed direction; the issue is a problem + behavior contract, not a design.
 
 ### 4. Create the Issue
 
@@ -163,12 +162,7 @@ Show the user:
 - Scenario count, rejected-alternatives count, target crate (if any).
 - A reminder: *"Open and unassigned. Carries problem, scenarios, and chosen approach — ready for pickup."*
 
-## Don't
+## Boundaries
 
-- **Don't auto-invoke.** Only run when the user explicitly asks or uses `/problem-first-issue`.
-- **Don't re-run Phases 1-3.** That's `/problem-first`'s job. If inputs are missing, send the user back there.
-- **Don't assign, label, milestone, or add to a project.** An open, unassigned issue is the whole output.
-- **Don't link a PR.** There is no PR at this stage.
-- **Don't invent Gherkin or an approach.** If the user hasn't agreed them, don't fabricate — send them back to `/problem-first`.
-- **Don't file an issue with only scenarios and no approach.** An issue the implementer can't pick up is worse than no issue.
-- **Don't descend into technical design.** The Approach is direction, not types or function signatures. Detailed design happens in `/problem-first-impl` and the eventual PR.
+- Phases 1-3 are `/problem-first`'s job; if the problem, scenarios, or approach are missing, send the user back there instead of inventing them.
+- The Approach is direction, not types or function signatures; detailed design happens in `/problem-first-impl` and the eventual PR.

--- a/.claude/skills/problem-first/SKILL.md
+++ b/.claude/skills/problem-first/SKILL.md
@@ -5,7 +5,7 @@ description: "Problem-first planning that reads product docs, challenges assumpt
 
 # Spec — Problem-First Planning
 
-You are a brutally honest planning partner. Your job is to make sure the problem is deeply understood before any technical work begins. You do NOT accept vague hand-waving. You challenge every assumption. You refuse to move forward until the problem is crystal clear.
+You are a planning partner. Your job is to make sure the problem is understood before any technical work begins: push back on vague statements and unexamined assumptions, and do not move to the next phase until the current one's exit criteria are met. When something is genuinely clear, say so and move on.
 
 This skill is the **intake phase**. It produces four things: a crisp problem statement, a set of Gherkin scenarios that describe the expected behavior, an agreed solution direction with the reasoning behind it, and an explicit doc-level alignment check. It does NOT write `.feature` files, GitHub issues, or code. When the intake is done, you suggest a continuation skill and stop.
 
@@ -13,7 +13,7 @@ The solution direction captured here is deliberately lightweight — enough that
 
 ## Philosophy
 
-Most engineering failures start with a poorly understood problem, not a bad implementation. Your role is to be the adversarial reviewer who forces clarity BEFORE code is written. You are not mean — you are rigorous. You push back because shipping the wrong thing is worse than shipping nothing.
+Most engineering failures start with a poorly understood problem, not a bad implementation. Your role is to force clarity before code is written, because shipping the wrong thing is worse than shipping nothing.
 
 Everything written — in docs, in specs, in this conversation — is a current hypothesis. Any of it can change if there is a winning argument. The goal is not to defend what exists but to converge on the right thing.
 
@@ -33,25 +33,13 @@ If something the user proposes contradicts the docs, flag it: *"This conflicts w
 
 ### Monorepo awareness
 
-This is a monorepo with multiple crates. When the user describes a problem, determine which crate it belongs to:
-
-| Crate | Domain |
-|-------|--------|
-| `lns-cli` | The `lns` developer CLI — clap-driven IPC client that drives the service. The shipping artifact. |
-| `lns-service` | Tray-resident background service — microVM lifecycle, OCI ingest, content/layer caches, supervisor relay, audit-chain writer. |
-| `lns-ipc` | Shared `Request`/`Response` types and wire codec for the lns-cli ↔ lns-service contract. |
-| `lns-policy` | Network rules and credential-provider policy (the run's `decisions.yaml`) plus per-machine credential decisions. |
-| `lns-init` | Static-musl PID-1 for the guest microVM. |
-| `lns-session` | Wire-protocol types (postcard) for the host ↔ guest session channel. |
-| `lns-session-broker` | Guest-side session host — PTY allocation, per-session workload forks, vsock framing. |
-| `lns-supervisor` | In-guest supervisor — agent process lifecycle, nftables lockdown, privilege drop, vsock relay. |
-| `bump-kernel` | Operator tooling for the kernel pin (`crates/lns-service/kernels.toml`). |
+This is a monorepo with multiple crates. When the user describes a problem, determine which crate it belongs to using the Project Overview table in the repo-root `CLAUDE.md` (the one place the crate list is maintained).
 
 If the work spans multiple crates, note this explicitly — the specs may need to live in more than one place, or the problem needs to be decomposed.
 
 ## Process
 
-Work through these phases in order. Do NOT skip phases. Do NOT rush. Each phase must be explicitly completed before moving to the next.
+Work through these phases in order; each one ends with the user's explicit confirmation before the next begins.
 
 ---
 
@@ -59,7 +47,7 @@ Work through these phases in order. Do NOT skip phases. Do NOT rush. Each phase 
 
 Start by stating what you understand the problem to be, based on the user's input and the product docs you've read. Then ask the user to confirm or correct.
 
-Challenge ruthlessly:
+Questions to settle:
 
 - **Who has this problem?** If the answer is vague ("users"), push for specifics.
 - **What happens today without this?** If nobody can articulate the pain, the problem may not exist.
@@ -189,17 +177,6 @@ Do not auto-invoke either continuation. Let the user decide.
 
 ## Rules
 
-- **Do your homework first.** Read the product docs and the repo-root/crate `CLAUDE.md` before asking the user questions that the docs already answer.
-- **Bring your own perspective.** Propose, don't just interrogate. Make the user's life easier by doing the thinking with them.
-- **Everything is a hypothesis.** Docs, specs, your assumptions, the user's assumptions — all of it can change with a winning argument.
-- **Contradictions must be resolved explicitly.** Never silently ignore a conflict between what exists and what's proposed.
-- **Never propose solutions during Phases 1-2.** Solution direction belongs in Phase 3. If you catch yourself suggesting an approach while still nailing down the problem or behavior, stop and refocus.
-- **Direction, not design, in Phase 3.** Shape and reasoning, not types or function signatures. Technical design is `/problem-first-impl`'s job.
-- **Phase 4 is doc-level only.** Don't open the target crate's source code here. Code-level checks (existing `.feature` overlap, source-vs-approach, assumption re-verification) belong in `/problem-first-impl`.
-- **Never skip Phase 4.** An issue filed on top of an unresolved doc conflict can't be trusted by whoever picks it up.
-- **Never accept "it's obvious" as an answer.** If it were obvious, it wouldn't need planning.
-- **Gherkin, an agreed approach, and doc alignment are the outputs of this skill.** Not code, not issues, not `.feature` files. Problem + scenarios + direction + alignment, all in chat.
-- **Use canonical terminology.** Reference `docs/` and the repo-root `CLAUDE.md`. Correct non-canonical terms when you see them.
-- **Be direct.** Say "I don't understand this" or "This is too vague" without hedging.
-- **Respect the user's time.** Be thorough but not tedious. If something is genuinely clear, acknowledge it and move on.
-- **Read the room.** If the user has clearly thought deeply about this already, adjust your intensity. If they're winging it, push harder.
+- **Solution direction belongs in Phase 3.** While the problem and behavior are still being settled (Phases 1-2), keep proposals to scenarios, not approaches.
+- **Use canonical terminology** from `docs/` and the repo-root `CLAUDE.md`, and correct non-canonical terms when you see them.
+- **Match your intensity to the user's preparation.** Someone who has already thought it through needs confirmation, not interrogation; someone winging it needs the harder questions.

--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -230,9 +230,10 @@ Use conventional commit format. The message should make sense on its own — som
 After committing, run relevant tests to make sure the fix works and nothing is broken:
 
 ```bash
-# Run the specific test file(s) touched or related to the change
-# The exact command depends on the project — check package.json, Makefile, etc.
+cargo test -p <crate>
 ```
+
+Scoped to the crates you touched; the full gate is `/green`'s job.
 
 If tests fail, fix them before moving on.
 
@@ -253,15 +254,7 @@ Keep it concise — reviewers appreciate brevity. Get the commit SHA with:
 git rev-parse --short HEAD
 ```
 
-Examples of good replies:
-
-> "Fixed — the test now asserts `code == 0` and verifies the binary was updated with expected content. (commit c244245)"
-
-> "Fixed — now uses `effectiveServer` for the `IsLocalServer` check. Also extended `IsLocalServer` to recognize `127.0.0.1` in addition to `localhost`. Added test case for the edge case. (commit a1b2c3d)"
-
-> "Fixed — replaced raw `Read` with a `bufio.Scanner` that reads exactly one line per call. Added `TestTerminalPrompter_ReadsExactlyOneLine` which verifies two consecutive prompts from a multi-line buffer. (commit d4e5f6a)"
-
-Notice the pattern: "Fixed — [what changed in plain language]. [tests added if any]. (commit [sha])"
+Shape of a fix reply: "Fixed — [what changed, in plain language]. [test added, if any]. (commit [short sha])"
 
 For non-fix replies (explanations, disagreements, questions), help the user draft something clear and constructive. Present the draft to the user for approval before posting.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,18 +36,24 @@ Never edit the specification to match the code. A divergence is work to be done,
 
 ## Project Overview
 
-Monorepo. Eight Rust crates and one shell-script package today; built to grow.
+Monorepo. A Cargo workspace (production crates, two operator tools, two test/coverage infra crates) and one shell-script package; `Cargo.toml` `members` is the authoritative list.
 
 | Package | Purpose |
 |---------|---------|
 | `crates/lns-cli` | The `lns` developer CLI — thin clap-driven IPC client that drives the daemon. The shipping artifact. |
 | `crates/lns-service` | Tray-resident background service. Owns the microVM lifecycle, OCI ingest, content / layer caches, supervisor relay, and audit-chain writer; exposes a local Unix-socket IPC. |
 | `crates/lns-ipc` | Shared `Request`/`Response` types and wire-format codec for the lns-cli ↔ lns-service contract. |
+| `crates/lns-spec` | The `lns.run/v1` document grammar — the shared definitions every `kind` is built from (`docs/sandbox-spec.md`). |
+| `crates/lns-policy` | Policy schema — file-format types shared between lns-service (enforcement) and lns-cli (run-summary introspection). |
+| `crates/lns-artifact` | Typed OCI artifact model — spec types, parsers, and producer-side validation. |
+| `crates/lns-audit` | Audit-timeline reader — merges per-run logs and the connection ledger into one chronological view. |
+| `crates/lns-ocsf` | OCSF v1.7.0 event builders for the audit logs. |
 | `crates/lns-init` | Static-musl PID-1 for the guest microVM. Mounts composefs/overlay then `fexecve`'s `lns-session-broker`. |
 | `crates/lns-session` | Wire-protocol types (postcard) for the host ↔ guest session channel. Shared by `lns-service` and `lns-session-broker`. |
 | `crates/lns-session-broker` | Static-musl guest-side session host. `lns-init` execs into it; it owns PTY allocation, per-session workload forks, and vsock framing. |
 | `crates/lns-supervisor` | Static-musl in-guest supervisor built on `lens-sandbox-core`. Embedded into `lns-service` and run inside the microVM; owns the agent process lifecycle, nftables network lockdown, privilege drop, and the vsock relay client. |
 | `crates/bump-kernel` | Operator tooling for managing the kernel pin (`crates/lns-service/kernels.toml`). |
+| `crates/bump-mise` | Operator tooling for the pinned mise tool-provisioning engine and its registry snapshot. |
 | `scripts/lns-install` | Installer shell script published to `get.lns.run`. |
 
 ## Conventions
@@ -70,7 +76,7 @@ Monorepo. Eight Rust crates and one shell-script package today; built to grow.
 
 ## Verification gate
 
-The **local pre-push gate** is `make lint && make complexity && make coverage` — three targets defined in the top-level Makefile, run serially by `scripts/hooks/pre-push`. The **CI required suite** runs the same three as parallel jobs (with `CARGO_LOCKED=--locked` for `lint` / `test`) plus `make test`, `make e2e`, the kernel pin drift check, and a path-gated `check-release-build` (real cross-builds + codesign). The Makefile is the single source of truth for both.
+The **local pre-push gate** is `make lint && make complexity && make coverage-affected` — three targets defined in the top-level Makefile, run serially by `scripts/hooks/pre-push` (`LNS_PREPUSH_FULL_COVERAGE=1` swaps the last step for full `make coverage`). The **CI required suite** runs the same three as parallel jobs (with `CARGO_LOCKED=--locked` for `lint` / `test`) plus `make test`, `make e2e`, the kernel pin drift check, and a path-gated `check-release-build` (real cross-builds + codesign). The Makefile is the single source of truth for both.
 
 - `make lint` — `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`. Also the gate's compile signal (clippy is a strict superset of `cargo check`).
 - `make complexity` — per-crate `cargo clippy -- -D clippy::cognitive_complexity` (per-crate because workspace feature unification disagrees with per-crate runs). For genuinely-branchy functions, use `#[allow(clippy::cognitive_complexity)]` with a one-line reason.
@@ -97,10 +103,10 @@ Two design implications fall out of this split:
 
 The 2 ↔ 3 balance is intentionally weighted toward Layer 2: the more behavior we can pin via Gherkin scenarios against a public API, the better. Layer 3 fills the gaps that aren't expressible as user-facing behaviors (e.g. "if `tokio::fs::rename` fails partway through atomic install, no half-written file remains" — a property, not a behavior).
 
-> **Migration status (2026-05).** The pyramid is operational:
+> **Where each layer lives today:**
 >
 > - Layer 1 lives in `crates/e2e-tests/` and spawns the real `lns` / `lns-service` binaries against real Unix sockets and tempdir homes. Its profraw is excluded from the coverage gate.
-> - Layer 2 lives in `crates/lns-cli/tests/behaviours/` (in-process via `lns_cli::cli::Cli`) and `crates/lns-service/tests/behaviours/` (in-process via `lns_service::ipc::handle_request`). Cross-crate deps are mocked at the public trait boundary (`ServiceClient` in lns-cli today; Handler-style extraction for lns-service streaming dispatch remains follow-up work).
+> - Layer 2 lives in `crates/lns-cli/tests/behaviours/` (in-process via `lns_cli::cli::Cli`) and `crates/lns-service/tests/behaviours/` (in-process via `lns_service::ipc::handle_request`). Cross-crate deps are mocked at the public trait boundary (`ServiceClient` in lns-cli; lns-service streaming dispatch has no Handler-style seam yet).
 > - Layer 3 exists as `#[cfg(test)] mod tests` blocks. Newer modules (kernel.rs, oci_layer_cache::install) use injected ports (`Fetcher`, `Fs`, `WritableFile`) with in-memory fakes; the still-tempfile-based modules are tracked in IGNORES under "needs ${X} port".
 >
 > Do not extend the cross-crate subprocess-spawning pattern. New behaviour goes in Layer 2 / Layer 3 with mocked cross-crate deps; only true end-to-end wiring confirmations belong in Layer 1.
@@ -189,7 +195,7 @@ The coverage gate is wired into `pre-push` via the in-tree hook at `scripts/hook
 make install-hooks
 ```
 
-That points `core.hooksPath` at the in-tree hooks dir so `make verify` + `make coverage-affected` run before every push. The hook refreshes `origin/main` before computing the affected set. Override to full workspace: `LNS_PREPUSH_FULL_COVERAGE=1 git push`. Bypass entirely (rare, intentional): `git push --no-verify`.
+That points `core.hooksPath` at the in-tree hooks dir so `make lint`, `make complexity`, and `make coverage-affected` run before every push. The hook refreshes `origin/main` before computing the affected set. Override to full workspace: `LNS_PREPUSH_FULL_COVERAGE=1 git push`. Bypass entirely (rare, intentional): `git push --no-verify`.
 
 ### Affected-crates coverage (CI + pre-push)
 


### PR DESCRIPTION
## Problem

The rule files told the agent things that are not true.

- `CLAUDE.md` said the pre-push hook runs `make verify`. That target does not exist in the `Makefile`. The hook runs `make lint`, `make complexity`, then `make coverage-affected`.
- `CLAUDE.md` said "Eight Rust crates". The workspace has 16 members. `lns-spec`, `lns-policy`, `lns-artifact`, `lns-audit`, `lns-ocsf`, and `bump-mise` were missing from the table.
- `code-review/SKILL.md` told the reviewer to read `docs/product/vision.md` and `docs/product/glossary.md`. There is no `docs/product/` directory.
- `create-pr/SKILL.md` said the label gate is a `labels` job in `.github/workflows/ci.yml`. The gate lives in `.github/workflows/pr-labels.yml`.
- The `problem-first*` skill files repeated the same rules two or three times each, and `problem-first/SKILL.md` carried a second copy of the crate table that had already drifted.

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` | The crate table lists every workspace member. The gate sentences name the targets the hook runs. The test-pyramid note drops the dated "migration status" framing. |
| `.claude/skills/code-review/SKILL.md` | Product context points at `CLAUDE.md`, `docs/README.md`, `docs/sandbox-spec.md`, and `docs/cli-spec.md`. |
| `.claude/skills/create-pr/SKILL.md` | The label gate points at `.github/workflows/pr-labels.yml`. |
| `.claude/skills/problem-first/SKILL.md` | The duplicated crate table is gone; it points at the `CLAUDE.md` table. The Rules block keeps the three rules that are not stated elsewhere in the file. |
| `.claude/skills/problem-first-impl/SKILL.md` | Removes the rules that repeat the Invocation-modes and Phase-4 text above them. |
| `.claude/skills/problem-first-issue/SKILL.md` | The "Don't" list becomes two boundaries; the rest repeated the Notes and step 4 text. |
| `.claude/skills/review-comments/SKILL.md` | The verify step names `cargo test -p <crate>` instead of a JavaScript-project placeholder. Three example replies become one shape line. |

## Verification

`npx markdownlint-cli2 "CLAUDE.md"` reports 0 issues. The `.claude/**` path is in the config `ignores`, so the skill files are not linted.

Every claim the new text makes is checked against the tree: each crate row matches a `crates/` directory and a `Cargo.toml` member, with a purpose that matches that crate's `description`; the gate sentences match `scripts/hooks/pre-push`; `.github/workflows/pr-labels.yml` and every named `docs/` path exist.

Docs only. No code changes.
