### PR TITLE
chore(gate): time the crate-scoped test run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Until that command runs, no hook exists and nothing says so — git has no dead-
 
 Three separate cargo target dirs, because cargo fingerprints the flags each step uses. Mixing them makes every step recompile what the previous one just built.
 
-- `target/` — `make dev`, `make lint`, `make test`, raw cargo, rust-analyzer. These agree on flags, so switching between them is free. Do not add `CARGO_INCREMENTAL` or extra `RUSTFLAGS` to `lint` or `test`.
+- `target/` — `make dev`, `make lint`, `make test`, `make test-crates`, raw cargo, rust-analyzer. These agree on flags, so switching between them is free. Do not add `CARGO_INCREMENTAL` or extra `RUSTFLAGS` to `lint` or `test`.
 - `target/complexity/` — `make complexity` only. It passes different clippy args than `lint`, so it gets its own dir.
 - `target/llvm-cov-target/` — `make coverage` only. It is instrumented.
 
@@ -113,7 +113,7 @@ Never inject a failure by removing a permission bit — root ignores it. Take th
 
 ### Gate telemetry
 
-Every gate step records itself — `make lint`, `test`, `complexity`, `coverage`, `coverage-data`, `parity` — no matter who runs it: a terminal, an agent, the pre-push hook, CI. Each public target is a timed wrapper around its own `-impl` target, so telemetry is not something a caller has to remember. Rows land in `<git-common-dir>/lns-gate/timings.tsv` — `.git/lns-gate/` in a plain checkout. That is the shared git directory, so every worktree of the repo appends to one history instead of restarting it per branch, and the log itself lands outside every working tree, where `cargo clean` and a branch switch cannot disturb it.
+Every gate step records itself — `make lint`, `test`, `test-crates`, `complexity`, `coverage`, `coverage-data`, `parity` — no matter who runs it: a terminal, an agent, the pre-push hook, CI. Each public target is a timed wrapper around its own `-impl` target, so telemetry is not something a caller has to remember. Rows land in `<git-common-dir>/lns-gate/timings.tsv` — `.git/lns-gate/` in a plain checkout. That is the shared git directory, so every worktree of the repo appends to one history instead of restarting it per branch, and the log itself lands outside every working tree, where `cargo clean` and a branch switch cannot disturb it.
 
 `make gate-report` reads the last 30 days: runs, failures, and min/median/max seconds per step, a count per coverage verdict, and `coverage-data` split by cold and warm cache — a full artifact clean and a counter-only clean are different runs and averaging them hides both. `scripts/gate-timing.sh report --since <days>` or `--all` widens it.
 
@@ -164,7 +164,7 @@ Scenarios that require booting a real microVM (`lns run <image>`) need Vz/KVM an
 
 ## Commands
 
-Run from the workspace root. For crate-scoped iteration, use cargo directly: `cd crates/foo && cargo test` (or `cargo test -p foo` from anywhere).
+Run from the workspace root. For crate-scoped iteration, use `make test-crates CRATES="lns-cli lns-ipc"` — a raw `cargo test -p foo` works but records no gate timing, so the telemetry undercounts the test step. Drop to cargo directly when you need a test-name filter (`cargo test -p lns-cli --lib <module>`).
 
 ```
 make dev             cargo build -p lns-cli -p lns-service (debug, skips cross-builds — inner loop)
@@ -173,6 +173,7 @@ make build-lns       just bin/lns
 make build-lns-service  just bin/lns-service
 make lint            cargo fmt --all -- --check + cargo clippy --workspace --all-targets -- -D warnings
 make test            cargo test --workspace --exclude e2e-tests --all-targets
+make test-crates     CRATES="a b" — the same tests narrowed to those crates, timed (inner loop)
 make complexity      per-crate cargo clippy -- -D clippy::cognitive_complexity (feature-unification)
 make fmt             cargo fmt --all
 make coverage          full workspace coverage gate (all crates, 100% floor)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: dev build build-lns build-lns-service test lint fmt complexity complexity-all clean coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks gate-report parity shell-tests \
-	lint-impl test-impl complexity-impl coverage-impl coverage-data-impl parity-impl coverage-affected-impl
+.PHONY: dev build build-lns build-lns-service test test-crates lint fmt complexity complexity-all clean coverage coverage-data coverage-affected coverage-lcov e2e e2e-microvm preflight-microvm audit install-hooks gate-report parity shell-tests \
+	lint-impl test-impl test-crates-impl complexity-impl coverage-impl coverage-data-impl parity-impl coverage-affected-impl
 
 CARGO ?= cargo
 
@@ -124,6 +124,26 @@ test:
 
 test-impl:
 	$(CARGO) test --workspace --exclude e2e-tests --all-targets $(CARGO_LOCKED)
+
+# The crate-scoped inner loop. A raw `cargo test -p …` is invisible to the
+# telemetry, so the narrow run gets a timed target too, labelled with the
+# crates it ran: `make test-crates CRATES="lns-cli lns-ipc"`.
+TEST_CRATES_SCOPE := $(foreach c,$(CRATES),-p $(c))
+
+test-crates:
+	@$(TIMED) test-crates -- $(MAKE) --no-print-directory test-crates-impl
+
+test-crates-impl:
+	@if [ -z "$(strip $(CRATES))" ]; then \
+		echo 'make test-crates: set CRATES="lns-cli lns-ipc"' >&2; \
+		exit 2; \
+	fi
+	@if [ -n "$(filter e2e-tests,$(CRATES))" ]; then \
+		echo 'make test-crates: e2e-tests is Layer 1 — run `make e2e`' >&2; \
+		exit 2; \
+	fi
+	@./scripts/gate-timing.sh detail test-crates "$(strip $(CRATES))"
+	$(CARGO) test $(TEST_CRATES_SCOPE) --all-targets $(CARGO_LOCKED)
 
 # Per-crate cargo invocations (not workspace-wide): workspace feature
 # unification expands shared deps differently than per-crate clippy,

--- a/crates/lns-cli/README.md
+++ b/crates/lns-cli/README.md
@@ -279,7 +279,7 @@ make test            # cargo test --workspace --exclude e2e-tests --all-targets
 make coverage        # instrumented tests + per-file 100% coverage floor
 ```
 
