### PR TITLE
fix(session): Keep DHCP leases active

### DIFF
--- a/crates/e2e-tests/features/microvm_egress.feature
+++ b/crates/e2e-tests/features/microvm_egress.feature
@@ -12,6 +12,10 @@ Feature: the network cage blocks denied egress from a real guest
   reliable assertion needs a deterministic host-side endpoint rather than a
   real-internet host, whose reachability makes the test flaky.
 
+  DHCP keepalive needs a manual macOS vmnet check. Start one sandbox and leave
+  it running. Start a second sandbox seven minutes later. Confirm that the
+  second sandbox gets a network address and can reach an allowed destination.
+
   Scenario: a deny-all policy blocks the workload's outbound connection
     Given the LNS service is running
     And a network policy that denies all egress

--- a/crates/lns-session-broker/src/main.rs
+++ b/crates/lns-session-broker/src/main.rs
@@ -42,9 +42,13 @@ fn main() -> ExitCode {
 
 #[cfg(target_os = "linux")]
 fn run() -> Result<i32, String> {
-    if let Err(e) = network::bring_up_eth0() {
-        eprintln!("lns-session-broker: best-effort network setup failed: {e}");
-    }
+    let dhcp_keepalive = match network::bring_up_eth0() {
+        Ok(()) => Some(network::start_dhcp_keepalive()),
+        Err(e) => {
+            eprintln!("lns-session-broker: best-effort network setup failed: {e}");
+            None
+        }
+    };
     // Must run after bring_up_eth0: it consumes the DNS the udhcpc hook stashed.
     if let Err(e) = network::configure_dns() {
         eprintln!("lns-session-broker: best-effort DNS setup failed: {e}");
@@ -85,6 +89,7 @@ fn run() -> Result<i32, String> {
     drop(accept_thread);
 
     reap_exec_sessions(&exec_sessions);
+    drop(dhcp_keepalive);
 
     match primary_outcome {
         Ok(out) => Ok(out.exit_code),

--- a/crates/lns-session-broker/src/network.rs
+++ b/crates/lns-session-broker/src/network.rs
@@ -2,13 +2,18 @@
 
 mod real;
 #[cfg(target_os = "linux")]
-pub use real::{bring_up_eth0, configure_dns};
+pub use real::{bring_up_eth0, configure_dns, start_dhcp_keepalive};
+
+use std::time::Duration;
 
 pub const BUSYBOX: &str = "/.lens/guest-tools/bin/busybox";
 pub const UDHCPC_SCRIPT_PATH: &str = "/tmp/lns-udhcpc.script";
+pub const UDHCPC_PID_PATH: &str = "/tmp/lns-udhcpc.pid";
+pub const UDHCPC_RENEW_COMMAND: &str = r#"pid=$("$1" cat "$2") && "$1" kill -USR1 "$pid""#;
 
 pub const DHCP_DNS_PATH: &str = "/.lens/dhcp-dns";
 pub const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
+pub const DHCP_RENEW_INTERVAL: Duration = Duration::from_secs(120);
 
 pub const FALLBACK_DNS: &[&str] = &["1.1.1.1", "8.8.8.8"];
 
@@ -19,10 +24,15 @@ deconfig)
     "$BB" ip addr flush dev "$interface" 2>/dev/null
     ;;
 bound|renew)
+    lease="${ip}|${mask:-24}|${router}|${dns}"
+    previous_lease=$("$BB" cat /.lens/dhcp-lease 2>/dev/null || true)
+    if [ "$previous_lease" = "$lease" ]; then
+        exit 0
+    fi
     "$BB" ip addr flush dev "$interface" 2>/dev/null
     "$BB" ip addr add "${ip}/${mask:-24}" dev "$interface"
     if [ -n "$router" ]; then
-        "$BB" ip route add default via "$router" dev "$interface" 2>/dev/null || true
+        "$BB" ip route replace default via "$router" dev "$interface"
     fi
     "$BB" mkdir -p /.lens
     : > /.lens/dhcp-dns
@@ -31,6 +41,7 @@ bound|renew)
             echo "$d" >> /.lens/dhcp-dns
         done
     fi
+    printf '%s\n' "$lease" > /.lens/dhcp-lease
     ;;
 esac
 "#;
@@ -54,6 +65,27 @@ pub trait FsWriter {
     fn write(&self, path: &str, contents: &[u8], mode: u32) -> std::io::Result<()>;
 }
 
+pub trait KeepaliveWaiter {
+    fn wait(&self, duration: Duration) -> bool;
+}
+
+pub fn keep_dhcp_alive_with(runner: &dyn CommandRunner, waiter: &dyn KeepaliveWaiter) {
+    while waiter.wait(DHCP_RENEW_INTERVAL) {
+        let _ = run_check(
+            runner,
+            "udhcpc renew",
+            &[
+                "sh",
+                "-c",
+                UDHCPC_RENEW_COMMAND,
+                "lns-dhcp-renew",
+                BUSYBOX,
+                UDHCPC_PID_PATH,
+            ],
+        );
+    }
+}
+
 pub fn bring_up_eth0_with(runner: &dyn CommandRunner, fs: &dyn FsWriter) -> Result<(), String> {
     run_check(
         runner,
@@ -74,7 +106,6 @@ pub fn bring_up_eth0_with(runner: &dyn CommandRunner, fs: &dyn FsWriter) -> Resu
             "udhcpc",
             "-i",
             "eth0",
-            "-q",
             "-n",
             "-t",
             "2",
@@ -82,6 +113,8 @@ pub fn bring_up_eth0_with(runner: &dyn CommandRunner, fs: &dyn FsWriter) -> Resu
             "3",
             "-s",
             UDHCPC_SCRIPT_PATH,
+            "-p",
+            UDHCPC_PID_PATH,
         ],
     )?;
     Ok(())
@@ -150,7 +183,7 @@ mod tests {
         for needle in [
             "$interface",
             "${ip}",
-            "\"$BB\" ip route add default",
+            "\"$BB\" ip route replace default",
             "/.lens/dhcp-dns",
             "echo \"$d\"",
         ] {
@@ -261,6 +294,27 @@ mod tests {
         next_result: RefCell<io::Result<()>>,
     }
 
+    struct FakeKeepaliveWaiter {
+        waits: RefCell<Vec<Duration>>,
+        results: RefCell<Vec<bool>>,
+    }
+
+    impl FakeKeepaliveWaiter {
+        fn once() -> Self {
+            Self {
+                waits: RefCell::new(Vec::new()),
+                results: RefCell::new(vec![false, true]),
+            }
+        }
+    }
+
+    impl KeepaliveWaiter for FakeKeepaliveWaiter {
+        fn wait(&self, duration: Duration) -> bool {
+            self.waits.borrow_mut().push(duration);
+            self.results.borrow_mut().pop().expect("wait result")
+        }
+    }
+
     impl FakeFsWriter {
         fn ok() -> Self {
             Self {
@@ -293,6 +347,53 @@ mod tests {
     }
 
     #[test]
+    fn keepalive_renews_after_120_seconds() {
+        let runner = FakeCommandRunner::with_outcomes(vec![ok(0)]);
+        let waiter = FakeKeepaliveWaiter::once();
+
+        keep_dhcp_alive_with(&runner, &waiter);
+
+        assert_eq!(
+            *waiter.waits.borrow(),
+            vec![DHCP_RENEW_INTERVAL, DHCP_RENEW_INTERVAL]
+        );
+        assert_eq!(
+            runner.calls(),
+            vec![(
+                BUSYBOX.to_string(),
+                vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    UDHCPC_RENEW_COMMAND.to_string(),
+                    "lns-dhcp-renew".to_string(),
+                    BUSYBOX.to_string(),
+                    UDHCPC_PID_PATH.to_string(),
+                ],
+            )]
+        );
+    }
+
+    #[test]
+    fn udhcpc_script_exits_before_applying_an_unchanged_lease() {
+        let comparison = UDHCPC_SCRIPT
+            .find("previous_lease")
+            .expect("lease comparison");
+        let address_apply = comparison
+            + UDHCPC_SCRIPT[comparison..]
+                .find("ip addr flush")
+                .expect("address apply");
+
+        assert!(comparison < address_apply);
+        assert!(UDHCPC_SCRIPT[comparison..address_apply].contains("exit 0"));
+    }
+
+    #[test]
+    fn udhcpc_script_applies_a_changed_address_once() {
+        assert_eq!(UDHCPC_SCRIPT.matches("ip addr add").count(), 1);
+        assert!(UDHCPC_SCRIPT.contains("printf '%s\\n' \"$lease\" > /.lens/dhcp-lease"));
+    }
+
+    #[test]
     fn bring_up_runs_lo_then_eth0_then_script_then_udhcpc() {
         let runner = FakeCommandRunner::with_outcomes(vec![ok(0), ok(0), ok(0)]);
         let fs = FakeFsWriter::ok();
@@ -310,7 +411,6 @@ mod tests {
                 "udhcpc",
                 "-i",
                 "eth0",
-                "-q",
                 "-n",
                 "-t",
                 "2",
@@ -318,6 +418,8 @@ mod tests {
                 "3",
                 "-s",
                 UDHCPC_SCRIPT_PATH,
+                "-p",
+                UDHCPC_PID_PATH,
             ],
         );
 

--- a/crates/lns-session-broker/src/network/real.rs
+++ b/crates/lns-session-broker/src/network/real.rs
@@ -1,10 +1,18 @@
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
 
 use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "linux")]
+use std::sync::mpsc::{self, Receiver};
+#[cfg(target_os = "linux")]
+use std::thread::JoinHandle;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
 
 use super::{CommandOutcome, CommandRunner, FsWriter};
 #[cfg(target_os = "linux")]
-use super::{DHCP_DNS_PATH, configure_dns_with, parse_dhcp_dns};
+use super::{
+    DHCP_DNS_PATH, KeepaliveWaiter, configure_dns_with, keep_dhcp_alive_with, parse_dhcp_dns,
+};
 
 #[derive(Default)]
 struct RealCommandRunner;
@@ -38,6 +46,49 @@ pub fn bring_up_eth0() -> Result<(), String> {
 pub fn configure_dns() -> Result<(), String> {
     let dhcp_dns = parse_dhcp_dns(&std::fs::read_to_string(DHCP_DNS_PATH).unwrap_or_default());
     configure_dns_with(&dhcp_dns, &RealFsWriter)
+}
+
+#[cfg(target_os = "linux")]
+struct StopWaiter {
+    stop: Receiver<()>,
+}
+
+#[cfg(target_os = "linux")]
+impl KeepaliveWaiter for StopWaiter {
+    fn wait(&self, duration: Duration) -> bool {
+        matches!(
+            self.stop.recv_timeout(duration),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub struct DhcpKeepalive {
+    stop: mpsc::Sender<()>,
+    thread: Option<JoinHandle<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for DhcpKeepalive {
+    fn drop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn start_dhcp_keepalive() -> DhcpKeepalive {
+    let (stop, receiver) = mpsc::channel();
+    let thread = std::thread::spawn(move || {
+        keep_dhcp_alive_with(&RealCommandRunner, &StopWaiter { stop: receiver });
+    });
+    DhcpKeepalive {
+        stop,
+        thread: Some(thread),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The guest stopped all DHCP traffic after its first lease. The host `bootpd` process could then stop after five idle minutes. A later guest in the same vmnet session could get no lease.

This PR keeps the first `udhcpc` process alive. The broker sends `SIGUSR1` every 120 seconds. Each signal makes `udhcpc` renew its lease with the host.

Part of #380

## Design

The broker removes `-q` from the initial `udhcpc` command. BusyBox then moves the client to the background after the first lease. The command writes its process ID to `/tmp/lns-udhcpc.pid`.

The initial command keeps `-n`. This option lets the client return an error when it gets no first lease. BusyBox clears `-n` after a successful lease and before it moves to the background. This behavior preserves the failure path for PR 2.

The broker owns a keepalive guard for the full run. The guard sends `SIGUSR1` through the bundled BusyBox every 120 seconds. The guard stops and joins its thread before the broker shuts down.

The hook stores the IP address, mask, router, and DNS values that it applied. A matching `bound` or `renew` event exits before it changes the address, route, or DHCP DNS file. A changed lease applies the address once and replaces the default route.

## Work items and commits

- `8ef1fa1` keeps `udhcpc` alive, schedules renewal, and makes the hook idempotent.
- `8ef1fa1` owns the keepalive guard in the broker for the full run.
- `a697391` records the manual macOS vmnet check in the e2e feature notes.

## Verification

The renewal test first failed because no 120-second wait or signal existed:

```text
left: []
right: [120s, 120s]
```

The hook test first failed because no lease comparison existed:

```text
lease comparison
```

The persistent-client test then failed against the timer-based prototype. It expected a `SIGUSR1` command but got a new `udhcpc` command. The implementation now sends the signal.

The changed-address test also passed a mutation check. A duplicate address application made it fail with `left: 2, right: 1`.

These scoped checks pass:

```text
cargo test -p lns-session-broker
123 passed; 0 failed

cargo clippy -p lns-session-broker -- -D warnings
Finished dev profile

cargo fmt --check
passed
```

## Manual verification

This check needs macOS vmnet. It did not run in this Linux environment.

1. Start an anchor sandbox: `lns run -d --name dhcp-anchor alpine:3.20 -- sleep 900`.
2. Wait seven minutes.
3. Start a second sandbox: `lns run --name dhcp-probe alpine:3.20 -- /.lens/guest-tools/bin/busybox ip -4 addr show dev eth0`.
4. Confirm that the second command shows an `inet` address for `eth0`.
5. Stop the anchor: `lns sandbox stop dhcp-anchor`.

## Deviations

The final implementation uses the preferred persistent client instead of the timer-based prototype. It keeps `-n` for the first lease because BusyBox clears this option after success. This choice keeps the no-lease failure path available for PR 2.

## Left out

This PR does not implement any PR 2 work item. It does not change the first-lease retry count. It does not add the fatal message, DNS warning, service exit reason, or audit event.

The macOS vmnet check remains manual. CI cannot run it.

## Screenshots

Not applicable. This change has no visual surface.
