### PR TITLE
feat: support registry auth without service

### DIFF
--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -728,6 +728,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn logout_reports_that_it_removed_the_file_without_a_running_service() {
+        let client = FakeClient::for_logout(LogoutOutcome::LoggedOutFromFile);
+        let mut out = Vec::new();
+        let code = logout(
+            &LogoutArgs {
+                registry: Some("ghcr.io".into()),
+            },
+            "docker.io",
+            &client,
+            &mut out,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "The background service was not running; removed ghcr.io from ~/.lns/registry-auth.json.\n"
+        );
+    }
+
+    #[tokio::test]
     async fn logout_surfaces_other_service_failures() {
         let client = FakeClient::for_logout(LogoutOutcome::Failed("store is unreadable".into()));
         let err = logout(

--- a/crates/lns-cli/src/login/mod.rs
+++ b/crates/lns-cli/src/login/mod.rs
@@ -65,6 +65,7 @@ pub enum LoginOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LogoutOutcome {
     LoggedOut,
+    LoggedOutFromFile,
     Failed(String),
     ServiceUnavailable,
 }
@@ -76,7 +77,7 @@ pub enum ListLoginsOutcome {
     ServiceUnavailable,
 }
 
-/// The service owns the registry login store, so every credential operation goes through it.
+/// Manages registry credentials through the running service or the local auth file.
 pub trait RegistryAuthClient {
     fn available<'a>(&'a self) -> LocalBoxFuture<'a, Result<bool>>;
     fn login<'a>(
@@ -188,10 +189,21 @@ pub async fn logout(
     let registry = target_registry(args.registry.as_deref(), default_registry)?;
     match client.logout(&registry).await? {
         LogoutOutcome::ServiceUnavailable => bail!("{SERVICE_REQUIRED}"),
+        LogoutOutcome::Failed(reason) if reason == format!("not logged in to {registry}") => {}
         LogoutOutcome::Failed(reason) => bail!("{reason}"),
         LogoutOutcome::LoggedOut => {}
+        LogoutOutcome::LoggedOutFromFile => {
+            writeln!(
+                out,
+                "The background service was not running; removed {registry} from ~/.lns/registry-auth.json."
+            )?;
+            return Ok(0);
+        }
     }
-    writeln!(out, "Logged out of {registry}.")?;
+    writeln!(
+        out,
+        "Logged out of {registry} through the background service."
+    )?;
     Ok(0)
 }
 
@@ -689,14 +701,35 @@ mod tests {
         assert!(
             String::from_utf8(out)
                 .unwrap()
-                .contains("Logged out of ghcr.io")
+                .contains("Logged out of ghcr.io through the background service")
         );
     }
 
     #[tokio::test]
-    async fn logout_surfaces_the_services_not_logged_in_answer() {
+    async fn logout_succeeds_when_the_service_has_no_stored_entry() {
         let client =
             FakeClient::for_logout(LogoutOutcome::Failed("not logged in to ghcr.io".into()));
+        let mut out = Vec::new();
+        let code = logout(
+            &LogoutArgs {
+                registry: Some("ghcr.io".into()),
+            },
+            "docker.io",
+            &client,
+            &mut out,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "Logged out of ghcr.io through the background service.\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn logout_surfaces_other_service_failures() {
+        let client = FakeClient::for_logout(LogoutOutcome::Failed("store is unreadable".into()));
         let err = logout(
             &LogoutArgs {
                 registry: Some("ghcr.io".into()),
@@ -707,7 +740,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(format!("{err:#}").contains("not logged in to ghcr.io"));
+        assert!(format!("{err:#}").contains("store is unreadable"));
     }
 
     #[tokio::test]

--- a/crates/lns-cli/src/login/real.rs
+++ b/crates/lns-cli/src/login/real.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use clap::FromArgMatches;
 use lns_ipc::{Request, Response, decode_frame, encode_frame, read_frame_bytes_async};
+use lns_policy::registry_auth::{RegistryAuthStore, RegistryCredential};
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 
@@ -17,7 +18,14 @@ pub fn run_login<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutur
     Box::pin(async move {
         let args = LoginArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let client = RealRegistryAuthClient::new(crate::service::socket_path()?);
+        let socket = crate::service::socket_path()?;
+        let socket_exists = socket.exists();
+        let service = RealRegistryAuthClient::new(socket);
+        let store = lns_policy::registry_auth::JsonFileRegistryAuthStore::new(
+            lns_ipc::registry_auth_path()?,
+        );
+        let file_login_allowed = args.username.is_some() && args.password_stdin;
+        let client = RegistryAuthRouter::new(service, store, socket_exists, file_login_allowed);
         let input = ctx.input;
         let mut out = ctx.out;
         super::run(
@@ -36,7 +44,13 @@ pub fn run_logout<'a>(matches: &'a clap::ArgMatches, ctx: RunCtx<'a>) -> RunFutu
     Box::pin(async move {
         let args = LogoutArgs::from_arg_matches(matches)?;
         let default_registry = configured_default_registry()?;
-        let client = RealRegistryAuthClient::new(crate::service::socket_path()?);
+        let socket = crate::service::socket_path()?;
+        let socket_exists = socket.exists();
+        let service = RealRegistryAuthClient::new(socket);
+        let store = lns_policy::registry_auth::JsonFileRegistryAuthStore::new(
+            lns_ipc::registry_auth_path()?,
+        );
+        let client = RegistryAuthRouter::new(service, store, socket_exists, false);
         let mut out = ctx.out;
         super::logout(&args, &default_registry, &client, &mut out).await
     })
@@ -80,6 +94,83 @@ impl WebLoginFlow for RealWebLoginFlow {
             let flow = super::WebLogin::new(client, RealBrowserOpener);
             flow.login(registry, out).await
         })
+    }
+}
+
+struct RegistryAuthRouter<C, S> {
+    service: C,
+    store: S,
+    socket_exists: bool,
+    file_login_allowed: bool,
+}
+
+impl<C, S> RegistryAuthRouter<C, S> {
+    fn new(service: C, store: S, socket_exists: bool, file_login_allowed: bool) -> Self {
+        Self {
+            service,
+            store,
+            socket_exists,
+            file_login_allowed,
+        }
+    }
+}
+
+impl<C: RegistryAuthClient, S: RegistryAuthStore> RegistryAuthClient for RegistryAuthRouter<C, S> {
+    fn available<'a>(&'a self) -> LocalBoxFuture<'a, Result<bool>> {
+        self.service.available()
+    }
+
+    fn login<'a>(
+        &'a self,
+        registry: &'a str,
+        username: &'a str,
+        secret: &'a str,
+    ) -> LocalBoxFuture<'a, Result<LoginOutcome>> {
+        if self.socket_exists || !self.file_login_allowed {
+            return self.service.login(registry, username, secret);
+        }
+        Box::pin(async move {
+            let mut state = self
+                .store
+                .load()
+                .context("reading the registry login store")?;
+            state.insert(
+                registry.to_string(),
+                RegistryCredential {
+                    username: username.to_string(),
+                    secret: secret.to_string(),
+                },
+            );
+            self.store
+                .save(&state)
+                .context("writing the registry login store")?;
+            crate::log::warn!(
+                "The background service was not running; the registry login was written to ~/.lns/registry-auth.json."
+            );
+            Ok(LoginOutcome::Stored)
+        })
+    }
+
+    fn logout<'a>(&'a self, registry: &'a str) -> LocalBoxFuture<'a, Result<LogoutOutcome>> {
+        if self.socket_exists {
+            return self.service.logout(registry);
+        }
+        Box::pin(async move {
+            let mut state = self
+                .store
+                .load()
+                .context("reading the registry login store")?;
+            if state.remove(registry).is_some() {
+                self.store
+                    .save(&state)
+                    .context("writing the registry login store")?;
+            }
+            Ok(LogoutOutcome::LoggedOutFromFile)
+        })
+    }
+
+    fn list<'a>(&'a self) -> LocalBoxFuture<'a, Result<ListLoginsOutcome>> {
+        self.service.list()
     }
 }
 
