### PR TITLE
fix(service): provisioned tools survive a login shell

### DIFF
--- a/crates/e2e-tests/features/microvm_tools.feature
+++ b/crates/e2e-tests/features/microvm_tools.feature
@@ -14,6 +14,9 @@ Feature: declared developer tools reach a real guest
   version, because the tool also has to *write* inside its own tree: cargo puts
   its package-cache lock and registry under a CARGO_HOME the engine placed
   there, and `rustc --version` passes even when that directory is read-only.
+  A login shell is covered here too: `/etc/profile` assigns PATH outright, so
+  only a real guest proves that the snippet the run writes under
+  /etc/profile.d puts the tool dirs back after that reset.
 
   Scenario: A declared tool is available to the workload
     Given the LNS service is running
@@ -26,6 +29,12 @@ Feature: declared developer tools reach a real guest
     And a lns.yaml declaring tools ["node@22"] over the pinned base image
     When the sandbox runs "npm --version"
     Then it prints an npm version
+
+  Scenario: A declared tool survives a login shell
+    Given the LNS service is running
+    And a lns.yaml declaring tools ["node@22"] over the pinned base image
+    When the sandbox runs "/bin/sh -lc 'command -v node'"
+    Then it prints the node binary inside the run's tool tree
 
   Scenario: Provisioning is disclosed, audited, and reused on the next run
     Given a clean lns cache home

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -944,6 +944,23 @@ fn nothing_provisioned_again(world: &mut E2eWorld) {
     );
 }
 
+#[then("it prints the node binary inside the run's tool tree")]
+fn prints_a_tool_tree_path(world: &mut E2eWorld) {
+    let result = world.result.as_ref().expect("a run result");
+    assert_eq!(
+        result.exit_code, 0,
+        "a login shell in the guest could not find the declared tool:\n{}\n{}",
+        result.stdout, result.stderr
+    );
+    let wanted = format!("{}/node/", lns_service::tools::cache::TOOLS_ROOT);
+    assert!(
+        result.stdout.contains(&wanted),
+        "expected a path under {wanted}, got:\n{}\n{}",
+        result.stdout,
+        result.stderr
+    );
+}
+
 #[then("it prints a node 22 version")]
 fn prints_a_node_22_version(world: &mut E2eWorld) {
     let result = world.result.as_ref().expect("a run result");

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -377,12 +377,14 @@ async fn orchestrate(
         )?;
     }
 
+    let mut login_shell_spec = None;
     let ensured_tools = if tool_requests.is_empty() {
         None
     } else {
+        let surveyed = crate::tools::image_survey::survey_off_runtime(&image.digests, &image.bytes)?;
         let target = crate::tools::ProvisionTarget {
             arch: crate::tools::host_arch(),
-            libc: crate::tools::libc::detect_libc_off_runtime(&image.digests, &image.bytes)?,
+            libc: surveyed.libc,
         };
         crate::tools::registry::refuse_libc_unsupported(
             &tool_requests,
@@ -407,6 +409,10 @@ async fn orchestrate(
             },
         )
         .await?;
+        login_shell_spec = crate::tools::login_shell::profile_spec(
+            &ensured.bin_paths,
+            surveyed.reads_etc_profile,
+        );
         Some(ensured)
     };
 
