### PR TITLE
[reading only, merges via #422] feat(sandbox): spec.image may name a Containerfile beside the document

### DIFF
--- a/crates/lns-artifact/src/image.rs
+++ b/crates/lns-artifact/src/image.rs
@@ -1,0 +1,133 @@
+use anyhow::{Result, bail};
+
+/// The names a build context may hold, in the order a directory is searched — `Containerfile` first, as Podman does.
+pub const CONTAINERFILE_NAMES: [&str; 2] = ["Containerfile", "Dockerfile"];
+
+/// What `spec.image` names: an image to pull, or a Containerfile beside the document for lns to build (§3.1.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageSource<'a> {
+    Reference(&'a str),
+    Containerfile(&'a str),
+}
+
+/// A value beginning `.`, `/` or `~` is a path — no OCI reference starts that way — so one predicate decides the form for validation, the run, and the push.
+pub fn source(image: &str) -> ImageSource<'_> {
+    let leading = image.trim_start().chars().next();
+    if matches!(leading, Some('.' | '/' | '~')) {
+        ImageSource::Containerfile(image)
+    } else {
+        ImageSource::Reference(image)
+    }
+}
+
+/// The path rules a Containerfile-form `spec.image` is held to: the artifact ships what it names, so it names something beside the document (§3.1.1).
+pub fn validate(image: &str) -> Result<()> {
+    let ImageSource::Containerfile(path) = source(image) else {
+        return Ok(());
+    };
+    if path.starts_with('~') {
+        bail!(
+            "spec.image {path:?} is built from a Containerfile beside the document, so it cannot be home-anchored; publish the image yourself and name it by reference instead"
+        );
+    }
+    if path.starts_with('/') {
+        bail!(
+            "spec.image {path:?} is built from a Containerfile beside the document, so it must be relative, such as ./image"
+        );
+    }
+    if path.split('/').any(|segment| segment == "..") {
+        bail!(
+            "spec.image {path:?} leaves the document's directory, and the artifact ships what it names; move the Containerfile into the project"
+        );
+    }
+    if path.chars().any(char::is_control) {
+        bail!("spec.image {path:?} must not contain control characters");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_registry_coordinate_is_an_image_to_pull() {
+        for reference in [
+            "alpine:3.20",
+            "ghcr.io/acme/base@sha256:abc",
+            "docker.io/library/node:24-bookworm",
+        ] {
+            assert_eq!(
+                source(reference),
+                ImageSource::Reference(reference),
+                "{reference} is a reference, so nothing about it is built"
+            );
+        }
+    }
+
+    #[test]
+    fn a_path_shaped_value_names_a_containerfile_to_build() {
+        for path in [
+            "./image",
+            ".",
+            "./build/api",
+            "../elsewhere",
+            "~/image",
+            "/srv/image",
+        ] {
+            assert_eq!(
+                source(path),
+                ImageSource::Containerfile(path),
+                "{path} is path-shaped, so it names a build rather than a registry coordinate"
+            );
+        }
+    }
+
+    #[test]
+    fn a_containerfile_path_that_leaves_the_document_is_refused_by_the_field_it_was_written_in() {
+        for path in ["../elsewhere", "./build/../../elsewhere"] {
+            let refusal = format!("{:#}", validate(path).unwrap_err());
+            assert!(
+                refusal.contains("spec.image") && refusal.contains(path),
+                "the author has to see which value is refused: {refusal}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_home_anchored_containerfile_path_is_refused_because_the_artifact_ships_what_it_names() {
+        let refusal = format!("{:#}", validate("~/image").unwrap_err());
+        assert!(
+            refusal.contains("spec.image") && refusal.contains("~/image"),
+            "got: {refusal}"
+        );
+    }
+
+    #[test]
+    fn an_absolute_containerfile_path_is_refused_and_the_relative_spelling_is_named() {
+        let refusal = format!("{:#}", validate("/srv/image").unwrap_err());
+        assert!(refusal.contains("./"), "got: {refusal}");
+    }
+
+    #[test]
+    fn a_control_character_is_refused_wherever_it_sits_in_the_path() {
+        assert!(validate("./im\nage").is_err());
+    }
+
+    #[test]
+    fn the_paths_beside_the_document_are_accepted() {
+        for path in ["./image", ".", "./image/Containerfile", "./a/b/c"] {
+            validate(path).unwrap_or_else(|e| panic!("{path} is beside the document: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn a_reference_is_held_to_no_path_rule() {
+        validate("ghcr.io/acme/base:1").expect("a reference is published as written");
+    }
+
+    #[test]
+    fn a_directory_holding_both_names_builds_the_containerfile_as_podman_does() {
+        assert_eq!(CONTAINERFILE_NAMES, ["Containerfile", "Dockerfile"]);
+    }
+}

--- a/crates/lns-artifact/src/lib.rs
+++ b/crates/lns-artifact/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod connector;
 pub mod disk;
+pub mod image;
 pub mod memory;
 pub mod merge;
 pub mod registry;

--- a/crates/lns-artifact/src/sandbox.rs
+++ b/crates/lns-artifact/src/sandbox.rs
@@ -310,6 +310,7 @@ fn parse_of_kind(config_json: &[u8], kind: spec::Kind) -> Result<Definition> {
     if kind != spec::Kind::Sandbox {
         refuse_the_blocks_that_describe_one_launch(&doc.spec, kind)?;
     }
+    crate::image::validate(&doc.spec.image)?;
     lns_spec::credential::validate_all(
         &doc.spec.credentials,
         lns_spec::credential::Source::Document,
@@ -1435,6 +1436,20 @@ mod tests {
             format!("{err:#}").contains("must carry an image"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn a_containerfile_path_that_leaves_the_document_refuses_the_whole_document() {
+        // Every load path parses, so an author hears about it at `validate` rather than at the build.
+        let err = parse(&def_json(r#"{"image":"../elsewhere"}"#)).unwrap_err();
+        assert!(format!("{err:#}").contains("spec.image"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_containerfile_path_beside_the_document_parses() {
+        let def = parse(&def_json(r#"{"image":"./image"}"#))
+            .expect("a path beside the document is a form spec.image takes");
+        assert_eq!(def.spec.image, "./image");
     }
 
     #[test]

--- a/crates/lns-cli/src/artifact/author.rs
+++ b/crates/lns-cli/src/artifact/author.rs
@@ -169,6 +169,13 @@ pub fn validate<F: Fs, W: Write>(
             project_dir,
             def.mixins(),
         ));
+        if let lns_artifact::sandbox::Document::Sandbox(sandbox) = &def {
+            problems.extend(super::image_build::image_problems(
+                fs,
+                project_dir,
+                &sandbox.spec.image,
+            ));
+        }
     }
     if problems.is_empty() {
         writeln!(out, "{name} is valid.")?;
@@ -230,7 +237,9 @@ pub fn inspect_local<F: Fs, W: Write>(
         | lns_artifact::sandbox::Document::Mixin(def) => def,
     };
     let composed = compose(fs, path.parent().unwrap_or(cwd), cwd, &def, mixins)?;
-    render_effective(as_mixin, &def.name, &composed, out)?;
+    let built_from =
+        super::image_build::built_from(fs, path.parent().unwrap_or(cwd), &def.spec.image)?;
+    render_effective(as_mixin, &def.name, &composed, built_from.as_deref(), out)?;
     Ok(0)
 }
 
@@ -316,6 +325,7 @@ fn render_effective<W: Write>(
     as_mixin: bool,
     name: &str,
     composed: &Composition,
+    built_from: Option<&str>,
     out: &mut W,
 ) -> Result<()> {
     let spec = &composed.spec;
@@ -323,7 +333,10 @@ fn render_effective<W: Write>(
         writeln!(out, "Mixin: {name}")?;
     } else {
         writeln!(out, "Sandbox: {name}")?;
-        writeln!(out, "  image:        {}", spec.image)?;
+        match built_from {
+            Some(containerfile) => writeln!(out, "  image:        built from {containerfile}")?,
+            None => writeln!(out, "  image:        {}", spec.image)?,
+        }
     }
     for mixin in &composed.mixins {
         writeln!(out, "  mixin: {mixin}")?;

--- a/crates/lns-cli/src/artifact/distribute.rs
+++ b/crates/lns-cli/src/artifact/distribute.rs
@@ -295,6 +295,16 @@ fn refuse_unpushable_tools(doc: &[u8]) -> Result<()> {
     })
 }
 
+/// A path-form `spec.image` publishes as the digest of an image lns built (§6), so a push that cannot build one refuses before it uploads anything.
+fn refuse_an_unbuilt_image(doc: &[u8]) -> Result<()> {
+    let image = serde_json::from_slice::<serde_json::Value>(doc)
+        .ok()
+        .and_then(|doc| doc["spec"]["image"].as_str().map(str::to_string))
+        .unwrap_or_default();
+    super::image_build::refuse_an_unbuilt_image(&image)
+        .map_err(|e| anyhow::anyhow!("refusing to push a sandbox no consumer can start: {e:#}"))
+}
+
 /// `lns push <ref>`: validate the document, pack each of its path filesets into a layer of the same artifact, and upload the whole thing in one step. The caller reads `./lns.yaml` into `doc`.
 pub async fn push<F, P, R, W>(
     ports: PushPorts<'_, F, P, R>,
@@ -320,6 +330,7 @@ where
         terminal,
     } = confirm;
     refuse_unpushable_tools(doc)?;
+    refuse_an_unbuilt_image(doc)?;
     // Packing first reads the directories offline, so a broken document or fileset refuses the push before it consults the index or uploads a mixin.
     pack_path_filesets(fs, cwd, doc)?;
     let plan = super::mixin_plan::plan_local_mixins(fs, cwd, doc, reference)?;
@@ -371,6 +382,7 @@ where
     W: Write,
 {
     refuse_unpushable_tools(doc)?;
+    refuse_an_unbuilt_image(doc)?;
     pack_path_filesets(fs, cwd, doc)?;
     let plan = super::mixin_plan::plan_local_mixins(fs, cwd, doc, reference)?;
     refuse_unpushable_planned_tools(&plan)?;

--- a/crates/lns-cli/src/artifact/image_build.rs
+++ b/crates/lns-cli/src/artifact/image_build.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use lns_artifact::image::{CONTAINERFILE_NAMES, ImageSource, source};
+
+use super::author::Fs;
+
+/// The Containerfile a path-form `spec.image` names, spelled as the author wrote it: a directory holds one under either name — `Containerfile` first, as Podman does — and a path naming a file is the Containerfile whatever it is called (§3.1.1).
+pub fn containerfile<F: Fs + ?Sized>(fs: &F, project_dir: &Path, path: &str) -> Result<String> {
+    let named = lns_artifact::sandbox::fold_path(&project_dir.join(path));
+    let stem = path.trim_end_matches('/');
+    if fs.is_dir(&named) {
+        return CONTAINERFILE_NAMES
+            .iter()
+            .find(|name| fs.exists(&named.join(name)))
+            .map(|name| format!("{stem}/{name}"))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "spec.image {path:?} names a directory holding no Containerfile or Dockerfile"
+                )
+            });
+    }
+    if fs.exists(&named) {
+        return Ok(stem.to_string());
+    }
+    bail!("spec.image {path:?} names no file or directory beside the document")
+}
+
+/// The offline validate/inspect guard: a path-form image must name a Containerfile this machine can read, so a typo is found where a fileset's is.
+pub fn image_problems<F: Fs + ?Sized>(fs: &F, project_dir: &Path, image: &str) -> Vec<String> {
+    match built_from(fs, project_dir, image) {
+        Ok(_) => Vec::new(),
+        Err(e) => vec![format!("{e:#}")],
+    }
+}
+
+/// The Containerfile line a render discloses, and `None` for an image that is pulled rather than built.
+pub fn built_from<F: Fs + ?Sized>(
+    fs: &F,
+    project_dir: &Path,
+    image: &str,
+) -> Result<Option<String>> {
+    match source(image) {
+        ImageSource::Reference(_) => Ok(None),
+        ImageSource::Containerfile(path) => containerfile(fs, project_dir, path).map(Some),
+    }
+}
+
+/// A path-form `spec.image` publishes as the digest of an image lns built ([§6](docs/sandbox-spec.md)), and lns has no builder yet, so the verbs that would need one refuse rather than hand a path to a registry.
+pub fn refuse_an_unbuilt_image(image: &str) -> Result<()> {
+    if let ImageSource::Containerfile(path) = source(image) {
+        bail!(
+            "spec.image {path:?} names a Containerfile, and building one is not yet supported; publish the image yourself and name it by reference"
+        );
+    }
+    Ok(())
+}

--- a/crates/lns-cli/src/artifact/mod.rs
+++ b/crates/lns-cli/src/artifact/mod.rs
@@ -10,6 +10,7 @@ use crate::service::client::SandboxService;
 pub mod author;
 pub mod distribute;
 pub mod fileset;
+pub mod image_build;
 pub mod mixin_offline;
 pub mod mixin_plan;
 pub mod real;

--- a/crates/lns-cli/src/run/target.rs
+++ b/crates/lns-cli/src/run/target.rs
@@ -46,6 +46,7 @@ pub fn resolve<F: Fs>(
     }
     let json = load_definition_json_at(fs, &file)?;
     let def = lns_artifact::sandbox::parse(&json)?;
+    crate::artifact::image_build::refuse_an_unbuilt_image(&def.spec.image)?;
     let paths: Vec<&str> = lns_artifact::merge::path_filesets(&def.spec)
         .map(|(_, _, path)| path)
         .collect();

--- a/crates/lns-cli/tests/behaviours/image_containerfile.feature
+++ b/crates/lns-cli/tests/behaviours/image_containerfile.feature
@@ -1,0 +1,78 @@
+Feature: an image built from a Containerfile beside the document
+  `spec.image` names either an OCI reference or a Containerfile beside the
+  document. The path form is held to the same boundary a fileset path is —
+  the artifact ships what it names — and the document says which file a build
+  would use before anything is built.
+
+  Scenario: a directory holding a Containerfile is an image the document may name
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "Containerfile"
+    When the user runs artifact command "validate"
+    Then the exit code is 0
+    And the output contains "valid"
+
+  Scenario: a directory holding neither name is refused, so the typo is found before the build
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "README.md"
+    When the user runs artifact command "validate"
+    Then the exit code is 1
+    And the output contains "spec.image"
+    And the output contains "Containerfile"
+
+  Scenario: an image path that leaves the document's directory is refused
+    Given an lns.yaml whose image is "../elsewhere"
+    When the user runs artifact command "validate"
+    Then the exit code is 1
+    And the output contains "spec.image"
+    And the output contains "../elsewhere"
+
+  Scenario: a home-anchored image path is refused
+    Given an lns.yaml whose image is "~/image"
+    When the user runs artifact command "validate"
+    Then the exit code is 1
+    And the output contains "home-anchored"
+
+  Scenario: inspect discloses the Containerfile a build would use
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "Dockerfile"
+    When the user runs artifact command "inspect"
+    Then the exit code is 0
+    And the output contains "built from ./image/Dockerfile"
+
+  Scenario: a directory holding both builds the Containerfile, as Podman does
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "Containerfile"
+    And the directory "image" holds a "Dockerfile"
+    When the user runs artifact command "inspect"
+    Then the exit code is 0
+    And the output contains "built from ./image/Containerfile"
+
+  Scenario: a path naming a file is the Containerfile whatever it is called
+    Given an lns.yaml whose image is "./image/base.containerfile"
+    And the directory "image" holds a "base.containerfile"
+    When the user runs artifact command "validate"
+    Then the exit code is 0
+    And the output contains "valid"
+
+  Scenario: a run of such a document says building is not yet supported
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "Containerfile"
+    When the user runs "lns run"
+    Then the command fails with an exit code other than 0
+    And the output contains "not yet supported"
+    And the output contains "./image"
+
+  Scenario: a push of such a document refuses before it publishes anything
+    Given an lns.yaml whose image is "./image"
+    And the directory "image" holds a "Containerfile"
+    And the registry accepts the push
+    When the user runs artifact command "push ghcr.io/team/hermes:1.4.0"
+    Then the command fails with an exit code other than 0
+    And the output contains "not yet supported"
+    And the published sandbox was not uploaded
+
+  Scenario: an image path naming nothing is refused where a fileset's typo is
+    Given an lns.yaml whose image is "./image"
+    When the user runs artifact command "validate"
+    Then the exit code is 1
+    And the output contains "names no file or directory"

--- a/crates/lns-cli/tests/behaviours/steps/image_containerfile.rs
+++ b/crates/lns-cli/tests/behaviours/steps/image_containerfile.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+use cucumber::given;
+
+use crate::world::BehaviourWorld;
+
+#[given(regex = r#"^an lns\.yaml whose image is "([^"]+)"$"#)]
+fn lns_yaml_with_image(w: &mut BehaviourWorld, image: String) {
+    w.author_files.insert(
+        PathBuf::from("/work/lns.yaml"),
+        format!(
+            "apiVersion: lns.run/v1\nkind: sandbox\nname: hermes\nspec:\n  image: \"{image}\"\n"
+        ),
+    );
+}
+
+#[given(regex = r#"^the directory "([^"]+)" holds a "([^"]+)"$"#)]
+fn directory_holds(w: &mut BehaviourWorld, dir: String, file: String) {
+    w.author_files.insert(
+        PathBuf::from("/work").join(dir).join(file),
+        "FROM docker.io/library/node:24-bookworm\n".to_string(),
+    );
+}

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -8,6 +8,7 @@ pub mod declared_tools;
 pub mod definition_selection;
 pub mod env_file;
 pub mod host_bind;
+pub mod image_containerfile;
 pub mod inspect_local_mixin;
 pub mod interactive_exec;
 pub mod local_decisions;

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -332,7 +332,8 @@ guest path, or port repeats.
 
 | Field | Required | Summary |
 |---|---|---|
-| [`image`](#311-image) | **REQUIRED** | The base OCI image the sandbox runs. |
+| [`image`](#311-image) | **REQUIRED** | The OCI image the sandbox runs, or the Containerfile lns builds it from. |
+| [`imageSource`](#6-publish-time-transforms) | published only | The Containerfile path the published image was built from. Written by `lns push`, never by an author. |
 | [`command`](#312-command-and-workdir) | optional | Replaces the image's default command; keeps its `ENTRYPOINT`. |
 | [`workdir`](#312-command-and-workdir) | optional | Absolute guest working directory. |
 | [`user`](#313-user) | optional | The user the workload runs as. |
@@ -355,11 +356,24 @@ image: ghcr.io/acme/base@sha256:<64 hex>
 
 | Field | Type | Rules |
 |---|---|---|
-| `image` | string | REQUIRED. MUST NOT be empty or whitespace. Any OCI reference form is accepted. |
+| `image` | string | REQUIRED. MUST NOT be empty or whitespace. Either an OCI reference or a path to a Containerfile, in the two forms below. |
 
 An author SHOULD pin the image by digest before publishing. A tag makes the
 published sandbox mutable underneath its consumers, which defeats the digest the
 consumer approved.
+
+**The two forms.**
+
+| Form | Written | Rules |
+|---|---|---|
+| OCI reference | `ghcr.io/acme/base@sha256:<64 hex>` | Any OCI reference form is accepted. Published as written; pin it by digest yourself. |
+| Containerfile path | `./image` | A value beginning `.`, `/` or `~` names a path rather than a reference. It MUST be relative and beside the document — no leading `/`, no leading `~`, no `..` segment, no control character — because the artifact ships what it names. A directory MUST hold a `Containerfile` or a `Dockerfile` and is the build context; when it holds both, `Containerfile` is the one built, as Podman does. A path naming a file is the Containerfile whatever it is called, and its parent directory is the context. |
+
+lns builds a Containerfile itself, in a build guest under the document's own
+[`egress`](#316-egress) and [`credentials`](#317-credentials): what a `RUN`
+reaches is decided by the same rules a run's traffic is, and no Docker on the
+host is involved. A published document never carries a path — see
+[§6](#6-publish-time-transforms).
 
 #### 3.1.2 `command` and `workdir`
 
@@ -2100,7 +2114,9 @@ Offline validation (`lns artifact validate`, and every load path including
   `name` matches the name pattern; no unrecognized field at any level, with the
   one exception [§1.2](#12-strict-decoding) states — the body of a connector
   method's `auth` whose `kind` this reader does not know.
-- **Sandbox**: `image` present and non-empty; `workdir` absolute with no `..`;
+- **Sandbox**: `image` present and non-empty, and, when it names a Containerfile
+  ([§3.1.1](#311-image)), relative and beside the document with no `..` segment;
+  `workdir` absolute with no `..`;
   `user` has at most one `:`, no empty segment, and no `=`, whitespace, control
   character, or quote.
 - **env**: every key is a legal environment-variable name; within one source, no
@@ -2191,12 +2207,13 @@ document: `lns artifact validate` cannot see it.
 
 ## 6. Publish-time transforms
 
-`lns push` publishes the document with three resolutions applied, so a consumer
+`lns push` publishes the document with every resolution below applied, so a consumer
 runs exactly what the author tested:
 
 | Surface | Transform |
 |---|---|
 | `filesets[].path` | The directory is packed into a layer of this artifact. The entry keeps its `path` and `guestPath`; the content is now part of the artifact's digest. |
+| `image` naming a Containerfile | The Containerfile and its context are built, the built image publishes beside this artifact, and `image` is rewritten to that image's digest reference. `imageSource` keeps the path the author wrote, and the Containerfile with its context packs into a layer, so what the guest starts from is disclosed with the rest of the document. |
 | `tools[]` | A fuzzy version (`node@22`, `python@latest`) is resolved against the tool's public version index and rewritten exact. |
 | `mixins[]` local entry | The document it names publishes first, as its own artifact, and the entry is rewritten to that artifact's digest ([§6.1](#61-a-local-mixin-publishes-with-the-document-that-names-it)). A digest-pinned entry publishes untouched. |
 | `README.md` | A `README.md` beside the document is packed into a `text/markdown` layer of this artifact ([§7.2](#72-the-readme-layer)). No file, no layer; the document itself never carries it. |


### PR DESCRIPTION
**[reading only, merges via [#422](https://github.com/lensapp/lens-sandbox/pull/422)]** This PR is not merged. Every slice of #393 lands through the single integration PR #422 against `main`.

Part of #393.

## The problem, and what changes

`spec.image` accepts only an OCI reference. #393 decides it may also name a Containerfile beside the document, which lns builds itself. The whole PRD is several PRs of work (a Containerfile parser, an in-guest instruction executor, per-instruction layer snapshots, a cache key, an image index per architecture, a `lns sandbox build` verb). **This PR lands the document layer only, and nothing else**: the grammar decides which of the two forms `spec.image` is in, the offline verbs answer for the path form, and the two verbs that would need a builder refuse it by name instead of handing a path to a registry.

Before: `image: ./image` was passed through as a registry coordinate — `lns validate` said the document was valid, and the run died later inside a pull with a reference-parse error naming nothing the author wrote. After: the path form is a recognised form with its own rules, and a form lns cannot build yet fails at the CLI, before an upload or a launch, saying so.

## Acceptance criteria → change

The PRD's testing decisions that this slice is answerable for:

| Criterion (#393) | Where |
|---|---|
| "Validation refuses `spec.image: ../elsewhere`" | `crates/lns-artifact/src/image.rs:24` `validate`, called from `crates/lns-artifact/src/sandbox.rs:313`, so every load path (validate, inspect, run preflight, push) runs it |
| "…`~/image`" | same, the home-anchored arm |
| "…a directory with neither `Containerfile` nor `Dockerfile`, each with the field name" | `crates/lns-cli/src/artifact/image_build.rs:10` `containerfile`, wired into validate at `crates/lns-cli/src/artifact/author.rs:173` |
| "A directory with both uses `Containerfile`" | `CONTAINERFILE_NAMES` (`crates/lns-artifact/src/image.rs:4`) is searched in order; observable because inspect discloses the chosen file (`crates/lns-cli/src/artifact/author.rs:337`) |
| "A file of any name is the Containerfile and its parent directory is the context" | `image_build.rs:24-27` — an existing non-directory path is the Containerfile as written |
| PRD field table: "A relative path beside the document, no `..`, not home-anchored" | `image.rs:24-49` |

Not attempted here, and so not claimed: the build guest, the instruction executor and its subset gate, the layer store import, publishing the image and rewriting `spec.image` to a digest with `imageSource`, the cache key, the architecture index, `lns sandbox build`, and the host-Docker switch.

## Implementation decisions

**One predicate decides the form, because validation, the run and the push must not disagree about it** — the same shape `names_a_local_path` already gives mixins, plus `~`:

```rust
pub fn source(image: &str) -> ImageSource<'_> {
    let leading = image.trim_start().chars().next();
    if matches!(leading, Some('.' | '/' | '~')) {
```

That makes `~/image` and `/srv/image` *path* forms that are then refused with a reason, rather than references that fail obscurely at pull time — which is what the PRD's acceptance list asks for.

**The path rules live in the grammar crate, so a document is refused wherever it is loaded.** `crates/lns-artifact/src/sandbox.rs:313`:

```rust
    crate::image::validate(&doc.spec.image)?;
```

**Resolving *which* file needs the filesystem, so it sits in the CLI behind the existing `Fs` seam** (the same one path filesets are checked through), never in the parser (`image_build.rs:13-27`):

```rust
    if fs.is_dir(&named) {
        return CONTAINERFILE_NAMES
            .iter()
            .find(|name| fs.exists(&named.join(name)))
```

**Run and push refuse rather than pretend.** `crates/lns-cli/src/run/target.rs:49` and `distribute.rs:333` / `:385` (both `push` and `push --dry-run`, beside `refuse_unpushable_tools`, so nothing is uploaded first):

```rust
            "spec.image {path:?} names a Containerfile, and building one is not yet supported; publish the image yourself and name it by reference"
```

A push that published a path would publish a document no consumer could run, which §6 forbids; a run that passed one to the service would fail inside a pull.

## Specification

`docs/sandbox-spec.md` is the normative target and the code does not reach it (AGENTS.md, "Transitional mode"), so the spec change is its own commit (e66a2f1f) and states the whole target — both forms of `image`, the build under the document's own `egress`, the push-time rewrite to a digest plus `imageSource`, and the field's appearance in §3.1, §5 and §6. The divergence this PR leaves is deliberate and named above. No user guide was touched: the path form does not ship yet, and a guide answers "how do I use this today".

## Tests (red first)

- Layer 3, `crates/lns-artifact/src/image.rs:52+` — 9 tests: classification of both forms, each refusal (escape, home anchor, absolute, control character), the accepted spellings, and that a reference is held to no path rule. Written first; watched fail (`cannot find function 'source' in this scope`, 11 errors) before the implementation existed.
- Layer 3, `crates/lns-artifact/src/sandbox.rs:1441+` — the refusal reaches the whole document at `parse`, and a path beside the document parses.
- Layer 2, `crates/lns-cli/tests/behaviours/image_containerfile.feature` — 10 scenarios over the real CLI verbs with the in-memory `Fs`: validate accepts a directory holding a Containerfile; refuses one holding neither, `../elsewhere`, `~/image`, and a path naming nothing; inspect discloses `built from ./image/Dockerfile` and prefers `Containerfile` when both exist; a named file of any extension is accepted; run refuses; push refuses and uploads nothing. Watched fail: 5 scenarios red before the CLI wiring, all green after.

## Checks actually run (local)

| Command | Result |
|---|---|
| `cargo test -p lns-artifact` | 383 passed |
| `make test-crates CRATES="lns-cli lns-artifact"` | pass — cucumber 545 scenarios / 2655 steps, all green |
| `cargo fmt --all -- --check` | clean (after `cargo fmt`) |
| `cargo clippy -p lns-artifact -p lns-cli --all-targets -- -D warnings` | clean |
| `cargo clippy -p <each> -- -D clippy::cognitive_complexity` (target/complexity) | clean |
| `make coverage COVERAGE_CRATES="lns-artifact lns-cli"` | new files at 100%: `lns-artifact/src/image.rs` 46/46, `lns-cli/src/artifact/image_build.rs` 24/24. `crates/lns-cli/` 43 at 100%, 0 failures |

**Limitations of the local run, stated plainly:**

- `make lint` as a whole fails on this machine at `scripts/affected-crates.test.sh` (4 cases expect a crate list, get `__FULL__`). It fails identically on unmodified `main` here (verified by stashing), so it is environmental, not this change. The Rust half of `lint` (fmt + clippy) was run directly and is clean.
- `cargo clippy --workspace` cannot complete here: `lns-service` depends on `gdk-sys`/`pango-sys` and this container has no GTK development libraries. So `lns-service` was **not** compiled, tested, or coverage-measured locally.
- The narrowed coverage run reports two pre-existing FAILs in `lns-artifact` (`connector.rs` 477/478, `tools/mod.rs` 203/212). Their uncovered lines are `Method::label`, `SafeVersion` and `is_safe_bin_path` — `pub` API exercised by `lns-service`'s suite, which the narrowed run does not execute. Neither file is touched by this PR.
- CI is the oracle for all three, and it has now answered: **every required check is green** on `d588e8f0` — `lint` 2m09s (so the `affected-crates.test.sh` failure really is local-only), `test` 3m23s, `coverage` 3m13s and `coverage-as-root` 4m05s (full workspace, so `lns-service` compiles, its suite passes, and the two `lns-artifact` files above are at 100% there), plus `audit`, `changes`, `labels`, `check`.

No fixture in the tree carried a path-shaped `spec.image` before this change (`grep` over `crates/`, `docs/`), so nothing that used to parse stops parsing.

## Deviations and omissions

- **`lns-service` is unchanged.** It never receives a path form: push refuses to publish one, and the local run path refuses before the launch request. Defence-in-depth there is left to the slice that adds the builder.
- **`spec.imageSource` is specified but not implemented** — it is written by the push-time build, which does not exist yet. Adding a field no producer writes would be speculative.
- **`lns sandbox build` is not added**, and `lns run` does not build on first run. Both need the executor.