@@ -167,5 +258,170 @@ impl RegistryAuthClient for RealRegistryAuthClient {
                 Some(other) => bail!("unexpected response during login list: {other:?}"),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::io;
+    use std::sync::Mutex;
+
+    use lns_policy::registry_auth::{RegistryAuthFile, RegistryCredential};
+
+    use super::*;
+
+    struct FakeService {
+        login_calls: Mutex<usize>,
+        logout_calls: Mutex<usize>,
+    }
+
+    impl FakeService {
+        fn new() -> Self {
+            Self {
+                login_calls: Mutex::new(0),
+                logout_calls: Mutex::new(0),
+            }
+        }
+    }
+
+    impl RegistryAuthClient for FakeService {
+        fn available<'a>(&'a self) -> LocalBoxFuture<'a, Result<bool>> {
+            Box::pin(async { Ok(true) })
+        }
+
+        fn login<'a>(
+            &'a self,
+            _registry: &'a str,
+            _username: &'a str,
+            _secret: &'a str,
+        ) -> LocalBoxFuture<'a, Result<LoginOutcome>> {
+            *self.login_calls.lock().expect("login calls lock") += 1;
+            Box::pin(async { Ok(LoginOutcome::Stored) })
+        }
+
+        fn logout<'a>(&'a self, _registry: &'a str) -> LocalBoxFuture<'a, Result<LogoutOutcome>> {
+            *self.logout_calls.lock().expect("logout calls lock") += 1;
+            Box::pin(async { Ok(LogoutOutcome::LoggedOut) })
+        }
+
+        fn list<'a>(&'a self) -> LocalBoxFuture<'a, Result<ListLoginsOutcome>> {
+            Box::pin(async { Ok(ListLoginsOutcome::Logins(Vec::new())) })
+        }
+    }
+
+    struct MemoryStore {
+        state: Mutex<RegistryAuthFile>,
+        saves: Mutex<usize>,
+    }
+
+    impl MemoryStore {
+        fn with_entry(registry: &str) -> Self {
+            Self {
+                state: Mutex::new(HashMap::from([(
+                    registry.to_string(),
+                    RegistryCredential {
+                        username: "old-user".into(),
+                        secret: "old-secret".into(),
+                    },
+                )])),
+                saves: Mutex::new(0),
+            }
+        }
+    }
+
+    impl RegistryAuthStore for MemoryStore {
+        fn load(&self) -> io::Result<RegistryAuthFile> {
+            Ok(self.state.lock().expect("state lock").clone())
+        }
+
+        fn save(&self, state: &RegistryAuthFile) -> io::Result<()> {
+            *self.state.lock().expect("state lock") = state.clone();
+            *self.saves.lock().expect("saves lock") += 1;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn headless_login_writes_the_file_when_the_service_socket_is_missing() {
+        let router = RegistryAuthRouter::new(
+            FakeService::new(),
+            MemoryStore::with_entry("quay.io"),
+            false,
+            true,
+        );
+
+        assert_eq!(
+            router.login("ghcr.io", "octocat", "token").await.unwrap(),
+            LoginOutcome::Stored
+        );
+        let state = router.store.load().unwrap();
+        assert_eq!(state["ghcr.io"].username, "octocat");
+        assert!(state.contains_key("quay.io"), "other hosts stay untouched");
+        assert_eq!(*router.service.login_calls.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn login_uses_the_service_without_writing_the_file_when_the_socket_exists() {
+        let router = RegistryAuthRouter::new(
+            FakeService::new(),
+            MemoryStore::with_entry("quay.io"),
+            true,
+            true,
+        );
+
+        router.login("ghcr.io", "octocat", "token").await.unwrap();
+
+        assert_eq!(*router.service.login_calls.lock().unwrap(), 1);
+        assert_eq!(*router.store.saves.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn logout_removes_only_the_file_entry_when_the_service_socket_is_missing() {
+        let router = RegistryAuthRouter::new(
+            FakeService::new(),
+            MemoryStore::with_entry("ghcr.io"),
+            false,
+            false,
+        );
+
+        assert_eq!(
+            router.logout("ghcr.io").await.unwrap(),
+            LogoutOutcome::LoggedOutFromFile
+        );
+        assert!(!router.store.load().unwrap().contains_key("ghcr.io"));
+        assert_eq!(*router.service.logout_calls.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn logout_succeeds_without_rewriting_a_file_that_has_no_entry() {
+        let router = RegistryAuthRouter::new(
+            FakeService::new(),
+            MemoryStore::with_entry("quay.io"),
+            false,
+            false,
+        );
+
+        assert_eq!(
+            router.logout("ghcr.io").await.unwrap(),
+            LogoutOutcome::LoggedOutFromFile
+        );
+        assert_eq!(*router.store.saves.lock().unwrap(), 0);
+        assert!(router.store.load().unwrap().contains_key("quay.io"));
+    }
+
+    #[tokio::test]
+    async fn logout_uses_the_service_without_writing_the_file_when_the_socket_exists() {
+        let router = RegistryAuthRouter::new(
+            FakeService::new(),
+            MemoryStore::with_entry("ghcr.io"),
+            true,
+            false,
+        );
+
+        router.logout("ghcr.io").await.unwrap();
+
+        assert_eq!(*router.service.logout_calls.lock().unwrap(), 1);
+        assert_eq!(*router.store.saves.lock().unwrap(), 0);
     }
 }


### PR DESCRIPTION
## Example

```console
$ printf '%s\n' "$LNS_HUB_TOKEN" | lns login -u me --password-stdin hub.lns.run
The background service was not running; the registry login was written to ~/.lns/registry-auth.json.
You are now logged in to hub.lns.run as me.

$ lns logout hub.lns.run
The background service was not running; removed hub.lns.run from ~/.lns/registry-auth.json.
```

## Summary

- Implement work item 4. Route non-interactive login to the mode-0600 registry auth file when the service socket is absent.
- Route logout through the service when its socket exists. Route logout through the auth file otherwise.
- Preserve other registry entries. Treat a missing logout entry as success.
- Keep browser login, password-flag login, and login listing dependent on the service.

## Verification

- `cargo test -p lns-cli`
- `cargo clippy -p lns-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- CI lint passed on the first push.
- CI coverage found an uncovered headless logout rendering branch. Commit `bed25481` adds its unit test.
- The first CI test failure was an unrelated existing environment-variable race in `config::tests::the_defaults_file_lives_in_the_one_directory_lns_keeps_everything_in`. This change does not touch config or environment handling.

## Scope

- Changed `crates/lns-cli` only.
- Auto-merge could not be enabled because this repository does not allow squash merges.
- No implementation deviations.
- Nothing was left out.

Part of #398. This PR implements work item 4.