@@ -418,6 +424,7 @@ async fn orchestrate(
     if let Some(ensured) = &ensured_tools {
         fileset_specs.extend(ensured.specs.iter().cloned());
     }
+    fileset_specs.extend(login_shell_spec);
     fileset_specs.extend(workload_ca_spec);
     fileset_specs.extend(crate::connector::writes::written_paths_manifest(
         &connector_writes,

--- a/crates/lns-service/src/run/orchestrator.rs
+++ b/crates/lns-service/src/run/orchestrator.rs
@@ -381,7 +381,8 @@ async fn orchestrate(
     let ensured_tools = if tool_requests.is_empty() {
         None
     } else {
-        let surveyed = crate::tools::image_survey::survey_off_runtime(&image.digests, &image.bytes)?;
+        let surveyed =
+            crate::tools::image_survey::survey_off_runtime(&image.digests, &image.bytes)?;
         let target = crate::tools::ProvisionTarget {
             arch: crate::tools::host_arch(),
             libc: surveyed.libc,
@@ -409,10 +410,8 @@ async fn orchestrate(
             },
         )
         .await?;
-        login_shell_spec = crate::tools::login_shell::profile_spec(
-            &ensured.bin_paths,
-            surveyed.reads_etc_profile,
-        );
+        login_shell_spec =
+            crate::tools::login_shell::profile_spec(&ensured.bin_paths, surveyed.reads_etc_profile);
         Some(ensured)
     };
 

--- a/crates/lns-service/src/tools/image_survey.rs
+++ b/crates/lns-service/src/tools/image_survey.rs
@@ -9,25 +9,32 @@ use flate2::read::GzDecoder;
 use super::Libc;
 use crate::composefs::changeset::{PathChange, classify_path};
 
+/// What one walk of an image's layers settles about the rootfs a run will boot: which libc a provisioned tool has to be built against, and whether a login shell there reads `/etc/profile`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageSurvey {
+    pub libc: Libc,
+    pub reads_etc_profile: bool,
+}
+
 /// Gunzipping and walking every layer is CPU work on borrowed data, so it moves off the async worker rather than holding one for the length of the scan; a current-thread runtime (tests) has nowhere to move it and runs it inline.
-pub fn detect_libc_off_runtime(
+pub fn survey_off_runtime(
     layer_digests: &[String],
     layers: &[impl AsRef<[u8]>],
-) -> Result<Libc> {
+) -> Result<ImageSurvey> {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| detect_libc_for(layer_digests, layers))
+            tokio::task::block_in_place(|| survey_for(layer_digests, layers))
         }
-        _ => detect_libc_for(layer_digests, layers),
+        _ => survey_for(layer_digests, layers),
     }
 }
 
-/// The flavor is a pure function of the layer set, so a warm run re-answers it from the digests instead of gunzipping every layer body again.
-pub fn detect_libc_for(layer_digests: &[String], layers: &[impl AsRef<[u8]>]) -> Result<Libc> {
-    static MEMO: OnceLock<Mutex<HashMap<String, Libc>>> = OnceLock::new();
+/// Every fact here is a pure function of the layer set, so a warm run re-answers them from the digests instead of gunzipping every layer body again.
+pub fn survey_for(layer_digests: &[String], layers: &[impl AsRef<[u8]>]) -> Result<ImageSurvey> {
+    static MEMO: OnceLock<Mutex<HashMap<String, ImageSurvey>>> = OnceLock::new();
     // Without digests there is nothing identifying to key on, and every such image would share one entry.
     if layer_digests.is_empty() {
-        return detect_libc(layers);
+        return survey(layers);
     }
     let memo = MEMO.get_or_init(|| Mutex::new(HashMap::new()));
     let key = layer_digests.join(" ");
@@ -38,16 +45,16 @@ pub fn detect_libc_for(layer_digests: &[String], layers: &[impl AsRef<[u8]>]) ->
     {
         return Ok(*hit);
     }
-    let verdict = detect_libc(layers)?;
+    let surveyed = survey(layers)?;
     memo.lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(key, verdict);
-    Ok(verdict)
+        .insert(key, surveyed);
+    Ok(surveyed)
 }
 
-/// Decide the image's libc flavor from the loaders and compatibility runtime visible after applying its layer changesets.
-pub fn detect_libc(layers: &[impl AsRef<[u8]>]) -> Result<Libc> {
-    let mut visible: BTreeMap<PathBuf, LibcEvidence> = BTreeMap::new();
+/// Decide the image's libc flavor and its login-shell entry point from what is visible after applying its layer changesets.
+pub fn survey(layers: &[impl AsRef<[u8]>]) -> Result<ImageSurvey> {
+    let mut visible: BTreeMap<PathBuf, Evidence> = BTreeMap::new();
     for (idx, layer) in layers.iter().enumerate() {
         let changes =
             scan_layer(layer.as_ref()).with_context(|| format!("scanning layer {idx}"))?;
@@ -59,25 +66,22 @@ pub fn detect_libc(layers: &[impl AsRef<[u8]>]) -> Result<Libc> {
                 visible.remove(&entry.path);
             } else {
                 visible.retain(|path, _| !path.starts_with(&entry.path));
-                if let Some(evidence) = libc_evidence(&entry.path) {
+                if let Some(evidence) = evidence_of(&entry.path) {
                     visible.insert(entry.path, evidence);
                 }
             }
         }
     }
-    let has_musl_loader = visible
-        .values()
-        .any(|evidence| *evidence == LibcEvidence::Loader(Libc::Musl));
-    let has_gnu_loader = visible
-        .values()
-        .any(|evidence| *evidence == LibcEvidence::Loader(Libc::Gnu));
-    let has_gcompat = visible
-        .values()
-        .any(|evidence| *evidence == LibcEvidence::Gcompat);
-    Ok(if has_musl_loader && (!has_gnu_loader || has_gcompat) {
-        Libc::Musl
-    } else {
-        Libc::Gnu
+    let holds = |wanted: Evidence| visible.values().any(|evidence| *evidence == wanted);
+    let has_musl_loader = holds(Evidence::Loader(Libc::Musl));
+    let has_gnu_loader = holds(Evidence::Loader(Libc::Gnu));
+    Ok(ImageSurvey {
+        libc: if has_musl_loader && (!has_gnu_loader || holds(Evidence::Gcompat)) {
+            Libc::Musl
+        } else {
+            Libc::Gnu
+        },
+        reads_etc_profile: holds(Evidence::LoginProfile),
     })
 }
 
@@ -132,28 +136,35 @@ fn materializes(entry_type: tar::EntryType) -> bool {
 
 const LOADER_DIRS: &[&str] = &["lib", "lib64", "usr/lib", "usr/lib64"];
 
+/// The login-shell entry point: it is what sources `/etc/profile.d`, so an image without it reads no snippet the host writes there.
+const LOGIN_PROFILE: &str = "etc/profile";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LibcEvidence {
+enum Evidence {
     Loader(Libc),
     Gcompat,
+    LoginProfile,
 }
 
-fn libc_evidence(path: &Path) -> Option<LibcEvidence> {
+fn evidence_of(path: &Path) -> Option<Evidence> {
     let rel = path.to_string_lossy();
     let rel = rel.trim_start_matches("./").trim_start_matches('/');
+    if rel == LOGIN_PROFILE {
+        return Some(Evidence::LoginProfile);
+    }
     let (dir, name) = rel.rsplit_once('/')?;
     let dir = dir.trim_start_matches("./");
     if !LOADER_DIRS.contains(&dir) && !dir.starts_with("usr/lib/") {
         return None;
     }
     if name.starts_with("ld-musl-") {
-        return Some(LibcEvidence::Loader(Libc::Musl));
+        return Some(Evidence::Loader(Libc::Musl));
     }
     if name.starts_with("ld-linux") || name == "libc.so.6" {
-        return Some(LibcEvidence::Loader(Libc::Gnu));
+        return Some(Evidence::Loader(Libc::Gnu));
     }
     if name.starts_with("libgcompat.so") {
-        return Some(LibcEvidence::Gcompat);
+        return Some(Evidence::Gcompat);
     }
     None
 }
@@ -202,24 +213,24 @@ mod tests {
     #[test]
     fn a_musl_loader_marks_the_image_musl() {
         let layer = layer_with(&["bin/sh", "lib/ld-musl-aarch64.so.1"]);
-        assert_eq!(detect_libc(&[layer]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[layer]).unwrap().libc, Libc::Musl);
     }
 
     #[test]
     fn a_gnu_loader_or_libc_marks_the_image_gnu() {
         let loader = layer_with(&["lib/ld-linux-aarch64.so.1"]);
-        assert_eq!(detect_libc(&[loader]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[loader]).unwrap().libc, Libc::Gnu);
         let libc = layer_with(&["usr/lib/x86_64-linux-gnu/libc.so.6"]);
-        assert_eq!(detect_libc(&[libc]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[libc]).unwrap().libc, Libc::Gnu);
     }
 
     #[test]
     fn a_loaderless_image_defaults_to_gnu() {
         // Every image fills lib/ with things that are not loaders.
         let layer = layer_with(&["app/server", "lib/libz.so.1", "usr/lib/libssl.so.3"]);
-        assert_eq!(detect_libc(&[layer]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[layer]).unwrap().libc, Libc::Gnu);
         let empty: [Vec<u8>; 0] = [];
-        assert_eq!(detect_libc(&empty).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&empty).unwrap().libc, Libc::Gnu);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -227,7 +238,7 @@ mod tests {
         let digests = vec!["sha256:offruntime".to_string()];
         let layers = vec![layer_with(&["lib/ld-musl-aarch64.so.1"])];
         assert_eq!(
-            detect_libc_off_runtime(&digests, &layers).unwrap(),
+            survey_off_runtime(&digests, &layers).unwrap().libc,
             Libc::Musl
         );
     }
@@ -237,7 +248,7 @@ mod tests {
         let digests = vec!["sha256:inline".to_string()];
         let layers = vec![layer_with(&["lib/ld-linux-aarch64.so.1"])];
         assert_eq!(
-            detect_libc_off_runtime(&digests, &layers).unwrap(),
+            survey_off_runtime(&digests, &layers).unwrap().libc,
             Libc::Gnu
         );
     }
@@ -249,10 +260,10 @@ mod tests {
             layer_with(&["bin/sh"]),
             layer_with(&["lib/ld-musl-x86_64.so.1"]),
         ];
-        assert_eq!(detect_libc_for(&digests, &layers).unwrap(), Libc::Musl);
+        assert_eq!(survey_for(&digests, &layers).unwrap().libc, Libc::Musl);
         let corrupt = vec![b"\x1f\x8bnot really gzip".to_vec(), Vec::new()];
         assert_eq!(
-            detect_libc_for(&digests, &corrupt).unwrap(),
+            survey_for(&digests, &corrupt).unwrap().libc,
             Libc::Musl,
             "bodies that would fail to scan are never opened on a hit"
         );
@@ -261,10 +272,10 @@ mod tests {
     #[test]
     fn an_undigested_layer_set_is_scanned_every_time_rather_than_sharing_one_entry() {
         let musl = vec![layer_with(&["lib/ld-musl-aarch64.so.1"])];
-        assert_eq!(detect_libc_for(&[], &musl).unwrap(), Libc::Musl);
+        assert_eq!(survey_for(&[], &musl).unwrap().libc, Libc::Musl);
         let gnu = vec![layer_with(&["lib/ld-linux-aarch64.so.1"])];
         assert_eq!(
-            detect_libc_for(&[], &gnu).unwrap(),
+            survey_for(&[], &gnu).unwrap().libc,
             Libc::Gnu,
             "a second undigested image gets its own verdict, not the first one's"
         );
@@ -274,14 +285,14 @@ mod tests {
     fn a_musl_loader_does_not_hide_a_corrupt_later_entry() {
         let mut layer = layer_with(&["lib/ld-musl-aarch64.so.1", "usr/lib/libc.so.6"]);
         layer[1024] ^= 0xff;
-        assert!(detect_libc(&[layer]).is_err());
+        assert!(survey(&[layer]).is_err());
     }
 
     #[test]
     fn a_borrowed_layer_set_is_scanned_without_owning_the_bytes() {
         let owned = layer_with(&["lib/ld-musl-aarch64.so.1"]);
         let borrowed: Vec<&[u8]> = vec![owned.as_slice()];
-        assert_eq!(detect_libc(&borrowed).unwrap(), Libc::Musl);
+        assert_eq!(survey(&borrowed).unwrap().libc, Libc::Musl);
     }
 
     #[test]
@@ -289,42 +300,42 @@ mod tests {
         // `alpine + apk add gcompat` adds a gnu loader without removing the musl one; reading that as glibc installs tool builds that cannot run.
         let alpine = layer_with(&["lib/ld-musl-x86_64.so.1", "bin/busybox"]);
         let gcompat = layer_with(&["lib/ld-linux-x86-64.so.2", "usr/lib/libgcompat.so.0"]);
-        assert_eq!(detect_libc(&[alpine, gcompat]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[alpine, gcompat]).unwrap().libc, Libc::Musl);
     }
 
     #[test]
     fn a_later_whiteout_can_replace_a_lower_musl_loader_with_gnu() {
         let musl = layer_with(&["lib/ld-musl-x86_64.so.1"]);
         let gnu = layer_with(&["lib/.wh.ld-musl-x86_64.so.1", "lib64/ld-linux-x86-64.so.2"]);
-        assert_eq!(detect_libc(&[musl, gnu]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[musl, gnu]).unwrap().libc, Libc::Gnu);
     }
 
     #[test]
     fn an_opaque_whiteout_preserves_a_same_layer_gnu_loader() {
         let musl = layer_with(&["lib/ld-musl-x86_64.so.1"]);
         let gnu = layer_with(&["lib/ld-linux-x86-64.so.2", "lib/.wh..wh..opq"]);
-        assert_eq!(detect_libc(&[musl, gnu]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[musl, gnu]).unwrap().libc, Libc::Gnu);
     }
 
     #[test]
     fn a_later_layer_can_still_add_the_only_loader_in_the_image() {
         let scratch = layer_with(&["app/server"]);
         let runtime = layer_with(&["lib/ld-musl-aarch64.so.1"]);
-        assert_eq!(detect_libc(&[scratch, runtime]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[scratch, runtime]).unwrap().libc, Libc::Musl);
     }
 
     #[test]
     fn a_directory_replacing_a_loader_path_removes_that_loader() {
         let musl = layer_with(&["lib/ld-musl-x86_64.so.1"]);
         let replacement = layer_with_typed("lib/ld-musl-x86_64.so.1", tar::EntryType::Directory);
-        assert_eq!(detect_libc(&[musl, replacement]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[musl, replacement]).unwrap().libc, Libc::Gnu);
     }
 
     #[test]
     fn an_entry_type_the_materializer_skips_does_not_hide_a_loader() {
         let musl = layer_with(&["lib/ld-musl-x86_64.so.1"]);
         let skipped = layer_with_typed("lib/ld-musl-x86_64.so.1", tar::EntryType::Link);
-        assert_eq!(detect_libc(&[musl, skipped]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[musl, skipped]).unwrap().libc, Libc::Musl);
     }
 
     #[test]
@@ -334,7 +345,7 @@ mod tests {
             "opt/toolchain/sysroot/ld-musl-x86_64.so.1",
             "src/musl/ld-linux-x86-64.so.2",
         ]);
-        assert_eq!(detect_libc(&[layer]).unwrap(), Libc::Gnu, "no loader found");
+        assert_eq!(survey(&[layer]).unwrap().libc, Libc::Gnu, "no loader found");
     }
 
     #[test]
@@ -344,7 +355,7 @@ mod tests {
             "lib/ld-linux-x86-64.so.2",
             "lib/libgcompat.so.0",
         ]);
-        assert_eq!(detect_libc(&[layer]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[layer]).unwrap().libc, Libc::Musl);
     }
 
     #[test]
@@ -354,7 +365,7 @@ mod tests {
             "usr/lib/x86_64-linux-gnu/libc.so.6",
             "lib/ld-musl-x86_64.so.1",
         ]);
-        assert_eq!(detect_libc(&[layer]).unwrap(), Libc::Gnu);
+        assert_eq!(survey(&[layer]).unwrap().libc, Libc::Gnu);
     }
 
     #[test]
@@ -366,12 +377,64 @@ mod tests {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         encoder.write_all(&raw).unwrap();
         let gz = encoder.finish().unwrap();
-        assert_eq!(detect_libc(&[gz]).unwrap(), Libc::Musl);
+        assert_eq!(survey(&[gz]).unwrap().libc, Libc::Musl);
+    }
+
+    #[test]
+    fn an_image_that_ships_etc_profile_is_reported_as_reading_it() {
+        // /etc/profile is what sources /etc/profile.d, so it decides whether writing a snippet there puts a declared tool back on a login shell's PATH.
+        let layer = layer_with(&["etc/profile", "lib/ld-musl-x86_64.so.1"]);
+        assert!(survey(&[layer]).unwrap().reads_etc_profile);
+    }
+
+    #[test]
+    fn an_image_with_no_etc_profile_is_reported_as_reading_none() {
+        // A distroless or scratch rootfs has no login shell at all; a file written for one would never be read.
+        let layer = layer_with(&["app/server", "etc/passwd", "etc/profile.d/other.sh"]);
+        let surveyed = survey(&[layer]).unwrap();
+        assert!(!surveyed.reads_etc_profile);
+        assert_eq!(surveyed.libc, Libc::Gnu, "one walk still settles both");
+    }
+
+    #[test]
+    fn a_later_layer_that_whites_out_etc_profile_takes_the_login_shell_with_it() {
+        let base = layer_with(&["etc/profile"]);
+        let stripped = layer_with(&["etc/.wh.profile"]);
+        assert!(!survey(&[base, stripped]).unwrap().reads_etc_profile);
+    }
+
+    #[test]
+    fn a_later_layer_can_add_the_login_shell_entry_point_the_base_lacked() {
+        let base = layer_with(&["app/server"]);
+        let added = layer_with(&["etc/profile"]);
+        assert!(survey(&[base, added]).unwrap().reads_etc_profile);
+    }
+
+    #[test]
+    fn the_memo_carries_every_fact_of_the_walk_rather_than_the_libc_alone() {
+        // Both answers come from one gunzip of the layer bodies; a hit that dropped one would send the second reader back through the whole scan.
+        let digests = vec!["sha256:cccc".to_string()];
+        let layers = vec![layer_with(&["etc/profile", "lib/ld-musl-x86_64.so.1"])];
+        assert_eq!(
+            survey_for(&digests, &layers).unwrap(),
+            ImageSurvey {
+                libc: Libc::Musl,
+                reads_etc_profile: true
+            }
+        );
+        let corrupt = vec![b"\x1f\x8bnot really gzip".to_vec()];
+        assert_eq!(
+            survey_for(&digests, &corrupt).unwrap(),
+            ImageSurvey {
+                libc: Libc::Musl,
+                reads_etc_profile: true
+            }
+        );
     }
 
     #[test]
     fn a_corrupt_layer_surfaces_the_layer_index() {
-        let err = detect_libc(&[b"\x1f\x8bnot really gzip".to_vec()]).unwrap_err();
+        let err = survey(&[b"\x1f\x8bnot really gzip".to_vec()]).unwrap_err();
         assert!(
             format!("{err:#}").contains("scanning layer 0"),
             "got: {err:#}"

--- a/crates/lns-service/src/tools/login_shell.rs
+++ b/crates/lns-service/src/tools/login_shell.rs
@@ -1,0 +1,135 @@
+use crate::log;
+use crate::runtime_layer::{RuntimeFileSpec, RuntimeSource};
+
+/// The file `/etc/profile` sources right after it assigns `PATH`, on Debian and on Alpine alike.
+pub const GUEST_PROFILE_SNIPPET_PATH: &str = "/etc/profile.d/lens-tools.sh";
+
+/// What a login shell has to read to keep the run's declared tools: `/etc/profile` assigns `PATH` outright, so every tool dir the workload's own PATH carries goes back in front of it from the file that reset sources next. An image with no `/etc/profile` sources nothing, so it gets no file.
+pub fn profile_spec(
+    bin_paths: &[String],
+    image_reads_etc_profile: bool,
+) -> Option<RuntimeFileSpec> {
+    if bin_paths.is_empty() {
+        return None;
+    }
+    if !image_reads_etc_profile {
+        log::debug!(
+            "the image ships no /etc/profile, so nothing would source {GUEST_PROFILE_SNIPPET_PATH}; the declared tools reach the workload on its own PATH only"
+        );
+        return None;
+    }
+    Some(RuntimeFileSpec {
+        guest_path: GUEST_PROFILE_SNIPPET_PATH.to_string(),
+        mode: 0o644,
+        source: RuntimeSource::Bytes(profile_snippet(bin_paths).into_bytes()),
+    })
+}
+
+const DIRS_PLACEHOLDER: &str = "{dirs}";
+
+/// Prepend rather than assign: a login shell that already read the user's own `~/.profile` keeps what it added, a dir the shell has is not repeated, and no blank segment is left behind — to `execvp` a blank one is the current directory.
+const SNIPPET: &str = r#"# Written by lns for this run: /etc/profile assigns PATH, which drops the tools this sandbox declared.
+lens_tools_prefix=''
+for lens_tools_dir in {dirs}; do
+    case ":${PATH-}:" in
+        *":$lens_tools_dir:"*) ;;
+        *) lens_tools_prefix="${lens_tools_prefix:+$lens_tools_prefix:}$lens_tools_dir" ;;
+    esac
+done
+if [ -n "$lens_tools_prefix" ]; then
+    PATH="$lens_tools_prefix${PATH:+:$PATH}"
+    export PATH
+fi
+unset lens_tools_prefix lens_tools_dir
+"#;
+
+fn profile_snippet(bin_paths: &[String]) -> String {
+    let dirs: Vec<String> = bin_paths.iter().map(|dir| shell_word(dir)).collect();
+    SNIPPET.replace(DIRS_PLACEHOLDER, &dirs.join(" "))
+}
+
+/// One shell word whatever the path holds: the dirs are interpolated into a `for` list, and a name carrying a quote would otherwise be re-read as shell syntax.
+fn shell_word(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dirs(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
+
+    fn body(spec: &RuntimeFileSpec) -> String {
+        String::from_utf8(
+            spec.source
+                .as_bytes()
+                .expect("the snippet travels as an inline body")
+                .to_vec(),
+        )
+        .expect("the snippet is utf-8")
+    }
+
+    #[test]
+    fn the_snippet_lands_where_etc_profile_sources_it_and_the_workload_can_read_it() {
+        // /etc/profile assigns PATH and then sources this directory, so a file anywhere else is never read; a workload that is not root still has to be able to read it.
+        let spec = profile_spec(&dirs(&["/.lens/tools/jq/1.7.1/data/installs/jq/1.7.1"]), true)
+            .expect("a declared tool stages a snippet");
+        assert_eq!(spec.guest_path, "/etc/profile.d/lens-tools.sh");
+        assert_eq!(spec.mode, 0o644);
+    }
+
+    #[test]
+    fn the_snippet_puts_the_tool_dirs_in_front_of_the_path_the_login_shell_has() {
+        // The whole body is pinned: it is POSIX shell that runs under Debian's bash and Alpine's ash, it keeps declaration order, it extends the shell's PATH rather than assigning one, it never dereferences an unset PATH (a `set -u` shell would abort the whole login), and it unsets its own two variables so the next profile.d file sees neither.
+        let spec = profile_spec(&dirs(&["/t/a/bin", "/t/b/bin"]), true).expect("a snippet");
+        assert_eq!(
+            body(&spec),
+            r#"# Written by lns for this run: /etc/profile assigns PATH, which drops the tools this sandbox declared.
+lens_tools_prefix=''
+for lens_tools_dir in '/t/a/bin' '/t/b/bin'; do
+    case ":${PATH-}:" in
+        *":$lens_tools_dir:"*) ;;
+        *) lens_tools_prefix="${lens_tools_prefix:+$lens_tools_prefix:}$lens_tools_dir" ;;
+    esac
+done
+if [ -n "$lens_tools_prefix" ]; then
+    PATH="$lens_tools_prefix${PATH:+:$PATH}"
+    export PATH
+fi
+unset lens_tools_prefix lens_tools_dir
+"#
+        );
+    }
+
+    #[test]
+    fn a_tool_dir_carrying_a_quote_arrives_as_one_literal_word() {
+        let spec = profile_spec(&dirs(&["/t/it's/bin"]), true).expect("a snippet");
+        assert!(
+            body(&spec).contains(r"for lens_tools_dir in '/t/it'\''s/bin'; do"),
+            "a dir the shell would re-read as syntax must arrive quoted: {}",
+            body(&spec)
+        );
+    }
+
+    #[test]
+    fn a_run_that_declared_no_tool_stages_nothing() {
+        // Nothing to put back, and a file whose `for` list is empty is a file the run did not need.
+        assert!(profile_spec(&[], true).is_none());
+    }
+
+    #[test]
+    fn an_image_with_no_etc_profile_stages_nothing_and_says_so_on_the_trace_stream() {
+        // Nothing would ever source the file, and a run is not worth failing — or warning — over a file no shell reads.
+        let messages = crate::test_env::captured_messages(|| {
+            assert!(profile_spec(&dirs(&["/t/a/bin"]), false).is_none());
+        });
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("no /etc/profile") && m.contains(GUEST_PROFILE_SNIPPET_PATH)),
+            "an operator reading the trace must be told which file was skipped and why: {messages:?}"
+        );
+    }
+}

--- a/crates/lns-service/src/tools/login_shell.rs
+++ b/crates/lns-service/src/tools/login_shell.rs
@@ -74,8 +74,11 @@ mod tests {
     #[test]
     fn the_snippet_lands_where_etc_profile_sources_it_and_the_workload_can_read_it() {
         // /etc/profile assigns PATH and then sources this directory, so a file anywhere else is never read; a workload that is not root still has to be able to read it.
-        let spec = profile_spec(&dirs(&["/.lens/tools/jq/1.7.1/data/installs/jq/1.7.1"]), true)
-            .expect("a declared tool stages a snippet");
+        let spec = profile_spec(
+            &dirs(&["/.lens/tools/jq/1.7.1/data/installs/jq/1.7.1"]),
+            true,
+        )
+        .expect("a declared tool stages a snippet");
         assert_eq!(spec.guest_path, "/etc/profile.d/lens-tools.sh");
         assert_eq!(spec.mode, 0o644);
     }

--- a/crates/lns-service/src/tools/login_shell.rs
+++ b/crates/lns-service/src/tools/login_shell.rs
@@ -109,10 +109,10 @@ unset lens_tools_prefix lens_tools_dir
     #[test]
     fn a_tool_dir_carrying_a_quote_arrives_as_one_literal_word() {
         let spec = profile_spec(&dirs(&["/t/it's/bin"]), true).expect("a snippet");
+        let body = body(&spec);
         assert!(
-            body(&spec).contains(r"for lens_tools_dir in '/t/it'\''s/bin'; do"),
-            "a dir the shell would re-read as syntax must arrive quoted: {}",
-            body(&spec)
+            body.contains(r"for lens_tools_dir in '/t/it'\''s/bin'; do"),
+            "a dir the shell would re-read as syntax must arrive quoted: {body}"
         );
     }
 

--- a/crates/lns-service/src/tools/mod.rs
+++ b/crates/lns-service/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod libc;
+pub mod login_shell;
 pub mod mise;
 pub(crate) mod provisioner;
 pub mod real;

--- a/crates/lns-service/src/tools/mod.rs
+++ b/crates/lns-service/src/tools/mod.rs
@@ -1,5 +1,5 @@
 pub mod cache;
-pub mod libc;
+pub mod image_survey;
 pub mod login_shell;
 pub mod mise;
 pub(crate) mod provisioner;

--- a/crates/lns-service/src/tools/real.rs
+++ b/crates/lns-service/src/tools/real.rs
@@ -108,8 +108,9 @@ pub async fn pre_provision_for_pull(
         .collect();
     let target = ProvisionTarget {
         arch: super::host_arch(),
-        libc: super::libc::detect_libc_off_runtime(&base_image.layer_digests, &layers)
-            .map_err(|e| ProvisionError::Engine(format!("reading the base image: {e:#}")))?,
+        libc: super::image_survey::survey_off_runtime(&base_image.layer_digests, &layers)
+            .map_err(|e| ProvisionError::Engine(format!("reading the base image: {e:#}")))?
+            .libc,
     };
     super::registry::refuse_libc_unsupported(&requests, &target, &sandbox.base_image)?;
     let content_store = crate::content_store::ContentStore::new(cache_dir()?.join("content"));

--- a/crates/lns-service/tests/behaviours/declared_tools.feature
+++ b/crates/lns-service/tests/behaviours/declared_tools.feature
@@ -12,6 +12,9 @@ Feature: declared developer tools are provisioned once per machine, outside work
   policy cage (covered against a live guest by the @microvm suite). A tool whose
   binaries are launchers rather than the payload itself resolves the rest through
   its own environment, so the workload gets those vars too — unless it sets them.
+  A login shell is the one process that throws the composed PATH away: /etc/profile
+  assigns PATH outright, so the same tool dirs are also written to the profile.d
+  snippet it sources next.
 
   Scenario: The strictest policy does not gate provisioning
     Given a lns.yaml declaring tools ["node@22"] that denies every destination
@@ -50,6 +53,11 @@ Feature: declared developer tools are provisioned once per machine, outside work
     And the sandbox sets that var itself
     When I run the sandbox
     Then the workload keeps the sandbox's value
+
+  Scenario: A declared tool survives a login shell
+    Given a lns.yaml declaring tools ["node@22"]
+    When I run the sandbox
+    Then a login shell in the guest finds the tool directories again
 
   Scenario: Tool provisioning is audited
     When tools are provisioned for a run

--- a/crates/lns-service/tests/behaviours/steps/declared_tools.rs
+++ b/crates/lns-service/tests/behaviours/steps/declared_tools.rs
@@ -178,6 +178,39 @@ fn workload_carries_the_tool_var(w: &mut BehaviourWorld) -> Result<(), String> {
     }
 }
 
+#[then("a login shell in the guest finds the tool directories again")]
+fn login_shell_finds_the_tool_dirs(w: &mut BehaviourWorld) -> Result<(), String> {
+    let rig = w.tools.as_ref().ok_or("no launch happened")?;
+    if let Some(error) = &rig.error {
+        return Err(format!("the launch failed: {error}"));
+    }
+    let ensured = rig.ensured.as_ref().ok_or("no tools were composed")?;
+    let spec = lns_service::tools::login_shell::profile_spec(&ensured.bin_paths, true)
+        .ok_or("the run staged no login-shell snippet for its declared tools")?;
+    if spec.guest_path != lns_service::tools::login_shell::GUEST_PROFILE_SNIPPET_PATH {
+        return Err(format!(
+            "the snippet must land where /etc/profile sources it, got {}",
+            spec.guest_path
+        ));
+    }
+    let body = spec
+        .source
+        .as_bytes()
+        .map(String::from_utf8_lossy)
+        .ok_or("the snippet carries no inline body")?;
+    for dir in &ensured.bin_paths {
+        if !body.contains(dir.as_str()) {
+            return Err(format!("expected {dir} in the snippet:\n{body}"));
+        }
+    }
+    if !body.contains("$PATH") {
+        return Err(format!(
+            "the snippet must extend the login shell's own PATH, not replace it:\n{body}"
+        ));
+    }
+    Ok(())
+}
+
 #[then("the workload keeps the sandbox's value")]
 fn workload_keeps_its_own_value(w: &mut BehaviourWorld) -> Result<(), String> {
     let env = composed_workload_env(w)?;

--- a/docs/running-workloads.md
+++ b/docs/running-workloads.md
@@ -831,9 +831,12 @@ spec:
   same versions, because prune reclaims the cached trees without touching what
   this machine already resolved.
 - Tools land read-only on the workload's `PATH`, ahead of the base image's own
-  copies. One caveat: a **login** shell (`sh -lc`, `bash -lc`) sources
-  `/etc/profile`, which on most images resets `PATH` outright and so discards the
-  tool dirs — run your command without `-l`, or re-export `PATH` yourself.
+  copies. A **login** shell (`sh -lc`, `bash -lc`) keeps them too: it sources
+  `/etc/profile`, which on most images resets `PATH` outright, so the run also
+  writes `/etc/profile.d/lens-tools.sh` — the file `/etc/profile` sources right
+  after that reset — which puts the same tool dirs back in front of whatever
+  `PATH` the shell then has. An image that ships no `/etc/profile` sources
+  nothing, so there the tool dirs reach only the processes lns starts.
   Nothing tool-related persists in the workload's writable layer — the
   per-machine tool cache is a host-side input, not guest state, so a workload
   that shadows a tool in its own overlay affects only that run and never the


### PR DESCRIPTION
## The defect

A sandbox declares `tools:` such as `gh@2.99.0`, `jq@1.7.1`, `ripgrep@14`,
`python@3.12`. The runtime provisions them under
`/.lens/tools/<tool>/<version>/data/installs/...` and puts those directories
on the PATH of the processes it starts. Nothing puts them on the PATH of a
login shell. On the `node:24-bookworm` image:

```
$ lns sandbox exec NAME -- sh -c 'echo $PATH'
/.lens/tools/ripgrep/14.1.1/data/installs/ripgrep/14.1.1/ripgrep-14.1.1-aarch64-unknown-linux-gnu:/.lens/tools/jq/1.7.1/data/installs/jq/1.7.1:/.lens/tools/python/3.12.14/data/installs/python/3.12.14/bin:/.lens/tools/rust/1.97.1/home/.cargo/bin:/.lens/tools/gh/2.99.0/data/installs/gh/2.99.0/gh_2.99.0_linux_arm64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

$ lns sandbox exec NAME -- bash -lc 'echo $PATH; command -v gh jq rg'
/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
```

`bash -l` reads `/etc/profile`, which on Debian assigns PATH unconditionally,
so every tool directory is gone and nothing under `/etc/profile.d` puts it
back. The OpenAI Codex CLI runs every shell command as `/bin/bash -lc
'<command>'`, so in a Codex workload `gh`, `jq` and `rg` exit 127 although the
sandbox declared them. `su -`, `ssh` and a Makefile with `SHELL := bash -l`
lose them the same way.

## The fix

A run that provisions tools now also writes `/etc/profile.d/lens-tools.sh`
(mode 0644, uid/gid 0) into its runtime layer — the file `/etc/profile`
sources right after the reset, on Debian and on Alpine alike. The body:

```sh
# Written by lns for this run: /etc/profile assigns PATH, which drops the tools this sandbox declared.
lens_tools_prefix=''
for lens_tools_dir in '/.lens/tools/jq/1.7.1/data/installs/jq/1.7.1' '/.lens/tools/gh/2.99.0/data/installs/gh/2.99.0/gh_2.99.0_linux_arm64/bin'; do
    case ":${PATH-}:" in
        *":$lens_tools_dir:"*) ;;
        *) lens_tools_prefix="${lens_tools_prefix:+$lens_tools_prefix:}$lens_tools_dir" ;;
    esac
done
if [ -n "$lens_tools_prefix" ]; then
    PATH="$lens_tools_prefix${PATH:+:$PATH}"
    export PATH
fi
unset lens_tools_prefix lens_tools_dir
```

It prepends rather than assigns, so a user's own `~/.profile` additions
survive. It skips a directory the shell already has, so no segment repeats and
no blank one is left behind. It reads `${PATH-}`, so a `set -u` login shell
does not abort. It unsets its own two variables, so the next `profile.d` file
sees neither. Each directory is a single-quoted shell word, with `'` escaped,
so a path the shell would re-read as syntax arrives as the literal it is.

The runtime layer creates `/etc/profile.d` when the image has none: a runtime
file spec creates every missing parent directory as root-owned 0755. An image
with no `/etc/profile` at all sources nothing, so it gets no file and the run
says so at debug level.

Deciding that needs one fact about the image's own rootfs, which the run
already walks the layers for: `tools/libc.rs` scanned every layer to decide
the libc a tool must be built against. That module is now
`tools/image_survey.rs` and returns `ImageSurvey { libc, reads_etc_profile }`
from one walk, memoised by layer digests as before. A second independent scan
would gunzip every layer body again for one boolean.

### Why PATH and not symlinks in /usr/local/bin

Symlinking each tool's binaries into `/usr/local/bin` would also survive
`/etc/profile` (Debian puts it first in the PATH it assigns), and it was
considered as the answer and as an addition. It is neither, for four reasons.

- It needs a list of executables per tool. The runtime knows each tool's *bin
  directories*, not which entries in them are the tool's public commands, so
  linking means guessing — the same guess that once put directories holding no
  executables on the PATH.
- Two tools that ship the same command name collide, and the collision is
  silent and order-dependent. On PATH, declaration order already decides, in
  one place (`workload_env::compose_guest_path`).
- A symlink breaks a tool that locates its payload relative to `argv[0]` or
  its own realpath; rustup's proxies and node's npm launcher are exactly that
  shape.
- `/usr/local/bin` belongs to the image and to the user. Writing a farm of
  links into it makes the sandbox's tool tree hard to tell apart from what the
  image installed, and `lns` owning `/etc/profile.d/lens-tools.sh` is one file
  a reader can attribute at a glance.

So the PATH prefix stays the single rule, and the snippet is the one place it
is restated.

## Tests

Red first, in the layer that owns each claim.

- **Layer 3, `tools/login_shell.rs`.** The whole generated body is pinned for a
  two-directory run, plus the quote escaping, the empty-tool-set case, and the
  no-`/etc/profile` case (which asserts the debug message names the file it
  skipped and why, through the crate's capturing subscriber).
- **Layer 3, `tools/image_survey.rs`.** Four new cases for the new fact: an
  image that ships `/etc/profile`, one that ships none (a `/etc/profile.d`
  entry alone is not a login shell), a later layer that whites it out, a later
  layer that adds it. One more pins that the digest memo carries both facts, so
  a hit does not send the second reader back through the scan.
- **Layer 2, `crates/lns-service/tests/behaviours/declared_tools.feature`.**
  "A declared tool survives a login shell" runs a real provision through
  `ensure_tools` and asserts every resolved bin path reaches the snippet, at
  the path `/etc/profile` sources, extending `$PATH` rather than replacing it.
- **Layer 1, `crates/e2e-tests/features/microvm_tools.feature`.** "A declared
  tool survives a login shell" boots a real guest over the pinned Alpine base
  and runs `/bin/sh -lc 'command -v node'`, asserting exit 0 and a path under
  `/.lens/tools/node/`. Alpine's `/etc/profile` assigns PATH and sources
  `/etc/profile.d/*.sh`, so the scenario exercises the busybox-ash side of the
  fix. It is `@microvm`-tagged: `make e2e-microvm`, not the PR gate.

The snippet's shell semantics were also checked by hand against `dash` and
`bash` (prepend, dedupe, empty PATH, unset PATH under `set -u`, a path holding
a quote) before the golden was written. Those runs are not a test in the tree:
Layer 2 and Layer 3 forbid subprocesses, so the file's behaviour is pinned as
the golden body plus the live `@microvm` scenario.

Verification: this sandbox cannot build `lns-service` (`tray-icon` needs GTK/atk
`.pc` files that are not installable here), so no local cargo step ran. CI is
the oracle for lint, complexity, coverage and tests.

## Documentation

`docs/running-workloads.md` carried the defect as a caveat ("run your command
without `-l`, or re-export PATH yourself"). It now describes what ships: a
login shell keeps the tools, and an image with no `/etc/profile` is the one
case where it does not. `docs/sandbox-spec.md` is unchanged — §3.1.8 already
says a declared tool is on the workload's PATH, and this is that promise being
kept, not a new format surface.

## Left out

- **`/.lens/bin` is not restored.** `/etc/profile` also drops the guest-tools
  directory the kernel PATH carries. The declared tools are the user-visible
  loss; putting the runtime's own dir back into a login shell is a separate
  decision, and this change does not make it.
- **An imageless run gets no snippet.** Its rootfs is busybox-static and ships
  no `/etc/profile`, so there is nothing to source one.
- **No `~/.bashrc` or `~/.zshrc` equivalent.** An interactive non-login shell
  inherits the workload PATH already, so it never lost the dirs.

## Downstream

The mahler kit carries a pre-start workaround for this defect —
`lensapp/mahler`, `mixins/login-shell-path.yaml`. It can be removed once this
ships.
