### PR TITLE
feat(connectors): --yes answers a connector grant on the host

### DIFF
--- a/crates/lns-cli/src/audit/timeline.rs
+++ b/crates/lns-cli/src/audit/timeline.rs
@@ -174,6 +174,7 @@ mod tests {
             Some("token"),
             Some("work"),
             Some("sha256:abc"),
+            Some("terminal"),
         )
         .to_string()
     }

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -439,6 +439,10 @@ async fn grant(
         run: args.run.clone(),
         method: method.name.clone(),
         connection: args.connection.clone(),
+        answered_by: match args.yes {
+            true => lns_ipc::AnswerSource::Flag,
+            false => lns_ipc::AnswerSource::Terminal,
+        },
     };
     match send(svc, req).await? {
         Response::ConnectorGranted {

--- a/crates/lns-cli/src/connector/mod.rs
+++ b/crates/lns-cli/src/connector/mod.rs
@@ -83,6 +83,13 @@ pub struct GrantArgs {
         help = "Which run this grants. Its id, its name, or a unique id prefix."
     )]
     pub run: String,
+    #[arg(
+        short = 'y',
+        long = "yes",
+        default_value_t = false,
+        help = "Answer the disclosure here, instead of at a terminal prompt. It still prints what the grant applies."
+    )]
+    pub yes: bool,
 }
 
 #[derive(clap::Args)]