-For crate-scoped iteration: `cd crates/lns-cli && cargo test` (or `cargo test -p lns-cli` from anywhere).
+For crate-scoped iteration: `make test-crates CRATES="lns-cli"` from the workspace root. A raw `cargo test -p lns-cli` works but records no gate timing.
 
 The local pre-push gate is `make lint && make complexity && make coverage` — see [`CLAUDE.md`](../../CLAUDE.md) for the full definition and the broader CI required suite.
 

--- a/scripts/make-test-crates.test.sh
+++ b/scripts/make-test-crates.test.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# The target under test wraps itself in gate telemetry, and every timed step
+# warns when hooks are not installed. That warning is not this suite's subject.
+export LNS_GATE_HOOK_WARNING=0
+
+. "$SCRIPT_DIR/test-lib.sh"
+
+PASS=0
+FAIL=0
+FAILURES=""
+ROOT=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$ROOT"
+    test_lib_cleanup
+}
+trap cleanup EXIT
+
+check() {
+    name=$1
+    expected=$2
+    actual=$3
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  ok   $name"
+    else
+        FAIL=$((FAIL + 1))
+        FAILURES="$FAILURES\n  FAILED $name: expected '$expected', got '$actual'"
+        echo "  FAIL $name: expected '$expected', got '$actual'"
+    fi
+}
+
+# A stand-in for cargo: it answers the `metadata` the Makefile reads at parse
+# time and records every other argv instead of building anything.
+write_fake_cargo() {
+    cat >"$1" <<'EOF'
+#!/bin/sh
+if [ "$1" = metadata ]; then
+    printf '{"workspace_root":"%s","target_directory":"%s/target"}\n' \
+        "$FAKE_WORKSPACE" "$FAKE_WORKSPACE"
+    exit 0
+fi
+printf '%s\n' "$*" >>"$FAKE_ARGV"
+EOF
+    chmod +x "$1"
+}
+
+run_target() {
+    dir=$(mktemp -d "$ROOT/case.XXXXXX")
+    write_fake_cargo "$dir/cargo"
+    ARGV="$dir/argv"
+    LOG="$dir/timings.tsv"
+    STDERR="$dir/stderr"
+    STATUS=0
+    FAKE_WORKSPACE="$dir" FAKE_ARGV="$ARGV" \
+        LNS_GATE_TIMING_LOG="$LOG" LNS_GATE_DETAIL_FILE="$dir/detail" \
+        LNS_GATE_TIMING=1 \
+        make -C "$REPO_ROOT" --no-print-directory CARGO="$dir/cargo" CARGO_LOCKED= "$@" \
+        >/dev/null 2>"$STDERR" || STATUS=$?
+}
+
+test_it_maps_crates_to_package_flags() {
+    echo "test_it_maps_crates_to_package_flags"
+    run_target test-crates CRATES="lns-ipc lns-cli"
+    check "exit status" "0" "$STATUS"
+    check "cargo argv" "test -p lns-ipc -p lns-cli --all-targets" "$(cat "$ARGV")"
+}
+
+test_it_records_one_timed_row_naming_the_crates() {
+    echo "test_it_records_one_timed_row_naming_the_crates"
+    run_target test-crates CRATES="lns-policy"
+    check "one row" "1" "$(grep -c '' "$LOG")"
+    check "step name" "test-crates" "$(cut -f2 "$LOG")"
+    check "recorded exit code" "0" "$(cut -f4 "$LOG")"
+    check "the crates label the row" "lns-policy" "$(cut -f7 "$LOG")"
+}
+
+test_it_passes_ci_strictness_through() {
+    echo "test_it_passes_ci_strictness_through"
+    run_target test-crates CRATES="lns-spec" CARGO_LOCKED="--locked"
+    check "cargo sees the strictness flag" \
+        "test -p lns-spec --all-targets --locked" "$(cat "$ARGV")"
+}
+
+# CI exports CARGO_LOCKED for `make lint`, which runs this harness. The
+# fixture states its own scope, or the assertions read the host.
+test_it_ignores_an_inherited_strictness_flag() {
+    echo "test_it_ignores_an_inherited_strictness_flag"
+    CARGO_LOCKED=--locked run_target test-crates CRATES="lns-ipc"
+    check "cargo argv" "test -p lns-ipc --all-targets" "$(cat "$ARGV")"
+}
+
+test_it_refuses_the_layer_1_crate() {
+    echo "test_it_refuses_the_layer_1_crate"
+    run_target test-crates CRATES="lns-cli e2e-tests"
+    check "exit status" "2" "$STATUS"
+    check "cargo test never runs" "0" "$(grep -c '' "$ARGV" 2>/dev/null || echo 0)"
+    check "it names the target that owns Layer 1" "1" "$(grep -c 'make e2e' "$STDERR")"
+}
+
+test_it_refuses_an_empty_crate_list() {
+    echo "test_it_refuses_an_empty_crate_list"
+    run_target test-crates
+    check "exit status" "2" "$STATUS"
+    check "cargo test never runs" "0" "$(grep -c '' "$ARGV" 2>/dev/null || echo 0)"
+    check "it names the variable" "1" "$(grep -c 'CRATES=' "$STDERR")"
+}
+
+test_it_maps_crates_to_package_flags
+test_it_records_one_timed_row_naming_the_crates
+test_it_passes_ci_strictness_through
+test_it_ignores_an_inherited_strictness_flag
+test_it_refuses_the_layer_1_crate
+test_it_refuses_an_empty_crate_list
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo "$FAILURES"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

