### PR TITLE
feat(actions): lns-login, lns-logout, and lns-push composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,11 @@ jobs:
   actions:
     needs: changes
     if: needs.changes.outputs.actions == 'true'
+    # Step-level `if:` cannot read `secrets`, so the staging self-test gates
+    # on these; unset in a fork, the steps skip.
+    env:
+      LNS_HUB_STAGING_TOKEN: ${{ secrets.LNS_HUB_STAGING_TOKEN }}
+      LNS_HUB_STAGING_NAMESPACE: ${{ vars.LNS_HUB_STAGING_NAMESPACE || secrets.LNS_HUB_STAGING_USERNAME }}
     strategy:
       fail-fast: false
       matrix:
@@ -476,6 +481,136 @@ jobs:
             echo "::error::setup-lns installed lns-service; it must extract lns only."
             exit 1
           fi
+
+      # lns-login / lns-logout against a host that cannot resolve: what they
+      # pin is the file `lns artifact push` reads, not a round trip. The
+      # runner has no lns-service, so this is the file fallback's own test.
+      - name: Another host is already logged in
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.lns"
+          printf '{"other.example.invalid":{"username":"keep","secret":"keep-me"}}' \
+            >"$HOME/.lns/registry-auth.json"
+          chmod 0600 "$HOME/.lns/registry-auth.json"
+          jq -e 'keys == ["other.example.invalid"]' "$HOME/.lns/registry-auth.json" >/dev/null
+
+      - name: lns-login (example.invalid)
+        uses: ./actions/lns-login
+        with:
+          registry: example.invalid
+          username: ci
+          password: not-a-real-token
+
+      - name: The login added one entry, 0600, and touched no other host
+        env:
+          EXPECTED_SECRET: not-a-real-token
+        run: |
+          set -euo pipefail
+          file="$HOME/.lns/registry-auth.json"
+          if [ -z "$(find "$file" -perm 600)" ]; then
+            echo "::error::registry-auth.json is not 0600."
+            ls -l "$file"
+            exit 1
+          fi
+          jq -e '
+            (keys | sort) == ["example.invalid", "other.example.invalid"]
+            and .["example.invalid"].username == "ci"
+            and .["example.invalid"].secret == $ENV.EXPECTED_SECRET
+            and .["other.example.invalid"].secret == "keep-me"
+          ' "$file" >/dev/null
+
+      - name: lns-logout (example.invalid)
+        uses: ./actions/lns-logout
+        with:
+          registry: example.invalid
+
+      - name: The logout removed that entry and left the other one
+        run: |
+          set -euo pipefail
+          file="$HOME/.lns/registry-auth.json"
+          if [ -z "$(find "$file" -perm 600)" ]; then
+            echo "::error::registry-auth.json is not 0600."
+            ls -l "$file"
+            exit 1
+          fi
+          jq -e '
+            keys == ["other.example.invalid"]
+            and .["other.example.invalid"].secret == "keep-me"
+          ' "$file" >/dev/null
+
+      - name: lns-push (sandbox fixture, dry run)
+        id: dry-sandbox
+        uses: ./actions/lns-push
+        with:
+          file: actions/lns-push/fixtures/sandbox.yaml
+          kind: sandbox
+          tags: |
+            lns-ci/actions-sandbox-fixture:sha-${{ github.sha }}
+            lns-ci/actions-sandbox-fixture:ci
+          push: false
+
+      - name: lns-push (mixin fixture, dry run)
+        id: dry-mixin
+        uses: ./actions/lns-push
+        with:
+          file: actions/lns-push/fixtures/mixin.yaml
+          kind: mixin
+          tags: lns-ci/actions-mixin-fixture:sha-${{ github.sha }}
+          push: false
+
+      - name: A dry run publishes nothing
+        env:
+          SANDBOX_DIGEST: ${{ steps.dry-sandbox.outputs.digest }}
+          SANDBOX_REFS: ${{ steps.dry-sandbox.outputs.refs }}
+          MIXIN_DIGEST: ${{ steps.dry-mixin.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ -n "$SANDBOX_DIGEST" ] || [ -n "$SANDBOX_REFS" ] || [ -n "$MIXIN_DIGEST" ]; then
+            echo "::error::push: false reported a digest or a ref."
+            exit 1
+          fi
+
+      # The one real publish: main only, ubuntu only, and only once a person
+      # has stored the staging credentials (issue #398).
+      - name: lns-login (hub.staging.lns.run)
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+          && matrix.runner == 'ubuntu-latest' && env.LNS_HUB_STAGING_TOKEN != ''
+        uses: ./actions/lns-login
+        with:
+          registry: hub.staging.lns.run
+          username: ${{ secrets.LNS_HUB_STAGING_USERNAME }}
+          password: ${{ secrets.LNS_HUB_STAGING_TOKEN }}
+
+      - name: lns-push (mixin fixture to hub.staging.lns.run)
+        id: staging
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+          && matrix.runner == 'ubuntu-latest' && env.LNS_HUB_STAGING_TOKEN != ''
+        uses: ./actions/lns-push
+        with:
+          file: actions/lns-push/fixtures/mixin.yaml
+          kind: mixin
+          tags: hub.staging.lns.run/${{ env.LNS_HUB_STAGING_NAMESPACE }}/ci-fixture:sha-${{ github.sha }}
+
+      - name: The staging push reported a digest
+        if: steps.staging.outcome == 'success'
+        env:
+          DIGEST: ${{ steps.staging.outputs.digest }}
+          REFS: ${{ steps.staging.outputs.refs }}
+        run: |
+          set -euo pipefail
+          case "$DIGEST" in
+            sha256:*) : ;;
+            *) echo "::error::the staging push reported digest '$DIGEST'."; exit 1 ;;
+          esac
+          printf '%s\n' "$REFS"
+
+      - name: lns-logout (hub.staging.lns.run)
+        if: always() && steps.staging.outcome != 'skipped'
+        uses: ./actions/lns-logout
+        with:
+          registry: hub.staging.lns.run
 
       # ci.yml publishes no lns build artifact, so the `binary` input is
       # exercised against a stand-in executable: what it pins is that the

