### PR TITLE
[reading only, merges via #422] feat(service): a build is keyed by its inputs, and lns sandbox build fills the cache

### DIFF
--- a/crates/e2e-tests/features/microvm_containerfile_cache.feature
+++ b/crates/e2e-tests/features/microvm_containerfile_cache.feature
@@ -1,0 +1,48 @@
+@microvm
+Feature: a build is remembered by its key, and only what changed is built again
+  Slice 4 of lensapp/lens-sandbox#393, the build cache and `lns sandbox build`. The
+  verb builds what `spec.image` names, fills the cache and publishes nothing. The image
+  is keyed by the `FROM` digest, the Containerfile's text, the context's content hash
+  and the architecture, so a second build of an untouched document runs nothing and
+  says so. One instruction is keyed by the image it stands on and by what it resolved
+  to, so an edited context file rebuilds the `COPY` that carries it and everything
+  after it, and nothing before it.
+
+  What ran is read two ways: from what the verb printed, and from the instructions the
+  service booted a guest for, which it names one line each in its own log. A `RUN` no
+  key answered is a boot; a `RUN` a key answers is not.
+
+  Like every @microvm scenario this boots real guests and reaches a real registry for
+  the base image, so it runs only via `make e2e-microvm`, never in CI's PR gate.
+
+  Scenario: an unchanged build runs nothing, and an edited context file rebuilds from the copy that carries it
+    Given a clean lns cache home
+    And the LNS service is running in that home
+    And the build context holds "app/index.js" containing "copied-by-lns"
+    And the project builds its image from this Containerfile
+      """
+      FROM {base}
+      RUN /bin/sh -c 'echo built-by-lns > /built-marker'
+      COPY app /srv/app
+      RUN /bin/sh -c 'cat /srv/app/index.js > /srv/derived'
+      """
+    When the user builds the sandbox definition
+    Then the exit code is 0
+    And the build reports the key it is remembered under
+    And the build reports the image it produced from "./image/Dockerfile"
+    And the service booted a guest for 2 instructions of that build
+    When the user builds the sandbox definition
+    Then the exit code is 0
+    And the output contains "nothing to build"
+    And the build reports the same key as the build before it
+    And the service booted a guest for 0 instructions of that build
+    When the build context file "app/index.js" is changed to "edited-by-hand"
+    And the user builds the sandbox definition
+    Then the exit code is 0
+    And the build reports a different key from the build before it
+    And the service booted a guest for 1 instruction of that build
+    When the user runs a microVM command "/bin/sh -c 'cat /built-marker; cat /srv/derived'"
+    Then the exit code is 0
+    And the output contains "built-by-lns"
+    And the output contains "edited-by-hand"
+    And the output does not contain "Building"

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -43,6 +43,10 @@ pub struct E2eWorld {
     pub run_budget: Option<std::time::Duration>,
     /// Destinations the definition's own policy allows, so a scenario whose workload really fetches something is not left at an approval prompt.
     pub project_egress: Vec<String>,
+    /// The build cache key each `lns sandbox build` printed, in the order the scenario asked for them.
+    pub build_keys: Vec<String>,
+    /// How many instructions the service had booted a guest for when the last build started.
+    pub instructions_before_build: usize,
 }
 
 impl E2eWorld {

--- a/crates/e2e-tests/tests/steps/microvm.rs
+++ b/crates/e2e-tests/tests/steps/microvm.rs
@@ -1883,3 +1883,96 @@ fn built_reference_of_last_run(world: &mut E2eWorld) -> Result<String, String> {
             )
         })
 }
+
+/// Slice 4 of lensapp/lens-sandbox#393: `lns sandbox build` builds and publishes nothing, so what
+/// it did is read off its own two lines and off the instructions the service booted a guest for.
+#[when("the user builds the sandbox definition")]
+fn build_definition(world: &mut E2eWorld) {
+    world.instructions_before_build = instructions_run(world);
+    run_lns_microvm_as(world, &["sandbox", "build"], Vec::new());
+    if let Some(key) = printed_key(world) {
+        world.build_keys.push(key);
+    }
+}
+
+#[when(regex = r#"^the build context file "([^"]+)" is changed to "([^"]*)"$"#)]
+fn context_file_is_changed(world: &mut E2eWorld, path: String, content: String) {
+    let content = format!("{content}\n");
+    match world
+        .project_context_files
+        .iter_mut()
+        .find(|(existing, _)| *existing == path)
+    {
+        Some(entry) => entry.1 = content,
+        None => world.project_context_files.push((path, content)),
+    }
+}
+
+#[then("the build reports the key it is remembered under")]
+fn the_build_reports_a_key(world: &mut E2eWorld) -> Result<(), String> {
+    match world.build_keys.last() {
+        Some(key) if key.len() == "sha256:".len() + 64 => Ok(()),
+        other => Err(format!("the build printed no usable key: {other:?}")),
+    }
+}
+
+#[then(regex = r#"^the build reports the image it produced from "([^"]+)"$"#)]
+fn the_build_reports_the_image(world: &mut E2eWorld, label: String) -> Result<(), String> {
+    let run = world.result.as_ref().ok_or("no CLI run captured")?;
+    let line = run
+        .stdout
+        .lines()
+        .find(|line| line.starts_with(&format!("built {label} as ")))
+        .ok_or_else(|| format!("the build must name what it built:\n{}", run.stdout))?;
+    match line.contains("@sha256:") {
+        true => Ok(()),
+        false => Err(format!("the built image must be named by digest: {line}")),
+    }
+}
+
+#[then("the build reports the same key as the build before it")]
+fn the_same_key(world: &mut E2eWorld) -> Result<(), String> {
+    match world.build_keys.as_slice() {
+        [.., before, now] if before == now => Ok(()),
+        keys => Err(format!("expected the last two keys to agree, got {keys:?}")),
+    }
+}
+
+#[then("the build reports a different key from the build before it")]
+fn a_different_key(world: &mut E2eWorld) -> Result<(), String> {
+    match world.build_keys.as_slice() {
+        [.., before, now] if before != now => Ok(()),
+        keys => Err(format!(
+            "expected the last two keys to differ, got {keys:?}"
+        )),
+    }
+}
+
+#[then(regex = r"^the service booted a guest for (\d+) instructions? of that build$")]
+fn instructions_of_that_build(world: &mut E2eWorld, expected: usize) -> Result<(), String> {
+    let ran = instructions_run(world) - world.instructions_before_build;
+    match ran == expected {
+        true => Ok(()),
+        false => Err(format!(
+            "expected {expected} instruction(s) to run, {ran} did\n--- service.log ---\n{}",
+            crate::steps::service::read_service_log(world),
+        )),
+    }
+}
+
+/// Every `RUN` the service reaches a guest for says so once, so counting the lines counts the steps no key answered.
+fn instructions_run(world: &E2eWorld) -> usize {
+    crate::steps::service::read_service_log(world)
+        .lines()
+        .filter(|line| line.contains("Running") && line.contains("instruction"))
+        .count()
+}
+
+fn printed_key(world: &E2eWorld) -> Option<String> {
+    world
+        .result
+        .as_ref()?
+        .stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("key ").map(|key| key.trim().to_string()))
+}

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -1514,6 +1514,61 @@ mod tests {
         assert!(format!("{err:#}").contains("unexpected response"));
     }
 
+    const A_DOCUMENT: &str =
+        "apiVersion: lns.run/v1\nkind: sandbox\nname: agent\nspec:\n  image: ./image\n";
+
+    #[tokio::test]
+    async fn build_surfaces_the_services_refusal_and_rejects_an_unrelated_answer() {
+        let svc = CannedService::holding_a_document(
+            Response::Error {
+                message: "there is nothing to build".into(),
+            },
+            A_DOCUMENT,
+        );
+        let err = build(&svc, &build_args(), &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("there is nothing to build"));
+
+        let svc = CannedService::holding_a_document(Response::Pong, A_DOCUMENT);
+        let err = build(&svc, &build_args(), &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    /// A document nobody wrote is named, and no build reaches the service.
+    #[tokio::test]
+    async fn build_names_the_document_it_could_not_read() {
+        let svc = CannedService::new(Response::Pong);
+
+        let err = build(&svc, &build_args(), &mut Vec::new())
+            .await
+            .unwrap_err();
+
+        assert!(format!("{err:#}").contains("lns.yaml"), "{err:#}");
+        assert!(svc.requests.lock().unwrap().is_empty());
+    }
+
+    /// A document that is not a document at all is named where it is, not where it went wrong later.
+    #[tokio::test]
+    async fn build_names_the_document_it_could_not_parse() {
+        let svc = CannedService::holding_a_document(Response::Pong, "spec: [unterminated\n");
+
+        let err = build(&svc, &build_args(), &mut Vec::new())
+            .await
+            .unwrap_err();
+
+        assert!(format!("{err:#}").contains("/work/lns.yaml"), "{err:#}");
+    }
+
+    fn build_args() -> SandboxBuildArgs {
+        SandboxBuildArgs {
+            file: None,
+            rebuild: false,
+        }
+    }
+
     #[tokio::test]
     async fn stopped_run_names_skip_the_running_and_fall_back_to_the_short_id() {
         let svc = CannedService::new(Response::RunList {

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -44,6 +44,10 @@ pub enum SandboxCommand {
     Rm(SandboxRmArgs),
     #[command(about = "Remove every stopped sandbox, writable layers included.")]
     Prune(SandboxPruneArgs),
+    #[command(
+        about = "Build the Containerfile this document's spec.image names; publishes nothing."
+    )]
+    Build(SandboxBuildArgs),
 }
 
 #[derive(clap::Args)]
@@ -88,6 +92,24 @@ pub struct SandboxStartArgs {
         help = "With -a: detach chord; on match the CLI detaches, leaving the sandbox running."
     )]
     pub detach_keys: DetachChord,
+}
+
+#[derive(clap::Args)]
+pub struct SandboxBuildArgs {
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "FILE",
+        help = "Document to build instead of ./lns.yaml."
+    )]
+    pub file: Option<std::path::PathBuf>,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Ignore the build cache for this build; every instruction runs again."
+    )]
+    pub rebuild: bool,
 }
 
 #[derive(clap::Args)]
@@ -368,7 +390,61 @@ where
         SandboxCommand::Attach(args) => attach(svc, args, term, stdout, stderr).await,
         SandboxCommand::Rm(args) => rm(svc, args, out).await,
         SandboxCommand::Save(args) => save(svc, args, out).await,
+        SandboxCommand::Build(args) => build(svc, args, out).await,
     }