@@ -382,12 +389,12 @@ async fn grant(
     writer: &mut impl Write,
     prompt: &mut impl Write,
 ) -> Result<i32> {
-    // cli-spec §3.3: `grant` is the card in a terminal, and no flag answers it, so a script cannot consent on a person's behalf.
-    if !terminal.is_available() {
+    // cli-spec §3.3: a person consents at the card, at a terminal prompt, or with `--yes` on the host, and never a script on their behalf.
+    if !args.yes && !terminal.is_available() {
         bail!(
-            "granting {} shows what it opens and asks you to confirm, and there is no terminal to ask at. No flag answers it: run `lns connector grant {}` from a terminal.",
-            args.name,
-            args.name
+            "granting {name} shows what it opens and asks you to confirm, and there is no terminal to ask at.\n       Run `lns connector grant {name} --run {run}` from a terminal, or pass --yes to answer here.",
+            name = args.name,
+            run = args.run
         );
     }
     let connector = installed_view(svc, &args.name).await?;
@@ -417,13 +424,15 @@ async fn grant(
             run = args.run
         )?;
     }
-    write!(prompt, "grant it? [y/N] ")?;
-    prompt.flush()?;
-    let answer = terminal.read_answer()?;
-    writeln!(prompt)?;
-    if !crate::terminal::is_affirmative(&answer) {
-        writeln!(writer, "nothing was granted")?;
-        return Ok(1);
+    if !args.yes {
+        write!(prompt, "grant it? [y/N] ")?;
+        prompt.flush()?;
+        let answer = terminal.read_answer()?;
+        writeln!(prompt)?;
+        if !crate::terminal::is_affirmative(&answer) {
+            writeln!(writer, "nothing was granted")?;
+            return Ok(1);
+        }
     }
     let req = Request::GrantConnector {
         name: args.name.clone(),
@@ -491,7 +500,12 @@ fn disclose(
     disclose_list(prompt, "opens", &method.opens)?;
     disclose_list(prompt, "writes", &method.writes)?;
     disclose_list(prompt, "sets", &method.sets())?;
-    for connection in &connector.connections {
+    // What is printed is what is granted, so a connection made for another method is not part of this disclosure.
+    for connection in connector
+        .connections
+        .iter()
+        .filter(|held| held.method == method.name)
+    {
         let authority = if connection.authority.is_empty() {
             "no authority reported".to_string()
         } else {
@@ -1190,6 +1204,7 @@ mod tests {
                     method: Some("token".into()),
                     connection: None,
                     run: "reviewer".into(),
+                    yes: false,
                 }),
                 &svc,
                 &["y"],
@@ -1217,6 +1232,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "1a2b".into(),
+                yes: false,
             }),
             &svc,
             &["n"],
@@ -1244,6 +1260,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &mut asking(&["y"]),
@@ -1280,6 +1297,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "revieweer".into(),
+                yes: false,
             }),
             &svc,
             &["y"],
@@ -1323,6 +1341,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &["y"],
@@ -1388,6 +1407,7 @@ mod tests {
                     method: Some("token".into()),
                     connection: None,
                     run: "reviewer".into(),
+                    yes: false,
                 }),
                 &svc,
                 &mut asking(&["y"]),
@@ -1443,6 +1463,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &mut asking(&["y"]),
@@ -1492,6 +1513,7 @@ mod tests {
                 method: Some("token".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &["y"],
@@ -1519,6 +1541,7 @@ mod tests {
                 method: Some("future".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
         ] {
             // No fileset on this one, so the only thing this version cannot honour is its auth kind.
@@ -1546,6 +1569,7 @@ mod tests {
                 method: Some("seeded".into()),
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &["y"],
@@ -1581,6 +1605,7 @@ mod tests {
                 method: None,
                 connection: None,
                 run: "reviewer".into(),
+                yes: false,
             }),
             &svc,
             &["y"],

--- a/crates/lns-cli/tests/behaviours/connector_cli.feature
+++ b/crates/lns-cli/tests/behaviours/connector_cli.feature
@@ -153,13 +153,64 @@ Feature: lns connector, on this machine
     Then the connector command exits 1
     And the output says nothing was granted
 
-  Scenario: granting with no terminal refuses, and no flag answers it
+  Scenario: granting with no terminal and without --yes refuses and names --yes
     Given the service holds the connector "some-provider" serving "api.some-provider.example"
     And there is no terminal
     When the user runs connector command "grant some-provider --run reviewer --method token"
     Then the connector command fails
     And the connector error says "granting"
-    And the connector error says "No flag answers it"
+    And the connector error says "there is no terminal to ask at"
+    And the connector error says "pass --yes to answer here"
+    And the connector error says "--run reviewer"
+
+  Scenario: with --yes it discloses, grants and exits 0 with no terminal
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And the service grants "some-provider" the method "token"
+    And there is no terminal
+    When the user runs connector command "grant some-provider --run reviewer --method token --yes"
+    Then the connector command succeeds
+    And the disclosure names what the method opens
+    And the disclosure names the file it writes
+    And the disclosure names the variables it sets
+    And the output says it was granted
+    And the connector output does not contain "grant it?"
+
+  Scenario: --yes with several offerable methods still refuses and names --method
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And there is no terminal
+    When the user runs connector command "grant some-provider --run reviewer --yes"
+    Then the connector command fails
+    And the connector error says "--method"
+
+  Scenario: --yes with several connections for the method still refuses and names --connection
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And the machine holds the connection "work" of "some-provider" for method "token"
+    And the machine holds the connection "home" of "some-provider" for method "token"
+    And the service refuses the grant with "some-provider holds 2 connections for method token, so name one with --connection"
+    And there is no terminal
+    When the user runs connector command "grant some-provider --run reviewer --method token --yes"
+    Then the connector command fails
+    And the connector error says "name one with --connection"
+
+  Scenario: --yes where the machine holds no connection says to connect first
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And the service refuses the grant with "some-provider authenticates and this machine holds no connection for method token; run `lns connector connect some-provider --method token` first"
+    And there is no terminal
+    When the user runs connector command "grant some-provider --run reviewer --method token --yes"
+    Then the connector command fails
+    And the connector error says "holds no connection for method token"
+    And the connector error says "lns connector connect some-provider --method token"
+
+  Scenario: the disclosure lists the connections of the granted method only
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And the machine holds the connection "work" of "some-provider" for method "token"
+    And the machine holds the connection "other-account" of "some-provider" for method "session"
+    And the service grants "some-provider" the method "token"
+    And the user types "y"
+    When the user runs connector command "grant some-provider --run reviewer --method token"
+    Then the connector command succeeds
+    And the disclosure names the connection "work"
+    And the connector output does not contain "other-account"
 
   Scenario: granting with no --run is a usage error, because there is no directory to fall back on
     Given the service holds the connector "some-provider" serving "api.some-provider.example"
@@ -182,6 +233,16 @@ Feature: lns connector, on this machine
     And the service grants "some-provider" the method "token"
     And the user types "y"
     When the user runs connector command "grant some-provider --run revieweer --method token"
+    Then the connector command succeeds
+    And the disclosure says no run is named "revieweer"
+    And the output says it reserved the decision
+
+  Scenario: --yes on a name no run holds reserves the decision for that name
+    Given the service holds the connector "some-provider" serving "api.some-provider.example"
+    And no run answers to that name
+    And the service grants "some-provider" the method "token"
+    And there is no terminal
+    When the user runs connector command "grant some-provider --run revieweer --method token --yes"
     Then the connector command succeeds
     And the disclosure says no run is named "revieweer"
     And the output says it reserved the decision

--- a/crates/lns-cli/tests/behaviours/connector_cli.feature
+++ b/crates/lns-cli/tests/behaviours/connector_cli.feature
@@ -128,6 +128,7 @@ Feature: lns connector, on this machine
     And the disclosure names the file it writes
     And the disclosure names the variables it sets
     And the output says it was granted
+    And the grant says the terminal answered it
 
   Scenario: a payload the method does not carry is stated, not omitted
     Given the service holds the connector "some-provider" serving "api.some-provider.example"
@@ -174,6 +175,7 @@ Feature: lns connector, on this machine
     And the disclosure names the variables it sets
     And the output says it was granted
     And the connector output does not contain "grant it?"
+    And the grant says the flag answered it
 
   Scenario: --yes with several offerable methods still refuses and names --method
     Given the service holds the connector "some-provider" serving "api.some-provider.example"

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -69,6 +69,7 @@ struct FakeConnectorService {
     held: Vec<ConnectorView>,
     dropped_connections: Option<usize>,
     refuse_message: Option<String>,
+    refuse_grant_message: Option<String>,
     unreachable: bool,
     requests: Arc<Mutex<Vec<Request>>>,
 }
@@ -88,6 +89,7 @@ impl FakeConnectorService {
             held: rig.held.clone(),
             dropped_connections: rig.dropped_connections,
             refuse_message: rig.refuse_message.clone(),
+            refuse_grant_message: rig.refuse_grant_message.clone(),
             unreachable: rig.unreachable,
             requests: rig.requests.clone(),
         }
@@ -98,6 +100,11 @@ impl FakeConnectorService {
             return None;
         }
         if let Some(message) = &self.refuse_message {
+            return Some(Response::Error {
+                message: message.clone(),
+            });
+        }
+        if let (Request::GrantConnector { .. }, Some(message)) = (req, &self.refuse_grant_message) {
             return Some(Response::Error {
                 message: message.clone(),
             });
@@ -225,6 +232,11 @@ fn service_uninstalls(world: &mut BehaviourWorld, name: String, dropped: usize) 
 #[given(expr = "the connector service refuses with {string}")]
 fn connector_service_refuses(world: &mut BehaviourWorld, message: String) {
     world.connector.refuse_message = Some(message);
+}
+
+#[given(expr = "the service refuses the grant with {string}")]
+fn connector_service_refuses_the_grant(world: &mut BehaviourWorld, message: String) {
+    world.connector.refuse_grant_message = Some(message);
 }
 
 #[given(expr = "the connector service is unreachable")]
@@ -632,6 +644,16 @@ fn says_forgot_reservation(world: &mut BehaviourWorld) {
     assert!(
         run.output.contains("reservation about some-provider"),
         "got: {}",
+        run.output
+    );
+}
+
+#[then(expr = "the disclosure names the connection {string}")]
+fn discloses_the_connection(world: &mut BehaviourWorld, label: String) {
+    let run = run_of(world);
+    assert!(
+        run.output.contains(&format!("connection {label}")),
+        "what is printed is what is granted, so the connection behind the method is named: {}",
         run.output
     );
 }

--- a/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/connector_cli.rs
@@ -648,6 +648,30 @@ fn says_forgot_reservation(world: &mut BehaviourWorld) {
     );
 }
 
+#[then(expr = "the grant says the {word} answered it")]
+fn grant_names_its_answer_source(world: &mut BehaviourWorld, source: String) {
+    let expected = match source.as_str() {
+        "flag" => lns_ipc::AnswerSource::Flag,
+        "terminal" => lns_ipc::AnswerSource::Terminal,
+        other => panic!("no answer source is named {other}"),
+    };
+    let sent = world
+        .connector
+        .requests
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|req| match req {
+            Request::GrantConnector { answered_by, .. } => Some(*answered_by),
+            _ => None,
+        })
+        .expect("a grant request must have been sent");
+    assert_eq!(
+        sent, expected,
+        "the service cannot tell a prompt from a flag, so the wire carries it"
+    );
+}
+
 #[then(expr = "the disclosure names the connection {string}")]
 fn discloses_the_connection(world: &mut BehaviourWorld, label: String) {
     let run = run_of(world);

--- a/crates/lns-cli/tests/behaviours/world.rs
+++ b/crates/lns-cli/tests/behaviours/world.rs
@@ -186,6 +186,8 @@ pub struct ConnectorCliRig {
     /// `Some` means the connector was installed; `None` makes uninstall answer that nothing is.
     pub dropped_connections: Option<usize>,
     pub refuse_message: Option<String>,
+    /// A refusal the service answers the grant with, so the probes the command makes first still answer.
+    pub refuse_grant_message: Option<String>,
     pub unreachable: bool,
     pub connected: Option<String>,
     pub granted: Option<(String, Option<String>)>,

--- a/crates/lns-ipc/src/ledger.rs
+++ b/crates/lns-ipc/src/ledger.rs
@@ -45,6 +45,25 @@ impl ConnectorVerb {
     }
 }
 
+/// Who answered a connector question: the card the tray holds, a terminal prompt, or `--yes` on the grant command. Only the wire carries it, because the service cannot tell one caller from another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerSource {
+    Card,
+    Terminal,
+    Flag,
+}
+
+impl AnswerSource {
+    pub fn word(self) -> &'static str {
+        match self {
+            Self::Card => "card",
+            Self::Terminal => "terminal",
+            Self::Flag => "flag",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum LedgerEvent {
@@ -65,6 +84,9 @@ pub enum LedgerEvent {
         /// The bytes the grant bound to; a decline answers for every version and a forget clears whatever was there, so neither carries one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         digest: Option<String>,
+        /// How the grant was answered. A forget answers no question, and a line written before this field read without one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        answered_by: Option<AnswerSource>,
     },
 }
 
@@ -123,8 +145,42 @@ mod tests {
             method: Some("token".into()),
             connection: Some("work".into()),
             digest: Some("sha256:abc".into()),
+            answered_by: Some(AnswerSource::Flag),
         });
         assert_eq!(back.event.name(), "connector");
+    }
+
+    #[test]
+    fn a_line_written_before_the_answer_source_reads_back_without_one() {
+        let line = r#"{"ts":"2026-06-29T14:02:11Z","run":"5e6f7a8b0000000000000000000000bb","microvm":"calm-finch","event":"connector","connector":"some-provider","verb":"granted","method":"token"}"#;
+        let back: LedgerRecord = serde_json::from_str(line).expect("deserialize");
+        assert_eq!(
+            back.event,
+            LedgerEvent::Connector {
+                connector: "some-provider".into(),
+                verb: ConnectorVerb::Granted,
+                method: Some("token".into()),
+                connection: None,
+                digest: None,
+                answered_by: None,
+            }
+        );
+    }
+
+    #[test]
+    fn every_answer_source_has_a_word_the_timeline_reads() {
+        for (source, word) in [
+            (AnswerSource::Card, "card"),
+            (AnswerSource::Terminal, "terminal"),
+            (AnswerSource::Flag, "flag"),
+        ] {
+            assert_eq!(source.word(), word);
+            assert_eq!(
+                serde_json::to_value(source).expect("serialize"),
+                serde_json::Value::String(word.to_string()),
+                "the wire spells it the way the timeline reads it"
+            );
+        }
     }
 
     #[test]
@@ -139,11 +195,13 @@ mod tests {
                 method: None,
                 connection: None,
                 digest: None,
+                answered_by: None,
             },
         };
         let line = serde_json::to_string(&record).expect("serialize");
         assert!(!line.contains("method"), "{line}");
         assert!(!line.contains("digest"), "{line}");
+        assert!(!line.contains("answered_by"), "{line}");
         assert_eq!(
             serde_json::from_str::<LedgerRecord>(&line).expect("deserialize"),
             record

--- a/crates/lns-ipc/src/lib.rs
+++ b/crates/lns-ipc/src/lib.rs
@@ -14,7 +14,7 @@ pub use codec::{
     decode_wire_frame_from_payload, decode_wire_frame_sync, encode_frame, encode_raw_frame,
     encode_wire_frame, read_frame_bytes_async,
 };
-pub use ledger::{ApprovalKind, ConnectorVerb, Decision, LedgerEvent, LedgerRecord};
+pub use ledger::{AnswerSource, ApprovalKind, ConnectorVerb, Decision, LedgerEvent, LedgerRecord};
 pub use paths::{
     LnsHomeError, audit_anchor_for_run, audit_log_for_run, audit_runs_root, build_cache_root,
     config_path, connection_ledger, connection_ledger_anchor, connector_grants_path,

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -144,12 +144,13 @@ pub enum Request {
         name: String,
         connection: Option<String>,
     },
-    /// `run` is the handle the user typed: only the service holds the registry that resolves it.
+    /// `run` is the handle the user typed: only the service holds the registry that resolves it, and `answered_by` is how the person answered, which nothing on this side could infer.
     GrantConnector {
         name: String,
         run: String,
         method: String,
         connection: Option<String>,
+        answered_by: crate::AnswerSource,
     },
     ForgetConnector {
         name: String,

--- a/crates/lns-ocsf/src/events.rs
+++ b/crates/lns-ocsf/src/events.rs
@@ -121,6 +121,7 @@ pub fn connector(
     method: Option<&str>,
     connection: Option<&str>,
     digest: Option<&str>,
+    answered_by: Option<&str>,
 ) -> Value {
     let mut ev = Event::new(
         "connector",
@@ -146,6 +147,9 @@ pub fn connector(
     }
     if let Some(digest) = digest {
         ev = ev.note("lns_connector_digest", digest.into());
+    }
+    if let Some(answered_by) = answered_by {
+        ev = ev.note("lns_answer_source", answered_by.into());
     }
     ev.build()
 }
@@ -517,6 +521,7 @@ mod tests {
             Some("token"),
             Some("work"),
             Some("sha256:abc"),
+            Some("flag"),
         );
         assert_schema_valid(&ev);
         assert_eq!(ev["message"], "granted some-provider token as work");
@@ -529,6 +534,10 @@ mod tests {
             "a grant binds to bytes, and which bytes is the whole of what it consented to"
         );
         assert_eq!(ev["service"]["name"], "some-provider");
+        assert_eq!(
+            ev["unmapped"]["lns_answer_source"], "flag",
+            "who answered is part of what the chain accounts for"
+        );
     }
 
     #[test]
@@ -540,10 +549,12 @@ mod tests {
             Some("open"),
             None,
             Some("sha256:abc"),
+            Some("card"),
         );
         assert_schema_valid(&ev);
         assert_eq!(ev["message"], "granted some-provider open");
         assert!(ev["unmapped"].get("lns_connection").is_none());
+        assert_eq!(ev["unmapped"]["lns_answer_source"], "card");
     }
 
     #[test]
@@ -552,12 +563,16 @@ mod tests {
             ("declined", "declined some-provider"),
             ("forgot", "forgot some-provider"),
         ] {
-            let ev = connector(&ctx(), "some-provider", verb, None, None, None);
+            let ev = connector(&ctx(), "some-provider", verb, None, None, None, None);
             assert_schema_valid(&ev);
             assert_eq!(ev["message"], expected);
             assert!(
                 ev["unmapped"].get("lns_connector_digest").is_none(),
                 "neither answers for one version of the bytes, so neither claims one"
+            );
+            assert!(
+                ev["unmapped"].get("lns_answer_source").is_none(),
+                "a line with no answer source reads as it always did"
             );
         }
     }

--- a/crates/lns-service/src/connector/real.rs
+++ b/crates/lns-service/src/connector/real.rs
@@ -33,6 +33,7 @@ pub enum Call {
         run: String,
         method: String,
         connection: Option<String>,
+        answered_by: lns_ipc::AnswerSource,
     },
     Forget {
         name: String,
@@ -159,7 +160,11 @@ impl crate::approval_flow::session::ConnectorPort for RealConnectorPort {
         })?;
         // A grant that changed nothing decided nothing, and a line for it would let the chain count re-runs of a command as decisions.
         if !granted.unchanged {
-            record_decision(&self.holder, &self.microvm, granted_event(name, &granted));
+            record_decision(
+                &self.holder,
+                &self.microvm,
+                granted_event(name, &granted, lns_ipc::AnswerSource::Card),
+            );
         }
         Ok(payload)
     }
@@ -199,13 +204,18 @@ fn microvm_of(holder: &GrantHolder) -> String {
     }
 }
 
-fn granted_event(name: &str, granted: &handler::Granted) -> lns_ipc::LedgerEvent {
+fn granted_event(
+    name: &str,
+    granted: &handler::Granted,
+    answered_by: lns_ipc::AnswerSource,
+) -> lns_ipc::LedgerEvent {
     lns_ipc::LedgerEvent::Connector {
         connector: name.to_string(),
         verb: lns_ipc::ConnectorVerb::Granted,
         method: Some(granted.method.clone()),
         connection: granted.connection.clone(),
         digest: Some(granted.digest.clone()),
+        answered_by: Some(answered_by),
     }
 }
 
@@ -225,6 +235,7 @@ fn connector_event(name: &str, verb: lns_ipc::ConnectorVerb) -> lns_ipc::LedgerE
         method: None,
         connection: None,
         digest: None,
+        answered_by: None,
     }
 }
 
@@ -480,6 +491,7 @@ pub async fn answer(call: Call) -> Result<Response> {
             run,
             method,
             connection,
+            answered_by,
         } => {
             let holder = holder_of(&run)?;
             let counted = paths_counted_at_boot_for(&holder);
@@ -495,7 +507,7 @@ pub async fn answer(call: Call) -> Result<Response> {
                 record_decision(
                     &holder,
                     &microvm_of(&holder),
-                    granted_event(&name, &granted),
+                    granted_event(&name, &granted, answered_by),
                 );
             }
             Ok(Response::ConnectorGranted {
@@ -1250,6 +1262,7 @@ mod tests {
             run: RUN.to_string(),
             method: "token".into(),
             connection: None,
+            answered_by: lns_ipc::AnswerSource::Terminal,
         })
         .await
         .expect_err("a live run with no counted set is one this process cannot vouch for");
@@ -1290,6 +1303,7 @@ mod tests {
             run: RUN.to_string(),
             method: "token".to_string(),
             connection: None,
+            answered_by: lns_ipc::AnswerSource::Terminal,
         })
         .await
         .expect("the boot made room for exactly this path, so the grant stands");
@@ -1311,6 +1325,7 @@ mod tests {
             run: RUN.to_string(),
             method: "token".to_string(),
             connection: None,
+            answered_by: lns_ipc::AnswerSource::Terminal,
         })
         .await;
         crate::run_registry::deregister(RUN);
@@ -1336,6 +1351,22 @@ mod tests {
             run_id: run_id.to_string(),
             _cancel: cancel,
         }
+    }
+
+    /// What each connector line in the ledger says answered it, read from the note the OCSF record carries.
+    fn answer_sources() -> Vec<Option<String>> {
+        let path = lns_ipc::connection_ledger().expect("the ledger path");
+        if !path.exists() {
+            return Vec::new();
+        }
+        lns_audit::stream_ledger(&path)
+            .expect("stream the ledger")
+            .map(|event| {
+                event.expect("a ledger line")["unmapped"]["lns_answer_source"]
+                    .as_str()
+                    .map(str::to_string)
+            })
+            .collect()
     }
 
     /// Every ledger line this machine holds, read back the way `lns audit` reads it.