--- a/actions/README.md
+++ b/actions/README.md
@@ -7,6 +7,9 @@ together as one release-please component, `lns-actions`, tagged
 | Action | What it does |
 | --- | --- |
 | [`setup-lns`](setup-lns/) | Installs the lns CLI and puts it on `PATH`. |
+| [`lns-login`](lns-login/) | Stores a hub credential on the runner. |
+| [`lns-logout`](lns-logout/) | Removes one registry's stored credential. |
+| [`lns-push`](lns-push/) | Validates, dry-runs and publishes a document. |
 
 ## Usage
 
@@ -14,8 +17,18 @@ together as one release-please component, `lns-actions`, tagged
 - uses: lensapp/lens-sandbox/actions/setup-lns@lns-actions-v0
   with:
     version: 0.25.0 # or omit: newest lns release
-- run: lns artifact validate -f lns.yaml
+- uses: lensapp/lens-sandbox/actions/lns-login@lns-actions-v0
+  with:
+    username: ${{ vars.LNS_HUB_USERNAME }}
+    password: ${{ secrets.LNS_HUB_TOKEN }}
+- uses: lensapp/lens-sandbox/actions/lns-push@lns-actions-v0
+  with:
+    file: lns.yaml
+    tags: acme/hermes:${{ github.ref_name }}
 ```
+
+Tags name a namespace: `<namespace>/<name>:<tag>` or
+`<host>/<namespace>/<name>:<tag>`. Nothing here assumes one.
 
 ## Pin policy
 

--- a/actions/lib/registry-auth.sh
+++ b/actions/lib/registry-auth.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# One registry entry in ~/.lns/registry-auth.json, added or removed. The CLI
+# owns that store; writing the file here is the fallback for a runner with no
+# lns-service, and it goes away when work item 4 of #398 ships headless login.
+set -euo pipefail
+
+NO_SERVICE='background service must be running'
+
+usage() {
+  {
+    echo "usage: registry-auth.sh add|remove"
+    echo "  env: LNS_ACTION_REGISTRY, LNS_ACTION_USERNAME (add), LNS_ACTION_PASSWORD (add)"
+  } >&2
+}
+
+canonical_registry() {
+  local host
+  host=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  host=${host%/}
+  case "$host" in
+    docker.io | index.docker.io | registry-1.docker.io | registry.hub.docker.com) echo docker.io ;;
+    *) echo "$host" ;;
+  esac
+}
+
+require_bare_host() {
+  case "$1" in
+    '')
+      echo "::error::registry must not be empty."
+      exit 1
+      ;;
+    *://*)
+      echo "::error::registry '$1' must be a bare host, not a URL (drop the scheme)."
+      exit 1
+      ;;
+    */*)
+      echo "::error::registry '$1' must be a bare host[:port], not a path."
+      exit 1
+      ;;
+  esac
+}
+
+auth_file() {
+  local home=${LNS_HOME:-}
+  if [ -z "$home" ]; then
+    home="$HOME/.lns"
+  fi
+  echo "$home/registry-auth.json"
+}
+
+require_lns() {
+  if ! command -v lns >/dev/null 2>&1; then
+    echo "::error::lns is not on PATH; run lensapp/lens-sandbox/actions/setup-lns first."
+    exit 1
+  fi
+}
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "::error::registry-auth needs jq, which is not on PATH."
+    exit 1
+  fi
+}
+
+# Rewrites the auth file through a jq program that reads the current entries,
+# keeping every other host and the 0600 the CLI writes.
+rewrite_auth_file() {
+  local program=$1
+  shift
+  local file current tmp
+  file=$(auth_file)
+  require_jq
+  mkdir -p "$(dirname "$file")"
+  current='{}'
+  if [ -s "$file" ]; then
+    if ! current=$(jq -e . "$file" 2>/dev/null); then
+      echo "::error::$file is not valid JSON; lns cannot read it either."
+      exit 1
+    fi
+  fi
+  tmp="$file.$$.tmp"
+  (
+    umask 077
+    printf '%s' "$current" | jq "$@" "$program" >"$tmp"
+  )
+  chmod 0600 "$tmp"
+  mv -f "$tmp" "$file"
+  printf 'wrote %s\n' "$file"
+}
+
+# The CLI owns the store, so only "no service" sends us to the file; every
+# other failure is the CLI's answer and stands.
+fallback_after_cli() {
+  local what=$1 output=$2 status=$3
+  if [ "$status" -eq 0 ]; then
+    printf '%s\n' "$output"
+    return 1
+  fi
+  case "$output" in
+    *"$NO_SERVICE"*)
+      printf 'lns-service is not running on this runner; %s writes %s directly.\n' \
+        "$what" "$(auth_file)" >&2
+      return 0
+      ;;
+    *)
+      printf '%s\n' "$output" >&2
+      echo "::error::lns $what failed."
+      exit 1
+      ;;
+  esac
+}
+
+add() {
+  local registry=$1 username=$2 output status
+  if [ -z "$username" ]; then
+    echo "::error::username is required."
+    exit 1
+  fi
+  if [ -z "${LNS_ACTION_PASSWORD:-}" ]; then
+    echo "::error::password is required."
+    exit 1
+  fi
+  require_lns
+  set +e
+  output=$(printf '%s' "$LNS_ACTION_PASSWORD" |
+    lns login "$registry" -u "$username" --password-stdin 2>&1)
+  status=$?
+  set -e
+  if fallback_after_cli login "$output" "$status"; then
+    # shellcheck disable=SC2016 # a jq program, not shell expansion
+    rewrite_auth_file '.[$registry] = {username: $username, secret: $ENV.LNS_ACTION_PASSWORD}' \
+      --arg registry "$registry" --arg username "$username"
+  fi
+  printf 'Logged in to %s as %s.\n' "$registry" "$username"
+}
+
+remove() {
+  local registry=$1 output status
+  require_lns
+  set +e
+  output=$(lns logout "$registry" 2>&1)
+  status=$?
+  set -e
+  if fallback_after_cli logout "$output" "$status"; then
+    # shellcheck disable=SC2016 # a jq program, not shell expansion
+    rewrite_auth_file 'del(.[$registry])' --arg registry "$registry"
+  fi
+  printf 'Logged out of %s.\n' "$registry"
+}
+
+main() {
+  local mode=${1:-} registry
+  registry=$(canonical_registry "${LNS_ACTION_REGISTRY:-}")
+  case "$mode" in
+    add)
+      require_bare_host "$registry"
+      add "$registry" "${LNS_ACTION_USERNAME:-}"
+      ;;
+    remove)
+      require_bare_host "$registry"
+      remove "$registry"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/actions/lib/registry-auth.sh
+++ b/actions/lib/registry-auth.sh
@@ -89,12 +89,21 @@ rewrite_auth_file() {
 }
 
 # The CLI owns the store, so only "no service" sends us to the file; every
-# other failure is the CLI's answer and stands.
+# other failure is the CLI's answer and stands, bar the one a caller names as
+# the state it asked for.
 fallback_after_cli() {
-  local what=$1 output=$2 status=$3
+  local what=$1 output=$2 status=$3 already=${4:-}
   if [ "$status" -eq 0 ]; then
     printf '%s\n' "$output"
     return 1
+  fi
+  if [ -n "$already" ]; then
+    case "$output" in
+      *"$already"*)
+        printf '%s\n' "$output"
+        return 1
+        ;;
+    esac
   fi
   case "$output" in
     *"$NO_SERVICE"*)
@@ -141,7 +150,7 @@ remove() {
   output=$(lns logout "$registry" 2>&1)
   status=$?
   set -e
-  if fallback_after_cli logout "$output" "$status"; then
+  if fallback_after_cli logout "$output" "$status" 'not logged in'; then
     # shellcheck disable=SC2016 # a jq program, not shell expansion
     rewrite_auth_file 'del(.[$registry])' --arg registry "$registry"
   fi

--- a/actions/lns-login/README.md
+++ b/actions/lns-login/README.md
@@ -1,0 +1,44 @@
+# `lns-login`
+
+Stores a hub credential on the runner so a later `lns artifact push` or
+`lns run` can authenticate. It calls `lns login --password-stdin`; when the
+runner has no `lns-service` — the usual case, since `setup-lns` installs the
+CLI only — it writes the one entry into `~/.lns/registry-auth.json` itself,
+mode 0600, leaving every other host in the file alone.
+
+```yaml
+- uses: lensapp/lens-sandbox/actions/setup-lns@lns-actions-v0
+- uses: lensapp/lens-sandbox/actions/lns-login@lns-actions-v0
+  with:
+    registry: hub.lns.run
+    username: ${{ vars.LNS_HUB_USERNAME }}
+    password: ${{ secrets.LNS_HUB_TOKEN }}
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `registry` | `hub.lns.run` | Registry host, a bare `host[:port]` — no scheme, no path. |
+| `username` | — | Username the token belongs to. Required. |
+| `password` | — | Password or token. Required. |
+
+## The token
+
+Pass a secret, never a literal. The action masks it with `::add-mask::` before
+anything else runs, and hands it to the script through the environment — it is
+never an argument to any process, so it cannot appear in `ps` output.
+
+Log out at the end of a job that runs untrusted steps afterwards:
+
+```yaml
+- uses: lensapp/lens-sandbox/actions/lns-logout@lns-actions-v0
+  if: always()
+  with:
+    registry: hub.lns.run
+```
+
+## Requirements
+
+`lns` on `PATH` (run [`setup-lns`](../setup-lns/) first) and `jq`, which both
+GitHub-hosted runner images carry.

