### PR TITLE
fix(service): The audit window is in the Dock and cmd-tab

### DIFF
--- a/crates/lns-service/Cargo.toml
+++ b/crates/lns-service/Cargo.toml
@@ -91,7 +91,7 @@ egui_material_icons = { version = "0.6", default-features = false, features = ["
 objc2                 = "0.6"
 objc2-foundation      = { version = "0.3", features = ["NSError", "NSString", "NSURL", "NSFileHandle", "NSObject"] }
 # Tray window joins every macOS Space so a notification shows on the active desktop, not the one it was created on.
-objc2-app-kit         = { version = "0.3", features = ["NSApplication", "NSResponder", "NSWindow"] }
+objc2-app-kit         = { version = "0.3", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSWindow"] }
 objc2-virtualization  = { version = "0.3", features = [
     "VZVirtualMachine",
     "VZVirtualMachineConfiguration",

--- a/crates/lns-service/src/tray.rs
+++ b/crates/lns-service/src/tray.rs
@@ -207,6 +207,7 @@ struct TrayApp {
     cards: CardState,
     audit: Arc<Mutex<AuditWindow>>,
     audit_open: Arc<AtomicBool>,
+    dock_shown: bool,
 }
 
 #[derive(Default)]
@@ -245,6 +246,7 @@ impl TrayApp {
             cards: CardState::default(),
             audit: Arc::new(Mutex::new(AuditWindow::default())),
             audit_open: Arc::new(AtomicBool::new(false)),
+            dock_shown: false,
         })
     }
 
@@ -262,7 +264,19 @@ impl TrayApp {
                 egui::ViewportCommand::Focus,
             );
         }
-        if !self.audit_open.load(Ordering::Relaxed) {
+        let open = self.audit_open.load(Ordering::Relaxed);
+        match visibility_transition(open, self.dock_shown) {
+            VisibilityTransition::Show => {
+                set_dock_presence(true);
+                self.dock_shown = true;
+            }
+            VisibilityTransition::Hide => {
+                set_dock_presence(false);
+                self.dock_shown = false;
+            }
+            VisibilityTransition::Unchanged => {}
+        }
+        if !open {
             return;
         }
         let audit = self.audit.clone();
@@ -1713,6 +1727,36 @@ pub fn install_activation_policy(opts: &mut eframe::NativeOptions) {
 
 #[cfg(not(target_os = "macos"))]
 pub fn install_activation_policy(_opts: &mut eframe::NativeOptions) {}
+
+/// Puts the app in the Dock and the cmd-tab list while the Audit window is open, and takes it back out when the window closes — a tray-resident service with no window belongs in neither.
+#[cfg(target_os = "macos")]
+fn set_dock_presence(shown: bool) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        crate::log::warn!("skipped Dock-presence change: not on the main thread");
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    let policy = if shown {
+        NSApplicationActivationPolicy::Regular
+    } else {
+        NSApplicationActivationPolicy::Accessory
+    };
+    if !app.setActivationPolicy(policy) {
+        crate::log::warn!("macOS refused the activation-policy change");
+        return;
+    }
+    if shown {
+        // `activate` is macOS 14+; the deprecated selector is the one every supported version answers.
+        #[allow(deprecated)]
+        app.activateIgnoringOtherApps(true);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_dock_presence(_shown: bool) {}
 
 /// Lets the always-on-top approval window appear on whichever macOS Space is active — including a full-screen app's Space — instead of staying pinned to the desktop it was created on.
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

The Audit window opened from the tray menu could not be reached with cmd-tab, and it had no Dock icon. The service sets `NSApplicationActivationPolicy::Accessory` once, on the winit event-loop builder, so the whole app is invisible to the Dock and the app switcher — including the one window a user is meant to work in.

This flips the policy for the lifetime of that window and leaves everything else alone.

### 1. Regular while the Audit window is open, Accessory otherwise

`set_dock_presence` calls `NSApplication::setActivationPolicy` on the main thread, and `activateIgnoringOtherApps(true)` when it shows so the window comes forward:

| Audit window | Activation policy | Dock icon | cmd-tab |
|---|---|---|---|
| closed | `Accessory` | no | no |
| open | `Regular` | yes | yes |

The flip is temporary, not permanent. Under a permanent `Regular` policy the tray-resident service would sit in the Dock with zero windows open, where clicking the icon does nothing and the entry invites "quit it from the Dock" — the opposite of "a sandbox you don't turn off".

The approval card is unaffected. Policy does not change its focus behaviour: `ViewportCommand::Visible(true)` reaches `makeKeyAndOrderFront`, which never activates the app across apps, so under either policy the card takes key focus only when LNS is already active.

### 2. The edges come from the existing transition helper

`render_audit_dashboard` derives Show/Hide from `visibility_transition(open, self.dock_shown)` — the same helper the approval viewport uses — placed before the `if !open { return; }` early exit so the Hide edge is reachable. The close path already stores `audit_open = false` and requests a ROOT repaint, so the next frame takes the icon back out of the Dock.

### 3. `activateIgnoringOtherApps`, not `activate`

`-[NSApplication activate]` is the cooperative macOS 14 API, and objc2-app-kit does not gate availability at compile time. On macOS 11-13 the selector is absent, so the call would raise `unrecognized selector` and abort the service. The repo declares no macOS floor (the installer checks arch only, nothing sets `MACOSX_DEPLOYMENT_TARGET`, so rustc's default for `aarch64-apple-darwin` is macOS 11), so the fix uses the deprecated selector every supported version answers. winit does the same internally.

`crates/lns-service/Cargo.toml` gains the `objc2-app-kit` `NSRunningApplication` feature: `setActivationPolicy` sits behind it, and `NSApplicationActivationPolicy` is defined in that module.

## Screenshots

### Before
<!-- Add a recording: tray → Audit, then cmd-tab — the window cannot be reached -->

### After
<!-- Add a recording: tray → Audit, the Dock icon appears and cmd-tab reaches the window -->

## Test instructions

Needs a macOS host — the changed code is behind `#[cfg(target_os = "macos")]` and does not compile on Linux.

1. `lns service start`, then look at the Dock and press cmd-tab. No LNS icon and no LNS entry: a tray-resident service with no window stays out of both.
2. Pick **Audit** from the tray menu. The window opens and comes to the front, an LNS Dock icon appears, and cmd-tab lists LNS.
3. Switch to another app, then cmd-tab back to LNS. The Audit window is reachable and takes focus.
4. Close the Audit window. The Dock icon disappears and the cmd-tab entry goes with it; the service keeps running in the tray.
5. Repeat steps 2 and 4 a few times. Every open re-adds the icon and every close removes it; no stale icon is left behind.
6. Trigger an approval card while the Audit window is closed. The card appears without a Dock icon and does not steal focus — keep typing in another app and the keystrokes land there.
7. Trigger an approval card while the Audit window is open. The card still does not steal focus, and the Dock icon stays until the Audit window closes.
8. On a macOS 13 host, repeat step 2. The service must open the window, not abort — this is the selector-availability fix.