@@ -1365,6 +1396,7 @@ mod tests {
             run: RUN.to_string(),
             method: "token".to_string(),
             connection: None,
+            answered_by: lns_ipc::AnswerSource::Terminal,
         })
         .await
         .expect("grant");
@@ -1395,6 +1427,7 @@ mod tests {
                 run: RUN.to_string(),
                 method: "token".to_string(),
                 connection: None,
+                answered_by: lns_ipc::AnswerSource::Terminal,
             })
         };
 
@@ -1484,6 +1517,7 @@ mod tests {
             run: "audit-reservation".to_string(),
             method: "token".to_string(),
             connection: None,
+            answered_by: lns_ipc::AnswerSource::Flag,
         })
         .await
         .expect("reserve a grant");
@@ -1492,6 +1526,11 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].detail, "granted some-provider token as work");
         assert_eq!(rows[0].run, "", "no run holds it yet");
+        assert_eq!(
+            answer_sources(),
+            [Some("flag".to_string())],
+            "the wire said the flag answered it, and the chain says so too"
+        );
     }
 
     #[test]
@@ -1530,6 +1569,11 @@ mod tests {
                 ("declined some-provider", OTHER_RUN),
             ],
             "the card's answer is the run's decision, and the account it settled on is part of it"
+        );
+        assert_eq!(
+            answer_sources(),
+            [Some("card".to_string()), None],
+            "the card answered the grant; a decline answers for every version and claims no source"
         );
     }
 