--- a/actions/lns-login/action.yml
+++ b/actions/lns-login/action.yml
@@ -1,0 +1,43 @@
+# lns-actions 0.1.0 # x-release-please-version
+name: lns login
+description: >-
+  Stores a hub credential for `lns artifact push` and `lns run`. Calls
+  `lns login --password-stdin`, and writes ~/.lns/registry-auth.json itself
+  only when the runner has no lns-service. Other hosts are left untouched.
+
+inputs:
+  registry:
+    description: Registry host to log in to, a bare host[:port].
+    required: false
+    default: hub.lns.run
+  username:
+    description: Username the token belongs to.
+    required: true
+  password:
+    description: >-
+      Password or token. Pass a secret, never a literal — it is masked before
+      it is used and reaches the script through the environment, never argv.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Mask the token
+      shell: bash
+      env:
+        INPUT_PASSWORD: ${{ inputs.password }}
+      run: |
+        set -euo pipefail
+        if [ -z "$INPUT_PASSWORD" ]; then
+          echo "::error::password is required."
+          exit 1
+        fi
+        echo "::add-mask::$INPUT_PASSWORD"
+
+    - name: Log in
+      shell: bash
+      env:
+        LNS_ACTION_REGISTRY: ${{ inputs.registry }}
+        LNS_ACTION_USERNAME: ${{ inputs.username }}
+        LNS_ACTION_PASSWORD: ${{ inputs.password }}
+      run: bash "$GITHUB_ACTION_PATH/../lib/registry-auth.sh" add