A crate-scoped `cargo test -p a -p b` writes no row to the gate timing log. `scripts/gate-timing.sh run` is the only writer, and only the `make` wrappers call it. `CLAUDE.md` then pointed the inner loop at raw cargo, so the instruction and the telemetry asked for opposite things: `make gate-report` shows 74 recorded runs of `test` against 170 of `lint`, and the difference is hand-run cargo.

The same run is also invisible to coverage — it uses `target/`, not the instrumented `target/llvm-cov-target/` — but that is by design and not what this PR changes.

## Change

- `make test-crates CRATES="lns-cli lns-ipc"` — the same tests as `make test`, narrowed to those crates, wrapped in `$(TIMED)` like every other step. The row carries the crate list in the detail column, the way `coverage-data` carries `cold`/`warm`.
- Two guards: an empty `CRATES` exits 2 and names the variable; `e2e-tests` exits 2 and names `make e2e`, because Layer 1 is not this target's job.
- `scripts/make-test-crates.test.sh` pins the target. It fakes cargo — the fake answers `cargo metadata` from a fixture and records every other argv — so the harness builds nothing. `make lint` picks it up through the existing `scripts/*.test.sh` glob.
- `CLAUDE.md` and `crates/lns-cli/README.md` now point crate-scoped iteration at the target, and say plainly that raw cargo records no timing. Dropping to cargo for a test-name filter stays documented.

## Verification

- The harness was red before the Makefile change and is green after: 14 assertions, in four environment modes — plain, `CI=1`, `CARGO_LOCKED=--locked`, and `LNS_GATE_TIMING=0`. The fixture pins its own `CARGO_LOCKED` and `LNS_GATE_TIMING` on the inner make command line, so its assertions do not read the host.
- `make test-crates CRATES="lns-spec"` ran the real tests and appended one row: `test-crates  1  0  main  1fb27b1a  lns-spec`.
- `make lint` (which runs the harness) and `make complexity` pass.
- markdownlint is clean.