--- a/crates/lns-service/src/connector/real.rs
+++ b/crates/lns-service/src/connector/real.rs
@@ -1353,16 +1353,23 @@ mod tests {
         }
     }
 
-    /// What each connector line in the ledger says answered it, read from the note the OCSF record carries.
-    fn answer_sources() -> Vec<Option<String>> {
+    fn ledger_events() -> Vec<serde_json::Map<String, serde_json::Value>> {
         let path = lns_ipc::connection_ledger().expect("the ledger path");
         if !path.exists() {
             return Vec::new();
         }
         lns_audit::stream_ledger(&path)
             .expect("stream the ledger")
+            .map(|event| event.expect("a ledger line"))
+            .collect()
+    }
+
+    /// What each connector line in the ledger says answered it, read from the note the OCSF record carries.
+    fn answer_sources() -> Vec<Option<String>> {
+        ledger_events()
+            .iter()
             .map(|event| {
-                event.expect("a ledger line")["unmapped"]["lns_answer_source"]
+                event["unmapped"]["lns_answer_source"]
                     .as_str()
                     .map(str::to_string)
             })
@@ -1371,13 +1378,9 @@ mod tests {
 
     /// Every ledger line this machine holds, read back the way `lns audit` reads it.
     fn recorded() -> Vec<lns_audit::Row> {
-        let path = lns_ipc::connection_ledger().expect("the ledger path");
-        if !path.exists() {
-            return Vec::new();
-        }
-        lns_audit::stream_ledger(&path)
-            .expect("stream the ledger")
-            .map(|event| lns_audit::read(&event.expect("a ledger line")).expect("a readable row"))
+        ledger_events()
+            .iter()
+            .map(|event| lns_audit::read(event).expect("a readable row"))
             .collect()
     }
 

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -416,11 +416,13 @@ fn connector_call(request: &Request) -> Option<crate::connector::real::Call> {
             run,
             method,
             connection,
+            answered_by,
         } => Call::Grant {
             name: name.clone(),
             run: run.clone(),
             method: method.clone(),
             connection: connection.clone(),
+            answered_by: *answered_by,
         },
         Request::ForgetConnector { name, run } => Call::Forget {
             name: name.clone(),
@@ -1951,6 +1953,7 @@ mod tests {
                     run: "reviewer".into(),
                     method: "token".into(),
                     connection: None,
+                    answered_by: lns_ipc::AnswerSource::Terminal,
                 },
                 now,
             )

--- a/crates/lns-service/src/ocsf_audit.rs
+++ b/crates/lns-service/src/ocsf_audit.rs
@@ -64,6 +64,7 @@ pub fn ledger_event(record: &LedgerRecord) -> Map<String, Value> {
             method,
             connection,
             digest,
+            answered_by,
         } => lns_ocsf::connector(
             &cx.ctx(),
             connector,
@@ -71,6 +72,7 @@ pub fn ledger_event(record: &LedgerRecord) -> Map<String, Value> {
             method.as_deref(),
             connection.as_deref(),
             digest.as_deref(),
+            answered_by.as_ref().map(|source| source.word()),
         ),
     };
     into_object(value)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -311,7 +311,7 @@ lns connector uninstall <ID>
 lns connector list [--format <table|json>]
 lns connector connect <ID> [--method <NAME>] [--as <CONNECTION>]
 lns connector disconnect <ID> [--connection <CONNECTION>]
-lns connector grant <ID> --run <RUN> [--method <NAME>] [--connection <CONNECTION>]
+lns connector grant <ID> --run <RUN> [--method <NAME>] [--connection <CONNECTION>] [--yes]
 lns connector forget <ID> --run <RUN>
 ```
 
@@ -322,7 +322,7 @@ lns connector forget <ID> --run <RUN>
 | `list`                | List what is installed: what each connector serves, each method and what it still needs (`ready to grant`, `connect first`, or that this `lns` cannot offer it), and the connections this machine holds. |
 | `connect <ID>`        | Ask for each value the method's authentication produces, at the terminal and without echoing it, and keep the result as a named connection. A `kind: token` authentication produces one value, so one method asks one question however many credentials draw on it. `--as` names it; otherwise `lns` suggests the first free name and you confirm, so a suggested name never replaces a connection you already hold. A name you give yourself — with `--as` or at the prompt — that a connection already uses re-authenticates that connection in place. Grants nothing: a run still decides whether to use it. Refused for a method with no `auth` — grant that instead. |
 | `disconnect <ID>`     | Drop one connection, or every connection of the connector when `--connection` is absent. Exits `1` when it holds none. The connector stays installed, and runs that granted a dropped connection keep their grants. |
-| `grant <ID>`          | Let one run use one method. `--run` names it — its id, its name, or a unique id prefix — and is required. Prints what that method opens, writes and sets, and the authority of each connection held, then asks. Where `--run` names no run, the disclosure says so and your answer reserves the decision for the run you next create with that name. An id or id prefix that resolves to nothing is an error, not a reservation. Exits `1` when you decline, and `1` when that run already granted that method and connection. A method that writes a file is refused for a run that started before the connector was installed: only a boot works out where the file lands, so restart the run and grant it there. |
+| `grant <ID>`          | Let one run use one method. `--run` names it — its id, its name, or a unique id prefix — and is required. Prints what that method opens, writes and sets, and the authority of each connection the method can use, then asks. `--yes` answers the disclosure on the command line, so a dispatcher reserves a grant for the run name it is about to use, with no prompt and no card. It still prints the disclosure, and it still refuses to choose: name the method with `--method` and the connection with `--connection` where more than one is offerable. Where `--run` names no run, the disclosure says so and your answer reserves the decision for the run you next create with that name. An id or id prefix that resolves to nothing is an error, not a reservation. Exits `1` when you decline, and `1` when that run already granted that method and connection. A method that writes a file is refused for a run that started before the connector was installed: only a boot works out where the file lands, so restart the run and grant it there. |
 | `forget <ID>`         | Clear one run's decision about one connector, granted or declined, so its next start asks again. It also clears a reservation waiting for a name. Exits `1` when there was nothing to clear. |
 
 `install` takes either a published reference or a local path — a directory
@@ -334,10 +334,33 @@ against your working directory. The digest a local install records is the one
 publishing that directory would produce, so a grant survives the publish, and
 naming the document records the same digest as naming its directory.
 
-`connect` and `grant` need a terminal by design: no flag answers either, so a
-script cannot consent or paste a secret on your behalf. `--method` is required
-when a connector declares more than one method this version can offer — `lns`
-refuses rather than choosing for you.
+`connect` needs a terminal by design: no flag answers it, so nothing pastes a
+secret on your behalf. `grant` needs a terminal or `--yes`: the flag runs on
+your machine as you, and you already hold the credential it grants, so typing it
+is you consenting to a disclosure you can read. `--method` is required when a
+connector declares more than one method this version can offer — `lns` refuses
+rather than choosing for you.
+
+```console
+$ lns connector grant github --run task-42 --yes
+granting github to task-42 would give it:
+  method   Personal access token
+  opens    github.com, api.github.com, codeload.github.com
+  writes   nothing
+  sets     GH_TOKEN
+  connection gh auth token (no authority reported)
+  no run is named task-42. This reserves the decision for the run you next create with that name.
+reserved github with token as gh auth token for task-42
+```
+
+Without a terminal and without the flag, `grant` refuses and names both ways
+out:
+
+```console
+$ lns connector grant github --run task-45
+error: granting github shows what it opens and asks you to confirm, and there is no terminal to ask at.
+       Run `lns connector grant github --run task-45` from a terminal, or pass --yes to answer here.
+```
 
 You do not have to grant anything ahead of time. When a run reaches a destination
 an installed connector serves, and that run has neither granted nor declined

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -357,7 +357,7 @@ lns connector uninstall <ID>
 lns connector list [--format <table|json>]
 lns connector connect <ID> [--method <NAME>] [--as <CONNECTION>]
 lns connector disconnect <ID> [--connection <CONNECTION>]
-lns connector grant <ID> --run <RUN> [--method <NAME>] [--connection <CONNECTION>]
+lns connector grant <ID> --run <RUN> [--method <NAME>] [--connection <CONNECTION>] [--yes]
 lns connector forget <ID> --run <RUN>
 ```
 
@@ -368,7 +368,7 @@ lns connector forget <ID> --run <RUN>
 | `list` | Lists what is installed: what each connector serves, its methods — marking those that need no connect — and the connections this machine holds for it. |
 | `connect` | Connects this machine, without waiting for a run to ask. Picks a method — `--method` names one, otherwise you choose — runs whatever authentication that method declares, and stores the result as a **connection**. A method with no `auth` has nothing to connect and is refused here — grant it instead. `--as` names it; otherwise the mechanism suggests one and you confirm. A machine may hold several connections of one connector, including several of one method: two accounts, or two sign-ins at different scopes. Connecting is not granting: a run still decides which connection to use. |
 | `disconnect` | Drops one connection, or every connection of a connector when `--connection` is absent. Exits `1` when the connector holds none — a connector whose methods all lack `auth` never holds one. The connector stays installed, runs that granted a dropped connection keep their grants, and you are asked to connect again the next time a request needs a value. |
-| `grant` | Grants one run a method before it asks for it. `--run` names the run and is required — there is no working directory to fall back on. Prints what the card would show — the destinations the method opens, the files it writes, the variables it sets, and the connection's authority where it authenticates — and asks. `--method` names the method; omitted, you choose when more than one is offerable. `--connection` names the connection behind it, and a method with no `auth` takes none; where one authenticates and this machine holds no connection, `grant` says to `connect` first rather than starting an authentication of its own. A run holds one grant per connector, so this replaces any prior one, and what it prints names the method it displaces. Where `--run` names no run, what it prints says so, and the answer reserves the decision for the run the user next creates with that name. Exits `1` when the run already granted that method and connection, or when a reservation for that name already names them. |
+| `grant` | Grants one run a method before it asks for it. `--run` names the run and is required — there is no working directory to fall back on. Prints what the card would show — the destinations the method opens, the files it writes, the variables it sets, and the authority of each connection of the method it grants — and asks. `--yes` answers that disclosure on the command line instead of at the prompt, so one command per run gives a dispatcher its grant with no terminal and no card; the disclosure is still printed, and `--yes` still chooses nothing. `--method` names the method; omitted, you choose when more than one is offerable. `--connection` names the connection behind it, and a method with no `auth` takes none; where one authenticates and this machine holds no connection, `grant` says to `connect` first rather than starting an authentication of its own. A run holds one grant per connector, so this replaces any prior one, and what it prints names the method it displaces. Where `--run` names no run, what it prints says so, and the answer reserves the decision for the run the user next creates with that name. Exits `1` when the run already granted that method and connection, or when a reservation for that name already names them. |
 | `forget` | Clears one run's decision about one connector, granted or declined, so the next start asks again. It also clears a reservation waiting for a name. The inverse of `grant`, and `--run` is required for the same reason. Exits `1` when there was nothing to forget. |
 
 Four verbs bound the decision, across two scopes. On the machine: `install`
@@ -385,9 +385,18 @@ naming that connection are invalidated and asked again
 **`grant` is the card in a terminal, not a shortcut past it.** It discloses
 exactly what the card discloses and then asks, so consent is never given to a
 payload nobody saw ([§7.2](#72-answering)). What it moves is *when* you decide,
-not *whether* you were told. There is deliberately no flag that answers it: with
-no terminal to ask at, `grant` refuses like any other prompt
-([§7.2](#72-answering)), so a script cannot consent on a person's behalf.
+not *whether* you were told.
+
+**A person consents in one of three ways: at the card, at the terminal prompt,
+or with `--yes` on `grant`.** The flag is not a script consenting on a person's
+behalf: it runs on the host as that person, who already holds the credential and
+can spend it directly, and the boundary's job — keeping the value out of the
+guest — is the same however the grant was answered. The disclosure prints in
+every one of the three, because consent by flag is still consent to something
+the person could read. With neither a terminal nor `--yes`, `grant` refuses like
+any other prompt ([§7.2](#72-answering)) and names both ways out. The card
+itself stays unanswerable by any flag, and the answer's source — `card`,
+`terminal` or `flag` — is recorded in the audit chain.
 
 **The card is the normal path.** It offers every method the connector declares,
 and for one that authenticates, every connection this machine holds plus the option
@@ -660,7 +669,8 @@ you may also answer early, at your terminal, with the same disclosure.
 - A prompt is written to stderr and read from your terminal. It never consumes
   stdin, so piping data into `lns run` can never be mistaken for a "yes".
 - `--yes` accepts what a document declares. `-f`/`--force` accepts a `prune`.
-  `-y` accepts an uninstall.
+  `-y` accepts an uninstall. `--yes` on `lns connector grant` accepts the
+  disclosure that command prints.
 - A verb that names its target does not ask: you already named it. `rm` removes
   what you pointed at, and `-f` on `lns sandbox rm` means "stop it first", not
   "delete without asking".

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -1418,6 +1418,12 @@ A grant MAY also be given ahead of any request, with the same disclosure and no
 held request (`lns connector grant`). The trigger decides when the card
 appears, never whether consent must be informed.
 
+**A person consents in one of three ways:** by answering the card, by answering
+the terminal prompt `lns connector grant` asks, or by typing `--yes` on that
+command, which answers the same disclosure on the host. All three disclose the
+whole payload first, and the audit chain records which of the three answered.
+The card itself is answerable by no flag.
+
 **A grant belongs to one run.** Not to a directory: the working directory
 roots the paths a reference resolves against, and nothing about consent
 ([§8.5](#85-what-the-working-directory-decides)). A run keeps what it was granted


### PR DESCRIPTION
## What this does

A person can now answer a connector grant on the command line. One command
per run gives a dispatcher its grant, with no terminal prompt and no tray
card.

```console
$ lns connector grant github --run task-42 --yes
granting github to task-42 would give it:
  method   Personal access token
  opens    github.com, api.github.com, codeload.github.com
  writes   nothing
  sets     GH_TOKEN
  connection gh auth token (no authority reported)
  no run is named task-42. This reserves the decision for the run you next create with that name.
reserved github with token as gh auth token for task-42
$ lns run -q -t=false --yes --name task-42 -f claude-code.yaml
```

The disclosure goes to stderr. The result line goes to stdout. The run the
person next creates with that name takes the grant.

## Before and after

Without a terminal, `grant` refused and named no way out.

Before:

```console
$ lns connector grant github --run task-45
error: granting github shows what it opens and asks you to confirm, and there is no terminal to ask at. No flag answers it: run `lns connector grant github` from a terminal.
```

After:

```console
$ lns connector grant github --run task-45
error: granting github shows what it opens and asks you to confirm, and there is no terminal to ask at.
       Run `lns connector grant github --run task-45` from a terminal, or pass --yes to answer here.
```

The refusal now names both ways out, and it repeats the `--run` it was given.

## What `--yes` does not do

- It does not choose. Several offerable methods still ask for `--method`.
  Several connections still ask for `--connection`.
- It does not connect. Where the method authenticates and the machine holds
  no connection, the service still says to `connect` first. A secret is
  pasted by a person, never by a flag.
- It does not answer a card. Reserve first.

## The answer source

`Request::GrantConnector` carries an `AnswerSource`: `card`, `terminal`, or
`flag`. The service cannot tell one caller from another, so the wire says it.
The value is stored with the decision and reaches the OCSF record as the
`lns_answer_source` note:

```console
$ lns audit task-42 --format jsonl | jq -r 'select(.unmapped.lns_verb=="granted") | .unmapped.lns_answer_source'
flag
```

This is an unversioned protocol change. Every caller changed. There is no
shim. A ledger line written before this field reads back without a source,
as it did.

## The disclosure

The disclosure now lists the connections of the chosen method only, so what
is printed is what is granted. A connection made for another method is no
longer shown.

## Tests

- `crates/lns-cli/tests/behaviours/connector_cli.feature`: the refusal that
  names `--yes`; `--yes` disclosing, granting and reserving with no
  terminal; `--yes` refusing to choose a method or a connection; `--yes`
  where the machine holds no connection; the disclosure listing one method's
  connections; and the source each grant sends.
- `crates/lns-ipc/src/ledger.rs`: the source round trips, a line without one
  reads back without one, and every value has the word the timeline reads.
- `crates/lns-ocsf/src/events.rs`: the note is set, and a decline claims no
  source.
- `crates/lns-service/src/connector/real.rs`: a reservation answered by the
  flag records `flag`, and a card grant records `card`.

Every scenario was written first and watched fail.

Closes #379