--- a/actions/lns-logout/README.md
+++ b/actions/lns-logout/README.md
@@ -1,0 +1,26 @@
+# `lns-logout`
+
+Removes one registry's stored credential. It calls `lns logout`; when the
+runner has no `lns-service` it deletes that one entry from
+`~/.lns/registry-auth.json` itself, leaving every other host in the file alone.
+
+```yaml
+- uses: lensapp/lens-sandbox/actions/lns-logout@lns-actions-v0
+  if: always()
+  with:
+    registry: hub.lns.run
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `registry` | `hub.lns.run` | Registry host, a bare `host[:port]` — no scheme, no path. |
+
+A registry that is not logged in is not an error: the step is safe under
+`if: always()`.
+
+## Requirements
+
+`lns` on `PATH` (run [`setup-lns`](../setup-lns/) first) and `jq`, which both
+GitHub-hosted runner images carry.

--- a/actions/lns-logout/action.yml
+++ b/actions/lns-logout/action.yml
@@ -1,0 +1,21 @@
+# lns-actions 0.1.0 # x-release-please-version
+name: lns logout
+description: >-
+  Removes one registry's stored credential. Calls `lns logout`, and edits
+  ~/.lns/registry-auth.json itself only when the runner has no lns-service.
+  Other hosts are left untouched.
+
+inputs:
+  registry:
+    description: Registry host to log out of, a bare host[:port].
+    required: false
+    default: hub.lns.run
+
+runs:
+  using: composite
+  steps:
+    - name: Log out
+      shell: bash
+      env:
+        LNS_ACTION_REGISTRY: ${{ inputs.registry }}
+      run: bash "$GITHUB_ACTION_PATH/../lib/registry-auth.sh" remove

--- a/actions/lns-push/README.md
+++ b/actions/lns-push/README.md
@@ -1,0 +1,72 @@
+# `lns-push`
+
+Publishes an lns document from a workflow: validate, dry run into the job
+summary, then push it under every tag given.
+
+```yaml
+- uses: lensapp/lens-sandbox/actions/setup-lns@lns-actions-v0
+- uses: lensapp/lens-sandbox/actions/lns-login@lns-actions-v0
+  with:
+    username: ${{ vars.LNS_HUB_USERNAME }}
+    password: ${{ secrets.LNS_HUB_TOKEN }}
+- id: push
+  uses: lensapp/lens-sandbox/actions/lns-push@lns-actions-v0
+  with:
+    file: mixins/gh/gh.yaml
+    kind: mixin
+    tags: |
+      acme/gh:sha-${{ github.sha }}
+      acme/gh:latest
+    push: ${{ github.event_name != 'pull_request' }}
+- run: echo "published ${{ steps.push.outputs.digest }}"
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `file` | — | Document to publish. Its directory roots the document's relative filesets and supplies the `README.md` layer. Required. |
+| `tags` | — | References to publish, one per line (commas also separate). Required. |
+| `push` | `true` | `false` stops after the dry run — what a pull request wants. |
+| `kind` | _(empty)_ | `sandbox` or `mixin`, the kind the document must be. Empty accepts either. |
+| `require-exact-tool-versions` | `true` | Fail when the dry run reports tool versions that resolve at push time. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `digest` | The manifest digest published, `sha256:…`. Empty when `push` is `false`. |
+| `refs` | Every reference pushed, one per line. Empty when `push` is `false`. |
+| `first-push` | `true` when the first tag's repository did not exist before this push. Empty when `push` is `false`. |
+
+## Tags name a namespace
+
+A tag is `<namespace>/<name>:<tag>` or `<host>/<namespace>/<name>:<tag>`.
+`gh:latest` is refused: nothing here assumes a namespace, because the
+namespace is yours, not this repository's. A tag without a host resolves
+against `hub.lns.run`.
+
+## What the job summary carries
+
+The dry run's output verbatim — the filesets and README layer it packed, the
+digest it would publish, and any mixin it would publish alongside — then, for
+a real push, the digest and every reference pushed. When the repository did
+not exist before, one more line:
+
+> `acme/gh` is new and private. Publish it at <https://hub.lns.run/acme/gh/settings>
+
+The hub decides that a new repository is private. Making it public is a
+setting on the hub until an API exists for it
+([#398](https://github.com/lensapp/lens-sandbox/issues/398), work item 7).
+
+`first-push` comes from an anonymous `GET /v2/<repo>/tags/list` before the
+push: a `404` means new. A repository that exists but is private answers `401`
+and is correctly reported as not new.
+
+## Requirements
+
+`lns` on `PATH` (run [`setup-lns`](../setup-lns/) first) and, for a real push,
+a credential from [`lns-login`](../lns-login/).
+
+The documents in [`fixtures/`](fixtures/) are what this repository's own CI
+pushes to exercise the action.

--- a/actions/lns-push/action.yml
+++ b/actions/lns-push/action.yml
@@ -1,0 +1,210 @@
+# lns-actions 0.1.0 # x-release-please-version
+name: lns push
+description: >-
+  Validates an lns document, dry-runs the push into the job summary, and
+  publishes it under every tag given. A tag without a namespace is refused —
+  nothing here assumes one.
+
+inputs:
+  file:
+    description: Document to publish, e.g. mixins/gh/gh.yaml.
+    required: true
+  tags:
+    description: >-
+      References to publish, one per line (commas also separate). Each is
+      `<namespace>/<name>:<tag>` or `<host>/<namespace>/<name>:<tag>`.
+    required: true
+  push:
+    description: Publish, or stop after the dry run.
+    required: false
+    default: "true"
+  kind:
+    description: >-
+      Kind the document must be (`sandbox` or `mixin`). Empty accepts either.
+    required: false
+    default: ""
+  require-exact-tool-versions:
+    description: >-
+      Fail when the dry run reports tool versions that resolve at push time,
+      so a published document pins what a consumer will install.
+    required: false
+    default: "true"
+
+outputs:
+  digest:
+    description: Manifest digest published, e.g. sha256:… (empty on a dry run).
+    value: ${{ steps.push.outputs.digest }}
+  refs:
+    description: Every reference pushed, one per line (empty on a dry run).
+    value: ${{ steps.push.outputs.refs }}
+  first-push:
+    description: >-
+      `true` when the first tag's repository did not exist before this push.
+    value: ${{ steps.push.outputs.first-push }}
+
+runs:
+  using: composite
+  steps:
+    - name: Read the tags
+      id: tags
+      shell: bash
+      env:
+        INPUT_TAGS: ${{ inputs.tags }}
+      run: |
+        set -euo pipefail
+
+        refuse() {
+          echo "::error::tag '$1' $2. Use <namespace>/<name>:<tag> or <host>/<namespace>/<name>:<tag> — lns-push never assumes a namespace."
+          exit 1
+        }
+
+        file="$RUNNER_TEMP/lns-push-tags.txt"
+        : >"$file"
+        first=""
+        host=""
+        repo=""
+        while IFS= read -r raw; do
+          tag=$(printf '%s' "$raw" | tr -d '[:space:]')
+          [ -n "$tag" ] || continue
+          case "${tag##*/}" in
+            *:*) : ;;
+            *) refuse "$tag" "names no tag" ;;
+          esac
+          repository=${tag%:*}
+          case "${repository%%/*}" in
+            *.* | *:* | localhost)
+              tag_host=${repository%%/*}
+              tag_repo=${repository#*/}
+              ;;
+            *)
+              tag_host=hub.lns.run
+              tag_repo=$repository
+              ;;
+          esac
+          case "$tag_repo" in
+            */*) : ;;
+            *) refuse "$tag" "has no namespace segment" ;;
+          esac
+          printf '%s\n' "$tag" >>"$file"
+          if [ -z "$first" ]; then
+            first=$tag
+            host=$tag_host
+            repo=$tag_repo
+          fi
+        done <<TAGS
+        $(printf '%s' "$INPUT_TAGS" | tr ',' '\n')
+        TAGS
+
+        if [ -z "$first" ]; then
+          echo "::error::tags is empty; give at least one <namespace>/<name>:<tag>."
+          exit 1
+        fi
+        {
+          echo "first=$first"
+          echo "host=$host"
+          echo "repository=$repo"
+          echo "file=$file"
+        } >>"$GITHUB_OUTPUT"
+
+    - name: Validate the document
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_KIND: ${{ inputs.kind }}
+      run: |
+        set -euo pipefail
+        if [ -n "$INPUT_KIND" ]; then
+          lns artifact validate -f "$INPUT_FILE" --kind "$INPUT_KIND"
+        else
+          lns artifact validate -f "$INPUT_FILE"
+        fi
+
+    - name: Dry run
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_EXACT_TOOLS: ${{ inputs.require-exact-tool-versions }}
+        FIRST_TAG: ${{ steps.tags.outputs.first }}
+      run: |
+        set -euo pipefail
+
+        set +e
+        output=$(lns artifact push "$FIRST_TAG" -f "$INPUT_FILE" --dry-run --yes 2>&1)
+        status=$?
+        set -e
+        printf '%s\n' "$output"
+        {
+          echo "### lns-push dry run — \`$FIRST_TAG\`"
+          echo
+          echo '```'
+          printf '%s\n' "$output"
+          echo '```'
+        } >>"$GITHUB_STEP_SUMMARY"
+        if [ "$status" -ne 0 ]; then
+          echo "::error::the dry run refused this document; nothing was pushed."
+          exit "$status"
+        fi
+        if [ "$INPUT_EXACT_TOOLS" = true ] &&
+          printf '%s\n' "$output" | grep -q 'resolve at push time'; then
+          echo "::error::the dry run reports tool versions that resolve at push time; pin them in the document, or set require-exact-tool-versions: false."
+          exit 1
+        fi
+
+    - name: Push
+      id: push
+      if: inputs.push == 'true'
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        TAGS_FILE: ${{ steps.tags.outputs.file }}
+        REGISTRY_HOST: ${{ steps.tags.outputs.host }}
+        REPOSITORY: ${{ steps.tags.outputs.repository }}
+      run: |
+        set -euo pipefail
+
+        code=$(curl -sS -o /dev/null -w '%{http_code}' -m 30 \
+          "https://$REGISTRY_HOST/v2/$REPOSITORY/tags/list" || echo 000)
+        first_push=false
+        if [ "$code" = 404 ]; then
+          first_push=true
+        fi
+
+        digest=""
+        refs=""
+        refs_md=""
+        while IFS= read -r tag; do
+          [ -n "$tag" ] || continue
+          set +e
+          output=$(lns artifact push "$tag" -f "$INPUT_FILE" --yes 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -ne 0 ]; then
+            echo "::error::pushing $tag failed."
+            exit "$status"
+          fi
+          pushed=$(printf '%s\n' "$output" | grep '^built and pushed ' | tail -1)
+          digest=${pushed##*@}
+          refs="$refs$tag"$'\n'
+          refs_md="$refs_md- \`$tag\`"$'\n'
+        done <"$TAGS_FILE"
+
+        {
+          echo "digest=$digest"
+          echo "first-push=$first_push"
+          echo 'refs<<LNS_REFS_EOF'
+          printf '%s' "$refs"
+          echo 'LNS_REFS_EOF'
+        } >>"$GITHUB_OUTPUT"
+
+        {
+          echo "### lns-push published"
+          echo
+          echo "Digest \`$digest\`, from \`$INPUT_FILE\`:"
+          echo
+          printf '%s' "$refs_md"
+          if [ "$first_push" = true ]; then
+            echo
+            echo "$REPOSITORY is new and private. Publish it at https://$REGISTRY_HOST/$REPOSITORY/settings"
+          fi
+        } >>"$GITHUB_STEP_SUMMARY"

--- a/actions/lns-push/fixtures/README.md
+++ b/actions/lns-push/fixtures/README.md
@@ -1,0 +1,16 @@
+# lns-push fixtures
+
+Two documents the `actions` CI job pushes, so every change to `lns-push` is
+tried against a real document of each kind before it is released.
+
+| File | Kind | Used for |
+| --- | --- | --- |
+| [`sandbox.yaml`](sandbox.yaml) | `sandbox` | A dry run on every pull request. |
+| [`mixin.yaml`](mixin.yaml) | `mixin` | A dry run on every pull request, and the one real push to hub.staging.lns.run from `main`. |
+
+This file is also the README layer both of them publish: `lns artifact push`
+packs the `README.md` beside the document, so pushing a fixture exercises that
+layer too.
+
+Neither document declares a tool, so the dry run reports nothing that resolves
+at push time and `require-exact-tool-versions` stays at its default.

--- a/actions/lns-push/fixtures/mixin.yaml
+++ b/actions/lns-push/fixtures/mixin.yaml
@@ -1,0 +1,10 @@
+apiVersion: lns.run/v1
+kind: mixin
+name: lns-actions-ci-fixture
+spec:
+  egress:
+    http:
+      - match: api.github.com
+        verdict: allow
+      - match: objects.githubusercontent.com
+        verdict: allow

--- a/actions/lns-push/fixtures/sandbox.yaml
+++ b/actions/lns-push/fixtures/sandbox.yaml
@@ -1,0 +1,14 @@
+apiVersion: lns.run/v1
+kind: sandbox
+name: lns-actions-ci-fixture
+spec:
+  image: docker.io/library/debian:bookworm-slim
+  command: sh -c "echo the lns-actions CI fixture ran"
+  workdir: /workspace
+  resources:
+    cpu: 1
+    memory: 512Mi
+  egress:
+    http:
+      - match: example.com
+        verdict: deny

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -68,6 +68,18 @@
         {
           "type": "generic",
           "path": "setup-lns/action.yml"
+        },
+        {
+          "type": "generic",
+          "path": "lns-login/action.yml"
+        },
+        {
+          "type": "generic",
+          "path": "lns-logout/action.yml"
+        },
+        {
+          "type": "generic",
+          "path": "lns-push/action.yml"
         }
       ]
     },


### PR DESCRIPTION
Part of #398 — work item 2: `lns-login`, `lns-logout` and `lns-push`.

**Stacked on #399** (work item 1, `feat/actions-setup-lns`), which this PR is based on. Merge #399 first; the base then retargets to `main`.

## What this adds

- **`actions/lib/registry-auth.sh`** — one registry entry in `~/.lns/registry-auth.json` (`$LNS_HOME` honoured, as the CLI does), added or removed with `jq`, mode 0600, every other host untouched, the file rewritten atomically under `umask 077`. It calls `lns login --password-stdin` / `lns logout` first and falls back to the file **only** when the CLI answers with the no-service message; every other CLI failure is the CLI's answer and fails the step. Design rule 4.
- **`actions/lns-login/action.yml`** — `registry` (default `hub.lns.run`), `username`, `password`. The token is masked with `::add-mask::` in its own first step, then reaches the script through `env:` — never argv, and `printf` into the CLI's stdin is a bash builtin, so it is in no process's command line. `jq` reads it as `$ENV.LNS_ACTION_PASSWORD`, so it is not a `--arg` either.
- **`actions/lns-logout/action.yml`** — `registry`, same fallback.
- **`actions/lns-push/action.yml`** — inputs `file`, `tags`, `push`, `kind`, `require-exact-tool-versions`; outputs `digest`, `refs`, `first-push`. Order: refuse a tag that names no namespace (design rule 3, with the accepted shapes in the message), `lns artifact validate -f FILE [--kind KIND]`, `lns artifact push FIRST_TAG --dry-run --yes` with its output verbatim in the job summary, then the real push per tag when `push` is true. `require-exact-tool-versions` (default true) fails on the dry run's `… tool version(s) resolve at push time` line. `digest` is parsed from `built and pushed <ref>@sha256:…` until #400 ships `--format json`. `first-push` is an anonymous `GET /v2/<repo>/tags/list`: `404` is new, and the summary then carries the settings link (design rule 6).
- **`actions/lns-push/fixtures/`** — one sandbox and one mixin document plus a README that is also the README layer both of them publish.
- READMEs for the three actions, the `actions/README.md` table and usage, and the three `action.yml` files in release-please `extra-files` with the same `x-release-please-version` marker `setup-lns` uses.
- **`ci.yml` `actions` job**: seed another host's entry, `lns-login` to `example.invalid` with a dummy token, assert the file shape (both hosts, 0600, seeded secret intact), `lns-logout`, assert only the seeded host remains and the mode held; `lns-push` with `push: false` on both fixtures, asserting no digest and no refs; and on `push` to `main`, ubuntu only, when the staging token secret is set, a real `lns-login` to `hub.staging.lns.run`, a push of the mixin fixture as `<staging namespace>/ci-fixture:sha-<sha>`, a digest assertion, and an `always()` logout.

## Decisions and deviations

- **Namespace for the staging push.** The issue names `secrets.LNS_HUB_STAGING_USERNAME` and `secrets.LNS_HUB_STAGING_TOKEN` but not where the namespace comes from. The job reads `vars.LNS_HUB_STAGING_NAMESPACE`, falling back to the username secret. Set the repository *variable* to keep the pushed refs out of the log's masking. Until a person stores the secrets (a task the issue tracks), these steps skip.
- **The staging steps are placed before the stand-in-`lns` steps** work item 1 added: `setup-lns` prepends to `PATH`, so after the stub is installed `lns` is the stub. Everything new therefore runs against the real newest release.
- **`first-push` and `digest` are empty on a dry run.** The tags/list probe runs in the push step, "before the push", so `push: false` does no network call at all. Documented in the action's README.
- **The mode assertion uses `find -perm 600`**, not `stat`, whose flags differ between the ubuntu and macOS runners.
- **No CI case for the namespace refusal.** It is unit-tested by hand and covered by the message in the README; asserting a deliberate step failure would need `continue-on-error` scaffolding the issue does not ask for.
- **Two `# shellcheck disable=SC2016` directives**, each one line with a reason: the strings are jq programs, not shell expansions.
- The repository has no shellcheck or actionlint job (design rule 10 refers to one that does not exist yet). Both were run locally over every changed script, every `run:` block of all four actions, and every workflow: clean, apart from a pre-existing SC2129 in `publish-kernel.yml` that this PR leaves alone. `markdownlint-cli2` is clean over `actions/**/*.md`.
- Scripts were exercised locally against the released `lns 0.25.0`: the file fallback add/remove round trip, tag parsing and both refusals, the dry run on both fixtures, and both sides of `require-exact-tool-versions`. The real push path is only exercisable in CI, which is why the main-branch staging self-test exists.

## CI evidence

GitHub runs no `pull_request` workflow for a PR whose base is not `main`, so this branch gets no checks of its own. It was run through CI as a throwaway draft against `main` (#403, closed, branch deleted): `actions (ubuntu-latest)` and `actions (macos-latest)` green over every new step, and `CI / check` green for the whole tree. On both runners the runner has no lns-service, so the login and logout steps exercised the file fallback exactly as intended:

```
lns-service is not running on this runner; login writes /home/runner/.lns/registry-auth.json directly.
Logged in to example.invalid as ci.
would pack README.md -> sha256:3654… (744 bytes)
would push hub.lns.run/lns-ci/actions-mixin-fixture:sha-…@sha256:0138… (952 bytes)
dry run — built and validated; nothing uploaded
```

The oracle was run twice, once per commit (#403 and #405, both closed with their branches deleted). When #399 merges and this PR retargets `main`, the same jobs run as its own required checks.

## Review

A self-review of the diff found one real bug, fixed in the second commit: with `lns-service` running, `lns logout` of a host that has no stored credential exits non-zero, so the `if: always()` cleanup step both READMEs recommend would have turned a passing job red. The file fallback was already idempotent (`jq del` of a missing key succeeds); the CLI path now agrees with it, while every other CLI failure still fails the step. GitHub-hosted runners never have the service, so CI cannot cover that branch — it was verified locally against a stub CLI, alongside the "credential rejected" case, which still fails.

No review threads have been opened on this PR yet.

## Not in this PR

Work items 3, 4 and 6 of #398: the fallback stays until headless `lns login` ships, and `lns-push` parses text until `--format json` does.