+}
+
+/// The document names the Containerfile; the service does the building, and the key it answers with is what names the build everywhere else.
+async fn build<W: std::io::Write>(
+    svc: &impl SandboxService,
+    args: &SandboxBuildArgs,
+    out: &mut W,
+) -> Result<i32> {
+    let (path, yaml) = svc.document(args.file.as_deref())?;
+    let definition = definition_json(&yaml, &path)?;
+    let definition_dir = path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_string_lossy()
+        .into_owned();
+    match svc
+        .one_shot(Request::BuildSandbox {
+            definition,
+            definition_dir,
+            rebuild: args.rebuild,
+        })
+        .await?
+    {
+        Response::SandboxBuilt {
+            key,
+            reference,
+            label,
+            layers,
+            reused,
+        } => {
+            writeln!(out, "key {key}")?;
+            match reused {
+                true => writeln!(
+                    out,
+                    "nothing to build: {label} is unchanged, and {reference} is what it builds to"
+                )?,
+                false => writeln!(
+                    out,
+                    "built {label} as {reference} ({layers} layer{})",
+                    if layers == 1 { "" } else { "s" }
+                )?,
+            }
+            Ok(0)
+        }
+        Response::Error { message } => Err(crate::service::reply::failure(&message)),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+fn definition_json(yaml: &str, path: &std::path::Path) -> Result<String> {
+    let value: serde_json::Value =
+        serde_yaml::from_str(yaml).with_context(|| format!("parsing {}", path.display()))?;
+    serde_json::to_string(&value).context("normalizing the definition to json")
 }
 
 /// §8.4 has the service render what ran and this machine write where the user said, so a document nobody named is never created.
@@ -730,7 +806,10 @@ async fn prune<W: std::io::Write, E: AsyncWriteExt + Unpin>(
         }
     }
     match svc.one_shot(Request::PruneRuns).await? {
-        Response::RunsPruned { mut removed, built_images } => {
+        Response::RunsPruned {
+            mut removed,
+            built_images,
+        } => {
             removed.sort_unstable();
             for run in &removed {
                 writeln!(out, "removed sandbox {run}")?;

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -817,6 +817,9 @@ async fn prune<W: std::io::Write, E: AsyncWriteExt + Unpin>(
             if removed.is_empty() {
                 writeln!(out, "No stopped sandboxes.")?;
             }
+            for reference in &built_images {
+                writeln!(out, "removed built image {reference}")?;
+            }
             Ok(0)
         }
         Response::Error { message } => Err(crate::service::reply::failure(&message)),

--- a/crates/lns-cli/src/sandbox/mod.rs
+++ b/crates/lns-cli/src/sandbox/mod.rs
@@ -730,7 +730,7 @@ async fn prune<W: std::io::Write, E: AsyncWriteExt + Unpin>(
         }
     }
     match svc.one_shot(Request::PruneRuns).await? {
-        Response::RunsPruned { mut removed } => {
+        Response::RunsPruned { mut removed, built_images } => {
             removed.sort_unstable();
             for run in &removed {
                 writeln!(out, "removed sandbox {run}")?;

--- a/crates/lns-cli/src/service/client.rs
+++ b/crates/lns-cli/src/service/client.rs
@@ -27,6 +27,8 @@ pub trait SandboxService: Send + Sync {
     fn load_policy(&self, path: &str) -> Option<serde_json::Value>;
     /// Where a rendered document lands, created rather than opened, so a path that is already there answers `AlreadyExists` instead of being replaced.
     fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()>;
+    /// The document `-f` selects, resolved against this machine's working directory and read from it.
+    fn document(&self, file: Option<&std::path::Path>) -> Result<(PathBuf, String)>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/lns-cli/src/service/real.rs
+++ b/crates/lns-cli/src/service/real.rs
@@ -287,6 +287,14 @@ impl SandboxService for RealSandboxService {
         serde_json::to_value(&policy).ok()
     }
 
+    fn document(&self, file: Option<&std::path::Path>) -> anyhow::Result<(PathBuf, String)> {
+        let cwd = std::env::current_dir().context("reading the current directory")?;
+        let path = crate::artifact::author::selected_definition_path(file, &cwd);
+        let yaml = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        Ok((path, yaml))
+    }
+
     fn write_document(&self, path: &std::path::Path, contents: &str) -> std::io::Result<()> {
         use std::io::Write as _;
         std::fs::OpenOptions::new()

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -11,6 +11,8 @@ use crate::service::client::{BoxFuture, SandboxService};
 
 pub(crate) struct CannedService {
     response: Response,
+    /// The document this machine holds, for a verb that reads one before it asks the service.
+    document: Option<String>,
     stats_response: Option<Response>,
     inspect_image_response: Option<Response>,
     remove_image_response: Option<Response>,
@@ -24,6 +26,7 @@ impl CannedService {
     pub fn new(response: Response) -> Self {
         Self {
             response,
+            document: None,
             stats_response: None,
             inspect_image_response: None,
             remove_image_response: None,
@@ -31,6 +34,13 @@ impl CannedService {
             list_images_response: None,
             frames: Vec::new(),
             requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn holding_a_document(response: Response, document: &str) -> Self {
+        Self {
+            document: Some(document.to_string()),
+            ..Self::new(response)
         }
     }
 
@@ -183,8 +193,13 @@ impl SandboxService for CannedService {
         Ok(())
     }
 
-    fn document(&self, _file: Option<&std::path::Path>) -> anyhow::Result<(PathBuf, String)> {
-        anyhow::bail!("this test service holds no documents")
+    fn document(&self, file: Option<&std::path::Path>) -> Result<(PathBuf, String)> {
+        let path =
+            crate::artifact::author::selected_definition_path(file, std::path::Path::new("/work"));
+        match &self.document {
+            Some(yaml) => Ok((path, yaml.clone())),
+            None => bail!("reading {}; run `lns init` to scaffold one", path.display()),
+        }
     }
 }
 

--- a/crates/lns-cli/src/test_service.rs
+++ b/crates/lns-cli/src/test_service.rs
@@ -182,6 +182,10 @@ impl SandboxService for CannedService {
     fn write_document(&self, _path: &std::path::Path, _contents: &str) -> std::io::Result<()> {
         Ok(())
     }
+
+    fn document(&self, _file: Option<&std::path::Path>) -> anyhow::Result<(PathBuf, String)> {
+        anyhow::bail!("this test service holds no documents")
+    }
 }
 
 pub(crate) async fn stream_with(frames: &[Vec<u8>]) -> tokio::io::DuplexStream {

--- a/crates/lns-cli/tests/behaviours/sandbox_build.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_build.feature
@@ -1,0 +1,55 @@
+Feature: building the image a document names
+  A document's `spec.image` may name a Containerfile beside it. `lns sandbox build`
+  builds that image now, fills the build cache and publishes nothing — the CI build
+  stage, or a "does this even build" check before a push. It prints the key the build
+  is remembered under, and a build whose key this machine already answers says so and
+  runs nothing.
+
+  Scenario: a build prints the key it is remembered under and the image it produced
+    Given a document whose spec.image names a Containerfile
+    And the service builds it into 3 layers
+    When the user runs sandbox command "build"
+    Then the exit code is 0
+    And the output contains "key sha256:"
+    And the output contains "built ./image/Containerfile"
+    And the output contains "lns-build.local/built@sha256:"
+    And the output contains "3 layers"
+    And the service was asked to build "/work/lns.yaml"
+
+  Scenario: an unchanged build is a no-op that says so
+    Given a document whose spec.image names a Containerfile
+    And the service answers that the key is already built
+    When the user runs sandbox command "build"
+    Then the exit code is 0
+    And the output contains "key sha256:"
+    And the output contains "nothing to build"
+    And the output contains "./image/Containerfile is unchanged"
+
+  Scenario: --rebuild ignores the cache for this build
+    Given a document whose spec.image names a Containerfile
+    And the service builds it into 3 layers
+    When the user runs sandbox command "build --rebuild"
+    Then the exit code is 0
+    And the build request ignores the cache
+
+  Scenario: -f selects the document to build
+    Given a document whose spec.image names a Containerfile
+    And a second document "lns.dev.yaml" whose spec.image names a Containerfile
+    And the service builds it into 3 layers
+    When the user runs sandbox command "build -f lns.dev.yaml"
+    Then the exit code is 0
+    And the service was asked to build "/work/lns.dev.yaml"
+
+  Scenario: a document that is not there is named rather than guessed at
+    Given the current directory has no lns.yaml
+    When the user runs sandbox command "build"
+    Then the command fails with an exit code other than 0
+    And the output contains "lns.yaml"
+    And the service received no request
+
+  Scenario: what the service refuses is what the user reads
+    Given a document whose spec.image names a Containerfile
+    And the service refuses the build with "spec.image \"alpine:3.20\" names an image to pull"
+    When the user runs sandbox command "build"
+    Then the command fails with an exit code other than 0
+    And the output contains "names an image to pull"

--- a/crates/lns-cli/tests/behaviours/sandbox_manage.feature
+++ b/crates/lns-cli/tests/behaviours/sandbox_manage.feature
@@ -194,6 +194,14 @@ Feature: managing cached sandboxes
     And the output contains "removed sandbox hermes"
     And the output contains "removed sandbox scribe"
 
+  Scenario: prune names the built images it dropped with the sandboxes
+    Given the service will sweep the stopped sandboxes "scribe" and "hermes"
+    And the sweep also drops a built image no document and no run names
+    And the user will answer "y" to the sandbox prompt
+    When the user runs sandbox command "prune"
+    Then the exit code is 0
+    And the output contains "removed built image lns-build.local/built@sha256:"
+
   Scenario: declining the prune prompt sweeps nothing
     Given the service will sweep the stopped sandboxes "scribe" and "hermes"
     And the user will answer "n" to the sandbox prompt

--- a/crates/lns-cli/tests/behaviours/steps/mod.rs
+++ b/crates/lns-cli/tests/behaviours/steps/mod.rs
@@ -18,6 +18,7 @@ pub mod pulled_host_path_consent;
 pub mod run;
 pub mod run_config_defaults;
 pub mod sandbox_author;
+pub mod sandbox_build;
 pub mod sandbox_cli;
 pub mod sandbox_distribute;
 pub mod sandbox_inspect_cli;

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_build.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_build.rs
@@ -77,7 +77,9 @@ fn the_service_was_asked_to_build(w: &mut BehaviourWorld, path: String) -> Resul
     let expected = PathBuf::from(&path);
     let expected_dir = expected.parent().expect("the fixture path names a file");
     if dir != expected_dir.to_string_lossy() {
-        return Err(format!("the build was rooted at {dir}, not {expected_dir:?}"));
+        return Err(format!(
+            "the build was rooted at {dir}, not {expected_dir:?}"
+        ));
     }
     let value: serde_json::Value =
         serde_json::from_str(&definition).map_err(|e| format!("definition was not json: {e}"))?;

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_build.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_build.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+
+use cucumber::{given, then};
+use lns_ipc::{Request, Response};
+
+use crate::world::BehaviourWorld;
+
+const KEY: &str = "sha256:5f0b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8";
+const BUILT: &str =
+    "lns-build.local/built@sha256:761743bb0a1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c";
+
+fn document() -> String {
+    "apiVersion: lns.run/v1\nkind: sandbox\nname: agent\nspec:\n  image: ./image\n".to_string()
+}
+
+#[given("a document whose spec.image names a Containerfile")]
+fn a_document_naming_a_containerfile(w: &mut BehaviourWorld) {
+    w.author_files
+        .insert(PathBuf::from("/work/lns.yaml"), document());
+}
+
+#[given(regex = r#"^a second document "([^"]+)" whose spec\.image names a Containerfile$"#)]
+fn a_second_document(w: &mut BehaviourWorld, name: String) {
+    w.author_files
+        .insert(PathBuf::from("/work").join(name), document());
+}
+
+#[given(regex = r"^the service builds it into (\d+) layers$")]
+fn the_service_builds_it(w: &mut BehaviourWorld, layers: usize) {
+    w.sandbox.response = Some(Response::SandboxBuilt {
+        key: KEY.to_string(),
+        reference: BUILT.to_string(),
+        label: "./image/Containerfile".to_string(),
+        layers,
+        reused: false,
+    });
+}
+
+#[given("the service answers that the key is already built")]
+fn the_key_is_already_built(w: &mut BehaviourWorld) {
+    w.sandbox.response = Some(Response::SandboxBuilt {
+        key: KEY.to_string(),
+        reference: BUILT.to_string(),
+        label: "./image/Containerfile".to_string(),
+        layers: 0,
+        reused: true,
+    });
+}
+
+#[given(regex = r#"^the service refuses the build with "(.+)"$"#)]
+fn the_service_refuses(w: &mut BehaviourWorld, message: String) {
+    w.sandbox.response = Some(Response::Error {
+        message: message.replace("\\\"", "\""),
+    });
+}
+
+fn build_request(w: &BehaviourWorld) -> Result<(String, String, bool), String> {
+    w.sandbox
+        .requests
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|request| match request {
+            Request::BuildSandbox {
+                definition,
+                definition_dir,
+                rebuild,
+            } => Some((definition.clone(), definition_dir.clone(), *rebuild)),
+            _ => None,
+        })
+        .ok_or_else(|| "no build reached the service".to_string())
+}
+
+#[then(regex = r#"^the service was asked to build "([^"]+)"$"#)]
+fn the_service_was_asked_to_build(w: &mut BehaviourWorld, path: String) -> Result<(), String> {
+    let (definition, dir, _) = build_request(w)?;
+    let expected = PathBuf::from(&path);
+    let expected_dir = expected.parent().expect("the fixture path names a file");
+    if dir != expected_dir.to_string_lossy() {
+        return Err(format!("the build was rooted at {dir}, not {expected_dir:?}"));
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(&definition).map_err(|e| format!("definition was not json: {e}"))?;
+    if value["spec"]["image"] != "./image" {
+        return Err(format!("the build carried {value:?}"));
+    }
+    Ok(())
+}
+
+#[then("the build request ignores the cache")]
+fn the_build_ignores_the_cache(w: &mut BehaviourWorld) -> Result<(), String> {
+    match build_request(w)?.2 {
+        true => Ok(()),
+        false => Err("the build did not ask the service to ignore the cache".to_string()),
+    }
+}

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_cli.rs
@@ -35,6 +35,8 @@ pub(crate) struct FakeSandboxService {
     existing_documents: Vec<PathBuf>,
     unwritable_documents: Vec<PathBuf>,
     written_documents: Arc<Mutex<Vec<(PathBuf, String)>>>,
+    /// The documents this machine holds, so a verb that reads one before it asks the service can.
+    documents: std::collections::HashMap<PathBuf, String>,
 }
 
 impl SandboxService for FakeSandboxService {
@@ -88,6 +90,7 @@ impl SandboxService for FakeSandboxService {
                 .filter(|r| matches!(r, Response::RunsPruned { .. }))
                 .or(Some(Response::RunsPruned {
                     removed: Vec::new(),
+                    built_images: Vec::new(),
                 })),
             _ => self.response.clone(),
         };
@@ -124,6 +127,14 @@ impl SandboxService for FakeSandboxService {
 
     fn load_policy(&self, _path: &str) -> Option<serde_json::Value> {
         self.policy.clone()
+    }
+
+    fn document(&self, file: Option<&Path>) -> anyhow::Result<(PathBuf, String)> {
+        let path = lns_cli::artifact::author::selected_definition_path(file, Path::new("/work"));
+        let yaml = self.documents.get(&path).ok_or_else(|| {
+            anyhow::anyhow!("reading {}; run `lns init` to scaffold one", path.display())
+        })?;
+        Ok((path, yaml.clone()))
     }
 
     fn write_document(&self, path: &Path, contents: &str) -> std::io::Result<()> {
@@ -559,6 +570,7 @@ pub(crate) fn fake_sandbox_service(w: &BehaviourWorld) -> FakeSandboxService {
         existing_documents: w.sandbox.existing_documents.clone(),
         unwritable_documents: w.sandbox.unwritable_documents.clone(),
         written_documents: w.sandbox.written_documents.clone(),
+        documents: w.author_files.clone(),
     }
 }
 

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -364,6 +364,7 @@ fn service_will_sweep(w: &mut BehaviourWorld, first: String, second: String) {
     });
     w.sandbox.response = Some(Response::RunsPruned {
         removed: vec![first, second],
+        built_images: Vec::new(),
     });
 }
 
@@ -398,5 +399,6 @@ fn stopped_run(n: u32, name: &str) -> RunSummary {
 fn service_sweeps_nothing(w: &mut BehaviourWorld) {
     w.sandbox.response = Some(Response::RunsPruned {
         removed: Vec::new(),
+        built_images: Vec::new(),
     });
 }

--- a/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
+++ b/crates/lns-cli/tests/behaviours/steps/sandbox_manage.rs
@@ -368,6 +368,15 @@ fn service_will_sweep(w: &mut BehaviourWorld, first: String, second: String) {
     });
 }
 
+/// A build's images are swept with the runs, so the one command that takes a machine back to clean reports both.
+#[given("the sweep also drops a built image no document and no run names")]
+fn the_sweep_also_drops_a_built_image(w: &mut BehaviourWorld) {
+    let Some(Response::RunsPruned { built_images, .. }) = w.sandbox.response.as_mut() else {
+        panic!("this scenario stages a run prune first");
+    };
+    built_images.push(format!("lns-build.local/built@sha256:{}", "a".repeat(64)));
+}
+
 #[given("the service reports one running sandbox and none stopped")]
 fn one_running_none_stopped(w: &mut BehaviourWorld) {
     w.sandbox.list_runs_response = Some(Response::RunList {

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -1844,6 +1844,31 @@ mod tests {
                 "1a2b3c4d0000000000000000000000aa".into(),
                 "5e6f7a8b0000000000000000000000bb".into(),
             ],
+            built_images: vec![format!("lns-build.local/built@sha256:{}", "a".repeat(64))],
+        };
+        let frame = crate::encode_frame(&resp).unwrap();
+        let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, resp);
+    }
+
+    /// The verb and its answer are one exchange: the key, the image, and whether anything was built.
+    #[test]
+    fn a_sandbox_build_survives_a_request_and_response_round_trip() {
+        let req = Request::BuildSandbox {
+            definition: r#"{"spec":{"image":"./image"}}"#.into(),
+            definition_dir: "/work".into(),
+            rebuild: true,
+        };
+        let frame = crate::encode_frame(&req).unwrap();
+        let decoded: Request = crate::decode_frame(&mut &frame[..]).unwrap();
+        assert_eq!(decoded, req);
+
+        let resp = Response::SandboxBuilt {
+            key: format!("sha256:{}", "b".repeat(64)),
+            reference: format!("lns-build.local/built@sha256:{}", "c".repeat(64)),
+            label: "./image/Containerfile".into(),
+            layers: 3,
+            reused: false,
         };
         let frame = crate::encode_frame(&resp).unwrap();
         let decoded: Response = crate::decode_frame(&mut &frame[..]).unwrap();

--- a/crates/lns-ipc/src/protocol.rs
+++ b/crates/lns-ipc/src/protocol.rs
@@ -74,6 +74,15 @@ pub enum Request {
         name: String,
     },
     PruneRuns,
+    /// Build what a local document's `spec.image` names, fill the build cache and publish nothing.
+    BuildSandbox {
+        /// The document as canonical JSON, the same shape a local run sends.
+        definition: String,
+        /// The document's absolute directory, which roots the Containerfile path `spec.image` names.
+        definition_dir: String,
+        /// Ignore every key this build would otherwise answer from, and write the ones it produces.
+        rebuild: bool,
+    },
     ListVolumes,
     CreateVolume {
         name: String,
@@ -232,6 +241,20 @@ pub enum Response {
     },
     RunsPruned {
         removed: Vec<String>,
+        /// The built images the sweep dropped: the ones no document on this machine and no run named any more.
+        #[serde(default)]
+        built_images: Vec<String>,
+    },
+    /// What one `lns sandbox build` decided: the key, the image, and whether it had to build it.
+    SandboxBuilt {
+        /// The build cache key: the `FROM` digest, the Containerfile text, the context's content hash and the architecture.
+        key: String,
+        reference: String,
+        /// What `spec.image` named, as the summary prints it.
+        label: String,
+        layers: usize,
+        /// True when the key answered outright, so the build ran nothing.
+        reused: bool,
     },
     RegistryLoginStored,
     RegistryLoggedOut,

--- a/crates/lns-service/src/containerfile/cache.rs
+++ b/crates/lns-service/src/containerfile/cache.rs
@@ -1,0 +1,394 @@
+//! Where a key is remembered, and what still answers for a built image.
+//!
+//! One entry per key: the image the key produced, and the Containerfile it was produced from. The
+//! second half is what makes a sweep possible — an image nothing on this machine names any more,
+//! neither a document nor a run, is an image `lns sandbox prune` drops.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// This cache's own directory, and not `lns_ipc::build_cache_root()`, whose sweeper owns everything under it.
+pub(crate) const CACHE_DIR: &str = "containerfile-builds";
+
+/// Which of the two keys an entry answers: the whole image, or one instruction over the image before it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    Image,
+    Step,
+}
+
+impl Kind {
+    fn dir(self) -> &'static str {
+        match self {
+            Self::Image => "images",
+            Self::Step => "steps",
+        }
+    }
+}
+
+/// One remembered build: what it produced, and the file it was built from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Entry {
+    pub reference: String,
+    /// The Containerfile's absolute path, so a sweep can ask whether the document is still here.
+    pub source: String,
+}
+
+/// The cache directory as the host holds it: a key nothing answers for is absent, not an error.
+pub(crate) trait CacheFs {
+    fn read(&self, path: &Path) -> Option<Vec<u8>>;
+    fn write(&self, path: &Path, bytes: &[u8]) -> Result<()>;
+    fn remove(&self, path: &Path) -> Result<()>;
+    fn list(&self, dir: &Path) -> Vec<PathBuf>;
+    fn exists(&self, path: &Path) -> bool;
+}
+
+pub(crate) struct BuildCache<'a, F: CacheFs> {
+    fs: &'a F,
+    root: PathBuf,
+}
+
+/// What a sweep decided: the built images something still names, and the entries it dropped.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct Swept {
+    pub kept: BTreeSet<String>,
+    pub dropped: usize,
+}
+
+impl<'a, F: CacheFs> BuildCache<'a, F> {
+    pub(crate) fn new(fs: &'a F, cache_root: &Path) -> Self {
+        Self {
+            fs,
+            root: cache_root.join(CACHE_DIR),
+        }
+    }
+
+    /// What this machine built for the key, while it still holds the image the entry names.
+    pub(crate) fn get(&self, kind: Kind, key: &str, holds: &dyn Fn(&str) -> bool) -> Option<Entry> {
+        let entry = self.entry_at(&self.path(kind, key))?;
+        holds(&entry.reference).then_some(entry)
+    }
+
+    pub(crate) fn remember(&self, kind: Kind, key: &str, entry: &Entry) -> Result<()> {
+        let path = self.path(kind, key);
+        let bytes = serde_json::to_vec(entry).context("writing a build cache entry")?;
+        self.fs
+            .write(&path, &bytes)
+            .with_context(|| format!("remembering this build at {}", path.display()))
+    }
+
+    /// Every entry whose document has left this machine, or whose image has, goes; what the rest name stays.
+    pub(crate) fn sweep(&self, holds: &dyn Fn(&str) -> bool) -> Swept {
+        let mut swept = Swept::default();
+        for kind in [Kind::Image, Kind::Step] {
+            for path in self.fs.list(&self.root.join(kind.dir())) {
+                match self.entry_at(&path) {
+                    Some(entry)
+                        if self.fs.exists(Path::new(&entry.source)) && holds(&entry.reference) =>
+                    {
+                        swept.kept.insert(entry.reference);
+                    }
+                    _ => {
+                        if self.fs.remove(&path).is_ok() {
+                            swept.dropped += 1;
+                        }
+                    }
+                }
+            }
+        }
+        swept
+    }
+
+    fn entry_at(&self, path: &Path) -> Option<Entry> {
+        serde_json::from_slice(&self.fs.read(path)?).ok()
+    }
+
+    fn path(&self, kind: Kind, key: &str) -> PathBuf {
+        self.root.join(kind.dir()).join(key.replace(':', "-"))
+    }
+}
+
+/// Every built image something still answers for: a document this machine holds a build of, and a run booted from one.
+pub(crate) fn still_referenced<F: CacheFs>(
+    fs: &F,
+    cache_root: &Path,
+    runs: &[String],
+    holds: &dyn Fn(&str) -> bool,
+) -> Swept {
+    let mut swept = BuildCache::new(fs, cache_root).sweep(holds);
+    for run in runs {
+        let path = crate::cache::run_dir(cache_root, run).join(super::real::BUILT_REFERENCE_FILE);
+        if let Some(bytes) = fs.read(&path)
+            && let Ok(reference) = String::from_utf8(bytes)
+        {
+            swept.kept.insert(reference.trim().to_string());
+        }
+    }
+    swept
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+
+    /// One cache directory in memory, plus the one way each write can fail.
+    #[derive(Default)]
+    pub(crate) struct FakeCacheFs {
+        files: RefCell<BTreeMap<PathBuf, Vec<u8>>>,
+        unwritable: bool,
+        unremovable: bool,
+    }
+
+    impl FakeCacheFs {
+        fn with(files: &[(&str, &str)]) -> Self {
+            let fs = Self::default();
+            for (path, body) in files {
+                fs.files
+                    .borrow_mut()
+                    .insert(PathBuf::from(path), body.as_bytes().to_vec());
+            }
+            fs
+        }
+
+        fn paths(&self) -> Vec<String> {
+            self.files
+                .borrow()
+                .keys()
+                .map(|path| path.display().to_string())
+                .collect()
+        }
+    }
+
+    impl CacheFs for FakeCacheFs {
+        fn read(&self, path: &Path) -> Option<Vec<u8>> {
+            self.files.borrow().get(path).cloned()
+        }
+
+        fn write(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+            if self.unwritable {
+                anyhow::bail!("read-only file system");
+            }
+            self.files
+                .borrow_mut()
+                .insert(path.to_path_buf(), bytes.to_vec());
+            Ok(())
+        }
+
+        fn remove(&self, path: &Path) -> Result<()> {
+            if self.unremovable {
+                anyhow::bail!("permission denied");
+            }
+            self.files.borrow_mut().remove(path);
+            Ok(())
+        }
+
+        fn list(&self, dir: &Path) -> Vec<PathBuf> {
+            self.files
+                .borrow()
+                .keys()
+                .filter(|path| path.parent() == Some(dir))
+                .cloned()
+                .collect()
+        }
+
+        fn exists(&self, path: &Path) -> bool {
+            self.files.borrow().contains_key(path)
+        }
+    }
+
+    fn entry(reference: &str, source: &str) -> Entry {
+        Entry {
+            reference: reference.to_string(),
+            source: source.to_string(),
+        }
+    }
+
+    fn everything(_: &str) -> bool {
+        true
+    }
+
+    fn nothing(_: &str) -> bool {
+        false
+    }
+
+    #[test]
+    fn a_key_is_answered_by_what_was_remembered_for_it_and_by_nothing_else() {
+        let fs = FakeCacheFs::default();
+        let cache = BuildCache::new(&fs, Path::new("/cache"));
+        let remembered = entry("built@sha256:one", "/work/image/Containerfile");
+
+        cache
+            .remember(Kind::Image, "sha256:aa", &remembered)
+            .expect("the cache is writable");
+
+        assert_eq!(
+            cache.get(Kind::Image, "sha256:aa", &everything),
+            Some(remembered)
+        );
+        assert_eq!(cache.get(Kind::Image, "sha256:bb", &everything), None);
+        assert_eq!(
+            cache.get(Kind::Step, "sha256:aa", &everything),
+            None,
+            "an instruction key and an image key are two keys, not one",
+        );
+    }
+
+    /// The manifest cache is the image; a reference it no longer holds is a key that answers for nothing.
+    #[test]
+    fn a_key_naming_an_image_this_machine_no_longer_holds_answers_nothing() {
+        let fs = FakeCacheFs::default();
+        let cache = BuildCache::new(&fs, Path::new("/cache"));
+        cache
+            .remember(
+                Kind::Step,
+                "sha256:aa",
+                &entry("built@sha256:gone", "/work/Containerfile"),
+            )
+            .unwrap();
+
+        assert_eq!(cache.get(Kind::Step, "sha256:aa", &nothing), None);
+    }
+
+    #[test]
+    fn an_entry_that_does_not_parse_answers_nothing_and_is_swept() {
+        let fs = FakeCacheFs::with(&[("/cache/containerfile-builds/images/sha256-aa", "{")]);
+        let cache = BuildCache::new(&fs, Path::new("/cache"));
+
+        assert_eq!(cache.get(Kind::Image, "sha256:aa", &everything), None);
+        assert_eq!(cache.sweep(&everything).dropped, 1);
+        assert!(fs.paths().is_empty());
+    }
+
+    #[test]
+    fn a_cache_that_cannot_be_written_names_the_entry_it_could_not_write() {
+        let fs = FakeCacheFs {
+            unwritable: true,
+            ..FakeCacheFs::default()
+        };
+        let refusal = format!(
+            "{:#}",
+            BuildCache::new(&fs, Path::new("/cache"))
+                .remember(
+                    Kind::Image,
+                    "sha256:aa",
+                    &entry("built@sha256:one", "/work/Containerfile")
+                )
+                .expect_err("an unwritable cache is reported")
+        );
+
+        assert!(
+            refusal.contains("containerfile-builds/images/sha256-aa"),
+            "{refusal}"
+        );
+        assert!(refusal.contains("read-only file system"), "{refusal}");
+    }
+
+    #[test]
+    fn an_entry_the_sweep_cannot_remove_is_not_counted_as_dropped() {
+        let fs = FakeCacheFs {
+            unremovable: true,
+            ..FakeCacheFs::with(&[("/cache/containerfile-builds/images/sha256-aa", "{")])
+        };
+
+        assert_eq!(
+            BuildCache::new(&fs, Path::new("/cache"))
+                .sweep(&everything)
+                .dropped,
+            0
+        );
+    }
+
+    fn populated() -> FakeCacheFs {
+        let fs = FakeCacheFs::default();
+        let cache = BuildCache::new(&fs, Path::new("/cache"));
+        cache
+            .remember(
+                Kind::Image,
+                "sha256:kept",
+                &entry("built@sha256:image", "/work/image/Containerfile"),
+            )
+            .unwrap();
+        cache
+            .remember(
+                Kind::Step,
+                "sha256:step",
+                &entry("built@sha256:step", "/work/image/Containerfile"),
+            )
+            .unwrap();
+        cache
+            .remember(
+                Kind::Image,
+                "sha256:orphan",
+                &entry("built@sha256:orphan", "/gone/image/Containerfile"),
+            )
+            .unwrap();
+        fs.write(Path::new("/work/image/Containerfile"), b"FROM base\n")
+            .unwrap();
+        fs
+    }
+
+    #[test]
+    fn a_build_whose_document_left_this_machine_is_dropped_and_its_image_is_named_by_nothing() {
+        let fs = populated();
+
+        let swept = BuildCache::new(&fs, Path::new("/cache")).sweep(&everything);
+
+        assert_eq!(swept.dropped, 1);
+        assert_eq!(
+            swept.kept,
+            BTreeSet::from([
+                "built@sha256:image".to_string(),
+                "built@sha256:step".to_string(),
+            ]),
+            "the intermediates of a document that is still here are still named by it",
+        );
+        assert!(
+            !fs.paths()
+                .iter()
+                .any(|path| path.ends_with("images/sha256-orphan")),
+            "{:?}",
+            fs.paths(),
+        );
+    }
+
+    #[test]
+    fn a_run_booted_from_a_built_image_names_it_even_when_no_document_does() {
+        let fs = FakeCacheFs::with(&[("/cache/runs/run-1/built-image", "built@sha256:booted\n")]);
+
+        let swept = still_referenced(&fs, Path::new("/cache"), &["run-1".into()], &everything);
+
+        assert_eq!(
+            swept.kept,
+            BTreeSet::from(["built@sha256:booted".to_string()])
+        );
+    }
+
+    #[test]
+    fn a_run_that_booted_no_built_image_names_none() {
+        let fs = populated();
+
+        let swept = still_referenced(
+            &fs,
+            Path::new("/cache"),
+            &["run-1".into(), "run-2".into()],
+            &everything,
+        );
+
+        assert_eq!(swept.kept.len(), 2);
+    }
+
+    #[test]
+    fn nothing_survives_a_sweep_once_the_manifests_are_gone() {
+        let fs = populated();
+
+        let swept = BuildCache::new(&fs, Path::new("/cache")).sweep(&nothing);
+
+        assert!(swept.kept.is_empty());
+        assert_eq!(swept.dropped, 3);
+    }
+}

--- a/crates/lns-service/src/containerfile/cache.rs
+++ b/crates/lns-service/src/containerfile/cache.rs
@@ -347,12 +347,12 @@ pub(crate) mod tests {
             ]),
             "the intermediates of a document that is still here are still named by it",
         );
+        let left = fs.paths();
         assert!(
-            !fs.paths()
+            !left
                 .iter()
                 .any(|path| path.ends_with("images/sha256-orphan")),
-            "{:?}",
-            fs.paths(),
+            "{left:?}"
         );
     }
 

--- a/crates/lns-service/src/containerfile/context.rs
+++ b/crates/lns-service/src/containerfile/context.rs
@@ -280,17 +280,17 @@ pub(crate) mod tests {
             self
         }
 
-        fn unreadable_bytes(&mut self, path: &str) -> &mut Self {
+        pub(crate) fn unreadable_bytes(&mut self, path: &str) -> &mut Self {
             self.unreadable_bytes = Some(format!("/ctx/{path}"));
             self
         }
 
-        fn unreadable_link(&mut self, path: &str) -> &mut Self {
+        pub(crate) fn unreadable_link(&mut self, path: &str) -> &mut Self {
             self.unreadable_link = Some(format!("/ctx/{path}"));
             self
         }
 
-        fn ghost(&mut self, dir: &str, name: &str) -> &mut Self {
+        pub(crate) fn ghost(&mut self, dir: &str, name: &str) -> &mut Self {
             self.ghost = Some((format!("/ctx/{dir}"), name.to_string()));
             self
         }

--- a/crates/lns-service/src/containerfile/executor.rs
+++ b/crates/lns-service/src/containerfile/executor.rs
@@ -6,7 +6,9 @@
 
 use anyhow::{Context, Result, bail};
 
+use super::cache::Kind;
 use super::exclude::only_the_workloads_writes;
+use super::key;
 use super::parse::{Command, Containerfile, HereDoc, InstructionKind, Transfer};
 use super::upper::ChangeSet;
 
@@ -82,7 +84,8 @@ pub(crate) struct Base {
     pub env: Vec<(String, String)>,
 }
 
-/// What the loop needs of the world: a registry, a build guest, the build context, and the local store.
+/// What the loop needs of the world: a registry, a build guest, the build context, the local store,
+/// and what this machine built for a key it has seen before.
 pub(crate) trait BuildHost {
     /// The digest-pinned reference the `FROM` resolved to, pulled so the build can stand on its config.
     async fn resolve_base(&self, image: &str) -> Result<Base>;
@@ -91,12 +94,31 @@ pub(crate) trait BuildHost {
     async fn holds_a_directory_at(&self, parent: &str, path: &str) -> Result<bool>;
     async fn copy(&self, step: &CopyStep) -> Result<ChangeSet>;
     async fn commit(&self, commit: &Commit<'_>) -> Result<String>;
+    /// The image this machine built for the key and still holds, if it built one.
+    async fn cached(&self, kind: Kind, key: &str) -> Option<String>;
+    async fn remember(&self, kind: Kind, key: &str, reference: &str);
+}
+
+/// What one build is asked for: the file, the bytes behind it, and whether the cache may answer.
+pub(crate) struct BuildPlan<'a> {
+    pub file: &'a Containerfile,
+    /// The Containerfile as it was written, comments and all — the key measures the file, not the parse.
+    pub text: &'a str,
+    pub context_hash: &'a str,
+    pub arch: &'a str,
+    pub rebuild: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Built {
     pub reference: String,
     pub layers: usize,
+    /// The image key, which names this build wherever it is reported.
+    pub key: String,
+    /// True when the key answered outright, so nothing was run and nothing was committed.
+    pub reused: bool,
+    /// How many leading instructions stood on an image this machine already had.
+    pub reused_steps: usize,
 }
 
 /// What the instructions have decided so far: the image to stand on, the scopes a `RUN` is given, and the config the next commit writes.
@@ -112,11 +134,14 @@ struct Build {
     workdir: String,
     shell: Vec<String>,
     layers: usize,
+    /// A build the user asked to rebuild reads no key, and still writes every one it produces.
+    rebuild: bool,
+    reused_steps: usize,
 }
 
-pub(crate) async fn build<H: BuildHost>(host: &H, file: &Containerfile) -> Result<Built> {
+pub(crate) async fn build<H: BuildHost>(host: &H, plan: &BuildPlan<'_>) -> Result<Built> {
     let mut global_args = Vec::new();
-    let mut instructions = file.instructions.iter();
+    let mut instructions = plan.file.instructions.iter();
     let from = loop {
         let Some(instruction) = instructions.next() else {
             bail!(
@@ -145,6 +170,19 @@ pub(crate) async fn build<H: BuildHost>(host: &H, file: &Containerfile) -> Resul
         .await
         .with_context(|| format!("line {line}: FROM {image}"))?;
 
+    let key = key::image_key(&base.reference, plan.text, plan.context_hash, plan.arch);
+    if !plan.rebuild
+        && let Some(reference) = host.cached(Kind::Image, &key).await
+    {
+        return Ok(Built {
+            reference,
+            layers: 0,
+            key,
+            reused: true,
+            reused_steps: plan.file.instructions.len(),
+        });
+    }
+
     let mut build = Build {
         parent: base.reference,
         base_env: base.env,
@@ -155,6 +193,8 @@ pub(crate) async fn build<H: BuildHost>(host: &H, file: &Containerfile) -> Resul
         workdir: DEFAULT_WORKDIR.to_string(),
         shell: DEFAULT_SHELL.map(str::to_string).to_vec(),
         layers: 0,
+        rebuild: plan.rebuild,
+        reused_steps: 0,
     };
     for instruction in instructions {
         let created_by = label(&instruction.kind);
@@ -162,9 +202,13 @@ pub(crate) async fn build<H: BuildHost>(host: &H, file: &Containerfile) -> Resul
             .await
             .with_context(|| format!("line {}: {created_by}", instruction.line))?;
     }
+    host.remember(Kind::Image, &key, &build.parent).await;
     Ok(Built {
         reference: build.parent,
         layers: build.layers,
+        key,
+        reused: false,
+        reused_steps: build.reused_steps,
     })
 }
 
@@ -183,7 +227,12 @@ async fn step<H: BuildHost>(
             return Ok(());
         }
         InstructionKind::Run { command, here_docs } => {
-            let outcome = host.run(&run_step(build, line, command, here_docs)).await?;
+            let step = run_step(build, line, command, here_docs);
+            let key = key::run_key(&build.parent, &step);
+            if reuse(host, build, &key, true).await {
+                return Ok(());
+            }
+            let outcome = host.run(&step).await?;
             let (changes, dropped) =
                 only_the_workloads_writes(outcome.changes, &outcome.fileset_paths);
             if dropped.total() > 0 {
@@ -193,12 +242,18 @@ async fn step<H: BuildHost>(
                     "the captured layer drops what this boot wrote for the guest",
                 );
             }
-            return commit(host, build, Some(&changes), kind).await;
+            return commit(host, build, Some(&changes), kind, &key).await;
         }
+        // The copied bytes are half of this instruction's key, so the context is read before the
+        // cache is asked; reading it costs no guest.
         InstructionKind::Copy(transfer) | InstructionKind::Add(transfer) => {
             let step = copy_step(host, build, line, transfer).await?;
             let changes = host.copy(&step).await?;
-            return commit(host, build, Some(&changes), kind).await;
+            let key = key::transfer_key(&build.parent, &label(kind), &changes);
+            if reuse(host, build, &key, true).await {
+                return Ok(());
+            }
+            return commit(host, build, Some(&changes), kind, &key).await;
         }
         InstructionKind::Env(pairs) => {
             for (key, value) in pairs {
@@ -247,7 +302,27 @@ async fn step<H: BuildHost>(
             }
         }
     }
-    commit(host, build, None, kind).await
+    let key = key::config_key(&build.parent, &label(kind), &build.config);
+    if reuse(host, build, &key, false).await {
+        return Ok(());
+    }
+    commit(host, build, None, kind, &key).await
+}
+
+/// A step this machine already has stands where the build was going to run one, and the build goes on from it.
+async fn reuse<H: BuildHost>(host: &H, build: &mut Build, key: &str, layer: bool) -> bool {
+    if build.rebuild {
+        return false;
+    }
+    let Some(reference) = host.cached(Kind::Step, key).await else {
+        return false;
+    };
+    build.parent = reference;
+    build.reused_steps += 1;
+    if layer {
+        build.layers += 1;
+    }
+    true
 }
 
 async fn commit<H: BuildHost>(
@@ -255,6 +330,7 @@ async fn commit<H: BuildHost>(
     build: &mut Build,
     layer: Option<&ChangeSet>,
     kind: &InstructionKind,
+    key: &str,
 ) -> Result<()> {
     build.parent = host
         .commit(&Commit {
@@ -264,6 +340,7 @@ async fn commit<H: BuildHost>(
             created_by: &label(kind),
         })
         .await?;
+    host.remember(Kind::Step, key, &build.parent).await;
     if layer.is_some() {
         build.layers += 1;
     }
@@ -579,6 +656,10 @@ mod tests {
     struct FakeHost {
         calls: Mutex<Vec<Call>>,
         commits: Mutex<usize>,
+        /// What this machine remembers, which survives from one build to the next of the same host.
+        remembered: Mutex<std::collections::BTreeMap<(String, String), String>>,
+        /// What the context answers a COPY with, so a test can edit a file between two builds.
+        copied_bytes: Mutex<Vec<u8>>,
         wrote: Mutex<Option<ChangeSet>>,
         fileset_paths: Vec<String>,
         base_env: Vec<(String, String)>,
@@ -593,7 +674,10 @@ mod tests {
 
     impl FakeHost {
         fn new() -> Self {
-            Self::default()
+            Self {
+                copied_bytes: Mutex::new(b"context\n".to_vec()),
+                ..Self::default()
+            }
         }
 
         /// What every RUN's guest leaves in its upper, so one build can be read as one change set.
@@ -727,7 +811,7 @@ mod tests {
                     mode: 0o644,
                     uid: 0,
                     gid: 0,
-                    bytes: b"context\n".to_vec(),
+                    bytes: self.copied_bytes.lock().unwrap().clone(),
                 }],
             })
         }
@@ -746,22 +830,49 @@ mod tests {
             });
             Ok(format!("lns-build.local/built@sha256:step{committed}"))
         }
+
+        async fn cached(&self, kind: Kind, key: &str) -> Option<String> {
+            self.remembered
+                .lock()
+                .unwrap()
+                .get(&(format!("{kind:?}"), key.to_string()))
+                .cloned()
+        }
+
+        async fn remember(&self, kind: Kind, key: &str, reference: &str) {
+            self.remembered.lock().unwrap().insert(
+                (format!("{kind:?}"), key.to_string()),
+                reference.to_string(),
+            );
+        }
     }
 
     fn containerfile(text: &str) -> crate::containerfile::parse::Containerfile {
         parse(text).expect("the subset accepts this file")
     }
 
+    fn plan<'a>(file: &'a Containerfile, text: &'a str) -> BuildPlan<'a> {
+        BuildPlan {
+            file,
+            text,
+            context_hash: "sha256:context",
+            arch: "arm64",
+            rebuild: false,
+        }
+    }
+
     async fn built(host: &FakeHost, text: &str) -> Built {
-        build(host, &containerfile(text))
+        let file = containerfile(text);
+        build(host, &plan(&file, text))
             .await
             .expect("this Containerfile builds")
     }
 
     async fn refused(host: &FakeHost, text: &str) -> String {
+        let file = containerfile(text);
         format!(
             "{:#}",
-            build(host, &containerfile(text))
+            build(host, &plan(&file, text))
                 .await
                 .expect_err("this Containerfile must stop the build")
         )
@@ -1467,7 +1578,7 @@ mod tests {
             ],
         };
 
-        let refusal = format!("{:#}", build(&host, &file).await.unwrap_err());
+        let refusal = format!("{:#}", build(&host, &plan(&file, "")).await.unwrap_err());
         assert!(refusal.contains("line 1"), "{refusal}");
         assert!(refusal.contains("RUN echo hi"), "{refusal}");
         assert!(refusal.contains("FROM"), "{refusal}");
@@ -1494,7 +1605,7 @@ mod tests {
             }],
         };
 
-        let refusal = format!("{:#}", build(&host, &file).await.unwrap_err());
+        let refusal = format!("{:#}", build(&host, &plan(&file, "")).await.unwrap_err());
         assert!(refusal.contains("FROM"), "{refusal}");
         assert!(parse("# nothing but a comment\n").is_err());
     }
@@ -1519,7 +1630,7 @@ mod tests {
             ],
         };
 
-        let refusal = format!("{:#}", build(&host, &file).await.unwrap_err());
+        let refusal = format!("{:#}", build(&host, &plan(&file, "")).await.unwrap_err());
         assert!(refusal.contains("line 2"), "{refusal}");
         assert!(refusal.contains("a second FROM"), "{refusal}");
         assert!(
@@ -1576,5 +1687,168 @@ mod tests {
         assert!(refusal.contains("line 2"), "{refusal}");
         assert!(refusal.contains("ENV MODE=research"), "{refusal}");
         assert!(refusal.contains("layer cache"), "{refusal}");
+    }
+
+    /// The whole image answers for the key, so a second build of an untouched document boots no
+    /// guest, commits nothing and says it did neither.
+    #[tokio::test]
+    async fn a_second_build_of_an_unchanged_containerfile_runs_nothing_at_all() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nRUN echo one\nUSER node\n";
+        let first = built(&host, text).await;
+
+        let second = built(&host, text).await;
+
+        assert_eq!(second.reference, first.reference);
+        assert_eq!(second.key, first.key);
+        assert!(second.reused, "an unchanged build is a no-op");
+        assert_eq!(host.runs().len(), 1, "the second build boots no guest");
+        assert_eq!(host.commits().len(), 2, "the second build commits nothing");
+    }
+
+    #[tokio::test]
+    async fn a_build_reuses_every_leading_step_and_rebuilds_from_the_first_that_differs() {
+        let host = FakeHost::new();
+        built(
+            &host,
+            "FROM alpine\nRUN echo one\nRUN echo two\nRUN echo three\n",
+        )
+        .await;
+
+        let again = built(
+            &host,
+            "FROM alpine\nRUN echo one\nRUN echo changed\nRUN echo three\n",
+        )
+        .await;
+
+        let commands: Vec<String> = host
+            .runs()
+            .into_iter()
+            .map(|step| step.argv.join(" "))
+            .collect();
+        assert_eq!(
+            commands,
+            [
+                "/bin/sh -c echo one",
+                "/bin/sh -c echo two",
+                "/bin/sh -c echo three",
+                "/bin/sh -c echo changed",
+                "/bin/sh -c echo three",
+            ],
+            "only the first RUN is reused; the one that changed and the one after it run again",
+        );
+        assert_eq!(again.reused_steps, 1);
+        assert_eq!(
+            again.layers, 3,
+            "a reused step still put a layer in the image"
+        );
+        assert!(!again.reused);
+    }
+
+    /// An `ARG` commits nothing, so the image the next `RUN` stands on is the same one, and the
+    /// line is the same line; only the environment the command resolves against tells them apart.
+    #[tokio::test]
+    async fn an_arg_the_run_reads_makes_it_a_different_step_although_the_line_is_unchanged() {
+        let host = FakeHost::new();
+        built(&host, "FROM alpine\nARG V=1\nRUN install agent@$V\n").await;
+
+        let again = built(&host, "FROM alpine\nARG V=2\nRUN install agent@$V\n").await;
+
+        let envs: Vec<Vec<String>> = host.runs().into_iter().map(|step| step.env).collect();
+        assert_eq!(envs, [[String::from("V=1")], [String::from("V=2")]]);
+        assert_eq!(
+            again.reused_steps, 0,
+            "the second RUN reaches the guest, because the value it reads is not the first one",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_copy_whose_file_changed_is_a_different_step_although_the_instruction_is_the_same() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nCOPY app /srv/app\nRUN echo after\n";
+        let file = containerfile(text);
+        build(&host, &plan(&file, text)).await.unwrap();
+        let before = host.commits().len();
+        *host.copied_bytes.lock().unwrap() = b"edited\n".to_vec();
+
+        let again = build(
+            &host,
+            &BuildPlan {
+                context_hash: "sha256:edited",
+                ..plan(&file, text)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            again.reused_steps, 0,
+            "the copy's own bytes are half of its key, so it is not the step it was",
+        );
+        assert_eq!(
+            host.commits().len(),
+            before + 2,
+            "the copy and the instruction after it are both committed again",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rebuild_reads_no_key_and_still_writes_every_one_it_produces() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nRUN echo one\n";
+        built(&host, text).await;
+
+        let file = containerfile(text);
+        let forced = build(
+            &host,
+            &BuildPlan {
+                rebuild: true,
+                ..plan(&file, text)
+            },
+        )
+        .await
+        .expect("a forced build builds");
+
+        assert!(!forced.reused);
+        assert_eq!(host.runs().len(), 2, "--rebuild boots the guest again");
+        assert_eq!(
+            built(&host, text).await.reference,
+            forced.reference,
+            "the build it forced is the one the next build finds",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_build_whose_context_changed_is_a_different_image_although_the_file_is_the_same() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nRUN echo one\n";
+        let file = containerfile(text);
+        let first = build(&host, &plan(&file, text)).await.unwrap();
+
+        let second = build(
+            &host,
+            &BuildPlan {
+                context_hash: "sha256:edited",
+                ..plan(&file, text)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(second.key, first.key);
+        assert!(!second.reused);
+    }
+
+    #[tokio::test]
+    async fn the_key_a_build_reports_is_the_one_the_next_build_of_it_answers() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nUSER node\n";
+        let key = built(&host, text).await.key;
+
+        assert!(key.starts_with("sha256:"), "{key}");
+        assert_eq!(
+            host.cached(Kind::Image, &key).await.as_deref(),
+            Some("lns-build.local/built@sha256:step1"),
+        );
     }
 }

--- a/crates/lns-service/src/containerfile/executor.rs
+++ b/crates/lns-service/src/containerfile/executor.rs
@@ -185,15 +185,15 @@ pub(crate) async fn build<H: BuildHost>(host: &H, plan: &BuildPlan<'_>) -> Resul
         });
     }
 
+    let ignoring = match plan.rebuild {
+        true => ", ignoring the cache",
+        false => "",
+    };
+    let count = plan.file.instructions.len();
     crate::log::info!(
         "Building",
-        "{} ({} instructions){}",
-        plan.label,
-        plan.file.instructions.len(),
-        match plan.rebuild {
-            true => ", ignoring the cache",
-            false => "",
-        },
+        "{} ({count} instructions){ignoring}",
+        plan.label
     );
     let mut build = Build {
         parent: base.reference,
@@ -1802,6 +1802,48 @@ mod tests {
             host.commits().len(),
             before + 2,
             "the copy and the instruction after it are both committed again",
+        );
+    }
+
+    /// A comment above the instructions is a different file and so a different image, and every
+    /// instruction is still the instruction it was: the build commits a new image and runs nothing.
+    #[tokio::test]
+    async fn a_containerfile_whose_instructions_are_unchanged_reuses_every_step_of_them() {
+        let host = FakeHost::new();
+        let text = "FROM alpine\nRUN echo one\nCOPY app /srv/app\nUSER node\n";
+        let file = containerfile(text);
+        build(&host, &plan(&file, text)).await.unwrap();
+        let runs = host.runs().len();
+        let commits = host.commits().len();
+
+        let again = build(
+            &host,
+            &plan(&file, "# what this image is for\nFROM alpine\nRUN echo one\nCOPY app /srv/app\nUSER node\n"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            again.reused_steps, 3,
+            "every instruction stands where it stood"
+        );
+        assert_eq!(
+            again.layers, 2,
+            "the two reused steps still put their layers in the image"
+        );
+        assert!(
+            !again.reused,
+            "the image key is a new one, so the image is remembered again"
+        );
+        assert_eq!(
+            host.runs().len(),
+            runs,
+            "no guest boots for a step a key answers"
+        );
+        assert_eq!(
+            host.commits().len(),
+            commits,
+            "and nothing is committed twice"
         );
     }
 

--- a/crates/lns-service/src/containerfile/executor.rs
+++ b/crates/lns-service/src/containerfile/executor.rs
@@ -102,6 +102,8 @@ pub(crate) trait BuildHost {
 /// What one build is asked for: the file, the bytes behind it, and whether the cache may answer.
 pub(crate) struct BuildPlan<'a> {
     pub file: &'a Containerfile,
+    /// What `spec.image` named, as every line about this build spells it.
+    pub label: &'a str,
     /// The Containerfile as it was written, comments and all — the key measures the file, not the parse.
     pub text: &'a str,
     pub context_hash: &'a str,
@@ -183,6 +185,16 @@ pub(crate) async fn build<H: BuildHost>(host: &H, plan: &BuildPlan<'_>) -> Resul
         });
     }
 
+    crate::log::info!(
+        "Building",
+        "{} ({} instructions){}",
+        plan.label,
+        plan.file.instructions.len(),
+        match plan.rebuild {
+            true => ", ignoring the cache",
+            false => "",
+        },
+    );
     let mut build = Build {
         parent: base.reference,
         base_env: base.env,
@@ -854,6 +866,7 @@ mod tests {
     fn plan<'a>(file: &'a Containerfile, text: &'a str) -> BuildPlan<'a> {
         BuildPlan {
             file,
+            label: "./image/Containerfile",
             text,
             context_hash: "sha256:context",
             arch: "arm64",

--- a/crates/lns-service/src/containerfile/key.rs
+++ b/crates/lns-service/src/containerfile/key.rs
@@ -368,6 +368,46 @@ mod tests {
         assert!(refusal.contains("/ctx/app.js"), "{refusal}");
     }
 
+    /// A file the directory lists and nothing answers for left between the two reads; the context
+    /// it describes is the one that is there, and the hash is of that.
+    #[test]
+    fn a_file_that_left_the_context_between_the_listing_and_the_read_is_not_in_the_hash() {
+        let mut context = one_file(b"one\n", 0o644);
+        context.dir("skills", 0o755).ghost("skills", "vanished.js");
+
+        let mut without = one_file(b"one\n", 0o644);
+        without.dir("skills", 0o755);
+        assert_eq!(hashed(&context), hashed(&without));
+    }
+
+    #[test]
+    fn a_context_file_whose_bytes_will_not_read_stops_the_build_naming_it() {
+        let mut context = one_file(b"one\n", 0o644);
+        context.unreadable_bytes("app.js");
+
+        let refusal = format!(
+            "{:#}",
+            context_hash(&context, Path::new("/ctx")).expect_err("an unreadable file is refused")
+        );
+
+        assert!(refusal.contains("/ctx/app.js"), "{refusal}");
+    }
+
+    #[test]
+    fn a_context_symlink_whose_target_will_not_read_stops_the_build_naming_it() {
+        let mut context = FakeContext::new();
+        context.symlink("main", "app.js");
+        context.unreadable_link("main");
+
+        let refusal = format!(
+            "{:#}",
+            context_hash(&context, Path::new("/ctx"))
+                .expect_err("an unreadable symlink is refused")
+        );
+
+        assert!(refusal.contains("/ctx/main"), "{refusal}");
+    }
+
     #[test]
     fn a_context_directory_that_will_not_list_stops_the_build_naming_it() {
         let mut context = one_file(b"one\n", 0o644);

--- a/crates/lns-service/src/containerfile/key.rs
+++ b/crates/lns-service/src/containerfile/key.rs
@@ -1,0 +1,227 @@
+//! What a build is keyed by: slice 4 of lensapp/lens-sandbox#393.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::containerfile::context::tests::FakeContext;
+    use crate::containerfile::upper::{Change, ChangeSet};
+    use std::path::Path;
+
+    fn hashed(context: &FakeContext) -> String {
+        context_hash(context, Path::new("/ctx")).expect("this context reads")
+    }
+
+    fn one_file(bytes: &[u8], mode: u32) -> FakeContext {
+        let mut context = FakeContext::new();
+        context.file("app.js", mode, bytes);
+        context
+    }
+
+    #[test]
+    fn the_from_digest_the_text_the_context_and_the_architecture_each_change_the_image_key() {
+        let key = image_key("base@sha256:aa", "FROM base\n", "sha256:ctx", "arm64");
+
+        assert_eq!(
+            key,
+            image_key("base@sha256:aa", "FROM base\n", "sha256:ctx", "arm64"),
+            "the same four inputs are the same image, so they are the same key",
+        );
+        for other in [
+            image_key("base@sha256:bb", "FROM base\n", "sha256:ctx", "arm64"),
+            image_key("base@sha256:aa", "FROM base\nRUN true\n", "sha256:ctx", "arm64"),
+            image_key("base@sha256:aa", "FROM base\n", "sha256:other", "arm64"),
+            image_key("base@sha256:aa", "FROM base\n", "sha256:ctx", "amd64"),
+        ] {
+            assert_ne!(key, other);
+        }
+    }
+
+    /// The key measures the file, not what the parser made of it, so a comment nobody executes still
+    /// decides the key — a build that reused across it would be a build nobody could explain.
+    #[test]
+    fn the_same_containerfile_with_different_whitespace_in_a_comment_is_a_different_text_and_so_a_different_key()
+     {
+        let one = image_key("base@sha256:aa", "# build the agent\nFROM base\n", "c", "arm64");
+        let other = image_key("base@sha256:aa", "#  build the agent\nFROM base\n", "c", "arm64");
+
+        assert_ne!(one, other);
+    }
+
+    #[test]
+    fn a_key_names_the_algorithm_that_made_it() {
+        for key in [
+            image_key("b", "t", "c", "arm64"),
+            step_key("parent", "RUN true", None),
+            hashed(&one_file(b"one\n", 0o644)),
+        ] {
+            assert!(key.starts_with("sha256:"), "{key}");
+            assert_eq!(key.len(), "sha256:".len() + 64, "{key}");
+        }
+    }
+
+    /// A context file rewritten with the bytes it already had is the same context: the key reads
+    /// content, and nothing a `touch` changes reaches it.
+    #[test]
+    fn a_touched_but_identical_context_file_is_the_same_key() {
+        let mut context = one_file(b"console.log(1)\n", 0o644);
+        let before = hashed(&context);
+
+        context.file("app.js", 0o644, b"console.log(1)\n");
+
+        assert_eq!(hashed(&context), before);
+    }
+
+    #[test]
+    fn the_content_the_name_and_the_mode_of_a_context_file_each_change_the_context_hash() {
+        let before = hashed(&one_file(b"one\n", 0o644));
+
+        assert_ne!(hashed(&one_file(b"two\n", 0o644)), before);
+        assert_ne!(hashed(&one_file(b"one\n", 0o755)), before);
+        let mut renamed = FakeContext::new();
+        renamed.file("other.js", 0o644, b"one\n");
+        assert_ne!(hashed(&renamed), before);
+    }
+
+    #[test]
+    fn a_file_added_beside_the_containerfile_changes_the_context_hash() {
+        let mut context = FakeContext::new();
+        context.file("Containerfile", 0o644, b"FROM base\n");
+        let before = hashed(&context);
+
+        context.file("skills/prompt.md", 0o644, b"be brief\n");
+
+        assert_ne!(hashed(&context), before);
+    }
+
+    #[test]
+    fn a_context_symlink_hashes_the_target_it_names_and_not_what_it_points_at() {
+        let mut one = FakeContext::new();
+        one.file("app.js", 0o644, b"one\n").symlink("main", "app.js");
+        let mut other = FakeContext::new();
+        other
+            .file("app.js", 0o644, b"one\n")
+            .symlink("main", "other.js");
+
+        assert_ne!(hashed(&one), hashed(&other));
+    }
+
+    #[test]
+    fn a_directory_the_context_holds_is_part_of_the_hash_even_when_it_is_empty() {
+        let mut context = FakeContext::new();
+        context.file("app.js", 0o644, b"one\n");
+        let before = hashed(&context);
+
+        context.dir("cache", 0o755);
+
+        assert_ne!(hashed(&context), before);
+    }
+
+    #[test]
+    fn a_context_the_host_cannot_read_stops_the_build_naming_what_it_could_not_read() {
+        let mut context = one_file(b"one\n", 0o644);
+        context.unreadable = Some("/ctx/app.js".into());
+
+        let refusal = format!(
+            "{:#}",
+            context_hash(&context, Path::new("/ctx")).expect_err("an unreadable context is refused")
+        );
+
+        assert!(refusal.contains("permission denied"), "{refusal}");
+        assert!(refusal.contains("/ctx/app.js"), "{refusal}");
+    }
+
+    #[test]
+    fn a_context_directory_that_will_not_list_stops_the_build_naming_it() {
+        let mut context = one_file(b"one\n", 0o644);
+        context.unlistable("");
+
+        let refusal = format!(
+            "{:#}",
+            context_hash(&context, Path::new("/ctx")).expect_err("a context that will not list is refused")
+        );
+
+        assert!(refusal.contains("/ctx"), "{refusal}");
+    }
+
+    #[test]
+    fn the_parent_the_instruction_and_the_copied_content_each_change_the_instruction_key() {
+        let key = step_key("built@sha256:parent", "COPY app /srv", Some("sha256:copied"));
+
+        assert_eq!(
+            key,
+            step_key("built@sha256:parent", "COPY app /srv", Some("sha256:copied")),
+        );
+        for other in [
+            step_key("built@sha256:other", "COPY app /srv", Some("sha256:copied")),
+            step_key("built@sha256:parent", "COPY app /opt", Some("sha256:copied")),
+            step_key("built@sha256:parent", "COPY app /srv", Some("sha256:edited")),
+            step_key("built@sha256:parent", "COPY app /srv", None),
+        ] {
+            assert_ne!(key, other);
+        }
+    }
+
+    /// A `RUN` has no copied content, and the key must not confuse "nothing copied" with a copy of
+    /// nothing — otherwise an empty `COPY` and the `RUN` beside it would share one entry.
+    #[test]
+    fn an_instruction_that_copies_nothing_is_keyed_apart_from_one_that_copies_an_empty_set() {
+        assert_ne!(
+            step_key("parent", "RUN true", None),
+            step_key("parent", "RUN true", Some(&changes_hash(&ChangeSet::default()))),
+        );
+    }
+
+    #[test]
+    fn the_copied_content_hash_follows_the_bytes_the_paths_and_the_modes() {
+        let copied = |path: &str, mode: u32, bytes: &[u8]| {
+            changes_hash(&ChangeSet {
+                changes: vec![Change::Regular {
+                    path: path.into(),
+                    mode,
+                    uid: 0,
+                    gid: 0,
+                    bytes: bytes.to_vec(),
+                }],
+            })
+        };
+        let before = copied("srv/app", 0o644, b"one\n");
+
+        assert_eq!(copied("srv/app", 0o644, b"one\n"), before);
+        assert_ne!(copied("srv/app", 0o644, b"two\n"), before);
+        assert_ne!(copied("srv/other", 0o644, b"one\n"), before);
+        assert_ne!(copied("srv/app", 0o755, b"one\n"), before);
+    }
+
+    #[test]
+    fn every_kind_of_copied_entry_reaches_the_content_hash() {
+        let one = ChangeSet {
+            changes: vec![
+                Change::Directory {
+                    path: "srv".into(),
+                    mode: 0o755,
+                    uid: 0,
+                    gid: 0,
+                },
+                Change::Symlink {
+                    path: "srv/main".into(),
+                    target: "app".into(),
+                    uid: 0,
+                    gid: 0,
+                },
+                Change::Removed {
+                    path: "srv/old".into(),
+                },
+            ],
+        };
+        let mut other = one.clone();
+        other.changes[1] = Change::Symlink {
+            path: "srv/main".into(),
+            target: "elsewhere".into(),
+            uid: 0,
+            gid: 0,
+        };
+
+        assert_ne!(changes_hash(&one), changes_hash(&other));
+        assert_eq!(changes_hash(&one), changes_hash(&one.clone()));
+    }
+}

--- a/crates/lns-service/src/containerfile/key.rs
+++ b/crates/lns-service/src/containerfile/key.rs
@@ -1,4 +1,168 @@
 //! What a build is keyed by: slice 4 of lensapp/lens-sandbox#393.
+//!
+//! An image is a function of the base it stands on, the Containerfile's own text, the bytes of the
+//! context beside it and the architecture a guest boots — so those four are the key, and a build
+//! whose key this machine already holds is not run again. One instruction is keyed the same way,
+//! by the image it stands on and its own text, plus what it copies when it copies anything.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+use super::context::{ContextFs, EntryKind};
+use super::upper::{Change, ChangeSet};
+
+/// The whole image: what a second `lns sandbox build` of an untouched document finds and does not run again.
+pub(crate) fn image_key(base: &str, text: &str, context: &str, arch: &str) -> String {
+    let mut fields = Fields::over("lns.build.image.v1");
+    fields.field(base.as_bytes());
+    fields.field(text.as_bytes());
+    fields.field(context.as_bytes());
+    fields.field(arch.as_bytes());
+    fields.finish()
+}
+
+/// One instruction over the image before it, which is what makes a build reuse its leading steps.
+pub(crate) fn step_key(parent: &str, instruction: &str, copied: Option<&str>) -> String {
+    let mut fields = Fields::over("lns.build.step.v1");
+    fields.field(parent.as_bytes());
+    fields.field(instruction.as_bytes());
+    match copied {
+        Some(copied) => {
+            fields.field(b"copied");
+            fields.field(copied.as_bytes());
+        }
+        None => fields.field(b"nothing copied"),
+    }
+    fields.finish()
+}
+
+/// Every byte the context holds, so a file edited beside the Containerfile is a different build and a file only touched is not.
+pub(crate) fn context_hash<F: ContextFs>(fs: &F, context: &Path) -> Result<String> {
+    let mut fields = Fields::over("lns.build.context.v1");
+    walk(fs, context, "", &mut fields)?;
+    Ok(fields.finish())
+}
+
+/// What a `COPY` or an `ADD` puts in its layer, which is the part of its key the instruction text cannot see.
+pub(crate) fn changes_hash(changes: &ChangeSet) -> String {
+    let mut fields = Fields::over("lns.build.copied.v1");
+    for change in &changes.changes {
+        match change {
+            Change::Directory {
+                path,
+                mode,
+                uid,
+                gid,
+            } => {
+                fields.field(b"directory");
+                fields.entry(path, *mode, *uid, *gid);
+            }
+            Change::Regular {
+                path,
+                mode,
+                uid,
+                gid,
+                bytes,
+            } => {
+                fields.field(b"regular");
+                fields.entry(path, *mode, *uid, *gid);
+                fields.field(bytes);
+            }
+            Change::Symlink {
+                path,
+                target,
+                uid,
+                gid,
+            } => {
+                fields.field(b"symlink");
+                fields.entry(path, 0, *uid, *gid);
+                fields.field(target.as_bytes());
+            }
+            Change::Removed { path } => {
+                fields.field(b"removed");
+                fields.field(path.as_bytes());
+            }
+        }
+    }
+    fields.finish()
+}
+
+fn walk<F: ContextFs>(fs: &F, directory: &Path, prefix: &str, fields: &mut Fields) -> Result<()> {
+    let mut names = fs
+        .entries(directory)
+        .with_context(|| format!("reading the build context at {}", directory.display()))?;
+    names.sort();
+    for name in names {
+        let path = directory.join(&name);
+        let relative = match prefix.is_empty() {
+            true => name.clone(),
+            false => format!("{prefix}/{name}"),
+        };
+        let Some(meta) = fs
+            .meta(&path)
+            .with_context(|| format!("reading {} in the build context", path.display()))?
+        else {
+            continue;
+        };
+        fields.field(relative.as_bytes());
+        match meta.kind {
+            EntryKind::Directory => {
+                fields.field(b"directory");
+                fields.field(&meta.mode.to_be_bytes());
+                walk(fs, &path, &relative, fields)?;
+            }
+            EntryKind::Regular => {
+                fields.field(b"regular");
+                fields.field(&meta.mode.to_be_bytes());
+                fields.field(
+                    &fs.read(&path).with_context(|| {
+                        format!("reading {} in the build context", path.display())
+                    })?,
+                );
+            }
+            EntryKind::Symlink => {
+                fields.field(b"symlink");
+                fields.field(
+                    fs.read_link(&path)
+                        .with_context(|| {
+                            format!("reading {} in the build context", path.display())
+                        })?
+                        .as_bytes(),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A digest over fields rather than over their concatenation: every field carries its own length, so no two different inputs can spell one key.
+struct Fields(Sha256);
+
+impl Fields {
+    fn over(domain: &str) -> Self {
+        let mut fields = Self(Sha256::new());
+        fields.field(domain.as_bytes());
+        fields
+    }
+
+    fn field(&mut self, bytes: &[u8]) {
+        self.0.update((bytes.len() as u64).to_be_bytes());
+        self.0.update(bytes);
+    }
+
+    fn entry(&mut self, path: &str, mode: u32, uid: u32, gid: u32) {
+        self.field(path.as_bytes());
+        self.field(&mode.to_be_bytes());
+        self.field(&uid.to_be_bytes());
+        self.field(&gid.to_be_bytes());
+    }
+
+    fn finish(self) -> String {
+        format!("sha256:{}", hex::encode(self.0.finalize()))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -28,7 +192,12 @@ mod tests {
         );
         for other in [
             image_key("base@sha256:bb", "FROM base\n", "sha256:ctx", "arm64"),
-            image_key("base@sha256:aa", "FROM base\nRUN true\n", "sha256:ctx", "arm64"),
+            image_key(
+                "base@sha256:aa",
+                "FROM base\nRUN true\n",
+                "sha256:ctx",
+                "arm64",
+            ),
             image_key("base@sha256:aa", "FROM base\n", "sha256:other", "arm64"),
             image_key("base@sha256:aa", "FROM base\n", "sha256:ctx", "amd64"),
         ] {
@@ -41,8 +210,18 @@ mod tests {
     #[test]
     fn the_same_containerfile_with_different_whitespace_in_a_comment_is_a_different_text_and_so_a_different_key()
      {
-        let one = image_key("base@sha256:aa", "# build the agent\nFROM base\n", "c", "arm64");
-        let other = image_key("base@sha256:aa", "#  build the agent\nFROM base\n", "c", "arm64");
+        let one = image_key(
+            "base@sha256:aa",
+            "# build the agent\nFROM base\n",
+            "c",
+            "arm64",
+        );
+        let other = image_key(
+            "base@sha256:aa",
+            "#  build the agent\nFROM base\n",
+            "c",
+            "arm64",
+        );
 
         assert_ne!(one, other);
     }
@@ -96,7 +275,8 @@ mod tests {
     #[test]
     fn a_context_symlink_hashes_the_target_it_names_and_not_what_it_points_at() {
         let mut one = FakeContext::new();
-        one.file("app.js", 0o644, b"one\n").symlink("main", "app.js");
+        one.file("app.js", 0o644, b"one\n")
+            .symlink("main", "app.js");
         let mut other = FakeContext::new();
         other
             .file("app.js", 0o644, b"one\n")
@@ -123,7 +303,8 @@ mod tests {
 
         let refusal = format!(
             "{:#}",
-            context_hash(&context, Path::new("/ctx")).expect_err("an unreadable context is refused")
+            context_hash(&context, Path::new("/ctx"))
+                .expect_err("an unreadable context is refused")
         );
 
         assert!(refusal.contains("permission denied"), "{refusal}");
@@ -133,28 +314,45 @@ mod tests {
     #[test]
     fn a_context_directory_that_will_not_list_stops_the_build_naming_it() {
         let mut context = one_file(b"one\n", 0o644);
-        context.unlistable("");
+        context.dir("skills", 0o755).unlistable("skills");
 
         let refusal = format!(
             "{:#}",
-            context_hash(&context, Path::new("/ctx")).expect_err("a context that will not list is refused")
+            context_hash(&context, Path::new("/ctx"))
+                .expect_err("a context that will not list is refused")
         );
 
-        assert!(refusal.contains("/ctx"), "{refusal}");
+        assert!(refusal.contains("/ctx/skills"), "{refusal}");
     }
 
     #[test]
     fn the_parent_the_instruction_and_the_copied_content_each_change_the_instruction_key() {
-        let key = step_key("built@sha256:parent", "COPY app /srv", Some("sha256:copied"));
+        let key = step_key(
+            "built@sha256:parent",
+            "COPY app /srv",
+            Some("sha256:copied"),
+        );
 
         assert_eq!(
             key,
-            step_key("built@sha256:parent", "COPY app /srv", Some("sha256:copied")),
+            step_key(
+                "built@sha256:parent",
+                "COPY app /srv",
+                Some("sha256:copied")
+            ),
         );
         for other in [
             step_key("built@sha256:other", "COPY app /srv", Some("sha256:copied")),
-            step_key("built@sha256:parent", "COPY app /opt", Some("sha256:copied")),
-            step_key("built@sha256:parent", "COPY app /srv", Some("sha256:edited")),
+            step_key(
+                "built@sha256:parent",
+                "COPY app /opt",
+                Some("sha256:copied"),
+            ),
+            step_key(
+                "built@sha256:parent",
+                "COPY app /srv",
+                Some("sha256:edited"),
+            ),
             step_key("built@sha256:parent", "COPY app /srv", None),
         ] {
             assert_ne!(key, other);
@@ -167,7 +365,11 @@ mod tests {
     fn an_instruction_that_copies_nothing_is_keyed_apart_from_one_that_copies_an_empty_set() {
         assert_ne!(
             step_key("parent", "RUN true", None),
-            step_key("parent", "RUN true", Some(&changes_hash(&ChangeSet::default()))),
+            step_key(
+                "parent",
+                "RUN true",
+                Some(&changes_hash(&ChangeSet::default()))
+            ),
         );
     }
 

--- a/crates/lns-service/src/containerfile/key.rs
+++ b/crates/lns-service/src/containerfile/key.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 
 use super::context::{ContextFs, EntryKind};
+use super::executor::{ConfigDraft, RunStep};
 use super::upper::{Change, ChangeSet};
 
 /// The whole image: what a second `lns sandbox build` of an untouched document finds and does not run again.
@@ -35,6 +36,47 @@ pub(crate) fn step_key(parent: &str, instruction: &str, copied: Option<&str>) ->
         }
         None => fields.field(b"nothing copied"),
     }
+    fields.finish()
+}
+
+/// A `RUN` as the guest is actually asked to run it: `ARG` reaches a command and its environment
+/// without committing anything of its own, so the written text alone does not tell two runs apart.
+pub(crate) fn run_key(parent: &str, step: &RunStep) -> String {
+    let mut fields = Fields::over("lns.build.step.v1");
+    fields.field(parent.as_bytes());
+    fields.field(b"RUN");
+    fields.each(&step.argv);
+    fields.field(b"env");
+    fields.each(&step.env);
+    fields.field(step.user.as_bytes());
+    fields.field(step.workdir.as_bytes());
+    fields.finish()
+}
+
+/// A `COPY` or an `ADD` by what it puts in its layer, which is where its sources, its destination and its `--chown` all end up.
+pub(crate) fn transfer_key(parent: &str, instruction: &str, copied: &ChangeSet) -> String {
+    step_key(parent, instruction, Some(&changes_hash(copied)))
+}
+
+/// An instruction that writes only config, by the config the image then carries — the same reason a `RUN` is keyed by its resolved command.
+pub(crate) fn config_key(parent: &str, instruction: &str, config: &ConfigDraft) -> String {
+    let mut fields = Fields::over("lns.build.step.v1");
+    fields.field(parent.as_bytes());
+    fields.field(instruction.as_bytes());
+    fields.field(b"config");
+    fields.pairs(&config.env);
+    fields.pairs(&config.labels);
+    for optional in [&config.user, &config.workdir] {
+        fields.field(optional.as_deref().unwrap_or_default().as_bytes());
+    }
+    for argv in [&config.entrypoint, &config.cmd, &config.shell] {
+        match argv {
+            Some(argv) => fields.each(argv),
+            None => fields.field(b"unset"),
+        }
+    }
+    fields.each(&config.exposed_ports);
+    fields.each(&config.volumes);
     fields.finish()
 }
 
@@ -150,6 +192,21 @@ impl Fields {
     fn field(&mut self, bytes: &[u8]) {
         self.0.update((bytes.len() as u64).to_be_bytes());
         self.0.update(bytes);
+    }
+
+    fn each(&mut self, values: &[String]) {
+        self.field(&(values.len() as u64).to_be_bytes());
+        for value in values {
+            self.field(value.as_bytes());
+        }
+    }
+
+    fn pairs(&mut self, values: &[(String, String)]) {
+        self.field(&(values.len() as u64).to_be_bytes());
+        for (key, value) in values {
+            self.field(key.as_bytes());
+            self.field(value.as_bytes());
+        }
     }
 
     fn entry(&mut self, path: &str, mode: u32, uid: u32, gid: u32) {
@@ -392,6 +449,175 @@ mod tests {
         assert_ne!(copied("srv/app", 0o644, b"two\n"), before);
         assert_ne!(copied("srv/other", 0o644, b"one\n"), before);
         assert_ne!(copied("srv/app", 0o755, b"one\n"), before);
+    }
+
+    fn run_step() -> RunStep {
+        RunStep {
+            parent: "built@sha256:parent".into(),
+            argv: vec!["/bin/sh".into(), "-c".into(), "npm i -g agent@1".into()],
+            env: vec!["VERSION=1".into()],
+            user: "root".into(),
+            workdir: "/".into(),
+            line: 4,
+        }
+    }
+
+    /// `ARG` commits nothing, so two builds can reach one parent with one written `RUN` line and
+    /// still run two different commands; the key is over what the guest is asked to run.
+    #[test]
+    fn a_run_is_keyed_by_the_command_the_env_the_user_and_the_workdir_it_resolved_to() {
+        let key = run_key("built@sha256:parent", &run_step());
+
+        assert_eq!(key, run_key("built@sha256:parent", &run_step()));
+        for changed in [
+            RunStep {
+                argv: vec!["/bin/sh".into(), "-c".into(), "npm i -g agent@2".into()],
+                ..run_step()
+            },
+            RunStep {
+                env: vec!["VERSION=2".into()],
+                ..run_step()
+            },
+            RunStep {
+                user: "node".into(),
+                ..run_step()
+            },
+            RunStep {
+                workdir: "/srv".into(),
+                ..run_step()
+            },
+        ] {
+            assert_ne!(key, run_key("built@sha256:parent", &changed));
+        }
+        assert_ne!(key, run_key("built@sha256:other", &run_step()));
+    }
+
+    /// The line a `RUN` was written on moves when a comment above it does, and moving a line
+    /// rebuilds nothing: the guest runs the same command in the same guest.
+    #[test]
+    fn the_line_a_run_was_written_on_is_not_part_of_its_key() {
+        assert_eq!(
+            run_key("built@sha256:parent", &run_step()),
+            run_key(
+                "built@sha256:parent",
+                &RunStep {
+                    line: 9,
+                    ..run_step()
+                }
+            ),
+        );
+    }
+
+    #[test]
+    fn a_transfer_is_keyed_by_the_instruction_and_by_what_it_copies() {
+        let copied = |bytes: &[u8]| ChangeSet {
+            changes: vec![Change::Regular {
+                path: "srv/app".into(),
+                mode: 0o644,
+                uid: 0,
+                gid: 0,
+                bytes: bytes.to_vec(),
+            }],
+        };
+        let key = transfer_key(
+            "built@sha256:parent",
+            "COPY app /srv/app",
+            &copied(b"one\n"),
+        );
+
+        assert_eq!(
+            key,
+            transfer_key(
+                "built@sha256:parent",
+                "COPY app /srv/app",
+                &copied(b"one\n")
+            ),
+        );
+        assert_ne!(
+            key,
+            transfer_key(
+                "built@sha256:parent",
+                "COPY app /srv/app",
+                &copied(b"two\n")
+            ),
+            "an edited context file is a different step, whatever the instruction says",
+        );
+        assert_ne!(
+            key,
+            transfer_key("built@sha256:parent", "ADD app /srv/app", &copied(b"one\n")),
+        );
+    }
+
+    #[test]
+    fn a_config_instruction_is_keyed_by_the_config_the_image_then_carries() {
+        let draft = ConfigDraft {
+            env: vec![("MODE".into(), "research".into())],
+            labels: vec![("org.opencontainers.image.title".into(), "agent".into())],
+            user: Some("node".into()),
+            workdir: Some("/srv".into()),
+            entrypoint: Some(vec!["/entry".into()]),
+            cmd: Some(vec!["--help".into()]),
+            shell: Some(vec!["/bin/bash".into(), "-c".into()]),
+            exposed_ports: vec!["8080".into()],
+            volumes: vec!["/data".into()],
+        };
+        let key = config_key("built@sha256:parent", "ENV MODE=research", &draft);
+
+        assert_eq!(
+            key,
+            config_key("built@sha256:parent", "ENV MODE=research", &draft)
+        );
+        assert_ne!(
+            key,
+            config_key("built@sha256:other", "ENV MODE=research", &draft)
+        );
+        assert_ne!(
+            key,
+            config_key("built@sha256:parent", "ENV MODE=review", &draft)
+        );
+        for changed in [
+            ConfigDraft {
+                env: vec![("MODE".into(), "review".into())],
+                ..draft.clone()
+            },
+            ConfigDraft {
+                labels: Vec::new(),
+                ..draft.clone()
+            },
+            ConfigDraft {
+                user: None,
+                ..draft.clone()
+            },
+            ConfigDraft {
+                workdir: Some("/opt".into()),
+                ..draft.clone()
+            },
+            ConfigDraft {
+                entrypoint: None,
+                ..draft.clone()
+            },
+            ConfigDraft {
+                cmd: Some(vec!["--serve".into()]),
+                ..draft.clone()
+            },
+            ConfigDraft {
+                shell: None,
+                ..draft.clone()
+            },
+            ConfigDraft {
+                exposed_ports: vec!["9090".into()],
+                ..draft.clone()
+            },
+            ConfigDraft {
+                volumes: Vec::new(),
+                ..draft.clone()
+            },
+        ] {
+            assert_ne!(
+                key,
+                config_key("built@sha256:parent", "ENV MODE=research", &changed)
+            );
+        }
     }
 
     #[test]

--- a/crates/lns-service/src/containerfile/locate.rs
+++ b/crates/lns-service/src/containerfile/locate.rs
@@ -73,19 +73,6 @@ fn in_directory<F: ContextFs>(fs: &F, directory: &Path, written: &str) -> Result
     )
 }
 
-/// Reuse is keyed on the Containerfile alone until slice 4 hashes the context, so a context holding
-/// anything else has no key that would notice an edit to it and must be built again.
-pub(crate) fn holds_only_its_containerfile<F: ContextFs>(fs: &F, located: &Located) -> bool {
-    let Ok(entries) = fs.entries(&located.context) else {
-        return false;
-    };
-    let named = located
-        .containerfile
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string());
-    entries.iter().all(|entry| Some(entry) == named.as_ref())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,48 +223,5 @@ mod tests {
 
         let refusal = refusal(&context, "./image");
         assert!(refusal.contains("permission denied"), "{refusal}");
-    }
-
-    #[test]
-    fn a_context_holding_nothing_but_the_containerfile_may_be_reused() {
-        let mut context = FakeContext::new();
-        context
-            .dir("image", 0o755)
-            .file("image/Containerfile", 0o644, b"FROM alpine\n");
-
-        assert!(holds_only_its_containerfile(
-            &context,
-            &located(&context, "./image")
-        ));
-    }
-
-    #[test]
-    fn a_context_holding_a_file_the_reuse_key_cannot_see_is_built_again() {
-        let mut context = FakeContext::new();
-        context
-            .dir("image", 0o755)
-            .file(
-                "image/Containerfile",
-                0o644,
-                b"FROM alpine\nCOPY app /srv/app\n",
-            )
-            .file("image/app", 0o644, b"one\n");
-
-        assert!(!holds_only_its_containerfile(
-            &context,
-            &located(&context, "./image")
-        ));
-    }
-
-    #[test]
-    fn a_context_that_will_not_list_is_built_again() {
-        let mut context = FakeContext::new();
-        context
-            .dir("image", 0o755)
-            .file("image/Containerfile", 0o644, b"FROM alpine\n");
-        let located = located(&context, "./image");
-        context.unlistable("image");
-
-        assert!(!holds_only_its_containerfile(&context, &located));
     }
 }

--- a/crates/lns-service/src/containerfile/mod.rs
+++ b/crates/lns-service/src/containerfile/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod executor;
 pub(crate) mod ext4_upper;
 pub(crate) mod image;
 pub(crate) mod import;
+pub(crate) mod key;
 pub(crate) mod locate;
 pub(crate) mod parse;
 pub mod real;

--- a/crates/lns-service/src/containerfile/mod.rs
+++ b/crates/lns-service/src/containerfile/mod.rs
@@ -1,6 +1,7 @@
 //! Slice 1 of the Containerfile executor (lensapp/lens-sandbox#393): what one guest wrote,
 //! captured as one OCI layer over its base image and imported where the boot path finds it.
 
+pub(crate) mod cache;
 pub(crate) mod context;
 pub(crate) mod exclude;
 pub(crate) mod executor;

--- a/crates/lns-service/src/containerfile/real.rs
+++ b/crates/lns-service/src/containerfile/real.rs
@@ -114,26 +114,12 @@ pub(crate) async fn build(
     };
     let plan = executor::BuildPlan {
         file: &file,
+        label: &located.label,
         text: &text,
         context_hash: &context_hash,
         arch: &arch,
         rebuild: request.rebuild,
     };
-    if !plan.rebuild {
-        log::info!(
-            "Building",
-            "{} ({} instructions)",
-            located.label,
-            file.instructions.len()
-        );
-    } else {
-        log::info!(
-            "Building",
-            "{} ({} instructions), ignoring the cache",
-            located.label,
-            file.instructions.len()
-        );
-    }
     let built = executor::build(&host, &plan)
         .await
         .with_context(|| format!("building {}", located.label))?;

--- a/crates/lns-service/src/containerfile/real.rs
+++ b/crates/lns-service/src/containerfile/real.rs
@@ -12,30 +12,38 @@ use crate::image::manifest_cache::ManifestCache;
 use crate::log;
 use crate::oci_layer_cache::LayerCache;
 
+use super::cache::{BuildCache, CacheFs, Entry, Kind};
 use super::context::{ContextFs, EntryKind, Meta};
 use super::executor::{self, Base, BuildHost, Commit, CopyStep, RunOutcome, RunStep};
 use super::ext4_upper::Ext4Upper;
 use super::image::ParentImage;
 use super::import::LocalStore;
-use super::locate::{self, Located};
+use super::key;
+use super::locate;
 use super::step;
 use super::upper::{self, ChangeSet};
 
 /// Where the reference of the image a run built lands, in the run's own directory: two runs ending together would overwrite one pointer, and removing the run removes what it built from.
 pub const BUILT_REFERENCE_FILE: &str = "built-image";
 
-/// Where "already built for this document on this machine" is remembered, which is this cache's own
-/// directory and not `lns_ipc::build_cache_root()`, whose sweeper owns everything under it. Slice 4
-/// of lensapp/lens-sandbox#393 replaces this with the real key — the `FROM` digest, the context's
-/// content hash and the architecture — and with `lns sandbox build`.
-const BUILT_POINTER_DIR: &str = "containerfile-builds";
+/// What a build was asked to do, and what a run and `lns sandbox build` both hand the executor.
+pub(crate) struct BuildRequest<'a> {
+    pub args: &'a RunImageArgs,
+    pub definition: &'a str,
+    pub image: &'a str,
+    pub rebuild: bool,
+}
 
-/// What a run boots from when its `spec.image` named a Containerfile.
+/// What one build produced: the image, the file it came from, and the key it is remembered under.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BuiltForRun {
     pub reference: String,
     pub label: String,
     pub layers: usize,
+    pub key: String,
+    /// True when the key answered outright, so this build ran nothing.
+    pub reused: bool,
+    pub reused_steps: usize,
 }
 
 pub(crate) fn names_a_containerfile(image: &str) -> bool {
@@ -50,7 +58,32 @@ pub(crate) async fn build_for_run(
     image: &str,
     frame_tx: Sender<WireFrame>,
 ) -> Result<BuiltForRun> {
-    let definition_dir = args.definition_dir.as_deref().with_context(|| {
+    let built = build(
+        &BuildRequest {
+            args,
+            definition,
+            image,
+            rebuild: false,
+        },
+        frame_tx,
+    )
+    .await?;
+    publish(&crate::cache::root()?, run_id, &built.reference);
+    log::info!(
+        "Image",
+        "{}",
+        step::built_line(&built.label, &built.reference)
+    );
+    Ok(built)
+}
+
+/// The build itself, with no run around it: `lns sandbox build` needs one, and a run is a caller.
+pub(crate) async fn build(
+    request: &BuildRequest<'_>,
+    frame_tx: Sender<WireFrame>,
+) -> Result<BuiltForRun> {
+    let image = request.image;
+    let definition_dir = request.args.definition_dir.as_deref().with_context(|| {
         format!(
             "spec.image {image:?} names a Containerfile beside the document, and this run carries no document directory to look in"
         )
@@ -65,86 +98,63 @@ pub(crate) async fn build_for_run(
             refusals.join("\n  ")
         )
     })?;
+    let context_hash = key::context_hash(&RealContextFs, &located.context)?;
 
     let cache_dir = crate::cache::root()?;
-    let pointer = pointer_path(&cache_dir, &located, &text);
-    let reusable = locate::holds_only_its_containerfile(&RealContextFs, &located);
-    let built = match reusable
-        .then(|| already_built(&cache_dir, &pointer))
-        .flatten()
-    {
-        Some(reference) => BuiltForRun {
-            reference,
-            label: located.label.clone(),
-            layers: 0,
-        },
-        None => {
-            let built =
-                run_the_instructions(args, definition, &located, &file, &cache_dir, frame_tx)
-                    .await?;
-            if reusable {
-                remember(&cache_dir, &pointer, &built.reference);
-            }
-            built
-        }
-    };
-    publish(&cache_dir, run_id, &built.reference);
-    log::info!(
-        "Image",
-        "{}",
-        step::built_line(&built.label, &built.reference)
-    );
-    Ok(built)
-}
-
-async fn run_the_instructions(
-    args: &RunImageArgs,
-    definition: &str,
-    located: &Located,
-    file: &super::parse::Containerfile,
-    cache_dir: &Path,
-    frame_tx: Sender<WireFrame>,
-) -> Result<BuiltForRun> {
+    let arch = crate::image::want_arch().to_string();
     let started = std::time::Instant::now();
-    log::info!(
-        "Building",
-        "{} ({} instructions)",
-        located.label,
-        file.instructions.len()
-    );
     let host = RealBuildHost {
         context: located.context.clone(),
-        args: args.clone(),
-        definition: definition.to_string(),
-        cache_dir: cache_dir.to_path_buf(),
+        source: located.containerfile.display().to_string(),
+        args: request.args.clone(),
+        definition: request.definition.to_string(),
+        cache_dir: cache_dir.clone(),
         frame_tx,
         steps: AtomicUsize::new(0),
     };
-    let built = executor::build(&host, file)
+    let plan = executor::BuildPlan {
+        file: &file,
+        text: &text,
+        context_hash: &context_hash,
+        arch: &arch,
+        rebuild: request.rebuild,
+    };
+    if !plan.rebuild {
+        log::info!(
+            "Building",
+            "{} ({} instructions)",
+            located.label,
+            file.instructions.len()
+        );
+    } else {
+        log::info!(
+            "Building",
+            "{} ({} instructions), ignoring the cache",
+            located.label,
+            file.instructions.len()
+        );
+    }
+    let built = executor::build(&host, &plan)
         .await
         .with_context(|| format!("building {}", located.label))?;
-    log::info!(
-        "Built",
-        "{} in {:.2?} ({} layer{})",
-        built.reference,
-        started.elapsed(),
-        built.layers,
-        if built.layers == 1 { "" } else { "s" },
-    );
+    if !built.reused {
+        log::info!(
+            "Built",
+            "{} in {:.2?} ({} layer{})",
+            built.reference,
+            started.elapsed(),
+            built.layers,
+            if built.layers == 1 { "" } else { "s" },
+        );
+    }
     Ok(BuiltForRun {
         reference: built.reference,
-        label: located.label.clone(),
+        label: located.label,
         layers: built.layers,
+        key: built.key,
+        reused: built.reused,
+        reused_steps: built.reused_steps,
     })
-}
-
-/// "Already built for this document on this machine", which is all the cache slice 3 keeps.
-fn remember(cache_dir: &Path, pointer: &Path, reference: &str) {
-    if let Err(e) = std::fs::create_dir_all(pointer.parent().unwrap_or(cache_dir))
-        .and_then(|()| std::fs::write(pointer, format!("{reference}\n")))
-    {
-        log::warn!("this build will not be reused; its pointer was not written: {e}");
-    }
 }
 
 /// What a build guest wrote, read off its upper volume once the guest has stopped.
@@ -156,26 +166,6 @@ pub(crate) fn capture_change_set(
     let upper_image = crate::cache::run_dir(&crate::cache::root()?, run_id).join("upper.img");
     let tree = Ext4Upper::open_run_upper(&upper_image)?;
     upper::capture(&tree)
-}
-
-fn already_built(cache_dir: &Path, pointer: &Path) -> Option<String> {
-    let reference = std::fs::read_to_string(pointer).ok()?.trim().to_string();
-    ManifestCache::new(cache_dir.join("manifests"))
-        .get(&reference)
-        .map(|_| reference)
-}
-
-/// One document built on one machine: the file's own text and where it sits, plus the architecture a guest boots.
-fn pointer_path(cache_dir: &Path, located: &Located, text: &str) -> PathBuf {
-    let key = <sha2::Sha256 as sha2::Digest>::digest(
-        format!(
-            "{}\0{}\0{text}",
-            located.containerfile.display(),
-            crate::image::want_arch(),
-        )
-        .as_bytes(),
-    );
-    cache_dir.join(BUILT_POINTER_DIR).join(hex::encode(key))
 }
 
 fn publish(cache_dir: &Path, run_id: &str, reference: &str) {
@@ -196,6 +186,8 @@ fn publish(cache_dir: &Path, run_id: &str, reference: &str) {
 
 struct RealBuildHost {
     context: PathBuf,
+    /// The Containerfile this build reads, which every entry records so a sweep can ask whether the document is still here.
+    source: String,
     args: RunImageArgs,
     definition: String,
     cache_dir: PathBuf,
@@ -264,6 +256,25 @@ impl BuildHost for RealBuildHost {
         super::context::stage(&RealContextFs, &self.context, step)
     }
 
+    async fn cached(&self, kind: Kind, key: &str) -> Option<String> {
+        BuildCache::new(&RealCacheFs, &self.cache_dir)
+            .get(kind, key, &|reference| self.holds(reference))
+            .map(|entry| entry.reference)
+    }
+
+    async fn remember(&self, kind: Kind, key: &str, reference: &str) {
+        if let Err(e) = BuildCache::new(&RealCacheFs, &self.cache_dir).remember(
+            kind,
+            key,
+            &Entry {
+                reference: reference.to_string(),
+                source: self.source.clone(),
+            },
+        ) {
+            log::warn!("this build will not be reused; its key was not written: {e:#}");
+        }
+    }
+
     async fn commit(&self, commit: &Commit<'_>) -> Result<String> {
         let manifests = self.cache_dir.join("manifests");
         let parent = parent_image(&manifests, commit.parent)?;
@@ -293,6 +304,54 @@ impl BuildHost for RealBuildHost {
             );
         }
         Ok(built.reference)
+    }
+}
+
+impl RealBuildHost {
+    /// A key answers only while the image it names is still in this machine's manifest cache.
+    fn holds(&self, reference: &str) -> bool {
+        holds_the_image(&self.cache_dir, reference)
+    }
+}
+
+/// Whether this machine still has the built image a key names.
+pub(crate) fn holds_the_image(cache_dir: &Path, reference: &str) -> bool {
+    ManifestCache::new(cache_dir.join("manifests"))
+        .get(reference)
+        .is_some()
+}
+
+/// The build cache directory as the host holds it.
+pub(crate) struct RealCacheFs;
+
+impl CacheFs for RealCacheFs {
+    fn read(&self, path: &Path) -> Option<Vec<u8>> {
+        std::fs::read(path).ok()
+    }
+
+    fn write(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
+    }
+
+    fn remove(&self, path: &Path) -> Result<()> {
+        std::fs::remove_file(path).with_context(|| format!("removing {}", path.display()))
+    }
+
+    fn list(&self, dir: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(|entry| Some(entry.ok()?.path()))
+            .collect()
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
     }
 }
 

--- a/crates/lns-service/src/containerfile/real.rs
+++ b/crates/lns-service/src/containerfile/real.rs
@@ -157,6 +157,116 @@ pub(crate) async fn build(
     })
 }
 
+/// `lns sandbox build`: the build a run would do, with no run around it and nothing published.
+pub async fn build_sandbox(
+    definition: &str,
+    definition_dir: &str,
+    rebuild: bool,
+) -> Result<lns_ipc::Response> {
+    let image = image_of(definition)?;
+    let (frame_tx, mut frames) = tokio::sync::mpsc::channel(1);
+    // A build asked for on its own has no run to carry a step's output to, so it is drained here rather than left to fill.
+    tokio::spawn(async move { while frames.recv().await.is_some() {} });
+    let mut args = args_for_a_build(definition, definition_dir);
+    args.image = Some(image.clone());
+    let built = build(
+        &BuildRequest {
+            args: &args,
+            definition,
+            image: &image,
+            rebuild,
+        },
+        frame_tx,
+    )
+    .await?;
+    Ok(lns_ipc::Response::SandboxBuilt {
+        key: built.key,
+        reference: built.reference,
+        label: built.label,
+        layers: built.layers,
+        reused: built.reused,
+    })
+}
+
+/// What `spec.image` names, refused here when it names an image rather than a file to build.
+fn image_of(definition: &str) -> Result<String> {
+    let document: serde_json::Value =
+        serde_json::from_str(definition).context("reading the document to build")?;
+    let image = document["spec"]["image"]
+        .as_str()
+        .context("this document declares no spec.image, so there is nothing to build")?
+        .to_string();
+    if !names_a_containerfile(&image) {
+        bail!(
+            "spec.image {image:?} names an image to pull, not a Containerfile beside the document; there is nothing to build"
+        );
+    }
+    Ok(image)
+}
+
+/// The run a build step is shaped from when no run asked for the build: the document, its directory, and this machine's defaults.
+fn args_for_a_build(definition: &str, definition_dir: &str) -> RunImageArgs {
+    RunImageArgs {
+        image: None,
+        resolved_image: None,
+        mixins: Vec::new(),
+        composed_mixins: Vec::new(),
+        name: None,
+        cpus: lns_artifact::resources::DEFAULT_VM_SIZE.cpus,
+        mem: lns_artifact::resources::DEFAULT_VM_SIZE.mem_mib,
+        cpus_explicit: false,
+        mem_explicit: false,
+        cpus_config: None,
+        mem_config: None,
+        sandbox_user: None,
+        sandbox_uid: None,
+        entrypoint: None,
+        hostname: None,
+        cmd: Vec::new(),
+        env: Vec::new(),
+        workdir: None,
+        debug: false,
+        tty: false,
+        stdin: false,
+        initial_winsize: None,
+        detached: false,
+        published_ports: Vec::new(),
+        volumes: Vec::new(),
+        binds: Vec::new(),
+        auto_remove: false,
+        verify_sandbox: false,
+        definition: Some(definition.to_string()),
+        definition_dir: Some(definition_dir.to_string()),
+        authored_egress: None,
+        packed_filesets: Vec::new(),
+        denied_host_paths: Vec::new(),
+    }
+}
+
+/// `lns sandbox prune`'s half of the build cache: the entries whose document has gone, and the
+/// images those entries were the last to name.
+pub struct RealBuiltImageSweep;
+
+impl crate::ipc::BuiltImageSweep for RealBuiltImageSweep {
+    async fn sweep(&self, cache_root: &Path, surviving_runs: &[String]) -> Result<Vec<String>> {
+        let named = super::cache::still_referenced(
+            &RealCacheFs,
+            cache_root,
+            surviving_runs,
+            &|reference| holds_the_image(cache_root, reference),
+        )
+        .kept;
+        crate::image_store::remove_unreferenced_builds_with(
+            &crate::image_store::RealFs,
+            &crate::image_store::real::RealCaches::new(cache_root),
+            &cache_root.join("images"),
+            &std::collections::HashSet::new(),
+            &named,
+        )
+        .await
+    }
+}
+
 /// What a build guest wrote, read off its upper volume once the guest has stopped.
 pub(crate) fn capture_change_set(
     run_id: &str,

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -1256,7 +1256,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(removed, [orphan.to_string()]);
+        assert_eq!(removed, vec![orphan.clone()]);
         assert!(fs.has(&record_path(Path::new(ROOT), named)));
         assert!(!fs.has(&record_path(Path::new(ROOT), orphan)));
         assert_eq!(

--- a/crates/lns-service/src/image_store/mod.rs
+++ b/crates/lns-service/src/image_store/mod.rs
@@ -1,4 +1,4 @@
-mod real;
+pub(crate) mod real;
 pub(crate) use real::RealFs;
 mod traits;
 
@@ -344,6 +344,41 @@ pub async fn remove_with<F: Fs, C: Caches>(
         reference,
         reclaimed_bytes,
     })
+}
+
+/// Drop every image a Containerfile build produced that nothing names any more, and reclaim the
+/// layers no surviving record needs; a built image is `RecordKind::Image`, which no verb of the
+/// image namespace can see or remove, so this is the only sweep that reaches one.
+pub async fn remove_unreferenced_builds_with<F: Fs, C: Caches>(
+    fs: &F,
+    caches: &C,
+    images_root: &Path,
+    pinned_layers: &HashSet<String>,
+    named: &std::collections::BTreeSet<String>,
+) -> Result<Vec<String>> {
+    let records = load_records(fs, images_root).await?;
+    let (unnamed, kept): (Vec<ImageRecord>, Vec<ImageRecord>) = records
+        .into_iter()
+        .partition(|record| record.kind == RecordKind::Image && !named.contains(&record.reference));
+    if unnamed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let kept_manifests = manifest_keep_set(kept.iter())?;
+    let mut removed = Vec::with_capacity(unnamed.len());
+    for record in &unnamed {
+        fs.remove_file(&record_path(images_root, &record.reference))
+            .await
+            .with_context(|| format!("removing image record for {}", record.reference))?;
+        let pinned = pinned_reference(&record.reference, &record.digest)?;
+        if !kept_manifests.contains(&pinned) {
+            caches.remove_manifest(&pinned)?;
+        }
+        removed.push(record.reference.clone());
+    }
+    let mut keep = layer_keep_set(kept.iter());
+    keep.extend(pinned_layers.iter().cloned());
+    caches.sweep_layers(&keep)?;
+    Ok(removed)
 }
 
 pub async fn tag_with<F: Fs>(fs: &F, images_root: &Path, from: &str, to: &str) -> Result<()> {
@@ -1191,6 +1226,76 @@ mod tests {
 
     fn no_pins() -> HashSet<String> {
         HashSet::new()
+    }
+
+    /// A built image is nobody's cached sandbox: `ListImages` hides it and `remove` refuses it, so
+    /// the sweep `lns sandbox prune` runs is the only thing that can take one back.
+    #[tokio::test]
+    async fn a_built_image_nothing_names_is_dropped_and_one_something_names_is_kept() {
+        let named = &format!("lns-build.local/built@sha256:{}", "a".repeat(64));
+        let orphan = &format!("lns-build.local/built@sha256:{}", "b".repeat(64));
+        let fs = FakeFs::with_records(&[
+            ImageRecord {
+                digest: format!("sha256:{}", "a".repeat(64)),
+                ..base_rec(named, &[("sha256:kept-layer", 7)])
+            },
+            ImageRecord {
+                digest: format!("sha256:{}", "b".repeat(64)),
+                ..base_rec(orphan, &[("sha256:gone-layer", 9)])
+            },
+        ]);
+        let caches = FakeCaches::default();
+
+        let removed = remove_unreferenced_builds_with(
+            &fs,
+            &caches,
+            Path::new(ROOT),
+            &no_pins(),
+            &std::collections::BTreeSet::from([named.to_string()]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(removed, [orphan.to_string()]);
+        assert!(fs.has(&record_path(Path::new(ROOT), named)));
+        assert!(!fs.has(&record_path(Path::new(ROOT), orphan)));
+        assert_eq!(
+            caches.removed_manifests.lock().unwrap().len(),
+            1,
+            "the manifest of the image that went goes with it",
+        );
+        assert_eq!(
+            *caches.swept_with.lock().unwrap(),
+            vec![HashSet::from(["sha256:kept-layer".to_string()])],
+            "the layers of the image that stays must survive the sweep",
+        );
+    }
+
+    /// A pulled image is not this sweep's business, however little names it; `lns artifact prune` owns that.
+    #[tokio::test]
+    async fn a_cached_sandbox_is_never_dropped_by_the_built_image_sweep() {
+        let fs = FakeFs::with_records(&[rec("registry.example.test/team/image:1", &[])]);
+        let caches = FakeCaches::default();
+
+        let removed = remove_unreferenced_builds_with(
+            &fs,
+            &caches,
+            Path::new(ROOT),
+            &no_pins(),
+            &std::collections::BTreeSet::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(removed.is_empty());
+        assert!(fs.has(&record_path(
+            Path::new(ROOT),
+            "registry.example.test/team/image:1"
+        )));
+        assert!(
+            caches.swept_with.lock().unwrap().is_empty(),
+            "a sweep with nothing to drop must not walk the layer cache",
+        );
     }
 
     #[tokio::test]

--- a/crates/lns-service/src/image_store/real.rs
+++ b/crates/lns-service/src/image_store/real.rs
@@ -72,13 +72,13 @@ impl RuntimeCacheFs for RealFs {
     }
 }
 
-pub(super) struct RealCaches {
+pub(crate) struct RealCaches {
     layers: LayerCache,
     manifests: ManifestCache,
 }
 
 impl RealCaches {
-    pub(super) fn new(cache_root: &Path) -> Self {
+    pub(crate) fn new(cache_root: &Path) -> Self {
         Self {
             layers: LayerCache::new(cache_root.join("layers")),
             manifests: ManifestCache::new(cache_root.join("manifests")),

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -901,20 +901,27 @@ where
     if !removed.is_empty() {
         note_pruned(&removed);
     }
+    Response::RunsPruned {
+        built_images: swept_built_images(cache_root, builds).await,
+        removed,
+    }
+}
+
+/// A sweep that fails takes no run prune down with it: the runs are already gone by the time it runs.
+async fn swept_built_images<B: BuiltImageSweep>(
+    cache_root: &std::path::Path,
+    builds: &B,
+) -> Vec<String> {
     let surviving: Vec<String> = crate::run_registry::snapshot()
         .into_iter()
         .map(|run| run.id)
         .collect();
-    let built_images = match builds.sweep(cache_root, &surviving).await {
+    match builds.sweep(cache_root, &surviving).await {
         Ok(built_images) => built_images,
         Err(e) => {
             crate::log::warn!("built images were not swept: {e:#}");
             Vec::new()
         }
-    };
-    Response::RunsPruned {
-        removed,
-        built_images,
     }
 }
 

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -3241,16 +3241,10 @@ mod tests {
                 Ok(vec!["lns-build.local/built@sha256:gone".into()])
             }
         }
-        let fs = ScriptedRunsDir(Vec::new());
+        let (fs, sweep) = (ScriptedRunsDir(Vec::new()), SweptOne);
+        let root = std::path::Path::new("/cache");
 
-        let resp = prune_runs_with(
-            &fs,
-            &NoopRemover,
-            std::path::Path::new("/cache"),
-            &SweptOne,
-            |_| {},
-        )
-        .await;
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &sweep, |_| {}).await;
 
         match resp {
             Response::RunsPruned { built_images, .. } => {
@@ -3274,7 +3268,8 @@ mod tests {
                 anyhow::bail!("the image index is not readable")
             }
         }
-        let fs = ScriptedRunsDir(Vec::new());
+        let (fs, sweep) = (ScriptedRunsDir(Vec::new()), SweepFails);
+        let root = std::path::Path::new("/cache");
         let warnings = Warnings::default();
         let guard =
             tracing::subscriber::set_default(tracing_subscriber::layer::SubscriberExt::with(
@@ -3282,20 +3277,13 @@ mod tests {
                 warnings.clone(),
             ));
 
-        let resp = prune_runs_with(
-            &fs,
-            &NoopRemover,
-            std::path::Path::new("/cache"),
-            &SweepFails,
-            |_| {},
-        )
-        .await;
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &sweep, |_| {}).await;
         drop(guard);
 
+        let recorded = warnings.recorded();
         assert!(
-            warnings.recorded().contains("built images were not swept"),
-            "{}",
-            warnings.recorded(),
+            recorded.contains("built images were not swept"),
+            "{recorded}"
         );
         match resp {
             Response::RunsPruned { built_images, .. } => assert!(built_images.is_empty()),
@@ -3744,14 +3732,9 @@ mod tests {
         assert!(probe.write(std::path::Path::new("/x"), b"").await.is_ok());
         assert!(probe.remove_file(std::path::Path::new("/x")).await.is_ok());
         let fs = ScriptedRunsDir(vec![std::path::PathBuf::from("/")]);
-        let resp = prune_runs_with(
-            &fs,
-            &NoopRemover,
-            std::path::Path::new("/cache"),
-            &SweepsNothing,
-            |_| {},
-        )
-        .await;
+        let sweep = SweepsNothing;
+        let root = std::path::Path::new("/cache");
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &sweep, |_| {}).await;
         assert!(
             matches!(&resp, Response::RunsPruned { removed, .. } if removed.is_empty()),
             "an unreadable entry is skipped, never swept blind: {resp:?}"

--- a/crates/lns-service/src/ipc/mod.rs
+++ b/crates/lns-service/src/ipc/mod.rs
@@ -601,6 +601,13 @@ pub async fn handle_request(request: &Request, started_at: Instant) -> Response 
         Request::InspectRun { run } => inspect_run_request(run),
         Request::RemoveRun { run, force } => image_response(remove_run_request(run, *force).await),
         Request::PruneRuns => image_response(prune_runs_request().await),
+        Request::BuildSandbox {
+            definition,
+            definition_dir,
+            rebuild,
+        } => image_response(
+            crate::containerfile::real::build_sandbox(definition, definition_dir, *rebuild).await,
+        ),
         Request::SaveRun { run, kind, name } => image_response(save_run_request(run, *kind, name)),
         Request::Unknown { method } => Response::Error {
             message: format!("unknown method: {method}"),
@@ -720,6 +727,7 @@ async fn prune_runs_request() -> anyhow::Result<Response> {
         &crate::image_store::RealFs,
         &crate::run::RealRemoveDir,
         &root,
+        &crate::containerfile::real::RealBuiltImageSweep,
         |removed| {
             for id in removed {
                 crate::connector::real::forget_what_a_run_decided(id);
@@ -830,17 +838,29 @@ where
     }
 }
 
+/// What a prune does about the images a Containerfile build left behind, given the runs that survive it.
+pub trait BuiltImageSweep {
+    /// Drop every built image no document on this machine and no surviving run names, and answer with what went.
+    fn sweep(
+        &self,
+        cache_root: &std::path::Path,
+        surviving_runs: &[String],
+    ) -> impl std::future::Future<Output = anyhow::Result<Vec<String>>> + Send;
+}
+
 /// Sweep every stopped run and every orphan run dir — the one command that takes a machine back to clean.
-pub async fn prune_runs_with<F, R, N>(
+pub async fn prune_runs_with<F, R, N, B>(
     fs: &F,
     remover: &R,
     cache_root: &std::path::Path,
+    builds: &B,
     note_pruned: N,
 ) -> Response
 where
     F: crate::image_store::Fs,
     R: crate::run::RemoveDir,
     N: Fn(&[String]),
+    B: BuiltImageSweep,
 {
     let mut removed = crate::run_registry::prune_exited();
     for id in &removed {
@@ -881,7 +901,21 @@ where
     if !removed.is_empty() {
         note_pruned(&removed);
     }
-    Response::RunsPruned { removed }
+    let surviving: Vec<String> = crate::run_registry::snapshot()
+        .into_iter()
+        .map(|run| run.id)
+        .collect();
+    let built_images = match builds.sweep(cache_root, &surviving).await {
+        Ok(built_images) => built_images,
+        Err(e) => {
+            crate::log::warn!("built images were not swept: {e:#}");
+            Vec::new()
+        }
+    };
+    Response::RunsPruned {
+        removed,
+        built_images,
+    }
 }
 
 fn volume_response(result: anyhow::Result<Response>) -> Response {
@@ -3164,6 +3198,138 @@ mod tests {
         }
     }
 
+    /// A document whose `spec.image` names an image to pull has nothing for `lns sandbox build` to do.
+    #[tokio::test]
+    async fn handle_request_build_sandbox_refuses_a_document_that_names_no_containerfile() {
+        let resp = handle_request(
+            &Request::BuildSandbox {
+                definition: serde_json::json!({"spec": {"image": "alpine:3.20"}}).to_string(),
+                definition_dir: "/work".into(),
+                rebuild: false,
+            },
+            Instant::now(),
+        )
+        .await;
+
+        match resp {
+            Response::Error { message } => assert!(
+                message.contains("names an image to pull, not a Containerfile"),
+                "{message}"
+            ),
+            other => unreachable!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// What a Containerfile build left behind is swept with the runs, and named in the same answer.
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn a_prune_answers_with_the_built_images_it_dropped() {
+        struct SweptOne;
+        impl BuiltImageSweep for SweptOne {
+            async fn sweep(
+                &self,
+                _cache_root: &std::path::Path,
+                _surviving_runs: &[String],
+            ) -> anyhow::Result<Vec<String>> {
+                Ok(vec!["lns-build.local/built@sha256:gone".into()])
+            }
+        }
+        let fs = ScriptedRunsDir(Vec::new());
+
+        let resp = prune_runs_with(
+            &fs,
+            &NoopRemover,
+            std::path::Path::new("/cache"),
+            &SweptOne,
+            |_| {},
+        )
+        .await;
+
+        match resp {
+            Response::RunsPruned { built_images, .. } => {
+                assert_eq!(built_images, ["lns-build.local/built@sha256:gone"]);
+            }
+            other => unreachable!("expected RunsPruned, got {other:?}"),
+        }
+    }
+
+    /// A sweep that fails takes no run prune down with it; the runs are already gone by then.
+    #[tokio::test]
+    #[serial_test::serial(env, global_runs)]
+    async fn a_prune_whose_built_image_sweep_fails_still_answers_for_the_runs() {
+        struct SweepFails;
+        impl BuiltImageSweep for SweepFails {
+            async fn sweep(
+                &self,
+                _cache_root: &std::path::Path,
+                _surviving_runs: &[String],
+            ) -> anyhow::Result<Vec<String>> {
+                anyhow::bail!("the image index is not readable")
+            }
+        }
+        let fs = ScriptedRunsDir(Vec::new());
+        let warnings = Warnings::default();
+        let guard =
+            tracing::subscriber::set_default(tracing_subscriber::layer::SubscriberExt::with(
+                tracing_subscriber::registry(),
+                warnings.clone(),
+            ));
+
+        let resp = prune_runs_with(
+            &fs,
+            &NoopRemover,
+            std::path::Path::new("/cache"),
+            &SweepFails,
+            |_| {},
+        )
+        .await;
+        drop(guard);
+
+        assert!(
+            warnings.recorded().contains("built images were not swept"),
+            "{}",
+            warnings.recorded(),
+        );
+        match resp {
+            Response::RunsPruned { built_images, .. } => assert!(built_images.is_empty()),
+            other => unreachable!("expected RunsPruned, got {other:?}"),
+        }
+    }
+
+    /// The events a test reads back, so a warning nobody would otherwise see can be asserted.
+    #[derive(Clone, Default)]
+    struct Warnings(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl Warnings {
+        fn recorded(&self) -> String {
+            self.0.lock().unwrap().join("\n")
+        }
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Warnings {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            struct Message(String);
+            impl tracing::field::Visit for Message {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        self.0 = format!("{value:?}");
+                    }
+                }
+            }
+            let mut message = Message(String::new());
+            event.record(&mut message);
+            self.0.lock().unwrap().push(message.0);
+        }
+    }
+
     #[tokio::test]
     #[serial_test::serial(env, global_runs)]
     async fn handle_request_inspect_run_returns_details_for_a_registered_run() {
@@ -3201,7 +3367,7 @@ mod tests {
         let resp = handle_request(&Request::PruneRuns, Instant::now()).await;
 
         match resp {
-            Response::RunsPruned { removed } => {
+            Response::RunsPruned { removed, .. } => {
                 assert!(
                     removed.contains(&id),
                     "{id} should be pruned, got {removed:?}"
@@ -3245,6 +3411,18 @@ mod tests {
             matches!(&resp, Response::Error { message } if message.contains("no active run with id")),
             "got {resp:?}"
         );
+    }
+
+    /// A machine where no Containerfile build ever ran, which is what most prune scenarios are about.
+    struct SweepsNothing;
+    impl BuiltImageSweep for SweepsNothing {
+        async fn sweep(
+            &self,
+            _cache_root: &std::path::Path,
+            _surviving_runs: &[String],
+        ) -> anyhow::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
     }
 
     struct NoopRemover;
@@ -3486,11 +3664,11 @@ mod tests {
         crate::run_registry::register(id.clone(), handle);
         let root = std::path::Path::new("/cache");
         let fs = ScriptedRunsDir(vec![crate::cache::run_dir(root, &id)]);
-        let resp = prune_runs_with(&fs, &NoopRemover, root, |_| {}).await;
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &SweepsNothing, |_| {}).await;
         let still_registered = crate::run_registry::status(&id).is_some();
         crate::run_registry::deregister(&id);
         assert!(
-            matches!(&resp, Response::RunsPruned { removed } if !removed.contains(&id)),
+            matches!(&resp, Response::RunsPruned { removed, .. } if !removed.contains(&id)),
             "a registered run's dir is not an orphan: {resp:?}"
         );
         assert!(still_registered);
@@ -3509,10 +3687,10 @@ mod tests {
         };
         assert!(fs.write(std::path::Path::new("/x"), b"").await.is_ok());
         assert!(fs.remove_file(std::path::Path::new("/x")).await.is_ok());
-        let resp = prune_runs_with(&fs, &NoopRemover, root, |_| {}).await;
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &SweepsNothing, |_| {}).await;
         crate::run_registry::deregister(&id);
         assert!(
-            matches!(&resp, Response::RunsPruned { removed } if !removed.contains(&id)),
+            matches!(&resp, Response::RunsPruned { removed, .. } if !removed.contains(&id)),
             "a run that registered after the snapshot must not be swept from under its boot: {resp:?}"
         );
     }
@@ -3534,9 +3712,9 @@ mod tests {
         };
         assert!(fs.write(std::path::Path::new("/x"), b"").await.is_ok());
         assert!(fs.remove_file(std::path::Path::new("/x")).await.is_ok());
-        let resp = prune_runs_with(&fs, &NoopRemover, root, |_| {}).await;
+        let resp = prune_runs_with(&fs, &NoopRemover, root, &SweepsNothing, |_| {}).await;
         match resp {
-            Response::RunsPruned { removed } => {
+            Response::RunsPruned { removed, .. } => {
                 assert!(
                     !removed.contains(&"damaged1".to_string()),
                     "a dir whose record cannot be read is damage to surface, not an orphan to sweep: {removed:?}"
@@ -3559,9 +3737,16 @@ mod tests {
         assert!(probe.write(std::path::Path::new("/x"), b"").await.is_ok());
         assert!(probe.remove_file(std::path::Path::new("/x")).await.is_ok());
         let fs = ScriptedRunsDir(vec![std::path::PathBuf::from("/")]);
-        let resp = prune_runs_with(&fs, &NoopRemover, std::path::Path::new("/cache"), |_| {}).await;
+        let resp = prune_runs_with(
+            &fs,
+            &NoopRemover,
+            std::path::Path::new("/cache"),
+            &SweepsNothing,
+            |_| {},
+        )
+        .await;
         assert!(
-            matches!(&resp, Response::RunsPruned { removed } if removed.is_empty()),
+            matches!(&resp, Response::RunsPruned { removed, .. } if removed.is_empty()),
             "an unreadable entry is skipped, never swept blind: {resp:?}"
         );
     }
@@ -3617,7 +3802,7 @@ mod tests {
         crate::run_registry::set_exit_code(&id2, 0);
         let resp = image_response(prune_runs_request().await);
         assert!(
-            matches!(&resp, Response::RunsPruned { removed } if removed.contains(&id2)),
+            matches!(&resp, Response::RunsPruned { removed, .. } if removed.contains(&id2)),
             "got {resp:?}"
         );
         let content = std::fs::read_to_string(crate::audit::audit_path(&id2).unwrap()).unwrap();

--- a/crates/lns-service/tests/behaviours/steps/run_removal.rs
+++ b/crates/lns-service/tests/behaviours/steps/run_removal.rs
@@ -353,6 +353,19 @@ async fn two_stopped_one_running(w: &mut BehaviourWorld) {
     w.startrun_target = Some(live);
 }
 
+/// The prune scenarios describe runs, not builds; what a build leaves behind is pinned in the service's own tests.
+struct NoBuilds;
+
+impl lns_service::ipc::BuiltImageSweep for NoBuilds {
+    async fn sweep(
+        &self,
+        _cache_root: &Path,
+        _surviving_runs: &[String],
+    ) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
 #[given("a run dir with no run record")]
 async fn an_orphan_run_dir(w: &mut BehaviourWorld) {
     hold_serial(w).await;
@@ -367,8 +380,10 @@ async fn i_run_prune(w: &mut BehaviourWorld) {
         fs.run_dirs = vec![Path::new(CACHE_ROOT).join("runs").join(orphan)];
     }
     let fake = remover(w);
-    w.response =
-        Some(lns_service::ipc::prune_runs_with(&fs, &fake, Path::new(CACHE_ROOT), |_| {}).await);
+    w.response = Some(
+        lns_service::ipc::prune_runs_with(&fs, &fake, Path::new(CACHE_ROOT), &NoBuilds, |_| {})
+            .await,
+    );
     w.startrun_status_after = w
         .startrun_target
         .as_ref()
@@ -378,7 +393,7 @@ async fn i_run_prune(w: &mut BehaviourWorld) {
 
 #[then("both stopped runs are removed")]
 fn both_stopped_runs_removed(w: &mut BehaviourWorld) -> Result<(), String> {
-    let Some(Response::RunsPruned { removed }) = &w.response else {
+    let Some(Response::RunsPruned { removed, .. }) = &w.response else {
         return Err(format!("expected RunsPruned, got {:?}", w.response));
     };
     for id in &w.prune_stopped {

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -230,6 +230,7 @@ lns sandbox attach <RUN> [--detach-keys <CHORD>]
 lns sandbox ls [-a] [--format <table|json>]
 lns sandbox inspect <RUN> [--format <table|json>]
 lns sandbox save <RUN> -f <FILE> [--kind <sandbox|mixin>]
+lns sandbox build [-f <FILE>] [--rebuild]
 lns sandbox rm <RUN> [-f]
 lns sandbox prune [-f]
 ```
@@ -296,8 +297,9 @@ contributed it. That summary is the one thing you approve.
 | `ls` | `lns ps` | Lists running sandboxes with their state, when each was created, when it last booted, CPU, and memory. A sandbox is created once and boots as often as you start it, so the two times differ on anything restarted. `-a` includes stopped ones. |
 | `inspect` | `lns inspect` | Prints one sandbox's live state and launch configuration, with its resolved mixin embedded. It reports the same two times `ls` does, under the same names. The vCPU and memory it reports are the size the sandbox booted with, for a running and for a stopped one. |
 | `save` | | Writes one sandbox out as a document you keep ([§3.2.3](#323-the-runs-decisions-and-saving-them)). `-f`/`--file` names the file and is required; `--kind mixin` writes what the run decided instead of the run as it resolved. Works on a running or a stopped sandbox. |
+| `build` | | Builds the Containerfile `spec.image` names, fills the build cache, and publishes nothing — the CI build stage, or a "does this even build" check before a push. `-f`/`--file` selects the document, defaulting to `./lns.yaml`. It prints the build cache key ([sandbox-spec §3.1.1](sandbox-spec.md#311-image)) and the image the build produced; a build whose key this machine already answers builds nothing and says so. `--rebuild` ignores the cache for this build and writes what it produces. A document whose `spec.image` names an image to pull is refused: there is nothing to build. |
 | `rm` | `lns rm` | Removes a stopped sandbox: its record and its writable layer, the name freed and the artifact released. What it granted, declined, and decided goes with it, so save anything worth keeping first ([§3.2.3](#323-the-runs-decisions-and-saving-them)). `-f`/`--force` stops a running one first. |
-| `prune` | | Removes every stopped sandbox, writable layers included, and what each granted, declined, and decided. Lists them and asks, unless `-f`/`--force`. |
+| `prune` | | Removes every stopped sandbox, writable layers included, and what each granted, declined, and decided. It also drops every image a Containerfile build produced that nothing names any more — no document on this machine, and no sandbox — and names each one it dropped. Lists the sandboxes and asks, unless `-f`/`--force`. |
 
 Interrupting `lns` at the terminal (`Ctrl-C`) stops the sandbox. The detach chord
 does not: it returns your terminal, exits `0`, and leaves the workload running.

--- a/docs/sandbox-spec.md
+++ b/docs/sandbox-spec.md
@@ -361,6 +361,31 @@ An author SHOULD pin the image by digest before publishing. A tag makes the
 published sandbox mutable underneath its consumers, which defeats the digest the
 consumer approved.
 
+**What a build is keyed by.** When `image` names a Containerfile beside the
+document, the image it builds to is a function of four inputs and of nothing
+else:
+
+| Input | Why |
+|---|---|
+| The digest the `FROM` resolved to | The build stands on that image, not on the tag that named it. |
+| The Containerfile's text, as written | Comments and whitespace included: the key measures the file, not the parse, so no reuse needs explaining. |
+| The content hash of the build context | Every file's path, mode and bytes, and every symlink's target. A file rewritten with the bytes it already had is the same context. |
+| The guest architecture | An arm64 image is not an amd64 one. |
+
+Same key, same image: a build whose key this machine already answers runs
+nothing. The key changes when the Containerfile, a context file, the `FROM`
+digest or the architecture changes, and only then.
+
+One instruction is keyed the same way, by the image it stands on and by what it
+resolved to: the parent image's digest, the instruction as it runs (a `RUN`'s
+command, environment, user and working directory; a config instruction's
+resulting config), and, for `COPY` and `ADD`, the content hash of the files
+copied. A build reuses every leading instruction whose key still answers and
+runs the rest, beginning with the first that differs.
+
+Nothing but a key decides reuse. An implementation MUST NOT reuse a build on a
+timestamp, a file's modification time, or the path a document sits at.
+
 #### 3.1.2 `command` and `workdir`
 
 | Field | Type | Rules |


### PR DESCRIPTION
**[reading only, merges via [#422](https://github.com/lensapp/lens-sandbox/pull/422)]** This PR is not merged. Every slice of #393 lands through the single integration PR #422 against `main`.

Part of #393 — slice 4, the build cache key and `lns sandbox build`. Stacked on
[#408](https://github.com/lensapp/lens-sandbox/pull/408) (slice 3, the executor) and
opened against `feat/containerfile-executor`.

A build is a function of four inputs, and a build whose key this machine already
answers runs nothing:

```
$ lns sandbox build
Building   ./image/Containerfile (4 instructions)
Running    instruction 1 on line 2: /bin/sh -c npm install -g @anthropic-ai/claude-code@2.1.263
Built      lns-build.local/built@sha256:761743bb… in 41.20s (2 layers)
key sha256:5f0b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8
built ./image/Containerfile as lns-build.local/built@sha256:761743bb… (2 layers)

$ lns sandbox build
key sha256:5f0b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8
nothing to build: ./image/Containerfile is unchanged, and lns-build.local/built@sha256:761743bb… is what it builds to

$ echo "one more skill" >> image/skills/prompt.md
$ lns sandbox build
key sha256:c41d0f9b…                      # a context file changed, so the image key did
built ./image/Containerfile as lns-build.local/built@sha256:9ab3c02e… (2 layers)
                                          # the RUN before the COPY was reused; nothing booted for it
```

The two `key`/`built` lines are the CLI's. The `Building` / `Running` / `Built` lines
are the service's own, and reach a terminal only on the `lns run` path — see
[deviations](#deviations).

## The slice 4 row of the Plan table, mapped to code and tests

| What the row asks for | Code | Tests |
|---|---|---|
| The image key: the `FROM` digest, the Containerfile text, the context content hash, the architecture | `containerfile/key.rs` — `image_key`, and `context_hash` over the `ContextFs` port | `the_from_digest_the_text_the_context_and_the_architecture_each_change_the_image_key`, `the_same_containerfile_with_different_whitespace_in_a_comment_is_a_different_text_and_so_a_different_key`, `a_touched_but_identical_context_file_is_the_same_key`, `the_content_the_name_and_the_mode_of_a_context_file_each_change_the_context_hash`, `a_file_added_beside_the_containerfile_changes_the_context_hash`, `a_context_symlink_hashes_the_target_it_names_and_not_what_it_points_at` |
| Same key, same image, no rebuild | `executor::build` asks the key before the first instruction and returns what it answers | `a_second_build_of_an_unchanged_containerfile_runs_nothing_at_all` |
| The instruction key: the parent layer digest, the instruction, and for `COPY`/`ADD` the content hash of the copied files | `key::run_key`, `key::transfer_key`, `key::config_key`; `executor::reuse` | `a_run_is_keyed_by_the_command_the_env_the_user_and_the_workdir_it_resolved_to`, `a_transfer_is_keyed_by_the_instruction_and_by_what_it_copies`, `a_config_instruction_is_keyed_by_the_config_the_image_then_carries`, `the_line_a_run_was_written_on_is_not_part_of_its_key` |
| A build reuses every leading step whose key matches and rebuilds from the first that differs | `executor::step` asks the step key before it boots a guest or commits | `a_build_reuses_every_leading_step_and_rebuilds_from_the_first_that_differs`, `a_containerfile_whose_instructions_are_unchanged_reuses_every_step_of_them`, `a_copy_whose_file_changed_is_a_different_step_although_the_instruction_is_the_same`, `an_arg_the_run_reads_makes_it_a_different_step_although_the_line_is_unchanged` |
| Where a key is remembered | `containerfile/cache.rs` — one JSON entry per key, under `~/.lns/containerfile-builds/{images,steps}/`, through a `CacheFs` port | `containerfile/cache.rs` 9 tests: what a key answers, what it stops answering when the image is gone, an entry that does not parse, a cache that cannot be written |
| `lns sandbox build [-f FILE] [--rebuild]` builds now, fills the cache, publishes nothing | `lns-cli` `SandboxCommand::Build` → `Request::BuildSandbox` → `containerfile::real::build_sandbox`, which builds with no run around it | Layer 2 `crates/lns-cli/tests/behaviours/sandbox_build.feature`, 6 scenarios; `build_surfaces_the_services_refusal_and_rejects_an_unrelated_answer`, `build_names_the_document_it_could_not_read`, `build_names_the_document_it_could_not_parse`; `handle_request_build_sandbox_refuses_a_document_that_names_no_containerfile` |
| It prints the key and the built digest, and an unchanged build is a no-op that says so | `sandbox::build` prints `key …` and either `built … as …` or `nothing to build: …` | the first three scenarios of `sandbox_build.feature` |
| `--rebuild` ignores the cache for this build | `BuildPlan.rebuild`, read by `executor::build` and `executor::reuse` | `a_rebuild_reads_no_key_and_still_writes_every_one_it_produces`; the `--rebuild` scenario |
| `lns sandbox prune` also drops built images nothing references (a document on this machine, or a run) | `cache::still_referenced` (entries whose Containerfile is gone go, and with them the images nothing else names) + `image_store::remove_unreferenced_builds_with` + the `BuiltImageSweep` port on `prune_runs_with` | `a_build_whose_document_left_this_machine_is_dropped_and_its_image_is_named_by_nothing`, `a_run_booted_from_a_built_image_names_it_even_when_no_document_does`, `nothing_survives_a_sweep_once_the_manifests_are_gone`, `a_built_image_nothing_names_is_dropped_and_one_something_names_is_kept`, `a_cached_sandbox_is_never_dropped_by_the_built_image_sweep`, `a_prune_answers_with_the_built_images_it_dropped`, `a_prune_whose_built_image_sweep_fails_still_answers_for_the_runs` |
| `lns run` of a path document uses the same cache, so the inner loop needs no verb | `real::build_for_run` is now a caller of `real::build`; slice 3's one-pointer cache and its "refuse reuse when the context holds anything" rule are deleted | `crates/e2e-tests/features/microvm_containerfile_cache.feature`; slice 3's build-and-boot scenario still asserts a second `lns run` prints no `Building` line |
| No push, no `spec.image` rewrite, no `imageSource`, no architecture index | untouched | — |

## The @microvm scenario, and how to run it

**I cannot boot a guest where I work** — no `/dev/kvm`, no Vz, no
cloud-hypervisor/virtiofsd. The feature is written to be right by reasoning and
**is unverified by me**. One command on an arm64 Mac:

```
LNS_E2E_FEATURE="a build is remembered by its key, and only what changed is built again" make e2e-microvm
```

`crates/e2e-tests/features/microvm_containerfile_cache.feature` builds a Containerfile
of `FROM`, `RUN`, `COPY` and a second `RUN` that reads what the `COPY` brought; builds
it again unchanged and reads the no-op line and the same key; then edits the context
file, builds again, and asserts a different key and **one** instruction booted a guest —
the `RUN` after the `COPY`, not the one before it. What ran is counted from the
service's own log, which names each instruction it boots a guest for on one line. It
ends by running the sandbox and reading the edited bytes out of the booted guest.

The slice 3 scenarios are unchanged and should still pass; the `Building` line now
comes from the executor rather than from `real.rs`, which is what keeps
`microvm_containerfile_build.feature`'s "a second run prints no `Building` line"
true — a build the key answers outright now prints nothing at all.

## Deviations

- **The instruction key is over the instruction as it resolved, not as it was
  written.** The Plan row says "the instruction text". An `ARG` commits nothing, so two
  builds can reach the same parent image with the same written `RUN` line and still run
  two different commands; keying on the text would hand the second build the first
  build's image. A `RUN` is therefore keyed by its argv, its environment, its user and
  its working directory; a `COPY`/`ADD` by its label and the content hash of what it
  copies (which is where its sources, destination, `--chown` and `--chmod` all end up);
  a config instruction by its label and the config the image then carries. The line
  number is deliberately **not** part of the key: moving an instruction down the file
  rebuilds nothing.
- **The parent is the parent image's digest-pinned reference, not "the parent layer
  digest".** It identifies the same thing more exactly: a config-only instruction
  produces no layer, and the image it produced is what the next instruction stands on.
- **`lns sandbox build` prints no progress.** It is a one-shot request, so the
  `Building` / `Running` / `Built` lines the build logs go to the service's log rather
  than to the caller's terminal. The verb's own two lines (`key`, `built`/`nothing to
  build`) are the answer. Streaming them the way `lns run` does needs the frame-forward
  plumbing `serve_prepared_run` owns, which is a change to the request dispatcher rather
  than to the build, and it is not what this row asks for.
- **The CLI reads the document through the `SandboxService` port**, beside
  `write_document` and `load_policy`, rather than through a second filesystem parameter
  on every sandbox verb. It resolves `-f` against this machine's working directory and
  reads the file; the fake reads the behaviours' in-memory documents.
- **`lns sandbox prune`, not `lns artifact prune`, is where the built-image sweep
  landed**, as the issue's CLI surface says. `lns artifact prune` already reaches a
  built image, through `prune_with`'s run-pinning partition; the new sweep is the one
  that knows about *documents*, and it is what answers review item 2.11 of #408 for the
  intermediates a build leaves behind.
- **A build cache entry records the Containerfile it was built from.** That is the only
  way a sweep can ask "does a document on this machine still name this image": the key
  itself is a hash and names nothing. An entry whose Containerfile has left the machine
  goes, and the images no surviving entry and no run names go with it.
- **`image_store::real` and `RealCaches` became `pub(crate)`** so the sweep's
  composition root could stay in `containerfile/real.rs`, which is the file the coverage
  table already exempts.

## What is left out

- **No push, no pull, no `spec.imageSource`, no architecture index** — slices 5 and 6.
  `lns push` refuses the path form as #394 left it.
- **`lns push --dry-run` does not print the key yet.** It is slice 5's row; the key it
  will print is `key::image_key`, which this branch lands.
- **A build cache entry is never invalidated by age or size.** Nothing sweeps a build
  whose document is still on this machine, however old, until the user runs
  `lns sandbox prune`.
- **Review items 2.11, 2.12 and 2.13 of #408 are only half-answered.** The built-image
  sweep now reaches the intermediates a failed build left behind (2.11) once the
  document goes, and `real.rs` lost the reuse pointer and its key to `cache.rs` and
  `key.rs` (2.13) — but `real.rs` keeps its coverage exemption for the composition root
  it still is, and each build step still leaves its own audit chain and ledger rows
  (2.12), which is the audit writer's change, not this one's.
- **The key does not read `.dockerignore`**, because nothing reads it yet (#408).
- **Streaming.** A captured layer is still held in memory twice. Unchanged from slice 3.


## What happened to this pull request

**It merged the moment it was opened, and that was not the intent.** `gh pr merge 410
--auto --rebase` was run right after `gh pr create`, as the standing workflow for this
repository asks. `feat/containerfile-executor` carries no required checks and no
required review, so GitHub had nothing to wait for and merged at once. Slice 4's eleven
commits are therefore on `feat/containerfile-executor` — [#408](https://github.com/lensapp/lens-sandbox/pull/408)
now shows slices 3 and 4 together, and #408's own description does not describe slice 4.
This description does.

Nothing was force-pushed to undo it: `feat/containerfile-executor` is another pull
request's head branch, and rewriting it is the dispatcher's call, not mine. Two ways
back, if slice 4 should be reviewed on its own: reset `feat/containerfile-executor` to
`713473aa` and reopen this branch against it, or review slice 4 as the last eleven
commits of #408 with this description beside it.

## Verification

Host-side, all of it Layer 2/3:

```
cargo test -p lns-service --lib containerfile   →  283 passed
cargo test -p lns-service                       →  2653 passed; 259 scenarios
cargo test -p lns-cli                           →  1052 passed; 542 scenarios
cargo test -p lns-ipc                           →  179 passed
cargo build -p e2e-tests --tests                →  builds (the @microvm scenario does not run here)
cargo clippy -p lns-service -p lns-cli -p lns-ipc -p e2e-tests --all-targets -- -D warnings  →  clean
cargo clippy -p lns-service -p lns-cli -p lns-ipc -- -D clippy::cognitive_complexity          →  clean
cargo fmt --all -- --check                      →  clean
```

**How that binary was built.** This sandbox has no GTK development libraries and no
package that installs them, so `lns-service` was compiled against stub `pkg-config`
packages and stub `.so` files with `-Wl,--unresolved-symbols=ignore-all`. Every run
above therefore links a binary whose tray/GUI symbols are stubs. That is sound for what
these runs measure — Layer 2 and Layer 3 tests exercise `lns_service::ipc::handle_request`
and the library modules in-process, none of which touch the tray — but **none of the runs
listed above exercised a real `lns-service` binary**: `cargo build -p e2e-tests --tests`
compiles the Layer 1 harness without running it, and neither `make e2e` nor
`make e2e-microvm` was run here. Everything that boots a guest or spawns the real
service — the @microvm containerfile scenarios included — is unverified by me.

Coverage, measured with the gate's own tools (`cargo llvm-cov` + `coverage-strip-ast` +
`scripts/coverage-floor.sh`):

```
[crates/lns-service/] 127 at 100%, 36 ignored, 0 failures
[crates/lns-cli/]      42 at 100%, 19 ignored, 0 failures
[crates/lns-ipc/]       7 at 100%,  0 ignored, 0 failures
```

`containerfile/key.rs` and `containerfile/cache.rs` go in at 100% and are not in
IGNORES. No entry was added to the table, and none was removed.

CI: this branch was pushed as `ci-oracle/containerfile-cache` and opened as a draft
against `main` for one run, since the workflow only triggers for pull requests based on
`main`; that draft is closed and its branch deleted. The run is
[actions/runs/34387861418](https://github.com/lensapp/lens-sandbox/actions/runs/34387861418),
green on every job: `lint`, `test`, `coverage`, `coverage-as-root`, `audit`,
`shell-tests-macos`, both `check-release-build`s and `labels`.

## Red first

`test(service): the key a build is remembered by, before there is one` (`787d01ef`) and
`test(cli): what lns sandbox build prints, before the verb exists` (`5126c7fb`) are each
a failing test ahead of the code that answers it. `cache.rs` and the prune sweep were
written with their tests rather than strictly test-first.


